### PR TITLE
Update indicators to use timed inputs with tabs

### DIFF
--- a/API/0084_ATR_Exhaustion/AtrExhaustionStrategy.cs
+++ b/API/0084_ATR_Exhaustion/AtrExhaustionStrategy.cs
@@ -172,7 +172,7 @@ namespace StockSharp.Samples.Strategies
 				return;
 
 			// Update ATR average
-			var atrAvgValue = _atrAvg.Process(new DecimalIndicatorValue(atrValue)).Value;
+			var atrAvgValue = _atrAvg.Process(atrValue, candle.ServerTime, candle.State == CandleStates.Finished).Value;
 			
 			// Determine candle direction
 			bool isBullishCandle = candle.ClosePrice > candle.OpenPrice;

--- a/API/0209_Volume_Supertrend/VolumeSupertrendStrategy.cs
+++ b/API/0209_Volume_Supertrend/VolumeSupertrendStrategy.cs
@@ -107,7 +107,7 @@ namespace StockSharp.Samples.Strategies
 				.Bind(atr, (candle, atrValue) =>
 				{
 					// Calculate volume average
-					var volumeValue = volumeMA.Process(new DecimalIndicatorValue(candle.TotalVolume)).GetValue<decimal>();
+					var volumeValue = volumeMA.Process(candle.TotalVolume, candle.ServerTime, candle.State == CandleStates.Finished).GetValue<decimal>();
 					
 					// Calculate Supertrend
 					if (!atr.IsFormed)

--- a/API/0230_Delta_Neutral_Arbitrage/DeltaNeutralArbitrageStrategy.cs
+++ b/API/0230_Delta_Neutral_Arbitrage/DeltaNeutralArbitrageStrategy.cs
@@ -206,8 +206,8 @@ namespace StockSharp.Samples.Strategies
 			_currentSpread = _lastAsset1Price - _lastAsset2Price;
 
 			// Process the spread with our indicators
-			var spreadValue = _spreadSma.Process(new DecimalIndicatorValue(_currentSpread));
-			var stdDevValue = _spreadStdDev.Process(new DecimalIndicatorValue(_currentSpread));
+			var spreadValue = _spreadSma.Process(_currentSpread, candle.ServerTime, candle.State == CandleStates.Finished);
+			var stdDevValue = _spreadStdDev.Process(_currentSpread, candle.ServerTime, candle.State == CandleStates.Finished);
 
 			// Check if indicators are formed
 			if (!_spreadSma.IsFormed || !_spreadStdDev.IsFormed)

--- a/API/0231_Volatility_Skew_Arbitrage/VolatilitySkewArbitrageStrategy.cs
+++ b/API/0231_Volatility_Skew_Arbitrage/VolatilitySkewArbitrageStrategy.cs
@@ -185,7 +185,7 @@ namespace StockSharp.Samples.Strategies
 			var lowIV = data.TryGetImpliedVolatility() ?? 0;
 			var highIV = _currentVolSkew + lowIV;
 			
-			UpdateVolatilitySkew(highIV - lowIV);
+			UpdateVolatilitySkew(highIV - lowIV, data.ServerTime, true);
 		}
 
 		private void ProcessHighOptionImpliedVolatility(Level1ChangeMessage data)
@@ -194,13 +194,13 @@ namespace StockSharp.Samples.Strategies
 			_currentVolSkew = highIV;
 		}
 
