### PR TITLE
Swap instrument order for Buy/Sell methods

### DIFF
--- a/API/0231_Volatility_Skew_Arbitrage/VolatilitySkewArbitrageStrategy.cs
+++ b/API/0231_Volatility_Skew_Arbitrage/VolatilitySkewArbitrageStrategy.cs
@@ -191,15 +191,15 @@ namespace StockSharp.Samples.Strategies
 			{
 				// Long low vol option, short high vol option
 				LogInfo($"Volatility skew above threshold: {volSkew} > {_avgVolSkew + Threshold * stdDev}");
-				BuyMarket(OptionWithLowVol, Volume);
-				SellMarket(OptionWithHighVol, Volume);
+				BuyMarket(Volume, OptionWithLowVol);
+				SellMarket(Volume, OptionWithHighVol);
 			}
 			else if (volSkew < _avgVolSkew - Threshold * stdDev && Position >= 0)
 			{
 				// Short low vol option, long high vol option
 				LogInfo($"Volatility skew below threshold: {volSkew} < {_avgVolSkew - Threshold * stdDev}");
-				SellMarket(OptionWithLowVol, Volume);
-				BuyMarket(OptionWithHighVol, Volume);
+				SellMarket(Volume, OptionWithLowVol);
+				BuyMarket(Volume, OptionWithHighVol);
 			}
 			else if (Math.Abs(volSkew - _avgVolSkew) < 0.2m * stdDev)
 			{
@@ -207,16 +207,16 @@ namespace StockSharp.Samples.Strategies
 				LogInfo($"Volatility skew returned to average: {volSkew} ≈ {_avgVolSkew}");
 				
 				if (GetPositionValue(OptionWithLowVol) > 0)
-					SellMarket(OptionWithLowVol, Math.Abs(GetPositionValue(OptionWithLowVol)));
+					SellMarket(Math.Abs(GetPositionValue(OptionWithLowVol)), OptionWithLowVol);
 					
 				if (GetPositionValue(OptionWithLowVol) < 0)
-					BuyMarket(OptionWithLowVol, Math.Abs(GetPositionValue(OptionWithLowVol)));
+					BuyMarket(Math.Abs(GetPositionValue(OptionWithLowVol)), OptionWithLowVol);
 					
 				if (GetPositionValue(OptionWithHighVol) > 0)
-					SellMarket(OptionWithHighVol, Math.Abs(GetPositionValue(OptionWithHighVol)));
+					SellMarket(Math.Abs(GetPositionValue(OptionWithHighVol)), OptionWithHighVol);
 					
 				if (GetPositionValue(OptionWithHighVol) < 0)
-					BuyMarket(OptionWithHighVol, Math.Abs(GetPositionValue(OptionWithHighVol)));
+					BuyMarket(Math.Abs(GetPositionValue(OptionWithHighVol)), OptionWithHighVol);
 			}
 		}
 

