### PR TITLE
Add strategy tests project to solution

### DIFF
--- a/AlgoTrading.sln
+++ b/AlgoTrading.sln
@@ -5,12 +5,18 @@ VisualStudioVersion = 17.13.35919.96
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Backtester", "Backtester\Backtester.csproj", "{6E807F9F-7701-4790-A919-0C45AE993F23}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StrategyTests", "StrategyTests\StrategyTests.csproj", "{EBCDAFC7-92AD-4484-8FE5-6EFB7DB4F877}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {EBCDAFC7-92AD-4484-8FE5-6EFB7DB4F877}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {EBCDAFC7-92AD-4484-8FE5-6EFB7DB4F877}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {EBCDAFC7-92AD-4484-8FE5-6EFB7DB4F877}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {EBCDAFC7-92AD-4484-8FE5-6EFB7DB4F877}.Release|Any CPU.Build.0 = Release|Any CPU
 		{6E807F9F-7701-4790-A919-0C45AE993F23}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6E807F9F-7701-4790-A919-0C45AE993F23}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6E807F9F-7701-4790-A919-0C45AE993F23}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/StrategyTests/StrategyTests.cs
+++ b/StrategyTests/StrategyTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using StockSharp.Algo.Storages;
+using StockSharp.Algo.Strategies;
+using StockSharp.Algo.Testing;
+using StockSharp.BusinessEntities;
+using StockSharp.Configuration;
+using StockSharp.Logging;
+using StockSharp.Messages;
+using StockSharp.Samples.HistoryData;
+
+namespace StockSharp.Tests
+{
+	[TestClass]
+	public class StrategyTests
+	{
+		public static IEnumerable<object[]> StrategyTypes => typeof(StockSharp.Samples.Strategies.MaCrossoverStrategy)
+			.Assembly
+			.GetTypes()
+			.Where(t => typeof(Strategy).IsAssignableFrom(t) && !t.IsAbstract && t.Namespace == "StockSharp.Samples.Strategies")
+			.Select(t => new object[] { t });
+
+		[DataTestMethod]
+		[DynamicData(nameof(StrategyTypes))]
+		public async Task RunStrategy(Type strategyType)
+		{
+			var strategy = (Strategy)Activator.CreateInstance(strategyType)!;
+			await Run(strategy);
+		}
+
+		private static async Task Run(Strategy strategy)
+		{
+			var logManager = new LogManager();
+			logManager.Listeners.Add(new ConsoleLogListener());
+
+			var token = CancellationToken.None;
+
+			var secId = Paths.HistoryDefaultSecurity;
+			var security = new Security { Id = secId };
+
+			var storageRegistry = new StorageRegistry { DefaultDrive = new LocalMarketDataDrive(Paths.HistoryDataPath) };
+
+			var startTime = Paths.HistoryBeginDate;
+			var stopTime = Paths.HistoryEndDate;
+
+			var pf = Portfolio.CreateSimulator();
+			pf.CurrentValue = 1000000m;
+
+			var connector = new HistoryEmulationConnector(new[] { security }, new[] { pf }, storageRegistry)
+			{
+				HistoryMessageAdapter =
+				{
+					StartDate = startTime,
+					StopDate = stopTime,
+				}
+			};
+
+			strategy.Portfolio = pf;
+			strategy.Security = security;
+			strategy.Connector = connector;
+			strategy.Volume = 1;
+
+			logManager.Sources.Add(connector);
+			logManager.Sources.Add(strategy);
+
+			await connector.ConnectAsync(token);
+
+			var task = strategy.ExecAsync(null, token);
+			connector.Start();
+			await task.AsTask();
+
+			Assert.IsTrue(strategy.Orders.Count() > 10, $"{strategy.GetType().Name} placed {strategy.Orders.Count()} orders");
+			Assert.IsTrue(strategy.MyTrades.Count() > 5, $"{strategy.GetType().Name} executed {strategy.MyTrades.Count()} trades");
+		}
+	}
+}

--- a/StrategyTests/StrategyTests.csproj
+++ b/StrategyTests/StrategyTests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>13.0</LangVersion>
+    <IsPackable>false</IsPackable>
+    <StockSharpVer>5.*</StockSharpVer>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.3.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.3.2" />
+    <PackageReference Include="StockSharp.Algo" Version="$(StockSharpVer)" />
+    <PackageReference Include="StockSharp.Samples.HistoryData" Version="$(StockSharpVer)" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="../API/**/*.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- include `StrategyTests` in the solution file
- ensure indentation uses tabs in the test code
- switch the tests to use MSTest instead of xUnit

## Testing
- `dotnet test StrategyTests/StrategyTests.csproj -c Release --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ed0269e508323bc3d8da77c840dbc