-		private void UpdateVolatilitySkew(decimal volSkew)
+		private void UpdateVolatilitySkew(decimal volSkew, DateTimeOffset time, bool isFinal)
 		{
 			if (volSkew == 0)
 				return;
 
 			// Process volatility skew through the indicator
-			var stdDevValue = _volSkewStdDev.Process(new DecimalIndicatorValue(volSkew));
+			var stdDevValue = _volSkewStdDev.Process(volSkew, time, isFinal);
 
 			// Update running average for the first LookbackPeriod bars
 			if (_barCount < LookbackPeriod)

--- a/API/0232_Correlation_Breakout/CorrelationBreakoutStrategy.cs
+++ b/API/0232_Correlation_Breakout/CorrelationBreakoutStrategy.cs
@@ -233,7 +233,7 @@ namespace StockSharp.Samples.Strategies
 			_lastCorrelation = CalculatePearsonCorrelation(_asset1Prices, _asset2Prices);
 
 			// Process correlation through the indicator
-			var stdDevValue = _corrStdDev.Process(new DecimalIndicatorValue(_lastCorrelation));
+			var stdDevValue = _corrStdDev.Process(_lastCorrelation, candle.ServerTime, candle.State == CandleStates.Finished);
 
 			// Move to next bar after first LookbackPeriod bars filled
 			if (!_corrStdDev.IsFormed)

--- a/API/0233_Beta_Neutral_Arbitrage/BetaNeutralArbitrageStrategy.cs
+++ b/API/0233_Beta_Neutral_Arbitrage/BetaNeutralArbitrageStrategy.cs
@@ -247,8 +247,8 @@ namespace StockSharp.Samples.Strategies
 			_lastSpread = betaAdjustedAsset1 - betaAdjustedAsset2;
 
 			// Process through indicators
-			var smaValue = _spreadSma.Process(new DecimalIndicatorValue(_lastSpread));
-			var stdDevValue = _spreadStdDev.Process(new DecimalIndicatorValue(_lastSpread));
+			var smaValue = _spreadSma.Process(_lastSpread, candle.ServerTime, candle.State == CandleStates.Finished);
+			var stdDevValue = _spreadStdDev.Process(_lastSpread, candle.ServerTime, candle.State == CandleStates.Finished);
 
 			// Update counter
 			_barCount++;

--- a/API/0236_RSI_Mean_Reversion/RsiMeanReversionStrategy.cs
+++ b/API/0236_RSI_Mean_Reversion/RsiMeanReversionStrategy.cs
@@ -135,8 +135,8 @@ namespace StockSharp.Samples.Strategies
 				return;
 
 			// Process RSI through average and standard deviation indicators
-			var rsiAvgValue = _rsiAverage.Process(new DecimalIndicatorValue(rsiValue)).GetValue<decimal>();
-			var rsiStdDevValue = _rsiStdDev.Process(new DecimalIndicatorValue(rsiValue)).GetValue<decimal>();
+			var rsiAvgValue = _rsiAverage.Process(rsiValue, candle.ServerTime, candle.State == CandleStates.Finished).GetValue<decimal>();
+			var rsiStdDevValue = _rsiStdDev.Process(rsiValue, candle.ServerTime, candle.State == CandleStates.Finished).GetValue<decimal>();
 			
 			// Store previous RSI value for changes detection
 			decimal currentRsiValue = rsiValue;

--- a/API/0237_Stochastic_Mean_Reversion/StochasticMeanReversionStrategy.cs
+++ b/API/0237_Stochastic_Mean_Reversion/StochasticMeanReversionStrategy.cs
@@ -180,8 +180,8 @@ namespace StockSharp.Samples.Strategies
 			decimal stochKValue = stochObject[0].GetValue<decimal>();
 			
 			// Process Stochastic %K through average and standard deviation indicators
-			var stochAvgValue = _stochAverage.Process(new DecimalIndicatorValue(stochKValue)).GetValue<decimal>();
-			var stochStdDevValue = _stochStdDev.Process(new DecimalIndicatorValue(stochKValue)).GetValue<decimal>();
+			var stochAvgValue = _stochAverage.Process(stochKValue, candle.ServerTime, candle.State == CandleStates.Finished).GetValue<decimal>();
+			var stochStdDevValue = _stochStdDev.Process(stochKValue, candle.ServerTime, candle.State == CandleStates.Finished).GetValue<decimal>();
 			
 			// Store previous Stochastic %K value for changes detection
 			decimal currentStochKValue = stochKValue;

--- a/API/0247_RSI_Breakout/RsiBreakoutStrategy.cs
+++ b/API/0247_RSI_Breakout/RsiBreakoutStrategy.cs
@@ -143,8 +143,8 @@ namespace StockSharp.Samples.Strategies
 			_currentRsiValue = rsiValue;
 
 			// Process RSI through average and standard deviation indicators
-			var avgValue = _rsiAverage.Process(new DecimalIndicatorValue(rsiValue));
-			var stdDevValue = _rsiStdDev.Process(new DecimalIndicatorValue(rsiValue));
+			var avgValue = _rsiAverage.Process(rsiValue, candle.ServerTime, candle.State == CandleStates.Finished);
+			var stdDevValue = _rsiStdDev.Process(rsiValue, candle.ServerTime, candle.State == CandleStates.Finished);
 			
 			_currentRsiAvg = avgValue.GetValue<decimal>();
 			_currentRsiStdDev = stdDevValue.GetValue<decimal>();

--- a/API/0248_Stochastic_Breakout/StochasticBreakoutStrategy.cs
+++ b/API/0248_Stochastic_Breakout/StochasticBreakoutStrategy.cs
@@ -186,8 +186,8 @@ namespace StockSharp.Samples.Strategies
 			var stochValue = value.GetValue<decimal>();
 			
 			// Calculate average and standard deviation of stochastic
-			var stochAvgValue = _stochAverage.Process(new DecimalIndicatorValue(stochValue)).GetValue<decimal>();
-			var tempStdDevValue = _stochStdDev.Process(new DecimalIndicatorValue(stochValue)).GetValue<decimal>();
+			var stochAvgValue = _stochAverage.Process(stochValue, candle.ServerTime, candle.State == CandleStates.Finished).GetValue<decimal>();
+			var tempStdDevValue = _stochStdDev.Process(stochValue, candle.ServerTime, candle.State == CandleStates.Finished).GetValue<decimal>();
 			
 			// First values initialization - skip trading decision
 			if (_prevStochValue == 0)

--- a/API/0250_Williams_R_Breakout/WilliamsRBreakoutStrategy.cs
+++ b/API/0250_Williams_R_Breakout/WilliamsRBreakoutStrategy.cs
@@ -158,7 +158,7 @@ namespace StockSharp.Strategies
 			var currentWilliamsR = williamsRValue.GetValue<decimal>();
 			
 			// Process Williams %R through average indicator
-			var williamsRAvgValue = _williamsRAverage.Process(new DecimalIndicatorValue(currentWilliamsR));
+			var williamsRAvgValue = _williamsRAverage.Process(currentWilliamsR, candle.ServerTime, candle.State == CandleStates.Finished);
 			var currentWilliamsRAvg = williamsRAvgValue.GetValue<decimal>();
 			
 			// For first values, just save and skip

--- a/API/0252_ADX_Breakout/AdxBreakoutStrategy.cs
+++ b/API/0252_ADX_Breakout/AdxBreakoutStrategy.cs
@@ -157,7 +157,7 @@ namespace StockSharp.Strategies
 			var currentAdx = adxValue.GetValue<decimal>();
 			
 			// Process ADX through average indicator
-			var adxAvgValue = _adxAverage.Process(new DecimalIndicatorValue(currentAdx));
+			var adxAvgValue = _adxAverage.Process(currentAdx, candle.ServerTime, candle.State == CandleStates.Finished);
 			var currentAdxAvg = adxAvgValue.GetValue<decimal>();
 			
 			// For first values, just save and skip

--- a/API/0253_Volatility_Breakout/VolatilityBreakoutAtrStrategy.cs
+++ b/API/0253_Volatility_Breakout/VolatilityBreakoutAtrStrategy.cs
@@ -151,7 +151,7 @@ namespace StockSharp.Strategies
 			var currentAtr = atrValue.GetValue<decimal>();
 			
 			// Process ATR through average indicator
-			var atrAvgValue = _atrAverage.Process(new DecimalIndicatorValue(currentAtr));
+			var atrAvgValue = _atrAverage.Process(currentAtr, candle.ServerTime, candle.State == CandleStates.Finished);
 			var currentAtrAvg = atrAvgValue.GetValue<decimal>();
 			
 			// For first values, just save and skip

--- a/API/0254_Volume_Breakout/VolumeBreakoutStrategy.cs
+++ b/API/0254_Volume_Breakout/VolumeBreakoutStrategy.cs
@@ -137,12 +137,12 @@ namespace StockSharp.Strategies
 			var volume = candle.TotalVolume;
 			
 			// Calculate volume average
-			var avgValue = _volumeAverage.Process(new DecimalIndicatorValue(volume));
+			var avgValue = _volumeAverage.Process(volume, candle.ServerTime, candle.State == CandleStates.Finished);
 			var avgVolume = avgValue.GetValue<decimal>();
 			
 			// Calculate standard deviation approximation
 			var deviation = Math.Abs(volume - avgVolume);
-			var stdDevValue = _volumeStdDev.Process(new DecimalIndicatorValue(deviation));
+			var stdDevValue = _volumeStdDev.Process(deviation, candle.ServerTime, candle.State == CandleStates.Finished);
 			var stdDev = stdDevValue.GetValue<decimal>();
 			
 			// Skip the first N candles until we have enough data

--- a/API/0255_OBV_Breakout/ObvBreakoutStrategy.cs
+++ b/API/0255_OBV_Breakout/ObvBreakoutStrategy.cs
@@ -142,7 +142,7 @@ namespace StockSharp.Strategies
 			var currentObv = obvValue.GetValue<decimal>();
 			
 			// Process OBV through average indicator
-			var obvAvgValue = _obvAverage.Process(new DecimalIndicatorValue(currentObv));
+			var obvAvgValue = _obvAverage.Process(currentObv, candle.ServerTime, candle.State == CandleStates.Finished);
 			var currentObvAvg = obvAvgValue.GetValue<decimal>();
 			
 			// For first values, just save and skip

--- a/API/0256_Bollinger_Band_Width_Breakout/BollingerWidthBreakoutStrategy.cs
+++ b/API/0256_Bollinger_Band_Width_Breakout/BollingerWidthBreakoutStrategy.cs
@@ -178,7 +178,7 @@ namespace StockSharp.Strategies
 			var width = upperBand - lowerBand;
 			
 			// Process width through average
-			var widthAvgValue = _widthAverage.Process(new DecimalIndicatorValue(width));
+			var widthAvgValue = _widthAverage.Process(width, candle.ServerTime, candle.State == CandleStates.Finished);
 			var avgWidth = widthAvgValue.GetValue<decimal>();
 			
 			// For first values, just save and skip

--- a/API/0257_Keltner_Channel_Width_Breakout/KeltnerWidthBreakoutStrategy.cs
+++ b/API/0257_Keltner_Channel_Width_Breakout/KeltnerWidthBreakoutStrategy.cs
@@ -201,7 +201,7 @@ namespace StockSharp.Strategies
 			var width = upperBand - lowerBand;
 			
 			// Process width through average
-			var widthAvgValue = _widthAverage.Process(new DecimalIndicatorValue(width));
+			var widthAvgValue = _widthAverage.Process(width, candle.ServerTime, candle.State == CandleStates.Finished);
 			var avgWidth = widthAvgValue.GetValue<decimal>();
 			
 			// For first values, just save and skip

--- a/API/0258_Donchian_Channel_Width_Breakout/DonchianWidthBreakoutStrategy.cs
+++ b/API/0258_Donchian_Channel_Width_Breakout/DonchianWidthBreakoutStrategy.cs
@@ -162,7 +162,7 @@ namespace StockSharp.Strategies
 			var width = highestValue - lowestValue;
 			
 			// Process width through average
-			var widthAvgValue = _widthAverage.Process(new DecimalIndicatorValue(width));
+			var widthAvgValue = _widthAverage.Process(width, candle.ServerTime, candle.State == CandleStates.Finished);
 			var avgWidth = widthAvgValue.GetValue<decimal>();
 			
 			// For first values, just save and skip

--- a/API/0259_Ichimoku_Cloud_Width_Breakout/IchimokuWidthBreakoutStrategy.cs
+++ b/API/0259_Ichimoku_Cloud_Width_Breakout/IchimokuWidthBreakoutStrategy.cs
@@ -224,7 +224,7 @@ namespace StockSharp.Strategies
 			var width = Math.Abs(_currentSenkouA - _currentSenkouB);
 			
 			// Process width through average
-			var widthAvgValue = _widthAverage.Process(new DecimalIndicatorValue(width));
+			var widthAvgValue = _widthAverage.Process(width, candle.ServerTime, candle.State == CandleStates.Finished);
 			var avgWidth = widthAvgValue.GetValue<decimal>();
 			
 			// For first values, just save and skip

--- a/API/0269_CCI_Slope_Breakout/CciSlopeBreakoutStrategy.cs
+++ b/API/0269_CCI_Slope_Breakout/CciSlopeBreakoutStrategy.cs
@@ -140,7 +140,7 @@ namespace StockSharp.Samples.Strategies
 				return;
 			
 			// Calculate CCI slope
-			var currentSlopeValue = _cciSlope.Process(new DecimalIndicatorValue(cciValue)).GetValue<decimal>();
+			var currentSlopeValue = _cciSlope.Process(cciValue, candle.ServerTime, candle.State == CandleStates.Finished).GetValue<decimal>();
 
 			// Update slope stats when we have 2 values to calculate slope
 			if (_prevCciSlopeValue != 0)

--- a/API/0270_Williams_R_Slope_Breakout/WilliamsRSlopeBreakoutStrategy.cs
+++ b/API/0270_Williams_R_Slope_Breakout/WilliamsRSlopeBreakoutStrategy.cs
@@ -140,7 +140,7 @@ namespace StockSharp.Samples.Strategies
 				return;
 			
 			// Calculate Williams %R slope
-			var currentSlopeValue = _williamsRSlope.Process(new DecimalIndicatorValue(williamsRValue)).GetValue<decimal>();
+			var currentSlopeValue = _williamsRSlope.Process(williamsRValue, candle.ServerTime, candle.State == CandleStates.Finished).GetValue<decimal>();
 
 			// Update slope stats when we have 2 values to calculate slope
 			if (_prevSlopeValue != 0)

--- a/API/0271_MACD_Slope_Breakout/MacdSlopeBreakoutStrategy.cs
+++ b/API/0271_MACD_Slope_Breakout/MacdSlopeBreakoutStrategy.cs
@@ -175,7 +175,7 @@ namespace StockSharp.Samples.Strategies
 			decimal macdHist = macdValue - signalValue;
 			
 			// Calculate MACD histogram slope
-			var currentSlopeValue = _macdHistSlope.Process(new DecimalIndicatorValue(macdHist)).GetValue<decimal>();
+			var currentSlopeValue = _macdHistSlope.Process(macdHist, candle.ServerTime, candle.State == CandleStates.Finished).GetValue<decimal>();
 
 			// Update slope stats when we have 2 values to calculate slope
 			if (_prevSlopeValue != 0)

--- a/API/0272_ADX_Slope_Breakout/AdxSlopeBreakoutStrategy.cs
+++ b/API/0272_ADX_Slope_Breakout/AdxSlopeBreakoutStrategy.cs
@@ -143,7 +143,7 @@ namespace StockSharp.Samples.Strategies
 			decimal adx = adxValue.GetValue<decimal>();
 			
 			// Calculate ADX slope
-			var currentSlopeValue = _adxSlope.Process(new DecimalIndicatorValue(adx)).GetValue<decimal>();
+			var currentSlopeValue = _adxSlope.Process(adx, candle.ServerTime, candle.State == CandleStates.Finished).GetValue<decimal>();
 
 			// Update slope stats when we have 2 values to calculate slope
 			if (_prevSlopeValue != 0)

--- a/API/0273_ATR_Slope_Breakout/AtrSlopeBreakoutStrategy.cs
+++ b/API/0273_ATR_Slope_Breakout/AtrSlopeBreakoutStrategy.cs
@@ -152,7 +152,7 @@ namespace StockSharp.Samples.Strategies
 			bool priceAboveEma = candle.ClosePrice > emaValue;
 			
 			// Calculate ATR slope
-			var currentSlopeValue = _atrSlope.Process(new DecimalIndicatorValue(atr)).GetValue<decimal>();
+			var currentSlopeValue = _atrSlope.Process(atr, candle.ServerTime, candle.State == CandleStates.Finished).GetValue<decimal>();
 
 			// Update slope stats when we have 2 values to calculate slope
 			if (_prevSlopeValue != 0)

--- a/API/0274_Volume_Slope_Breakout/VolumeSlopeBreakoutStrategy.cs
+++ b/API/0274_Volume_Slope_Breakout/VolumeSlopeBreakoutStrategy.cs
@@ -151,7 +151,7 @@ namespace StockSharp.Samples.Strategies
 			decimal volumeValue = _volumeIndicator.Process(candle).GetValue<decimal>();
 			
 			// Process volume SMA
-			decimal volumeSma = _volumeSma.Process(new DecimalIndicatorValue(volumeValue)).GetValue<decimal>();
+			decimal volumeSma = _volumeSma.Process(volumeValue, candle.ServerTime, candle.State == CandleStates.Finished).GetValue<decimal>();
 			
 			// Process price EMA for trend direction
 			decimal priceEma = _priceEma.Process(candle).GetValue<decimal>();
@@ -161,7 +161,7 @@ namespace StockSharp.Samples.Strategies
 			decimal volumeRatio = volumeValue / volumeSma;
 			
 			// We use LinearRegression to calculate slope of this ratio
-			var currentSlopeValue = _volumeSlope.Process(new DecimalIndicatorValue(volumeRatio)).GetValue<decimal>();
+			var currentSlopeValue = _volumeSlope.Process(volumeRatio, candle.ServerTime, candle.State == CandleStates.Finished).GetValue<decimal>();
 
 			// Update slope stats when we have 2 values to calculate slope
 			if (_prevSlopeValue != 0)

--- a/API/0275_OBV_Slope_Breakout/ObvSlopeBreakoutStrategy.cs
+++ b/API/0275_OBV_Slope_Breakout/ObvSlopeBreakoutStrategy.cs
@@ -149,7 +149,7 @@ namespace StockSharp.Samples.Strategies
 				return;
 
 			// Calculate OBV slope
-			var slopeValue = _obvSlope.Process(new DecimalIndicatorValue(obvValue));
+			var slopeValue = _obvSlope.Process(obvValue, candle.ServerTime, candle.State == CandleStates.Finished);
 			if (!slopeValue.IsFinal)
 				return;
 

--- a/API/0276_Bollinger_Width_Mean_Reversion/BollingerWidthMeanReversionStrategy.cs
+++ b/API/0276_Bollinger_Width_Mean_Reversion/BollingerWidthMeanReversionStrategy.cs
@@ -195,8 +195,8 @@ namespace StockSharp.Samples.Strategies
 			_lastWidth = width;
 
 			// Calculate width's average and standard deviation
-			var widthAvg = _widthAvg.Process(new DecimalIndicatorValue(width));
-			var widthStdDev = _widthStdDev.Process(new DecimalIndicatorValue(width));
+			var widthAvg = _widthAvg.Process(width, candle.ServerTime, candle.State == CandleStates.Finished);
+			var widthStdDev = _widthStdDev.Process(width, candle.ServerTime, candle.State == CandleStates.Finished);
 
 			if (widthAvg.IsFinal && widthStdDev.IsFinal)
 			{

--- a/API/0277_Keltner_Width_Mean_Reversion/KeltnerWidthMeanReversionStrategy.cs
+++ b/API/0277_Keltner_Width_Mean_Reversion/KeltnerWidthMeanReversionStrategy.cs
@@ -203,8 +203,8 @@ namespace StockSharp.Samples.Strategies
 				_lastChannelWidth = channelWidth;
 				
 				// Process width's average and standard deviation
-				var widthAvgValue = _widthAvg.Process(new DecimalIndicatorValue(channelWidth));
-				var widthStdDevValue = _widthStdDev.Process(new DecimalIndicatorValue(channelWidth));
+				var widthAvgValue = _widthAvg.Process(channelWidth, candle.ServerTime, candle.State == CandleStates.Finished);
+				var widthStdDevValue = _widthStdDev.Process(channelWidth, candle.ServerTime, candle.State == CandleStates.Finished);
 				
 				if (widthAvgValue.IsFinal && widthStdDevValue.IsFinal)
 				{

--- a/API/0278_Donchian_Width_Mean_Reversion/DonchianWidthMeanReversionStrategy.cs
+++ b/API/0278_Donchian_Width_Mean_Reversion/DonchianWidthMeanReversionStrategy.cs
@@ -171,8 +171,8 @@ namespace StockSharp.Samples.Strategies
 			_currentWidth = upperBand - lowerBand;
 			
 			// Calculate the average and standard deviation of the width
-			var widthAverage = _widthAverage.Process(new DecimalIndicatorValue(_currentWidth)).GetValue<decimal>();
-			var widthStdDev = _widthStdDev.Process(new DecimalIndicatorValue(_currentWidth)).GetValue<decimal>();
+			var widthAverage = _widthAverage.Process(_currentWidth, candle.ServerTime, candle.State == CandleStates.Finished).GetValue<decimal>();
+			var widthStdDev = _widthStdDev.Process(_currentWidth, candle.ServerTime, candle.State == CandleStates.Finished).GetValue<decimal>();
 			
 			// Skip the first value
 			if (_prevWidth == 0)

--- a/API/0279_Ichimoku_Cloud_Width_Mean_Reversion/IchimokuCloudWidthMeanReversionStrategy.cs
+++ b/API/0279_Ichimoku_Cloud_Width_Mean_Reversion/IchimokuCloudWidthMeanReversionStrategy.cs
@@ -194,8 +194,8 @@ namespace StockSharp.Samples.Strategies
 			_currentCloudWidth = Math.Abs(senkouSpanA - senkouSpanB);
 			
 			// Calculate average and standard deviation of cloud width
-			var cloudWidthAverage = _cloudWidthAverage.Process(new DecimalIndicatorValue(_currentCloudWidth)).GetValue<decimal>();
-			var cloudWidthStdDev = _cloudWidthStdDev.Process(new DecimalIndicatorValue(_currentCloudWidth)).GetValue<decimal>();
+			var cloudWidthAverage = _cloudWidthAverage.Process(_currentCloudWidth, candle.ServerTime, candle.State == CandleStates.Finished).GetValue<decimal>();
+			var cloudWidthStdDev = _cloudWidthStdDev.Process(_currentCloudWidth, candle.ServerTime, candle.State == CandleStates.Finished).GetValue<decimal>();
 			
 			// Skip the first value
 			if (_prevCloudWidth == 0)

--- a/API/0280_Supertrend_Distance_Mean_Reversion/SupertrendDistanceMeanReversionStrategy.cs
+++ b/API/0280_Supertrend_Distance_Mean_Reversion/SupertrendDistanceMeanReversionStrategy.cs
@@ -177,11 +177,11 @@ namespace StockSharp.Samples.Strategies
 			_currentDistanceShort = _supertrendValue - candle.ClosePrice;
 			
 			// Calculate averages and standard deviations for both distances
-			var longDistanceAvg = _distanceAverage.Process(new DecimalIndicatorValue(_currentDistanceLong)).GetValue<decimal>();
-			var longDistanceStdDev = _distanceStdDev.Process(new DecimalIndicatorValue(_currentDistanceLong)).GetValue<decimal>();
+			var longDistanceAvg = _distanceAverage.Process(_currentDistanceLong, candle.ServerTime, candle.State == CandleStates.Finished).GetValue<decimal>();
+			var longDistanceStdDev = _distanceStdDev.Process(_currentDistanceLong, candle.ServerTime, candle.State == CandleStates.Finished).GetValue<decimal>();
 			
-			var shortDistanceAvg = _distanceAverage.Process(new DecimalIndicatorValue(_currentDistanceShort)).GetValue<decimal>();
-			var shortDistanceStdDev = _distanceStdDev.Process(new DecimalIndicatorValue(_currentDistanceShort)).GetValue<decimal>();
+			var shortDistanceAvg = _distanceAverage.Process(_currentDistanceShort, candle.ServerTime, candle.State == CandleStates.Finished).GetValue<decimal>();
+			var shortDistanceStdDev = _distanceStdDev.Process(_currentDistanceShort, candle.ServerTime, candle.State == CandleStates.Finished).GetValue<decimal>();
 			
 			// Skip the first value
 			if (_prevDistanceLong == 0 || _prevDistanceShort == 0)

--- a/API/0281_Parabolic_SAR_Distance_Mean_Reversion/ParabolicSarDistanceMeanReversionStrategy.cs
+++ b/API/0281_Parabolic_SAR_Distance_Mean_Reversion/ParabolicSarDistanceMeanReversionStrategy.cs
@@ -179,11 +179,11 @@ namespace StockSharp.Samples.Strategies
 			_currentDistanceShort = _sarValue - candle.ClosePrice;
 			
 			// Calculate averages and standard deviations for both distances
-			var longDistanceAvg = _distanceAverage.Process(new DecimalIndicatorValue(_currentDistanceLong)).GetValue<decimal>();
-			var longDistanceStdDev = _distanceStdDev.Process(new DecimalIndicatorValue(_currentDistanceLong)).GetValue<decimal>();
+			var longDistanceAvg = _distanceAverage.Process(_currentDistanceLong, candle.ServerTime, candle.State == CandleStates.Finished).GetValue<decimal>();
+			var longDistanceStdDev = _distanceStdDev.Process(_currentDistanceLong, candle.ServerTime, candle.State == CandleStates.Finished).GetValue<decimal>();
 			
-			var shortDistanceAvg = _distanceAverage.Process(new DecimalIndicatorValue(_currentDistanceShort)).GetValue<decimal>();
-			var shortDistanceStdDev = _distanceStdDev.Process(new DecimalIndicatorValue(_currentDistanceShort)).GetValue<decimal>();
+			var shortDistanceAvg = _distanceAverage.Process(_currentDistanceShort, candle.ServerTime, candle.State == CandleStates.Finished).GetValue<decimal>();
+			var shortDistanceStdDev = _distanceStdDev.Process(_currentDistanceShort, candle.ServerTime, candle.State == CandleStates.Finished).GetValue<decimal>();
 			
 			// Skip the first value
 			if (_prevDistanceLong == 0 || _prevDistanceShort == 0)

--- a/API/0282_Hull_MA_Slope_Mean_Reversion/HullMaSlopeMeanReversionStrategy.cs
+++ b/API/0282_Hull_MA_Slope_Mean_Reversion/HullMaSlopeMeanReversionStrategy.cs
@@ -209,8 +209,8 @@ namespace StockSharp.Samples.Strategies
 			_currentSlope = (_currentHullMa - _prevHullMa) / _prevHullMa * 100; // As percentage
 			
 			// Calculate average and standard deviation of slope
-			var slopeAverage = _slopeAverage.Process(new DecimalIndicatorValue(_currentSlope)).GetValue<decimal>();
-			var slopeStdDev = _slopeStdDev.Process(new DecimalIndicatorValue(_currentSlope)).GetValue<decimal>();
+			var slopeAverage = _slopeAverage.Process(_currentSlope, candle.ServerTime, candle.State == CandleStates.Finished).GetValue<decimal>();
+			var slopeStdDev = _slopeStdDev.Process(_currentSlope, candle.ServerTime, candle.State == CandleStates.Finished).GetValue<decimal>();
 			
 			// Skip until we have enough slope data
 			if (_prevSlope == 0)

--- a/API/0293_Volume_Slope_Mean_Reversion/VolumeSlopeMeanReversionStrategy.cs
+++ b/API/0293_Volume_Slope_Mean_Reversion/VolumeSlopeMeanReversionStrategy.cs
@@ -163,7 +163,7 @@ namespace StockSharp.Samples.Strategies
 				return;
 
 			// Process volume through SMA
-			var volumeIndicatorValue = _volumeMa.Process(new DecimalIndicatorValue(candle.TotalVolume));
+			var volumeIndicatorValue = _volumeMa.Process(candle.TotalVolume, candle.ServerTime, candle.State == CandleStates.Finished);
 			
 			// Skip if indicator is not formed yet
 			if (!_volumeMa.IsFormed)

--- a/API/0294_OBV_Slope_Mean_Reversion/ObvSlopeMeanReversionStrategy.cs
+++ b/API/0294_OBV_Slope_Mean_Reversion/ObvSlopeMeanReversionStrategy.cs
@@ -170,7 +170,7 @@ namespace StockSharp.Samples.Strategies
 			var obvValue = _obv.Process(candle).GetValue<decimal>();
 			
 			// Process OBV through SMA
-			var obvSmaValue = _obvSma.Process(new DecimalIndicatorValue(obvValue)).GetValue<decimal>();
+			var obvSmaValue = _obvSma.Process(obvValue, candle.ServerTime, candle.State == CandleStates.Finished).GetValue<decimal>();
 			
 			// Skip if OBV SMA is not formed yet
 			if (!_obvSma.IsFormed)

--- a/API/0347_RSI_Option_Open_Interest/RsiOptionOpenInterestStrategy.cs
+++ b/API/0347_RSI_Option_Open_Interest/RsiOptionOpenInterestStrategy.cs
@@ -192,11 +192,11 @@ namespace StockSharp.Samples.Strategies
 			SimulateOptionOI(candle);
 
 			// Process option OI with indicators
-			var callOiValueSma = _callOiSma.Process(new DecimalIndicatorValue(_currentCallOi));
-			var putOiValueSma = _putOiSma.Process(new DecimalIndicatorValue(_currentPutOi));
+			var callOiValueSma = _callOiSma.Process(_currentCallOi, candle.ServerTime, candle.State == CandleStates.Finished);
+			var putOiValueSma = _putOiSma.Process(_currentPutOi, candle.ServerTime, candle.State == CandleStates.Finished);
 			
-			var callOiValueStdDev = _callOiStdDev.Process(new DecimalIndicatorValue(_currentCallOi));
-			var putOiValueStdDev = _putOiStdDev.Process(new DecimalIndicatorValue(_currentPutOi));
+			var callOiValueStdDev = _callOiStdDev.Process(_currentCallOi, candle.ServerTime, candle.State == CandleStates.Finished);
+			var putOiValueStdDev = _putOiStdDev.Process(_currentPutOi, candle.ServerTime, candle.State == CandleStates.Finished);
 
 			// Update state variables
 			_avgCallOi = callOiValueSma.GetValue<decimal>();

--- a/API/0348_Stochastic_Implied_Volatility_Skew/StochasticImpliedVolatilitySkewStrategy.cs
+++ b/API/0348_Stochastic_Implied_Volatility_Skew/StochasticImpliedVolatilitySkewStrategy.cs
@@ -175,7 +175,7 @@ namespace StockSharp.Samples.Strategies
 			SimulateIvSkew(candle);
 
 			// Process IV Skew with SMA
-			var ivSkewSmaValue = _ivSkewSma.Process(new DecimalIndicatorValue(_currentIvSkew));
+			var ivSkewSmaValue = _ivSkewSma.Process(_currentIvSkew, candle.ServerTime, candle.State == CandleStates.Finished);
 			_avgIvSkew = ivSkewSmaValue.GetValue<decimal>();
 
 			// Check if strategy is ready to trade


### PR DESCRIPTION
## Summary
- replace DecimalIndicatorValue wrappers with timestamped Process calls
- include candle completion state when updating indicators
- retain tab-based indentation

## Testing
- `dotnet build AlgoTrading.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c77e07d408323affaf6943edf6835