--- a/API/0232_Correlation_Breakout/CorrelationBreakoutStrategy.cs
+++ b/API/0232_Correlation_Breakout/CorrelationBreakoutStrategy.cs
@@ -244,15 +244,15 @@ namespace StockSharp.Samples.Strategies
 			{
 				// Correlation breakdown - go long Asset1, short Asset2
 				LogInfo($"Correlation breakdown: {_lastCorrelation} < {_avgCorrelation - Threshold * stdDev}");
-				BuyMarket(Asset1, Volume);
-				SellMarket(Asset2, Volume);
+				BuyMarket(Volume, Asset1);
+				SellMarket(Volume, Asset2);
 			}
 			else if (_lastCorrelation > _avgCorrelation + Threshold * stdDev && GetPositionValue(Asset1) >= 0 && GetPositionValue(Asset2) <= 0)
 			{
 				// Correlation spike - go short Asset1, long Asset2
 				LogInfo($"Correlation spike: {_lastCorrelation} > {_avgCorrelation + Threshold * stdDev}");
-				SellMarket(Asset1, Volume);
-				BuyMarket(Asset2, Volume);
+				SellMarket(Volume, Asset1);
+				BuyMarket(Volume, Asset2);
 			}
 			else if (Math.Abs(_lastCorrelation - _avgCorrelation) < 0.2m * stdDev)
 			{
@@ -260,16 +260,16 @@ namespace StockSharp.Samples.Strategies
 				LogInfo($"Correlation returned to average: {_lastCorrelation} ≈ {_avgCorrelation}");
 				
 				if (GetPositionValue(Asset1) > 0)
-					SellMarket(Asset1, Math.Abs(GetPositionValue(Asset1)));
+					SellMarket(Math.Abs(GetPositionValue(Asset1)), Asset1);
 					
 				if (GetPositionValue(Asset1) < 0)
-					BuyMarket(Asset1, Math.Abs(GetPositionValue(Asset1)));
+					BuyMarket(Math.Abs(GetPositionValue(Asset1)), Asset1);
 					
 				if (GetPositionValue(Asset2) > 0)
-					SellMarket(Asset2, Math.Abs(GetPositionValue(Asset2)));
+					SellMarket(Math.Abs(GetPositionValue(Asset2)), Asset2);
 					
 				if (GetPositionValue(Asset2) < 0)
-					BuyMarket(Asset2, Math.Abs(GetPositionValue(Asset2)));
+					BuyMarket(Math.Abs(GetPositionValue(Asset2)), Asset2);
 			}
 		}
 

--- a/API/0233_Beta_Neutral_Arbitrage/BetaNeutralArbitrageStrategy.cs
+++ b/API/0233_Beta_Neutral_Arbitrage/BetaNeutralArbitrageStrategy.cs
@@ -263,8 +263,8 @@ namespace StockSharp.Samples.Strategies
 				decimal asset1Volume = Volume;
 				decimal asset2Volume = Volume * (_asset1Beta / _asset2Beta);
 
-				BuyMarket(Asset1, asset1Volume);
-				SellMarket(Asset2, asset2Volume);
+				BuyMarket(asset1Volume, Asset1);
+				SellMarket(asset2Volume, Asset2);
 			}
 			else if (_lastSpread > _avgSpread + threshold * spreadStdDev && GetPositionValue(Asset1) >= 0 && GetPositionValue(Asset2) <= 0)
 			{
@@ -275,8 +275,8 @@ namespace StockSharp.Samples.Strategies
 				decimal asset1Volume = Volume;
 				decimal asset2Volume = Volume * (_asset1Beta / _asset2Beta);
 
-				SellMarket(Asset1, asset1Volume);
-				BuyMarket(Asset2, asset2Volume);
+				SellMarket(asset1Volume, Asset1);
+				BuyMarket(asset2Volume, Asset2);
 			}
 			else if (Math.Abs(_lastSpread - _avgSpread) < 0.2m * spreadStdDev)
 			{
@@ -284,16 +284,16 @@ namespace StockSharp.Samples.Strategies
 				LogInfo($"Spread returned to average: {_lastSpread} ≈ {_avgSpread}");
 
 				if (GetPositionValue(Asset1) > 0)
-					SellMarket(Asset1, Math.Abs(GetPositionValue(Asset1)));
+					SellMarket(Math.Abs(GetPositionValue(Asset1)), Asset1);
 
 				if (GetPositionValue(Asset1) < 0)
-					BuyMarket(Asset1, Math.Abs(GetPositionValue(Asset1)));
+					BuyMarket(Math.Abs(GetPositionValue(Asset1)), Asset1);
 
 				if (GetPositionValue(Asset2) > 0)
-					SellMarket(Asset2, Math.Abs(GetPositionValue(Asset2)));
+					SellMarket(Math.Abs(GetPositionValue(Asset2)), Asset2);
 
 				if (GetPositionValue(Asset2) < 0)
-					BuyMarket(Asset2, Math.Abs(GetPositionValue(Asset2)));
+					BuyMarket(Math.Abs(GetPositionValue(Asset2)), Asset2);
 			}
 		}
 

