### PR TITLE
Switch to TimeFrame() extension

### DIFF
--- a/API/0001_MA_CrossOver/MaCrossoverStrategy.cs
+++ b/API/0001_MA_CrossOver/MaCrossoverStrategy.cs
@@ -83,7 +83,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1.0m, 5.0m, 1.0m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(1)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(1).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0002_NDay_Breakout/NdayBreakoutStrategy.cs
+++ b/API/0002_NDay_Breakout/NdayBreakoutStrategy.cs
@@ -90,7 +90,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1.0m, 3.0m, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromDays(1)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "Strategy Parameters");
         }
 

--- a/API/0003_ADX_Trend/AdxTrendStrategy.cs
+++ b/API/0003_ADX_Trend/AdxTrendStrategy.cs
@@ -95,7 +95,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(15, 25, 1);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
                 
             _adxAboveThreshold = false;

--- a/API/0004_Parabolic_SAR_Trend/ParabolicSarTrendStrategy.cs
+++ b/API/0004_Parabolic_SAR_Trend/ParabolicSarTrendStrategy.cs
@@ -64,7 +64,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(0.1m, 0.5m, 0.1m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
                 
             _prevSarValue = 0;

--- a/API/0005_Donchian_Channel/DonchianChannelStrategy.cs
+++ b/API/0005_Donchian_Channel/DonchianChannelStrategy.cs
@@ -50,7 +50,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(10, 50, 5);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
                 
             _prevClosePrice = 0;

--- a/API/0006_Tripple_MA/TripleMaCrossoverStrategy.cs
+++ b/API/0006_Tripple_MA/TripleMaCrossoverStrategy.cs
@@ -93,7 +93,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1, 3, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
                 
             _prevIsShortAboveMiddle = false;

--- a/API/0007_Keltner_Channel_Breakout/KeltnerChannelBreakoutStrategy.cs
+++ b/API/0007_Keltner_Channel_Breakout/KeltnerChannelBreakoutStrategy.cs
@@ -81,7 +81,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1, 3, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
                 
             _prevClosePrice = 0;

--- a/API/0008_Hull_MA_Trend/HullMaTrendStrategy.cs
+++ b/API/0008_Hull_MA_Trend/HullMaTrendStrategy.cs
@@ -78,7 +78,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1, 3, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
                 
             _prevHmaValue = 0;

--- a/API/0009_MACD_Trend/MacdTrendStrategy.cs
+++ b/API/0009_MACD_Trend/MacdTrendStrategy.cs
@@ -93,7 +93,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1, 3, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
                 
             _prevIsMacdAboveSignal = false;

--- a/API/0010_Super_Trend/SupertrendStrategy.cs
+++ b/API/0010_Super_Trend/SupertrendStrategy.cs
@@ -64,7 +64,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(2.0m, 4.0m, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
                 
             _prevIsPriceAboveSupertrend = false;

--- a/API/0011_Ichimoku_Kumo_Breakout/IchimokuKumoBreakoutStrategy.cs
+++ b/API/0011_Ichimoku_Kumo_Breakout/IchimokuKumoBreakoutStrategy.cs
@@ -82,7 +82,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(40, 60, 4);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
                 
             _prevTenkanValue = 0;

--- a/API/0012_Heikin_Ashi_Consecutive/HeikinAshiConsecutiveStrategy.cs
+++ b/API/0012_Heikin_Ashi_Consecutive/HeikinAshiConsecutiveStrategy.cs
@@ -69,7 +69,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1, 3, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
             
             _bullishCount = 0;

--- a/API/0013_DMI_Power_Move/DmiPowerMoveStrategy.cs
+++ b/API/0013_DMI_Power_Move/DmiPowerMoveStrategy.cs
@@ -106,7 +106,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1, 3, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0014_TradingView_Supertrend_Flip/TradingviewSupertrendFlipStrategy.cs
+++ b/API/0014_TradingView_Supertrend_Flip/TradingviewSupertrendFlipStrategy.cs
@@ -83,7 +83,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(10, 30, 5);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
                 
             _prevSupertrendValue = 0;

--- a/API/0015_Gann_Swing_Breakout/GannSwingBreakoutStrategy.cs
+++ b/API/0015_Gann_Swing_Breakout/GannSwingBreakoutStrategy.cs
@@ -72,7 +72,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(10, 50, 5);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
                 
             _lastSwingHigh = null;

--- a/API/0016_RSI_Divergence/RsiDivergenceStrategy.cs
+++ b/API/0016_RSI_Divergence/RsiDivergenceStrategy.cs
@@ -63,7 +63,7 @@ namespace StockSharp.Samples.Strategies
                 .SetDisplay("Stop Loss %", "Stop loss percentage", "Risk Management")
                 .SetCanOptimize(true);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0017_Williams_R/WilliamsPercentRStrategy.cs
+++ b/API/0017_Williams_R/WilliamsPercentRStrategy.cs
@@ -59,7 +59,7 @@ namespace StockSharp.Samples.Strategies
                 .SetRange(0.5m, 5m, 0.5m)
                 .SetCanOptimize(true);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0018_ROC_Impulce/RocImpulseStrategy.cs
+++ b/API/0018_ROC_Impulce/RocImpulseStrategy.cs
@@ -62,7 +62,7 @@ namespace StockSharp.Samples.Strategies
                 .SetDisplay("ATR Multiplier", "Multiplier for ATR stop loss", "Risk Management")
                 .SetCanOptimize(true);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0019_CCI_Breakout/CciBreakoutStrategy.cs
+++ b/API/0019_CCI_Breakout/CciBreakoutStrategy.cs
@@ -59,7 +59,7 @@ namespace StockSharp.Samples.Strategies
                 .SetDisplay("Stop Loss %", "Stop loss percentage", "Risk Management")
                 .SetCanOptimize(true);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0020_Momentum_Percentage/MomentumPercentageStrategy.cs
+++ b/API/0020_Momentum_Percentage/MomentumPercentageStrategy.cs
@@ -74,7 +74,7 @@ namespace StockSharp.Samples.Strategies
                 .SetDisplay("Stop Loss %", "Stop loss percentage", "Risk Management")
                 .SetCanOptimize(true);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0021_Bollinger_Squeeze/BollingerSqueezeStrategy.cs
+++ b/API/0021_Bollinger_Squeeze/BollingerSqueezeStrategy.cs
@@ -78,7 +78,7 @@ namespace StockSharp.Samples.Strategies
                 .SetDisplay("Squeeze Threshold", "Threshold for Bollinger Bands width to identify squeeze", "Strategy")
                 .SetCanOptimize(true);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0022_ADX_DI/AdxDiStrategy.cs
+++ b/API/0022_ADX_DI/AdxDiStrategy.cs
@@ -74,7 +74,7 @@ namespace StockSharp.Samples.Strategies
                 .SetDisplay("ATR Multiplier", "Multiplier for ATR stop loss", "Risk Management")
                 .SetCanOptimize(true);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0023_Elder_Impulse/ElderImpulseStrategy.cs
+++ b/API/0023_Elder_Impulse/ElderImpulseStrategy.cs
@@ -108,7 +108,7 @@ namespace StockSharp.Samples.Strategies
                 .SetDisplay("Stop Loss %", "Stop loss percentage", "Risk Management")
                 .SetCanOptimize(true);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0024_RSI_Laguerre/LaguerreRsiStrategy.cs
+++ b/API/0024_RSI_Laguerre/LaguerreRsiStrategy.cs
@@ -59,7 +59,7 @@ namespace StockSharp.Samples.Strategies
                 .SetDisplay("Stop Loss %", "Stop loss percentage", "Risk Management")
                 .SetCanOptimize(true);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0025_Stochastic_RSI_Cross/StochasticRsiCrossStrategy.cs
+++ b/API/0025_Stochastic_RSI_Cross/StochasticRsiCrossStrategy.cs
@@ -109,7 +109,7 @@ namespace StockSharp.Samples.Strategies
                 .SetDisplay("Stop Loss %", "Stop loss percentage", "Risk Management")
                 .SetCanOptimize(true);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0026_RSI_Reversion/RsiReversionStrategy.cs
+++ b/API/0026_RSI_Reversion/RsiReversionStrategy.cs
@@ -104,7 +104,7 @@ namespace StockSharp.Samples.Strategies
                 .SetDisplay("Stop Loss %", "Stop loss percentage", "Risk Management")
                 .SetCanOptimize(true);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0027_Bollinger_Reversion/BollingerReversionStrategy.cs
+++ b/API/0027_Bollinger_Reversion/BollingerReversionStrategy.cs
@@ -74,7 +74,7 @@ namespace StockSharp.Samples.Strategies
                 .SetDisplay("ATR Multiplier", "Multiplier for ATR stop loss", "Risk Management")
                 .SetCanOptimize(true);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0028_ZScore/ZScoreStrategy.cs
+++ b/API/0028_ZScore/ZScoreStrategy.cs
@@ -117,7 +117,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1.0m, 5.0m, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplayName("Candle Type")
                 .SetDescription("Type of candles to use")
                 .SetGroup("Data");

--- a/API/0029_MA_Deviation/MaDeviationStrategy.cs
+++ b/API/0029_MA_Deviation/MaDeviationStrategy.cs
@@ -99,7 +99,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1.0m, 3.0m, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplayName("Candle Type")
                 .SetDescription("Type of candles to use")
                 .SetGroup("Data");

--- a/API/0030_VWAP_Reversion/VwapReversionStrategy.cs
+++ b/API/0030_VWAP_Reversion/VwapReversionStrategy.cs
@@ -65,7 +65,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1.0m, 5.0m, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplayName("Candle Type")
                 .SetDescription("Type of candles to use")
                 .SetGroup("Data");

--- a/API/0031_Keltner_Reversion/KeltnerReversionStrategy.cs
+++ b/API/0031_Keltner_Reversion/KeltnerReversionStrategy.cs
@@ -99,7 +99,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1.0m, 3.0m, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplayName("Candle Type")
                 .SetDescription("Type of candles to use")
                 .SetGroup("Data");

--- a/API/0032_ATR_Reversion/AtrReversionStrategy.cs
+++ b/API/0032_ATR_Reversion/AtrReversionStrategy.cs
@@ -101,7 +101,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1.0m, 5.0m, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplayName("Candle Type")
                 .SetDescription("Type of candles to use")
                 .SetGroup("Data");

--- a/API/0033_MACD_Zero/MacdZeroStrategy.cs
+++ b/API/0033_MACD_Zero/MacdZeroStrategy.cs
@@ -101,7 +101,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1.0m, 5.0m, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplayName("Candle Type")
                 .SetDescription("Type of candles to use")
                 .SetGroup("Data");

--- a/API/0034_Low_Vol_Reversion/LowVolReversionStrategy.cs
+++ b/API/0034_Low_Vol_Reversion/LowVolReversionStrategy.cs
@@ -119,7 +119,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1.0m, 3.0m, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplayName("Candle Type")
                 .SetDescription("Type of candles to use")
                 .SetGroup("Data");

--- a/API/0035_Bollinger_B_Reversion/BollingerPercentBStrategy.cs
+++ b/API/0035_Bollinger_B_Reversion/BollingerPercentBStrategy.cs
@@ -99,7 +99,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1.0m, 5.0m, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplayName("Candle Type")
                 .SetDescription("Type of candles to use")
                 .SetGroup("Data");

--- a/API/0036_ATR_Expansion/AtrExpansionStrategy.cs
+++ b/API/0036_ATR_Expansion/AtrExpansionStrategy.cs
@@ -84,7 +84,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1.0m, 3.0m, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplayName("Candle Type")
                 .SetDescription("Type of candles to use")
                 .SetGroup("Data");

--- a/API/0037_VIX_Trigger/VixTriggerStrategy.cs
+++ b/API/0037_VIX_Trigger/VixTriggerStrategy.cs
@@ -77,7 +77,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1.0m, 5.0m, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplayName("Candle Type")
                 .SetDescription("Type of candles to use")
                 .SetGroup("Data");

--- a/API/0038_BB_Width/BbWidthStrategy.cs
+++ b/API/0038_BB_Width/BbWidthStrategy.cs
@@ -84,7 +84,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1.0m, 3.0m, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplayName("Candle Type")
                 .SetDescription("Type of candles to use")
                 .SetGroup("Data");

--- a/API/0039_HV_Breakout/HvBreakoutStrategy.cs
+++ b/API/0039_HV_Breakout/HvBreakoutStrategy.cs
@@ -86,7 +86,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1.0m, 5.0m, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplayName("Candle Type")
                 .SetDescription("Type of candles to use")
                 .SetGroup("Data");

--- a/API/0040_ATR_Trailing/AtrTrailingStrategy.cs
+++ b/API/0040_ATR_Trailing/AtrTrailingStrategy.cs
@@ -85,7 +85,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(10, 50, 5);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplayName("Candle Type")
                 .SetDescription("Type of candles to use")
                 .SetGroup("Data");

--- a/API/0041_Vol_Adjusted_MA/VolAdjustedMaStrategy.cs
+++ b/API/0041_Vol_Adjusted_MA/VolAdjustedMaStrategy.cs
@@ -81,7 +81,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1.0m, 3.0m, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles for strategy calculation", "Strategy Parameters");
                 
             _prevAdjustedUpperBand = 0;

--- a/API/0042_IV_Spike/IvSpikeStrategy.cs
+++ b/API/0042_IV_Spike/IvSpikeStrategy.cs
@@ -81,7 +81,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1.2m, 2.0m, 0.1m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles for strategy calculation", "Strategy Parameters");
                 
             _previousIV = 0;

--- a/API/0043_VCP/VcpStrategy.cs
+++ b/API/0043_VCP/VcpStrategy.cs
@@ -66,7 +66,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(10, 30, 5);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles for strategy calculation", "Strategy Parameters");
                 
             _prevCandleRange = 0;

--- a/API/0044_ATR_Range/AtrRangeStrategy.cs
+++ b/API/0044_ATR_Range/AtrRangeStrategy.cs
@@ -82,7 +82,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(3, 10, 1);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles for strategy calculation", "Strategy Parameters");
                 
             _nBarsAgoPrice = 0;

--- a/API/0045_Choppiness_Index_Breakout/ChoppinessIndexBreakoutStrategy.cs
+++ b/API/0045_Choppiness_Index_Breakout/ChoppinessIndexBreakoutStrategy.cs
@@ -98,7 +98,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(55m, 70m, 2.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles for strategy calculation", "Strategy Parameters");
                 
             _prevChoppiness = 100m; // Initialize to high value

--- a/API/0046_Volume_Spike/VolumeSpikeStrategy.cs
+++ b/API/0046_Volume_Spike/VolumeSpikeStrategy.cs
@@ -82,7 +82,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1.5m, 3.0m, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles for strategy calculation", "Strategy Parameters");
                 
             _previousVolume = 0;

--- a/API/0047_OBV_Breakout/ObvBreakoutStrategy.cs
+++ b/API/0047_OBV_Breakout/ObvBreakoutStrategy.cs
@@ -68,7 +68,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(10, 30, 5);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles for strategy calculation", "Strategy Parameters");
                 
             _highestOBV = decimal.MinValue;

--- a/API/0048_VWAP_Breakout/VwapBreakoutStrategy.cs
+++ b/API/0048_VWAP_Breakout/VwapBreakoutStrategy.cs
@@ -35,7 +35,7 @@ namespace StockSharp.Samples.Strategies
         /// </summary>
         public VWAPBreakoutStrategy()
         {
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles for strategy calculation", "Strategy Parameters");
                 
             _previousClosePrice = 0;

--- a/API/0049_VWMA/VwmaStrategy.cs
+++ b/API/0049_VWMA/VwmaStrategy.cs
@@ -52,7 +52,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(5, 30, 5);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles for strategy calculation", "Strategy Parameters");
                 
             _previousClosePrice = 0;

--- a/API/0050_AD/ADStrategy.cs
+++ b/API/0050_AD/ADStrategy.cs
@@ -51,7 +51,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(10, 50, 10);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles for strategy calculation", "Strategy Parameters");
                 
             _previousADValue = 0;

--- a/API/0051_Volume_Weighted_Price_Breakout/VolumeWeightedPriceBreakoutStrategy.cs
+++ b/API/0051_Volume_Weighted_Price_Breakout/VolumeWeightedPriceBreakoutStrategy.cs
@@ -64,7 +64,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(10, 30, 5);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles for strategy calculation", "Strategy Parameters");
         }
 

--- a/API/0052_Volume_Divergence/VolumeDivergenceStrategy.cs
+++ b/API/0052_Volume_Divergence/VolumeDivergenceStrategy.cs
@@ -68,7 +68,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(7, 28, 7);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles for strategy calculation", "Strategy Parameters");
                 
             _previousClose = 0;

--- a/API/0053_Volume_MA_Cross/VolumeMaCrossStrategy.cs
+++ b/API/0053_Volume_MA_Cross/VolumeMaCrossStrategy.cs
@@ -68,7 +68,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(30, 100, 10);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles for strategy calculation", "Strategy Parameters");
                 
             _previousFastVolumeMA = 0;

--- a/API/0054_Cumulative_Delta_Breakout/CumulativeDeltaBreakoutStrategy.cs
+++ b/API/0054_Cumulative_Delta_Breakout/CumulativeDeltaBreakoutStrategy.cs
@@ -53,7 +53,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(10, 50, 10);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles for strategy calculation", "Strategy Parameters");
                 
             _cumulativeDelta = 0;

--- a/API/0055_Volume_Surge/VolumeSurgeStrategy.cs
+++ b/API/0055_Volume_Surge/VolumeSurgeStrategy.cs
@@ -80,7 +80,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1.5m, 3.0m, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles for strategy calculation", "Strategy Parameters");
         }
 

--- a/API/0056_Double_Bottom/DoubleBottomStrategy.cs
+++ b/API/0056_Double_Bottom/DoubleBottomStrategy.cs
@@ -77,7 +77,7 @@ namespace StockSharp.Samples.Strategies
                 .SetDisplay("Similarity %", "Maximum percentage difference between two bottoms", "Pattern Parameters")
                 .SetCanOptimize(true);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
 
             _stopLossPercent = Param(nameof(StopLossPercent), 1.0m)

--- a/API/0057_Double_Top/DoubleTopStrategy.cs
+++ b/API/0057_Double_Top/DoubleTopStrategy.cs
@@ -77,7 +77,7 @@ namespace StockSharp.Samples.Strategies
                 .SetDisplay("Similarity %", "Maximum percentage difference between two tops", "Pattern Parameters")
                 .SetCanOptimize(true);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
 
             _stopLossPercent = Param(nameof(StopLossPercent), 1.0m)

--- a/API/0058_RSI_Overbought_Oversold/RsiOverboughtOversoldStrategy.cs
+++ b/API/0058_RSI_Overbought_Oversold/RsiOverboughtOversoldStrategy.cs
@@ -99,7 +99,7 @@ namespace StockSharp.Samples.Strategies
                 .SetDisplay("Neutral Level", "RSI level for exiting positions", "Signal Parameters")
                 .SetCanOptimize(true);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
 
             _stopLossPercent = Param(nameof(StopLossPercent), 2.0m)

--- a/API/0060_Shooting_Star/ShootingStarStrategy.cs
+++ b/API/0060_Shooting_Star/ShootingStarStrategy.cs
@@ -70,7 +70,7 @@ namespace StockSharp.Samples.Strategies
                 .SetDisplay("Shadow/Body Ratio", "Minimum ratio of upper shadow to body length", "Pattern Parameters")
                 .SetCanOptimize(true);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
 
             _stopLossPercent = Param(nameof(StopLossPercent), 1.0m)

--- a/API/0061_MACD_Divergence/MacdDivergenceStrategy.cs
+++ b/API/0061_MACD_Divergence/MacdDivergenceStrategy.cs
@@ -108,7 +108,7 @@ namespace StockSharp.Samples.Strategies
                 .SetDisplay("Divergence Period", "Number of bars to look back for divergence", "Signal Parameters")
                 .SetCanOptimize(true);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
 
             _stopLossPercent = Param(nameof(StopLossPercent), 2.0m)

--- a/API/0063_Engulfing_Bullish/EngulfingBullishStrategy.cs
+++ b/API/0063_Engulfing_Bullish/EngulfingBullishStrategy.cs
@@ -64,7 +64,7 @@ namespace StockSharp.Samples.Strategies
         /// </summary>
         public EngulfingBullishStrategy()
         {
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
 
             _stopLossPercent = Param(nameof(StopLossPercent), 1.0m)

--- a/API/0064_Engulfing_Bearish/EngulfingBearishStrategy.cs
+++ b/API/0064_Engulfing_Bearish/EngulfingBearishStrategy.cs
@@ -64,7 +64,7 @@ namespace StockSharp.Samples.Strategies
         /// </summary>
         public EngulfingBearishStrategy()
         {
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
 
             _stopLossPercent = Param(nameof(StopLossPercent), 1.0m)

--- a/API/0065_Pinbar_Reversal/PinbarReversalStrategy.cs
+++ b/API/0065_Pinbar_Reversal/PinbarReversalStrategy.cs
@@ -93,7 +93,7 @@ namespace StockSharp.Samples.Strategies
                 .SetDisplay("Opposite Tail Ratio", "Maximum ratio of opposite tail to body", "Pattern Parameters")
                 .SetCanOptimize(true);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
 
             _stopLossPercent = Param(nameof(StopLossPercent), 1.0m)

--- a/API/0066_Three_Bar_Reversal_Up/ThreeBarReversalUpStrategy.cs
+++ b/API/0066_Three_Bar_Reversal_Up/ThreeBarReversalUpStrategy.cs
@@ -66,7 +66,7 @@ namespace StockSharp.Samples.Strategies
         /// </summary>
         public ThreeBarReversalUpStrategy()
         {
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
 
             _stopLossPercent = Param(nameof(StopLossPercent), 1.0m)

--- a/API/0067_Three_Bar_Reversal_Down/ThreeBarReversalDownStrategy.cs
+++ b/API/0067_Three_Bar_Reversal_Down/ThreeBarReversalDownStrategy.cs
@@ -66,7 +66,7 @@ namespace StockSharp.Samples.Strategies
         /// </summary>
         public ThreeBarReversalDownStrategy()
         {
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
 
             _stopLossPercent = Param(nameof(StopLossPercent), 1.0m)

--- a/API/0068_CCI_Divergence/CciDivergenceStrategy.cs
+++ b/API/0068_CCI_Divergence/CciDivergenceStrategy.cs
@@ -98,7 +98,7 @@ namespace StockSharp.Samples.Strategies
                 .SetDisplay("Divergence Period", "Number of bars to look back for divergence", "Signal Parameters")
                 .SetCanOptimize(true);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
 
             _stopLossPercent = Param(nameof(StopLossPercent), 2.0m)

--- a/API/0080_Pivot_Point_Reversal/PivotPointReversalStrategy.cs
+++ b/API/0080_Pivot_Point_Reversal/PivotPointReversalStrategy.cs
@@ -92,7 +92,7 @@ namespace StockSharp.Samples.Strategies
             var subscription = SubscribeCandles(CandleType);
             
             // Subscribe to the previous day's candles to get OHLC data
-            var dailySubscription = SubscribeCandles(DataType.TimeFrame(TimeSpan.FromDays(1)));
+            var dailySubscription = SubscribeCandles(TimeSpan.FromDays(1).TimeFrame());
             
             // Process daily candles to get previous day's data
             dailySubscription

--- a/API/0081_VWAP_Bounce/VwapBounceStrategy.cs
+++ b/API/0081_VWAP_Bounce/VwapBounceStrategy.cs
@@ -43,7 +43,7 @@ namespace StockSharp.Samples.Strategies
         /// </summary>
         public VwapBounceStrategy()
         {
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
                 
             _stopLoss = Param(nameof(StopLoss), new Unit(2, UnitTypes.Percent))

--- a/API/0082_Volume_Exhaustion/VolumeExhaustionStrategy.cs
+++ b/API/0082_Volume_Exhaustion/VolumeExhaustionStrategy.cs
@@ -93,7 +93,7 @@ namespace StockSharp.Samples.Strategies
                 .SetDisplay("ATR Multiplier", "Multiplier for ATR stop-loss", "Risk Management")
                 .SetCanOptimize(true);
                 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0083_ADX_Weakening/AdxWeakeningStrategy.cs
+++ b/API/0083_ADX_Weakening/AdxWeakeningStrategy.cs
@@ -78,7 +78,7 @@ namespace StockSharp.Samples.Strategies
                 .SetRange(1m, 3m, 0.5m)
                 .SetCanOptimize(true);
                 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0084_ATR_Exhaustion/AtrExhaustionStrategy.cs
+++ b/API/0084_ATR_Exhaustion/AtrExhaustionStrategy.cs
@@ -108,7 +108,7 @@ namespace StockSharp.Samples.Strategies
                 .SetRange(1m, 3m, 0.5m)
                 .SetCanOptimize(true);
                 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0085_Ichimoku_Tenkan/IchimokuTenkanKijunStrategy.cs
+++ b/API/0085_Ichimoku_Tenkan/IchimokuTenkanKijunStrategy.cs
@@ -80,7 +80,7 @@ namespace StockSharp.Samples.Strategies
                 .SetRange(40, 60, 4)
                 .SetCanOptimize(true);
                 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(30)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(30).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0086_Heikin_Ashi_Reversal/HeikinAshiReversalStrategy.cs
+++ b/API/0086_Heikin_Ashi_Reversal/HeikinAshiReversalStrategy.cs
@@ -43,7 +43,7 @@ namespace StockSharp.Samples.Strategies
         /// </summary>
         public HeikinAshiReversalStrategy()
         {
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
                 
             _stopLoss = Param(nameof(StopLoss), new Unit(2, UnitTypes.Percent))

--- a/API/0087_Parabolic_SAR_Reversal/ParabolicSarReversalStrategy.cs
+++ b/API/0087_Parabolic_SAR_Reversal/ParabolicSarReversalStrategy.cs
@@ -63,7 +63,7 @@ namespace StockSharp.Samples.Strategies
                 .SetRange(0.1m, 0.3m, 0.05m)
                 .SetCanOptimize(true);
                 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0088_Supertrend_Reversal/SupertrendReversalStrategy.cs
+++ b/API/0088_Supertrend_Reversal/SupertrendReversalStrategy.cs
@@ -70,7 +70,7 @@ namespace StockSharp.Samples.Strategies
                 .SetRange(2.0m, 4.0m, 0.5m)
                 .SetCanOptimize(true);
                 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0089_Hull_MA_Reversal/HullMaReversalStrategy.cs
+++ b/API/0089_Hull_MA_Reversal/HullMaReversalStrategy.cs
@@ -65,7 +65,7 @@ namespace StockSharp.Samples.Strategies
                 .SetRange(1.5m, 3.0m, 0.5m)
                 .SetCanOptimize(true);
                 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0090_Donchian_Reversal/DonchianReversalStrategy.cs
+++ b/API/0090_Donchian_Reversal/DonchianReversalStrategy.cs
@@ -64,7 +64,7 @@ namespace StockSharp.Samples.Strategies
                 .SetRange(1m, 3m, 0.5m)
                 .SetCanOptimize(true);
                 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0091_MACD_Histogram_Reversal/MacdHistogramReversalStrategy.cs
+++ b/API/0091_MACD_Histogram_Reversal/MacdHistogramReversalStrategy.cs
@@ -93,7 +93,7 @@ namespace StockSharp.Samples.Strategies
                 .SetRange(1m, 3m, 0.5m)
                 .SetCanOptimize(true);
                 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0092_RSI_Hook_Reversal/RsiHookReversalStrategy.cs
+++ b/API/0092_RSI_Hook_Reversal/RsiHookReversalStrategy.cs
@@ -108,7 +108,7 @@ namespace StockSharp.Samples.Strategies
                 .SetRange(1m, 3m, 0.5m)
                 .SetCanOptimize(true);
                 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0093_Stochastic_Hook_Reversal/StochasticHookReversalStrategy.cs
+++ b/API/0093_Stochastic_Hook_Reversal/StochasticHookReversalStrategy.cs
@@ -138,7 +138,7 @@ namespace StockSharp.Samples.Strategies
                 .SetRange(1m, 3m, 0.5m)
                 .SetCanOptimize(true);
                 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0094_CCI_Hook_Reversal/CciHookReversalStrategy.cs
+++ b/API/0094_CCI_Hook_Reversal/CciHookReversalStrategy.cs
@@ -93,7 +93,7 @@ namespace StockSharp.Samples.Strategies
                 .SetRange(1m, 3m, 0.5m)
                 .SetCanOptimize(true);
                 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0095_Williams_R_Hook_Reversal/WilliamsRHookReversalStrategy.cs
+++ b/API/0095_Williams_R_Hook_Reversal/WilliamsRHookReversalStrategy.cs
@@ -108,7 +108,7 @@ namespace StockSharp.Samples.Strategies
                 .SetRange(1m, 3m, 0.5m)
                 .SetCanOptimize(true);
                 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0101_Harami_Bullish/HaramiBullishStrategy.cs
+++ b/API/0101_Harami_Bullish/HaramiBullishStrategy.cs
@@ -44,7 +44,7 @@ namespace StockSharp.Samples.Strategies
         /// </summary>
         public HaramiBullishStrategy()
         {
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                          .SetDisplay("Candle Type", "Type of candles to use for pattern detection", "General");
             
             _stopLossPercent = Param(nameof(StopLossPercent), 1m)

--- a/API/0102_Harami_Bearish/HaramiBearishStrategy.cs
+++ b/API/0102_Harami_Bearish/HaramiBearishStrategy.cs
@@ -44,7 +44,7 @@ namespace StockSharp.Samples.Strategies
         /// </summary>
         public HaramiBearishStrategy()
         {
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                          .SetDisplay("Candle Type", "Type of candles to use for pattern detection", "General");
             
             _stopLossPercent = Param(nameof(StopLossPercent), 1m)

--- a/API/0103_Dark_Pool_Prints/DarkPoolPrintsStrategy.cs
+++ b/API/0103_Dark_Pool_Prints/DarkPoolPrintsStrategy.cs
@@ -76,7 +76,7 @@ namespace StockSharp.Samples.Strategies
         /// </summary>
         public DarkPoolPrintsStrategy()
         {
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use for analysis", "General");
 
             _volumePeriod = Param(nameof(VolumePeriod), 20)

--- a/API/0104_Rejection_Candle/RejectionCandleStrategy.cs
+++ b/API/0104_Rejection_Candle/RejectionCandleStrategy.cs
@@ -45,7 +45,7 @@ namespace StockSharp.Samples.Strategies
         /// </summary>
         public RejectionCandleStrategy()
         {
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                          .SetDisplay("Candle Type", "Type of candles to use for pattern detection", "General");
             
             _stopLossPercent = Param(nameof(StopLossPercent), 1m)

--- a/API/0105_False_Breakout_Trap/FalseBreakoutTrapStrategy.cs
+++ b/API/0105_False_Breakout_Trap/FalseBreakoutTrapStrategy.cs
@@ -70,7 +70,7 @@ namespace StockSharp.Samples.Strategies
         /// </summary>
         public FalseBreakoutTrapStrategy()
         {
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                          .SetDisplay("Candle Type", "Type of candles to use for analysis", "General");
             
             _lookbackPeriod = Param(nameof(LookbackPeriod), 20)

--- a/API/0106_Spring_Reversal/SpringReversalStrategy.cs
+++ b/API/0106_Spring_Reversal/SpringReversalStrategy.cs
@@ -67,7 +67,7 @@ namespace StockSharp.Samples.Strategies
         /// </summary>
         public SpringReversalStrategy()
         {
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                          .SetDisplay("Candle Type", "Type of candles to use for analysis", "General");
             
             _lookbackPeriod = Param(nameof(LookbackPeriod), 20)

--- a/API/0107_Upthrust_Reversal/UpthrustReversalStrategy.cs
+++ b/API/0107_Upthrust_Reversal/UpthrustReversalStrategy.cs
@@ -67,7 +67,7 @@ namespace StockSharp.Samples.Strategies
         /// </summary>
         public UpthrustReversalStrategy()
         {
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                          .SetDisplay("Candle Type", "Type of candles to use for analysis", "General");
             
             _lookbackPeriod = Param(nameof(LookbackPeriod), 20)

--- a/API/0108_Wyckoff_Accumulation/WyckoffAccumulationStrategy.cs
+++ b/API/0108_Wyckoff_Accumulation/WyckoffAccumulationStrategy.cs
@@ -93,7 +93,7 @@ namespace StockSharp.Samples.Strategies
         /// </summary>
         public WyckoffAccumulationStrategy()
         {
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                          .SetDisplay("Candle Type", "Type of candles to use for analysis", "General");
             
             _maPeriod = Param(nameof(MaPeriod), 20)

--- a/API/0109_Wyckoff_Distribution/WyckoffDistributionStrategy.cs
+++ b/API/0109_Wyckoff_Distribution/WyckoffDistributionStrategy.cs
@@ -93,7 +93,7 @@ namespace StockSharp.Samples.Strategies
         /// </summary>
         public WyckoffDistributionStrategy()
         {
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                          .SetDisplay("Candle Type", "Type of candles to use for analysis", "General");
             
             _maPeriod = Param(nameof(MaPeriod), 20)

--- a/API/0110_RSI_Failure_Swing/RsiFailureSwingStrategy.cs
+++ b/API/0110_RSI_Failure_Swing/RsiFailureSwingStrategy.cs
@@ -78,7 +78,7 @@ namespace StockSharp.Samples.Strategies
         /// </summary>
         public RsiFailureSwingStrategy()
         {
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                          .SetDisplay("Candle Type", "Type of candles to use for analysis", "General");
             
             _rsiPeriod = Param(nameof(RsiPeriod), 14)

--- a/API/0111_Stochastic_Failure_Swing/StochasticFailureSwingStrategy.cs
+++ b/API/0111_Stochastic_Failure_Swing/StochasticFailureSwingStrategy.cs
@@ -98,7 +98,7 @@ namespace StockSharp.Samples.Strategies
         /// </summary>
         public StochasticFailureSwingStrategy()
         {
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                          .SetDisplay("Candle Type", "Type of candles to use for analysis", "General");
             
             _kPeriod = Param(nameof(KPeriod), 14)

--- a/API/0112_CCI_Failure_Swing/CciFailureSwingStrategy.cs
+++ b/API/0112_CCI_Failure_Swing/CciFailureSwingStrategy.cs
@@ -78,7 +78,7 @@ namespace StockSharp.Samples.Strategies
         /// </summary>
         public CciFailureSwingStrategy()
         {
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                          .SetDisplay("Candle Type", "Type of candles to use for analysis", "General");
             
             _cciPeriod = Param(nameof(CciPeriod), 20)

--- a/API/0113_Bullish_Abandoned_Baby/BullishAbandonedBabyStrategy.cs
+++ b/API/0113_Bullish_Abandoned_Baby/BullishAbandonedBabyStrategy.cs
@@ -41,7 +41,7 @@ namespace StockSharp.Strategies
         /// </summary>
         public BullishAbandonedBabyStrategy()
         {
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use for analysis", "Candles");
 
             _stopLossPercent = Param(nameof(StopLossPercent), 1m)

--- a/API/0114_Bearish_Abandoned_Baby/BearishAbandonedBabyStrategy.cs
+++ b/API/0114_Bearish_Abandoned_Baby/BearishAbandonedBabyStrategy.cs
@@ -41,7 +41,7 @@ namespace StockSharp.Strategies
         /// </summary>
         public BearishAbandonedBabyStrategy()
         {
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use for analysis", "Candles");
 
             _stopLossPercent = Param(nameof(StopLossPercent), 1m)

--- a/API/0115_Volume_Climax_Reversal/VolumeClimaxReversalStrategy.cs
+++ b/API/0115_Volume_Climax_Reversal/VolumeClimaxReversalStrategy.cs
@@ -73,7 +73,7 @@ namespace StockSharp.Strategies
         /// </summary>
         public VolumeClimaxReversalStrategy()
         {
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "Candles");
 
             _volumePeriod = Param(nameof(VolumePeriod), 20)

--- a/API/0116_Day_of_Week/DayOfWeekStrategy.cs
+++ b/API/0116_Day_of_Week/DayOfWeekStrategy.cs
@@ -57,7 +57,7 @@ namespace StockSharp.Samples.Strategies
                 .SetGreaterThanZero()
                 .SetDisplay("MA Period", "Moving average period for trend confirmation", "Strategy");
             
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles for strategy", "Strategy");
         }
 

--- a/API/0117_Month_of_Year/MonthOfYearStrategy.cs
+++ b/API/0117_Month_of_Year/MonthOfYearStrategy.cs
@@ -57,7 +57,7 @@ namespace StockSharp.Samples.Strategies
                 .SetGreaterThanZero()
                 .SetDisplay("MA Period", "Moving average period for trend confirmation", "Strategy");
             
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromDays(1)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles for strategy", "Strategy");
         }
 

--- a/API/0118_Turnaround_Tuesday/TurnaroundTuesdayStrategy.cs
+++ b/API/0118_Turnaround_Tuesday/TurnaroundTuesdayStrategy.cs
@@ -60,7 +60,7 @@ namespace StockSharp.Samples.Strategies
                 .SetGreaterThanZero()
                 .SetDisplay("MA Period", "Moving average period for trend confirmation", "Strategy");
             
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromDays(1)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles for strategy", "Strategy");
             
             _prevClosePrice = 0;

--- a/API/0119_End_of_Month_Strength/EndOfMonthStrategy.cs
+++ b/API/0119_End_of_Month_Strength/EndOfMonthStrategy.cs
@@ -57,7 +57,7 @@ namespace StockSharp.Samples.Strategies
                 .SetGreaterThanZero()
                 .SetDisplay("MA Period", "Moving average period for trend confirmation", "Strategy");
             
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromDays(1)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles for strategy", "Strategy");
         }
 

--- a/API/0120_First_Day_of_Month/FirstDayOfMonthStrategy.cs
+++ b/API/0120_First_Day_of_Month/FirstDayOfMonthStrategy.cs
@@ -57,7 +57,7 @@ namespace StockSharp.Samples.Strategies
                 .SetGreaterThanZero()
                 .SetDisplay("MA Period", "Moving average period for trend confirmation", "Strategy");
             
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromDays(1)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles for strategy", "Strategy");
         }
 

--- a/API/0121_Santa_Claus_Rally/SantaClausRallyStrategy.cs
+++ b/API/0121_Santa_Claus_Rally/SantaClausRallyStrategy.cs
@@ -58,7 +58,7 @@ namespace StockSharp.Samples.Strategies
                 .SetGreaterThanZero()
                 .SetDisplay("MA Period", "Moving average period for trend confirmation", "Strategy");
             
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromDays(1)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles for strategy", "Strategy");
         }
 

--- a/API/0122_January_Effect/JanuaryEffectStrategy.cs
+++ b/API/0122_January_Effect/JanuaryEffectStrategy.cs
@@ -57,7 +57,7 @@ namespace StockSharp.Samples.Strategies
                 .SetGreaterThanZero()
                 .SetDisplay("MA Period", "Moving average period for trend confirmation", "Strategy");
             
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromDays(1)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles for strategy", "Strategy");
         }
 

--- a/API/0123_Monday_Weakness/MondayWeaknessStrategy.cs
+++ b/API/0123_Monday_Weakness/MondayWeaknessStrategy.cs
@@ -58,7 +58,7 @@ namespace StockSharp.Samples.Strategies
                 .SetGreaterThanZero()
                 .SetDisplay("MA Period", "Moving average period for trend confirmation", "Strategy");
             
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromDays(1)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles for strategy", "Strategy");
         }
 

--- a/API/0124_Pre-Holiday_Strength/PreHolidayStrengthStrategy.cs
+++ b/API/0124_Pre-Holiday_Strength/PreHolidayStrengthStrategy.cs
@@ -72,7 +72,7 @@ namespace StockSharp.Samples.Strategies
                 .SetGreaterThanZero()
                 .SetDisplay("MA Period", "Moving average period for trend confirmation", "Strategy");
             
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromDays(1)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles for strategy", "Strategy");
             
             _inPreHolidayPosition = false;

--- a/API/0125_Post-Holiday_Weakness/PostHolidayWeaknessStrategy.cs
+++ b/API/0125_Post-Holiday_Weakness/PostHolidayWeaknessStrategy.cs
@@ -72,7 +72,7 @@ namespace StockSharp.Samples.Strategies
                 .SetGreaterThanZero()
                 .SetDisplay("MA Period", "Moving average period for trend confirmation", "Strategy");
             
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromDays(1)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles for strategy", "Strategy");
             
             _inPostHolidayPosition = false;

--- a/API/0126_Quarterly_Expiry/QuarterlyExpiryStrategy.cs
+++ b/API/0126_Quarterly_Expiry/QuarterlyExpiryStrategy.cs
@@ -57,7 +57,7 @@ namespace StockSharp.Samples.Strategies
                 .SetGreaterThanZero()
                 .SetDisplay("MA Period", "Moving average period for trend confirmation", "Strategy");
             
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromDays(1)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles for strategy", "Strategy");
         }
 

--- a/API/0127_Open_Drive/OpenDriveStrategy.cs
+++ b/API/0127_Open_Drive/OpenDriveStrategy.cs
@@ -79,7 +79,7 @@ namespace StockSharp.Samples.Strategies
                 .SetGreaterThanZero()
                 .SetDisplay("MA Period", "Moving average period for trend confirmation", "Strategy");
             
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles for strategy", "Strategy");
             
             _prevClosePrice = 0;

--- a/API/0128_Midday_Reversal/MiddayReversalStrategy.cs
+++ b/API/0128_Midday_Reversal/MiddayReversalStrategy.cs
@@ -46,7 +46,7 @@ namespace StockSharp.Samples.Strategies
                 .SetNotNegative()
                 .SetDisplay("Stop Loss %", "Stop loss percentage from entry price", "Protection");
             
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(30)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(30).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles for strategy", "Strategy");
             
             _prevCandleClose = 0;

--- a/API/0129_Overnight_Gap/OvernightGapStrategy.cs
+++ b/API/0129_Overnight_Gap/OvernightGapStrategy.cs
@@ -59,7 +59,7 @@ namespace StockSharp.Samples.Strategies
                 .SetGreaterThanZero()
                 .SetDisplay("MA Period", "Moving average period for trend confirmation", "Strategy");
             
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromDays(1)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles for strategy", "Strategy");
             
             _prevClosePrice = 0;

--- a/API/0130_Lunch_Break_Fade/LunchBreakFadeStrategy.cs
+++ b/API/0130_Lunch_Break_Fade/LunchBreakFadeStrategy.cs
@@ -56,7 +56,7 @@ namespace StockSharp.Strategies.Samples
         /// </summary>
         public LunchBreakFadeStrategy()
         {
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                           .SetDisplay("Candle Type", "Type of candles to use", "General");
                           
             _lunchHour = Param(nameof(LunchHour), 13)

--- a/API/0131_MACD_RSI/MacdRsiStrategy.cs
+++ b/API/0131_MACD_RSI/MacdRsiStrategy.cs
@@ -104,7 +104,7 @@ namespace StockSharp.Strategies.Samples
         /// </summary>
         public MacdRsiStrategy()
         {
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                           .SetDisplay("Candle Type", "Type of candles to use", "General");
                           
             _macdFast = Param(nameof(MacdFast), 12)

--- a/API/0132_Bollinger_Stochastic/BollingerStochasticStrategy.cs
+++ b/API/0132_Bollinger_Stochastic/BollingerStochasticStrategy.cs
@@ -118,7 +118,7 @@ namespace StockSharp.Strategies.Samples
         /// </summary>
         public BollingerStochasticStrategy()
         {
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                           .SetDisplay("Candle Type", "Type of candles to use", "General");
                           
             _bollingerPeriod = Param(nameof(BollingerPeriod), 20)

--- a/API/0133_MA_Volume/MaVolumeStrategy.cs
+++ b/API/0133_MA_Volume/MaVolumeStrategy.cs
@@ -77,7 +77,7 @@ namespace StockSharp.Strategies.Samples
         /// </summary>
         public MaVolumeStrategy()
         {
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                           .SetDisplay("Candle Type", "Type of candles to use", "General");
                           
             _maPeriod = Param(nameof(MaPeriod), 20)

--- a/API/0134_ADX_MACD/AdxMacdStrategy.cs
+++ b/API/0134_ADX_MACD/AdxMacdStrategy.cs
@@ -98,7 +98,7 @@ namespace StockSharp.Strategies.Samples
         /// </summary>
         public AdxMacdStrategy()
         {
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                           .SetDisplay("Candle Type", "Type of candles to use", "General");
                           
             _adxPeriod = Param(nameof(AdxPeriod), 14)

--- a/API/0135_Ichimoku_RSI/IchimokuRsiStrategy.cs
+++ b/API/0135_Ichimoku_RSI/IchimokuRsiStrategy.cs
@@ -104,7 +104,7 @@ namespace StockSharp.Strategies.Samples
         /// </summary>
         public IchimokuRsiStrategy()
         {
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(30)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(30).TimeFrame())
                           .SetDisplay("Candle Type", "Type of candles to use", "General");
                           
             _tenkanPeriod = Param(nameof(TenkanPeriod), 9)

--- a/API/0136_Supertrend_Volume/SupertrendVolumeStrategy.cs
+++ b/API/0136_Supertrend_Volume/SupertrendVolumeStrategy.cs
@@ -83,7 +83,7 @@ namespace StockSharp.Strategies.Samples
         /// </summary>
         public SupertrendVolumeStrategy()
         {
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                           .SetDisplay("Candle Type", "Type of candles to use", "General");
                           
             _supertrendPeriod = Param(nameof(SupertrendPeriod), 10)

--- a/API/0137_Bollinger_RSI/BollingerRsiStrategy.cs
+++ b/API/0137_Bollinger_RSI/BollingerRsiStrategy.cs
@@ -120,7 +120,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(60m, 80m, 5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
 
             _stopLossAtr = Param(nameof(StopLossAtr), 2.0m)

--- a/API/0138_MA_Stochastic/MaStochasticStrategy.cs
+++ b/API/0138_MA_Stochastic/MaStochasticStrategy.cs
@@ -143,7 +143,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1.0m, 5.0m, 1.0m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0139_ATR_MACD/AtrMacdStrategy.cs
+++ b/API/0139_ATR_MACD/AtrMacdStrategy.cs
@@ -145,7 +145,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1.0m, 3.0m, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0140_VWAP_RSI/VwapRsiStrategy.cs
+++ b/API/0140_VWAP_RSI/VwapRsiStrategy.cs
@@ -96,7 +96,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1.0m, 3.0m, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0141_Donchian_Volume/DonchianVolumeStrategy.cs
+++ b/API/0141_Donchian_Volume/DonchianVolumeStrategy.cs
@@ -97,7 +97,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1.0m, 3.0m, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0142_Keltner_Stochastic/KeltnerStochasticStrategy.cs
+++ b/API/0142_Keltner_Stochastic/KeltnerStochasticStrategy.cs
@@ -179,7 +179,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1.0m, 3.0m, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0143_Parabolic_SAR_RSI/ParabolicSarRsiStrategy.cs
+++ b/API/0143_Parabolic_SAR_RSI/ParabolicSarRsiStrategy.cs
@@ -110,7 +110,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(60m, 80m, 5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0144_Hull_MA_Volume/HullMaVolumeStrategy.cs
+++ b/API/0144_Hull_MA_Volume/HullMaVolumeStrategy.cs
@@ -113,7 +113,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(7, 21, 7);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0145_ADX_Stochastic/AdxStochasticStrategy.cs
+++ b/API/0145_ADX_Stochastic/AdxStochasticStrategy.cs
@@ -158,7 +158,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1.0m, 3.0m, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0146_MACD_Volume/MacdVolumeStrategy.cs
+++ b/API/0146_MACD_Volume/MacdVolumeStrategy.cs
@@ -130,7 +130,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1.0m, 3.0m, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0147_Bollinger_Volume/BollingerVolumeStrategy.cs
+++ b/API/0147_Bollinger_Volume/BollingerVolumeStrategy.cs
@@ -128,7 +128,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(7, 21, 7);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0148_RSI_Stochastic/RsiStochasticStrategy.cs
+++ b/API/0148_RSI_Stochastic/RsiStochasticStrategy.cs
@@ -174,7 +174,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1.0m, 3.0m, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0149_MA_ADX/MaAdxStrategy.cs
+++ b/API/0149_MA_ADX/MaAdxStrategy.cs
@@ -85,7 +85,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(7, 28, 7);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
 
             _stopLossPercent = Param(nameof(StopLossPercent), 2m)

--- a/API/0150_VWAP_Stochastic/VwapStochasticStrategy.cs
+++ b/API/0150_VWAP_Stochastic/VwapStochasticStrategy.cs
@@ -127,7 +127,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1m, 5m, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0151_Ichimoku_Volume/IchimokuVolumeStrategy.cs
+++ b/API/0151_Ichimoku_Volume/IchimokuVolumeStrategy.cs
@@ -105,7 +105,7 @@ namespace StockSharp.Samples.Strategies
             _stopLoss = Param(nameof(StopLoss), new Unit(2, UnitTypes.Percent))
                 .SetDisplay("Stop Loss", "Stop loss percent or value", "Risk Management");
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Candle type for strategy", "General");
 
             _averageVolume = 0;

--- a/API/0152_Supertrend_RSI/SupertrendRsiStrategy.cs
+++ b/API/0152_Supertrend_RSI/SupertrendRsiStrategy.cs
@@ -107,7 +107,7 @@ namespace StockSharp.Samples.Strategies
                 .SetRange(1, 100)
                 .SetDisplay("RSI Overbought", "RSI level to consider market overbought", "RSI Parameters");
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Candle type for strategy", "General");
         }
 

--- a/API/0153_Bollinger_ADX/BollingerAdxStrategy.cs
+++ b/API/0153_Bollinger_ADX/BollingerAdxStrategy.cs
@@ -110,7 +110,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1.0m, 3.0m, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0154_MA_CCI/MaCciStrategy.cs
+++ b/API/0154_MA_CCI/MaCciStrategy.cs
@@ -109,7 +109,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1.0m, 5.0m, 1.0m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0155_VWAP_Volume/VwapVolumeStrategy.cs
+++ b/API/0155_VWAP_Volume/VwapVolumeStrategy.cs
@@ -81,7 +81,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1.0m, 3.0m, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0156_Donchian_RSI/DonchianRsiStrategy.cs
+++ b/API/0156_Donchian_RSI/DonchianRsiStrategy.cs
@@ -115,7 +115,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1.0m, 3.0m, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0157_Keltner_Volume/KeltnerVolumeStrategy.cs
+++ b/API/0157_Keltner_Volume/KeltnerVolumeStrategy.cs
@@ -109,7 +109,7 @@ namespace StockSharp.Samples.Strategies
             _stopLoss = Param(nameof(StopLoss), new Unit(2, UnitTypes.Atr))
                 .SetDisplay("Stop Loss", "Stop loss in ATR or value", "Risk Management");
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Candle type for strategy", "General");
 
             _averageVolume = 0;

--- a/API/0158_Parabolic_SAR_Stochastic/ParabolicSarStochasticStrategy.cs
+++ b/API/0158_Parabolic_SAR_Stochastic/ParabolicSarStochasticStrategy.cs
@@ -134,7 +134,7 @@ namespace StockSharp.Samples.Strategies
                 .SetRange(1, 100)
                 .SetDisplay("Overbought Level", "Level above which market is considered overbought", "Stochastic Parameters");
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Candle type for strategy", "General");
 
             _lastStochK = 50; // Initialize to a neutral value

--- a/API/0159_Hull_MA_RSI/HullMaRsiStrategy.cs
+++ b/API/0159_Hull_MA_RSI/HullMaRsiStrategy.cs
@@ -104,7 +104,7 @@ namespace StockSharp.Samples.Strategies
             _stopLoss = Param(nameof(StopLoss), new Unit(2, UnitTypes.Atr))
                 .SetDisplay("Stop Loss", "Stop loss in ATR or value", "Risk Management");
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Candle type for strategy", "General");
 
             _prevHmaValue = 0;

--- a/API/0160_ADX_Volume/AdxVolumeStrategy.cs
+++ b/API/0160_ADX_Volume/AdxVolumeStrategy.cs
@@ -92,7 +92,7 @@ namespace StockSharp.Samples.Strategies
             _stopLoss = Param(nameof(StopLoss), new Unit(2, UnitTypes.Atr))
                 .SetDisplay("Stop Loss", "Stop loss in ATR or value", "Risk Management");
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Candle type for strategy", "General");
 
             _averageVolume = 0;

--- a/API/0161_MACD_CCI/MacdCciStrategy.cs
+++ b/API/0161_MACD_CCI/MacdCciStrategy.cs
@@ -128,7 +128,7 @@ namespace StockSharp.Samples.Strategies
             _stopLoss = Param(nameof(StopLoss), new Unit(2, UnitTypes.Percent))
                 .SetDisplay("Stop Loss", "Stop loss percent or value", "Risk Management");
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Candle type for strategy", "General");
         }
 

--- a/API/0162_Bollinger_CCI/BollingerCciStrategy.cs
+++ b/API/0162_Bollinger_CCI/BollingerCciStrategy.cs
@@ -114,7 +114,7 @@ namespace StockSharp.Samples.Strategies
             _stopLoss = Param(nameof(StopLoss), new Unit(2, UnitTypes.Atr))
                 .SetDisplay("Stop Loss", "Stop loss in ATR or value", "Risk Management");
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Candle type for strategy", "General");
         }
 

--- a/API/0163_RSI_Williams_R/RsiWilliamsRStrategy.cs
+++ b/API/0163_RSI_Williams_R/RsiWilliamsRStrategy.cs
@@ -130,7 +130,7 @@ namespace StockSharp.Samples.Strategies
             _stopLoss = Param(nameof(StopLoss), new Unit(2, UnitTypes.Percent))
                 .SetDisplay("Stop Loss", "Stop loss percent or value", "Risk Management");
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Candle type for strategy", "General");
         }
 

--- a/API/0164_MA_Williams_R/MaWilliamsRStrategy.cs
+++ b/API/0164_MA_Williams_R/MaWilliamsRStrategy.cs
@@ -115,7 +115,7 @@ namespace StockSharp.Samples.Strategies
             _stopLoss = Param(nameof(StopLoss), new Unit(2, UnitTypes.Percent))
                 .SetDisplay("Stop Loss", "Stop loss percent or value", "Risk Management");
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Candle type for strategy", "General");
         }
 

--- a/API/0165_VWAP_CCI/VwapCciStrategy.cs
+++ b/API/0165_VWAP_CCI/VwapCciStrategy.cs
@@ -86,7 +86,7 @@ namespace StockSharp.Samples.Strategies
             _stopLoss = Param(nameof(StopLoss), new Unit(2, UnitTypes.Percent))
                 .SetDisplay("Stop Loss", "Stop loss percent or value", "Risk Management");
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Candle type for strategy", "General");
         }
 

--- a/API/0167_Keltner_RSI/KeltnerRsiStrategy.cs
+++ b/API/0167_Keltner_RSI/KeltnerRsiStrategy.cs
@@ -148,7 +148,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(1.0m, 3.0m, 0.5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0168_Parabolic_SAR_Volume/ParabolicSarRsiStrategy.cs
+++ b/API/0168_Parabolic_SAR_Volume/ParabolicSarRsiStrategy.cs
@@ -110,7 +110,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(20, 35, 5);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0187_Donchian_MACD/DonchianMacdStrategy.cs
+++ b/API/0187_Donchian_MACD/DonchianMacdStrategy.cs
@@ -118,7 +118,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetDisplay("Stop-Loss %", "Stop-loss percentage from entry price", "Risk Management");
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0188_Parabolic_SAR_Volume/ParabolicSarVolumeStrategy.cs
+++ b/API/0188_Parabolic_SAR_Volume/ParabolicSarVolumeStrategy.cs
@@ -84,7 +84,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetDisplay("Volume Period", "Period for volume moving average", "Indicators");
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0189_Hull_MA_RSI/HullMaRsiStrategy.cs
+++ b/API/0189_Hull_MA_RSI/HullMaRsiStrategy.cs
@@ -110,7 +110,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetDisplay("RSI Overbought", "Level above which RSI is considered overbought", "Indicators");
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
 
             _stopLossAtr = Param(nameof(StopLossAtr), 2m)

--- a/API/0190_VWAP_ADX/VwapAdxStrategy.cs
+++ b/API/0190_VWAP_ADX/VwapAdxStrategy.cs
@@ -69,7 +69,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(10, 20, 1);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplayName("Candle Type")
                 .SetDescription("Timeframe of data for strategy")
                 .SetCategories("General");

--- a/API/0191_Bollinger_Volume/BollingerVolumeStrategy.cs
+++ b/API/0191_Bollinger_Volume/BollingerVolumeStrategy.cs
@@ -102,7 +102,7 @@ namespace StockSharp.Samples.Strategies
                 .SetDescription("ATR multiplier for stop loss calculation")
                 .SetCategories("Risk Management");
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplayName("Candle Type")
                 .SetDescription("Timeframe of data for strategy")
                 .SetCategories("General");

--- a/API/0192_Ichimoku_Volume/IchimokuVolumeStrategy.cs
+++ b/API/0192_Ichimoku_Volume/IchimokuVolumeStrategy.cs
@@ -103,7 +103,7 @@ namespace StockSharp.Samples.Strategies
                 .SetDescription("Period for volume average calculation")
                 .SetCategories("Indicators");
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplayName("Candle Type")
                 .SetDescription("Timeframe of data for strategy")
                 .SetCategories("General");

--- a/API/0193_Supertrend_ADX/SupertrendAdxStrategy.cs
+++ b/API/0193_Supertrend_ADX/SupertrendAdxStrategy.cs
@@ -104,7 +104,7 @@ namespace StockSharp.Samples.Strategies
 				.SetCanOptimize(true)
 				.SetOptimize(20m, 30m, 5m);
 
-			_candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
 				.SetDisplay("Candle Type", "Type of candles to use", "General");
 
 			_lastSupertrend = 0;

--- a/API/0194_Keltner_MACD/KeltnerMacdStrategy.cs
+++ b/API/0194_Keltner_MACD/KeltnerMacdStrategy.cs
@@ -153,7 +153,7 @@ namespace StockSharp.Samples.Strategies
                 .SetDescription("ATR multiplier for stop loss calculation")
                 .SetCategories("Risk Management");
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplayName("Candle Type")
                 .SetDescription("Timeframe of data for strategy")
                 .SetCategories("General");

--- a/API/0195_Donchian_RSI/DonchianRsiStrategy.cs
+++ b/API/0195_Donchian_RSI/DonchianRsiStrategy.cs
@@ -87,7 +87,7 @@ namespace StockSharp.Samples.Strategies
                 .SetDescription("Stop loss percentage from entry price")
                 .SetCategories("Risk Management");
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(30)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(30).TimeFrame())
                 .SetDisplayName("Candle Type")
                 .SetDescription("Timeframe of data for strategy")
                 .SetCategories("General");

--- a/API/0196_Parabolic_SAR_Stochastic/ParabolicSarStochasticStrategy.cs
+++ b/API/0196_Parabolic_SAR_Stochastic/ParabolicSarStochasticStrategy.cs
@@ -117,7 +117,7 @@ namespace StockSharp.Samples.Strategies
                 .SetDescription("Period for %D line calculation")
                 .SetCategories("Indicators");
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplayName("Candle Type")
                 .SetDescription("Timeframe of data for strategy")
                 .SetCategories("General");

--- a/API/0197_Hull_MA_ADX/HullMaAdxStrategy.cs
+++ b/API/0197_Hull_MA_ADX/HullMaAdxStrategy.cs
@@ -90,7 +90,7 @@ namespace StockSharp.Samples.Strategies
                 .SetDescription("ATR multiplier for stop loss calculation")
                 .SetCategories("Risk Management");
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplayName("Candle Type")
                 .SetDescription("Timeframe of data for strategy")
                 .SetCategories("General");

--- a/API/0198_VWAP_MACD/VwapMacdStrategy.cs
+++ b/API/0198_VWAP_MACD/VwapMacdStrategy.cs
@@ -102,7 +102,7 @@ namespace StockSharp.Samples.Strategies
                 .SetDescription("Stop loss percentage from entry price")
                 .SetCategories("Risk Management");
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
                 .SetDisplayName("Candle Type")
                 .SetDescription("Timeframe of data for strategy")
                 .SetCategories("General");

--- a/API/0199_Bollinger_RSI/BollingerRsiStrategy.cs
+++ b/API/0199_Bollinger_RSI/BollingerRsiStrategy.cs
@@ -117,7 +117,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(60, 80, 5);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
         }
 

--- a/API/0200_Ichimoku_ADX/IchimokuAdxStrategy.cs
+++ b/API/0200_Ichimoku_ADX/IchimokuAdxStrategy.cs
@@ -122,7 +122,7 @@ namespace StockSharp.Samples.Strategies
                 .SetCanOptimize(true)
                 .SetOptimize(20m, 30m, 5m);
 
-            _candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
                 .SetDisplay("Candle Type", "Type of candles to use", "General");
                 
             // Initialize state tracking variables

--- a/API/0211_CCI_VWAP/CciVwapStrategy.cs
+++ b/API/0211_CCI_VWAP/CciVwapStrategy.cs
@@ -66,7 +66,7 @@ namespace StockSharp.Strategies
 				.SetCanOptimize(true)
 				.SetOptimize(1m, 3m, 0.5m);
 				
-			_candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
 				.SetDisplay("Candle type", "Type of candles to use", "General");
 		}
 		

--- a/API/0212_Williams_R_Ichimoku/WilliamsIchimokuStrategy.cs
+++ b/API/0212_Williams_R_Ichimoku/WilliamsIchimokuStrategy.cs
@@ -100,7 +100,7 @@ namespace StockSharp.Strategies
 				.SetCanOptimize(true)
 				.SetOptimize(40, 60, 4);
 				
-			_candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
 				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 		

--- a/API/0213_MA_Parabolic_SAR/MaParabolicSarStrategy.cs
+++ b/API/0213_MA_Parabolic_SAR/MaParabolicSarStrategy.cs
@@ -85,7 +85,7 @@ namespace StockSharp.Strategies
 				.SetCanOptimize(true)
 				.SetOptimize(0.1m, 0.3m, 0.05m);
 				
-			_candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
 				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 		

--- a/API/0214_Bollinger_Supertrend/BollingerSupertrendStrategy.cs
+++ b/API/0214_Bollinger_Supertrend/BollingerSupertrendStrategy.cs
@@ -103,7 +103,7 @@ namespace StockSharp.Strategies
 				.SetCanOptimize(true)
 				.SetOptimize(2.0m, 4.0m, 0.5m);
 				
-			_candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
 				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 		

--- a/API/0215_RSI_Donchian/RsiDonchianStrategy.cs
+++ b/API/0215_RSI_Donchian/RsiDonchianStrategy.cs
@@ -86,7 +86,7 @@ namespace StockSharp.Strategies
 				.SetCanOptimize(true)
 				.SetOptimize(1m, 3m, 0.5m);
 				
-			_candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
 				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 		

--- a/API/0216_Mean_Reversion/MeanReversionStrategy.cs
+++ b/API/0216_Mean_Reversion/MeanReversionStrategy.cs
@@ -83,7 +83,7 @@ namespace StockSharp.Strategies
 				.SetCanOptimize(true)
 				.SetOptimize(1m, 3m, 0.5m);
 				
-			_candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
 				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 		

--- a/API/0217_Pairs_Trading/PairsTradingStrategy.cs
+++ b/API/0217_Pairs_Trading/PairsTradingStrategy.cs
@@ -95,7 +95,7 @@ namespace StockSharp.Strategies
 				.SetCanOptimize(true)
 				.SetOptimize(1m, 3m, 0.5m);
 				
-			_candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
 				.SetDisplay("Candle Type", "Type of candles to use", "General");
 				
 			_secondSecurity = Param<Security>(nameof(SecondSecurity))

--- a/API/0218_ZScore_Reversal/ZScoreReversalStrategy.cs
+++ b/API/0218_ZScore_Reversal/ZScoreReversalStrategy.cs
@@ -85,7 +85,7 @@ namespace StockSharp.Strategies
 				.SetCanOptimize(true)
 				.SetOptimize(1m, 3m, 0.5m);
 				
-			_candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(10)))
+			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(10).TimeFrame())
 				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 		

--- a/API/0219_Statistical_Arbitrage/StatisticalArbitrageStrategy.cs
+++ b/API/0219_Statistical_Arbitrage/StatisticalArbitrageStrategy.cs
@@ -79,7 +79,7 @@ namespace StockSharp.Strategies
 				.SetCanOptimize(true)
 				.SetOptimize(1m, 3m, 0.5m);
 				
-			_candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
 				.SetDisplay("Candle Type", "Type of candles to use", "General");
 				
 			_secondSecurity = Param<Security>(nameof(SecondSecurity))

--- a/API/0283_MA_Slope_Mean_Reversion/MaSlopeMeanReversionStrategy.cs
+++ b/API/0283_MA_Slope_Mean_Reversion/MaSlopeMeanReversionStrategy.cs
@@ -107,7 +107,7 @@ namespace StockSharp.Samples.Strategies
 				.SetCanOptimize(true)
 				.SetOptimize(1.0m, 3.0m, 0.5m);
 
-			_candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
 				.SetDisplayName("Candle Type")
 				.SetDescription("Type of candles to use")
 				.SetCategory("General");

--- a/API/0284_EMA_Slope_Mean_Reversion/EmaSlopeMeanReversionStrategy.cs
+++ b/API/0284_EMA_Slope_Mean_Reversion/EmaSlopeMeanReversionStrategy.cs
@@ -107,7 +107,7 @@ namespace StockSharp.Samples.Strategies
 				.SetCanOptimize(true)
 				.SetOptimize(1.0m, 3.0m, 0.5m);
 
-			_candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
 				.SetDisplayName("Candle Type")
 				.SetDescription("Type of candles to use")
 				.SetCategory("General");

--- a/API/0285_VWAP_Slope_Mean_Reversion/VwapSlopeMeanReversionStrategy.cs
+++ b/API/0285_VWAP_Slope_Mean_Reversion/VwapSlopeMeanReversionStrategy.cs
@@ -90,7 +90,7 @@ namespace StockSharp.Samples.Strategies
 				.SetCanOptimize(true)
 				.SetOptimize(1.0m, 3.0m, 0.5m);
 
-			_candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
 				.SetDisplayName("Candle Type")
 				.SetDescription("Type of candles to use")
 				.SetCategory("General");

--- a/API/0286_RSI_Slope_Mean_Reversion/RsiSlopeMeanReversionStrategy.cs
+++ b/API/0286_RSI_Slope_Mean_Reversion/RsiSlopeMeanReversionStrategy.cs
@@ -107,7 +107,7 @@ namespace StockSharp.Samples.Strategies
 				.SetCanOptimize(true)
 				.SetOptimize(1.0m, 3.0m, 0.5m);
 
-			_candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
 				.SetDisplayName("Candle Type")
 				.SetDescription("Type of candles to use")
 				.SetCategory("General");

--- a/API/0287_Stochastic_Slope_Mean_Reversion/StochasticSlopeMeanReversionStrategy.cs
+++ b/API/0287_Stochastic_Slope_Mean_Reversion/StochasticSlopeMeanReversionStrategy.cs
@@ -141,7 +141,7 @@ namespace StockSharp.Samples.Strategies
 				.SetCanOptimize(true)
 				.SetOptimize(1.0m, 3.0m, 0.5m);
 
-			_candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
 				.SetDisplayName("Candle Type")
 				.SetDescription("Type of candles to use")
 				.SetCategory("General");

--- a/API/0288_CCI_Slope_Mean_Reversion/CciSlopeMeanReversionStrategy.cs
+++ b/API/0288_CCI_Slope_Mean_Reversion/CciSlopeMeanReversionStrategy.cs
@@ -107,7 +107,7 @@ namespace StockSharp.Samples.Strategies
 				.SetCanOptimize(true)
 				.SetOptimize(1.0m, 3.0m, 0.5m);
 
-			_candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
 				.SetDisplayName("Candle Type")
 				.SetDescription("Type of candles to use")
 				.SetCategory("General");

--- a/API/0295_Pairs_Trading_Volatility_Filter/PairsTradingVolatilityFilterStrategy.cs
+++ b/API/0295_Pairs_Trading_Volatility_Filter/PairsTradingVolatilityFilterStrategy.cs
@@ -127,8 +127,8 @@ namespace StockSharp.Strategies
 		{
 			if (Security1 != null && Security2 != null)
 			{
-				yield return (Security1, DataType.TimeFrame(TimeSpan.FromMinutes(5)));
-				yield return (Security2, DataType.TimeFrame(TimeSpan.FromMinutes(5)));
+				yield return (Security1, TimeSpan.FromMinutes(5).TimeFrame());
+				yield return (Security2, TimeSpan.FromMinutes(5).TimeFrame());
 			}
 		}
 		

--- a/API/0331_Supertrend_Volume_Spike/SupertrendVolumeSpikeStrategy.cs
+++ b/API/0331_Supertrend_Volume_Spike/SupertrendVolumeSpikeStrategy.cs
@@ -91,7 +91,7 @@ namespace StockSharp.Samples.Strategies
 				.SetGreaterThan(0)
 				.SetDisplay("Volume Deviation Multiplier", "Standard deviation multiplier for volume spike detection", "Volume Settings");
 
-			_candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
 				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 

--- a/API/0332_Donchian_Hurst_Exponent/DonchianHurstExponentStrategy.cs
+++ b/API/0332_Donchian_Hurst_Exponent/DonchianHurstExponentStrategy.cs
@@ -89,7 +89,7 @@ namespace StockSharp.Samples.Strategies
 				.SetGreaterThan(0)
 				.SetDisplay("Stop Loss %", "Stop Loss percentage from entry price", "Risk Management");
 
-			_candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
 				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 

--- a/API/0333_Keltner_Seasonal_Filter/KeltnerSeasonalFilterStrategy.cs
+++ b/API/0333_Keltner_Seasonal_Filter/KeltnerSeasonalFilterStrategy.cs
@@ -88,7 +88,7 @@ namespace StockSharp.Samples.Strategies
 			_seasonalThreshold = Param(nameof(SeasonalThreshold), 0.5m)
 				.SetDisplay("Seasonal Threshold", "Minimum seasonal strength to consider for trading", "Seasonal Settings");
 
-			_candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
 				.SetDisplay("Candle Type", "Type of candles to use", "General");
 
 			// Initialize seasonal returns (this would typically be loaded from historical data)

--- a/API/0334_Hull_MA_K-Means_Cluster/HullKmeansClusterStrategy.cs
+++ b/API/0334_Hull_MA_K-Means_Cluster/HullKmeansClusterStrategy.cs
@@ -91,7 +91,7 @@ namespace StockSharp.Samples.Strategies
 				.SetGreaterThanZero()
 				.SetDisplay("RSI Period", "Period for RSI calculation as a clustering feature", "Indicator Settings");
 
-			_candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
 				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 

--- a/API/0335_VWAP_Hidden_Markov_Model/VwapHiddenMarkovModelStrategy.cs
+++ b/API/0335_VWAP_Hidden_Markov_Model/VwapHiddenMarkovModelStrategy.cs
@@ -79,7 +79,7 @@ namespace StockSharp.Samples.Strategies
 				.SetGreaterThan(0)
 				.SetDisplay("Stop Loss %", "Stop Loss percentage from entry price", "Risk Management");
 
-			_candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
 				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 

--- a/API/0336_Parabolic_SAR_RSI_Divergence/ParabolicSarRsiDivergenceStrategy.cs
+++ b/API/0336_Parabolic_SAR_RSI_Divergence/ParabolicSarRsiDivergenceStrategy.cs
@@ -75,7 +75,7 @@ namespace StockSharp.Samples.Strategies
 				.SetGreaterThanZero()
 				.SetDisplay("RSI Period", "Period for RSI calculation", "Indicator Settings");
 
-			_candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
 				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 

--- a/API/0337_Adaptive_RSI_Volume_Filter/AdaptiveRsiVolumeFilterStrategy.cs
+++ b/API/0337_Adaptive_RSI_Volume_Filter/AdaptiveRsiVolumeFilterStrategy.cs
@@ -95,7 +95,7 @@ namespace StockSharp.Samples.Strategies
 				.SetGreaterThanZero()
 				.SetDisplay("Volume Lookback", "Number of periods to calculate volume average", "Volume Settings");
 
-			_candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
 				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 

--- a/API/0338_Adaptive_Bollinger_Breakout/BollingerAdaptiveBreakoutStrategy.cs
+++ b/API/0338_Adaptive_Bollinger_Breakout/BollingerAdaptiveBreakoutStrategy.cs
@@ -105,7 +105,7 @@ namespace StockSharp.Samples.Strategies
 				.SetGreaterThanZero()
 				.SetDisplay("ATR Period", "Period for ATR volatility calculation", "Indicator Settings");
 
-			_candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
 				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 

--- a/API/0339_MACD_Sentiment_Filter/MacdWithSentimentFilterStrategy.cs
+++ b/API/0339_MACD_Sentiment_Filter/MacdWithSentimentFilterStrategy.cs
@@ -123,7 +123,7 @@ namespace StockSharp.Samples.Strategies
 				.SetCanOptimize(true)
 				.SetOptimize(1m, 3m, 0.5m);
 				
-			_candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
 				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 		

--- a/API/0340_Ichimoku_Implied_Volatility/IchimokuWithIVStrategy.cs
+++ b/API/0340_Ichimoku_Implied_Volatility/IchimokuWithIVStrategy.cs
@@ -109,7 +109,7 @@ namespace StockSharp.Samples.Strategies
 				.SetCanOptimize(true)
 				.SetOptimize(10, 30, 5);
 				
-			_candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
 				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 		

--- a/API/0341_Supertrend_Put_Call_Ratio/SupertrendPCRStrategy.cs
+++ b/API/0341_Supertrend_Put_Call_Ratio/SupertrendPCRStrategy.cs
@@ -111,7 +111,7 @@ namespace StockSharp.Samples.Strategies
 				.SetCanOptimize(true)
 				.SetOptimize(1m, 3m, 0.5m);
 				
-			_candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
 				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 		

--- a/API/0342_Donchian_Sentiment_Spike/DonchianSentimentStrategy.cs
+++ b/API/0342_Donchian_Sentiment_Spike/DonchianSentimentStrategy.cs
@@ -112,7 +112,7 @@ namespace StockSharp.Samples.Strategies
 				.SetCanOptimize(true)
 				.SetOptimize(1m, 3m, 0.5m);
 				
-			_candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
 				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 		

--- a/API/0343_Keltner_Reinforcement_Learning_Signal/KeltnerWithRLStrategy.cs
+++ b/API/0343_Keltner_Reinforcement_Learning_Signal/KeltnerWithRLStrategy.cs
@@ -120,7 +120,7 @@ namespace StockSharp.Samples.Strategies
 				.SetCanOptimize(true)
 				.SetOptimize(1m, 3m, 0.5m);
 				
-			_candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
 				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 		

--- a/API/0344_Hull_MA_Implied_Volatility_Breakout/HullMAWithIVBreakoutStrategy.cs
+++ b/API/0344_Hull_MA_Implied_Volatility_Breakout/HullMAWithIVBreakoutStrategy.cs
@@ -113,7 +113,7 @@ namespace StockSharp.Samples.Strategies
 				.SetCanOptimize(true)
 				.SetOptimize(1m, 3m, 0.5m);
 				
-			_candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
 				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 		

--- a/API/0345_VWAP_Behavioral_Bias_Filter/VwapWithBehavioralBiasStrategy.cs
+++ b/API/0345_VWAP_Behavioral_Bias_Filter/VwapWithBehavioralBiasStrategy.cs
@@ -95,7 +95,7 @@ namespace StockSharp.Samples.Strategies
 				.SetCanOptimize(true)
 				.SetOptimize(1m, 3m, 0.5m);
 				
-			_candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
 				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 		

--- a/Designer/Gallery/CSharp/SmaStrategy.cs
+++ b/Designer/Gallery/CSharp/SmaStrategy.cs
@@ -37,7 +37,7 @@
 
 		public SmaStrategy()
 		{
-			_candleTypeParam = this.Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(1)));
+			_candleTypeParam = this.Param(nameof(CandleType), TimeSpan.FromMinutes(1).TimeFrame());
 			_long = this.Param(nameof(Long), 80);
 			_short = this.Param(nameof(Short), 20);
 		}


### PR DESCRIPTION
## Summary
- replace usages of `DataType.TimeFrame` with the `TimeFrame()` extension across strategies

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c55f25e1c8323905cae546fd6cf9e