### PR TITLE
Fix indicator context with tabs only

### DIFF
--- a/API/0115_Volume_Climax_Reversal/VolumeClimaxReversalStrategy.cs
+++ b/API/0115_Volume_Climax_Reversal/VolumeClimaxReversalStrategy.cs
@@ -139,7 +139,7 @@ namespace StockSharp.Strategies
 
 			// Process indicators
 			var maValue = _ma.Process(candle).ToDecimal();
-			var volumeAverageValue = _volumeAverage.Process(candle.TotalVolume).ToDecimal();
+			var volumeAverageValue = _volumeAverage.Process(candle.TotalVolume, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal();
 			var atrValue = _atr.Process(candle).ToDecimal();
 
 			// Check if strategy is ready to trade

--- a/API/0295_Pairs_Trading_Volatility_Filter/PairsTradingVolatilityFilterStrategy.cs
+++ b/API/0295_Pairs_Trading_Volatility_Filter/PairsTradingVolatilityFilterStrategy.cs
@@ -204,7 +204,7 @@ namespace StockSharp.Strategies
 				
 			// Store ATR value for volatility filter
 			_currentAtr = atrValue;
-			var atrSmaValue = _atrSma.Process(atrValue).ToDecimal();
+			var atrSmaValue = _atrSma.Process(atrValue, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal();
 			_averageAtr = atrSmaValue;
 			
 			// Check if we have all necessary data to make a trading decision
@@ -224,8 +224,8 @@ namespace StockSharp.Strategies
 			_currentSpread = price1 - (price2 * _volumeRatio);
 			
 			// Calculate spread statistics
-			var spreadSmaValue = _spreadSma.Process(_currentSpread).ToDecimal();
-			var stdDevValue = _stdDev.Process(_currentSpread).ToDecimal();
+			var spreadSmaValue = _spreadSma.Process(_currentSpread, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal();
+			var stdDevValue = _stdDev.Process(_currentSpread, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal();
 			
 			_averageSpread = spreadSmaValue;
 			_standardDeviation = stdDevValue;

--- a/API/0296_Z-Score_Volume_Filter/ZscoreVolumeFilterStrategy.cs
+++ b/API/0296_Z-Score_Volume_Filter/ZscoreVolumeFilterStrategy.cs
@@ -145,9 +145,9 @@ namespace StockSharp.Strategies
 			_currentVolume = candle.TotalVolume;
 			
 			// Process indicators
-			_averagePrice = _priceSma.Process(_currentPrice).ToDecimal();
-			_priceStdDeviation = _priceStdDev.Process(_currentPrice).ToDecimal();
-			_averageVolume = _volumeSma.Process(_currentVolume).ToDecimal();
+			_averagePrice = _priceSma.Process(_currentPrice, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal();
+			_priceStdDeviation = _priceStdDev.Process(_currentPrice, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal();
+			_averageVolume = _volumeSma.Process(_currentVolume, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal();
 			
 			// Check trading signals
 			CheckSignal();

--- a/API/0297_Volatility_Skew_Momentum/VolatilitySkewMomentumStrategy.cs
+++ b/API/0297_Volatility_Skew_Momentum/VolatilitySkewMomentumStrategy.cs
@@ -224,8 +224,8 @@ namespace StockSharp.Strategies
 					_currentSkew = impliedVolatility;
 					
 					// Process indicators
-					_averageSkew = _volatilitySkewSma.Process(_currentSkew).ToDecimal();
-					_skewStdDeviation = _volatilitySkewStdDev.Process(_currentSkew).ToDecimal();
+					_averageSkew = _volatilitySkewSma.Process(_currentSkew, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal();
+					_skewStdDeviation = _volatilitySkewStdDev.Process(_currentSkew, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal();
 					
 					// Check for trading signals
 					CheckSignal();

--- a/API/0298_Correlation_Mean_Reversion/CorrelationMeanReversionStrategy.cs
+++ b/API/0298_Correlation_Mean_Reversion/CorrelationMeanReversionStrategy.cs
@@ -202,7 +202,7 @@ namespace StockSharp.Strategies
 			_security1Updated = true;
 			
 			// Update correlation and check for signals
-			CalculateCorrelation();
+			CalculateCorrelation(candle.ServerTime, candle.State == CandleStates.Finished);
 		}
 		
 		private void ProcessSecurity2Candle(ICandleMessage candle)
@@ -215,10 +215,10 @@ namespace StockSharp.Strategies
 			_security2Updated = true;
 			
 			// Update correlation and check for signals
-			CalculateCorrelation();
+			CalculateCorrelation(candle.ServerTime, candle.State == CandleStates.Finished);
 		}
 		
-		private void CalculateCorrelation()
+		private void CalculateCorrelation(DateTimeOffset time, bool isFinal)
 		{
 			// Only proceed if both securities have been updated
 			if (!_security1Updated || !_security2Updated)
@@ -247,8 +247,8 @@ namespace StockSharp.Strategies
 			_currentCorrelation = CalculateCorrelationCoefficient(_security1Prices.ToArray(), _security2Prices.ToArray());
 			
 			// Process indicators
-			_averageCorrelation = _correlationSma.Process(_currentCorrelation).ToDecimal();
-			_correlationStdDeviation = _correlationStdDev.Process(_currentCorrelation).ToDecimal();
+			_averageCorrelation = _correlationSma.Process(_currentCorrelation, time, isFinal).ToDecimal();
+			_correlationStdDeviation = _correlationStdDev.Process(_currentCorrelation, time, isFinal).ToDecimal();
 			
 			// Check for trading signals
 			CheckSignal();


### PR DESCRIPTION
## Summary
- pass candle time and final state when processing volume averages and spreads
- ensure every file uses tab-based indentation
- fix tab alignment in CorrelationMeanReversionStrategy

## Testing
- `dotnet build AlgoTrading.sln -c Release` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685ec9d204d88323beeab4b5cc790d98