--- a/API/0295_Pairs_Trading_Volatility_Filter/PairsTradingVolatilityFilterStrategy.cs
+++ b/API/0295_Pairs_Trading_Volatility_Filter/PairsTradingVolatilityFilterStrategy.cs
@@ -264,8 +264,8 @@ namespace StockSharp.Strategies
 					_entryPrice = _currentSpread;
 					
 					// Execute trades
-					BuyMarket(Security1, volume1);
-					SellMarket(Security2, volume2);
+					BuyMarket(volume1, Security1);
+					SellMarket(volume2, Security2);
 					
 					LogInfo($"LONG SPREAD: {Security1.Code} vs {Security2.Code}, Z-Score: {zScore:F2}, Volatility: Low");
 				}
@@ -280,8 +280,8 @@ namespace StockSharp.Strategies
 					_entryPrice = _currentSpread;
 					
 					// Execute trades
-					SellMarket(Security1, volume1);
-					BuyMarket(Security2, volume2);
+					SellMarket(volume1, Security1);
+					BuyMarket(volume2, Security2);
 					
 					LogInfo($"SHORT SPREAD: {Security1.Code} vs {Security2.Code}, Z-Score: {zScore:F2}, Volatility: Low");
 				}

--- a/API/0297_Volatility_Skew_Momentum/VolatilitySkewMomentumStrategy.cs
+++ b/API/0297_Volatility_Skew_Momentum/VolatilitySkewMomentumStrategy.cs
@@ -271,14 +271,14 @@ namespace StockSharp.Strategies
 				if (skewZScore > SkewThreshold && isPositiveMomentum)
 				{
 					// Sell options (overpriced volatility) when underlying has positive momentum
-					SellMarket(OptionSecurity, Volume);
+					SellMarket(Volume, OptionSecurity);
 					LogInfo($"SHORT OPTION: Skew Z-Score: {skewZScore:F2}, Momentum: Positive");
 				}
 				// Volatility is lower than normal (underpriced options) with negative momentum in underlying
 				else if (skewZScore < -SkewThreshold && !isPositiveMomentum)
 				{
 					// Buy options (underpriced volatility) when underlying has negative momentum
-					BuyMarket(OptionSecurity, Volume);
+					BuyMarket(Volume, OptionSecurity);
 					LogInfo($"LONG OPTION: Skew Z-Score: {skewZScore:F2}, Momentum: Negative");
 				}
 			}

--- a/API/0298_Correlation_Mean_Reversion/CorrelationMeanReversionStrategy.cs
+++ b/API/0298_Correlation_Mean_Reversion/CorrelationMeanReversionStrategy.cs
@@ -304,8 +304,8 @@ namespace StockSharp.Strategies
 				if (correlationZScore < -DeviationThreshold)
 				{
 					// Long Security1, Short Security2
-					BuyMarket(Security1, Volume);
-					SellMarket(Security2, Volume);
+					BuyMarket(Volume, Security1);
+					SellMarket(Volume, Security2);
 					
 					LogInfo($"LONG {Security1.Code}, SHORT {Security2.Code}: Correlation Z-Score: {correlationZScore:F2}");
 				}
@@ -313,8 +313,8 @@ namespace StockSharp.Strategies
 				else if (correlationZScore > DeviationThreshold)
 				{
 					// Short Security1, Long Security2
-					SellMarket(Security1, Volume);
-					BuyMarket(Security2, Volume);
+					SellMarket(Volume, Security1);
+					BuyMarket(Volume, Security2);
 					
 					LogInfo($"SHORT {Security1.Code}, LONG {Security2.Code}: Correlation Z-Score: {correlationZScore:F2}");
 				}


### PR DESCRIPTION
## Summary
- update BuyMarket and SellMarket calls to take the instrument as the last parameter
- keep existing tab-based indentation

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685db7b047408323b582e26e47eef4df