### PR TITLE
Refactor MACD initialization

### DIFF
--- a/API/0009_MACD_Trend/MacdTrendStrategy.cs
+++ b/API/0009_MACD_Trend/MacdTrendStrategy.cs
@@ -111,13 +111,16 @@ namespace StockSharp.Samples.Strategies
 			base.OnStarted(time);
 
 			// Create MACD indicator with signal line
-			var macd = new MovingAverageConvergenceDivergence
-			{
-				FastEma = new ExponentialMovingAverage { Length = FastEmaPeriod },
-				SlowEma = new ExponentialMovingAverage { Length = SlowEmaPeriod },
-				SignalEma = new ExponentialMovingAverage { Length = SignalPeriod }
-			};
 
+			var macd = new MovingAverageConvergenceDivergenceSignal
+			{
+				Macd =
+				{
+					ShortMa = { Length = FastEmaPeriod },
+					LongMa = { Length = SlowEmaPeriod },
+				},
+				SignalMa = { Length = SignalPeriod }
+			};
 			// Create subscription and bind indicator
 			var subscription = SubscribeCandles(CandleType);
 			subscription

--- a/API/0033_MACD_Zero/MacdZeroStrategy.cs
+++ b/API/0033_MACD_Zero/MacdZeroStrategy.cs
@@ -112,13 +112,16 @@ namespace StockSharp.Samples.Strategies
 			_prevMacd = 0;
 
 			// Create MACD indicator with signal line
+
 			var macd = new MovingAverageConvergenceDivergenceSignal
 			{
-				FastEma = new ExponentialMovingAverage { Length = FastPeriod },
-				SlowEma = new ExponentialMovingAverage { Length = SlowPeriod },
-				SignalEma = new ExponentialMovingAverage { Length = SignalPeriod }
+				Macd =
+				{
+					ShortMa = { Length = FastPeriod },
+					LongMa = { Length = SlowPeriod },
+				},
+				SignalMa = { Length = SignalPeriod }
 			};
-
 			// Create subscription and bind MACD indicator
 			var subscription = SubscribeCandles(CandleType);
 			subscription

--- a/API/0061_MACD_Divergence/MacdDivergenceStrategy.cs
+++ b/API/0061_MACD_Divergence/MacdDivergenceStrategy.cs
@@ -138,13 +138,16 @@ namespace StockSharp.Samples.Strategies
 			_bearishDivergence = false;
 
 			// Create MACD indicator
-			var macd = new MovingAverageConvergenceDivergence
-			{
-				FastMa = new ExponentialMovingAverage { Length = FastMacdPeriod },
-				SlowMa = new ExponentialMovingAverage { Length = SlowMacdPeriod },
-				SignalMa = new ExponentialMovingAverage { Length = SignalPeriod }
-			};
 
+			var macd = new MovingAverageConvergenceDivergenceSignal
+			{
+				Macd =
+				{
+					ShortMa = { Length = FastMacdPeriod },
+					LongMa = { Length = SlowMacdPeriod },
+				},
+				SignalMa = { Length = SignalPeriod }
+			};
 			// Create candle subscription
 			var subscription = SubscribeCandles(CandleType);
 

--- a/API/0131_MACD_RSI/MacdRsiStrategy.cs
+++ b/API/0131_MACD_RSI/MacdRsiStrategy.cs
@@ -160,13 +160,16 @@ namespace StockSharp.Strategies.Samples
 			);
 			
 			// Create indicators
-			var macd = new MovingAverageConvergenceDivergence
-			{
-				FastMa = new ExponentialMovingAverage { Length = MacdFast },
-				SlowMa = new ExponentialMovingAverage { Length = MacdSlow },
-				SignalMa = new ExponentialMovingAverage { Length = MacdSignal }
-			};
 			
+			var macd = new MovingAverageConvergenceDivergenceSignal
+			{
+				Macd =
+				{
+					ShortMa = { Length = MacdFast },
+					LongMa = { Length = MacdSlow },
+				},
+				SignalMa = { Length = MacdSignal }
+			};
 			var rsi = new RelativeStrengthIndex { Length = RsiPeriod };
 			
 			// Create candle subscription

--- a/API/0139_ATR_MACD/AtrMacdStrategy.cs
+++ b/API/0139_ATR_MACD/AtrMacdStrategy.cs
@@ -174,13 +174,15 @@ namespace StockSharp.Samples.Strategies
 				Length = AtrAvgPeriod
 			};
 
-			var macd = new MovingAverageConvergenceDivergence
+			var macd = new MovingAverageConvergenceDivergenceSignal
 			{
-				FastEma = new ExponentialMovingAverage { Length = MacdFast },
-				SlowEma = new ExponentialMovingAverage { Length = MacdSlow },
-				SignalEma = new ExponentialMovingAverage { Length = MacdSignal }
+				Macd =
+				{
+					ShortMa = { Length = MacdFast },
+					LongMa = { Length = MacdSlow },
+				},
+				SignalMa = { Length = MacdSignal }
 			};
-
 			// Create subscription and bind indicators
 			var subscription = SubscribeCandles(CandleType);
 

--- a/API/0146_MACD_Volume/MacdVolumeStrategy.cs
+++ b/API/0146_MACD_Volume/MacdVolumeStrategy.cs
@@ -151,13 +151,16 @@ namespace StockSharp.Samples.Strategies
 			_avgVolume = 0;
 
 			// Create indicators
-			var macd = new MovingAverageConvergenceDivergence
-			{
-				FastEma = new ExponentialMovingAverage { Length = MacdFast },
-				SlowEma = new ExponentialMovingAverage { Length = MacdSlow },
-				SignalEma = new ExponentialMovingAverage { Length = MacdSignal }
-			};
 
+			var macd = new MovingAverageConvergenceDivergenceSignal
+			{
+				Macd =
+				{
+					ShortMa = { Length = MacdFast },
+					LongMa = { Length = MacdSlow },
+				},
+				SignalMa = { Length = MacdSignal }
+			};
 			var volumeAvg = new SimpleMovingAverage
 			{
 				Length = VolumePeriod

--- a/API/0161_MACD_CCI/MacdCciStrategy.cs
+++ b/API/0161_MACD_CCI/MacdCciStrategy.cs
@@ -144,13 +144,16 @@ namespace StockSharp.Samples.Strategies
 			base.OnStarted(time);
 
 			// Create indicators
-			var macd = new MovingAverageConvergenceDivergence
-			{
-				FastMa = new ExponentialMovingAverage { Length = FastPeriod },
-				SlowMa = new ExponentialMovingAverage { Length = SlowPeriod },
-				SignalMa = new ExponentialMovingAverage { Length = SignalPeriod }
-			};
 
+			var macd = new MovingAverageConvergenceDivergenceSignal
+			{
+				Macd =
+				{
+					ShortMa = { Length = FastPeriod },
+					LongMa = { Length = SlowPeriod },
+				},
+				SignalMa = { Length = SignalPeriod }
+			};
 			var cci = new CommodityChannelIndex { Length = CciPeriod };
 
 			// Setup candle subscription

--- a/API/0171_MACD_Williams_R/MacdWilliamsRStrategy.cs
+++ b/API/0171_MACD_Williams_R/MacdWilliamsRStrategy.cs
@@ -127,13 +127,16 @@ namespace StockSharp.Samples.Strategies
 			base.OnStarted(time);
 
 			// Create indicators
-			var macd = new MovingAverageConvergenceDivergence
-			{
-				FastMa = new ExponentialMovingAverage { Length = MacdFast },
-				SlowMa = new ExponentialMovingAverage { Length = MacdSlow },
-				SignalMa = new ExponentialMovingAverage { Length = MacdSignal }
-			};
 
+			var macd = new MovingAverageConvergenceDivergenceSignal
+			{
+				Macd =
+				{
+					ShortMa = { Length = MacdFast },
+					LongMa = { Length = MacdSlow },
+				},
+				SignalMa = { Length = MacdSignal }
+			};
 			var williamsR = new WilliamsR { Length = WilliamsRPeriod };
 
 			// Enable position protection with stop-loss

--- a/API/0174_MACD_VWAP/MacdVwapStrategy.cs
+++ b/API/0174_MACD_VWAP/MacdVwapStrategy.cs
@@ -111,13 +111,16 @@ namespace StockSharp.Samples.Strategies
 			base.OnStarted(time);
 
 			// Create indicators
-			var macd = new MovingAverageConvergenceDivergence
-			{
-				FastMa = new ExponentialMovingAverage { Length = MacdFast },
-				SlowMa = new ExponentialMovingAverage { Length = MacdSlow },
-				SignalMa = new ExponentialMovingAverage { Length = MacdSignal }
-			};
 
+			var macd = new MovingAverageConvergenceDivergenceSignal
+			{
+				Macd =
+				{
+					ShortMa = { Length = MacdFast },
+					LongMa = { Length = MacdSlow },
+				},
+				SignalMa = { Length = MacdSignal }
+			};
 			var vwap = new VolumeWeightedMovingAverage();
 
 			// Enable position protection with stop-loss

--- a/API/0194_Keltner_MACD/KeltnerMacdStrategy.cs
+++ b/API/0194_Keltner_MACD/KeltnerMacdStrategy.cs
@@ -157,13 +157,16 @@ namespace StockSharp.Samples.Strategies
 			// Create indicators
 			_ema = new ExponentialMovingAverage { Length = EmaPeriod };
 			_atr = new AverageTrueRange { Length = AtrPeriod };
-			_macd = new MovingAverageConvergenceDivergence
-			{
-				FastMa = new ExponentialMovingAverage { Length = MacdFastPeriod },
-				SlowMa = new ExponentialMovingAverage { Length = MacdSlowPeriod },
-				SignalMa = new ExponentialMovingAverage { Length = MacdSignalPeriod }
-			};
 
+				_macd = new MovingAverageConvergenceDivergenceSignal
+				{
+					Macd =
+					{
+						ShortMa = { Length = MacdFastPeriod },
+						LongMa = { Length = MacdSlowPeriod },
+					},
+					SignalMa = { Length = MacdSignalPeriod }
+				};
 			// Initialize variables
 			_prevMacd = 0;
 			_prevSignal = 0;

--- a/API/0198_VWAP_MACD/VwapMacdStrategy.cs
+++ b/API/0198_VWAP_MACD/VwapMacdStrategy.cs
@@ -110,13 +110,16 @@ namespace StockSharp.Samples.Strategies
 			base.OnStarted(time);
 
 			// Create MACD indicator
-			_macd = new MovingAverageConvergenceDivergence
-			{
-				FastMa = new ExponentialMovingAverage { Length = MacdFastPeriod },
-				SlowMa = new ExponentialMovingAverage { Length = MacdSlowPeriod },
-				SignalMa = new ExponentialMovingAverage { Length = MacdSignalPeriod }
-			};
 
+				_macd = new MovingAverageConvergenceDivergenceSignal
+				{
+					Macd =
+					{
+						ShortMa = { Length = MacdFastPeriod },
+						LongMa = { Length = MacdSlowPeriod },
+					},
+					SignalMa = { Length = MacdSignalPeriod }
+				};
 			// Initialize variables
 			_prevMacd = 0;
 			_prevSignal = 0;

--- a/API/0251_MACD_Breakout/MacdBreakoutStrategy.cs
+++ b/API/0251_MACD_Breakout/MacdBreakoutStrategy.cs
@@ -146,13 +146,16 @@ namespace StockSharp.Samples.Strategies
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			// Initialize indicators
-			_macd = new MovingAverageConvergenceDivergence
-			{
-				LongMa = new ExponentialMovingAverage { Length = SlowEmaPeriod },
-				ShortMa = new ExponentialMovingAverage { Length = FastEmaPeriod },
-				SignalMa = new ExponentialMovingAverage { Length = SignalPeriod }
-			};
 			
+				_macd = new MovingAverageConvergenceDivergenceSignal
+				{
+					Macd =
+					{
+						ShortMa = { Length = FastEmaPeriod },
+						LongMa = { Length = SlowEmaPeriod },
+					},
+					SignalMa = { Length = SignalPeriod }
+				};
 			_macdHistSma = new SimpleMovingAverage { Length = SmaPeriod };
 			_macdHistStdDev = new StandardDeviation { Length = SmaPeriod };
 

--- a/API/0271_MACD_Slope_Breakout/MacdSlopeBreakoutStrategy.cs
+++ b/API/0271_MACD_Slope_Breakout/MacdSlopeBreakoutStrategy.cs
@@ -126,13 +126,15 @@ namespace StockSharp.Samples.Strategies
 			base.OnStarted(time);
 			
 			// Initialize indicators
-			_macd = new MovingAverageConvergenceDivergence
+			_macd = new MovingAverageConvergenceDivergenceSignal
 			{
-				FastEma = new ExponentialMovingAverage { Length = FastEma },
-				SlowEma = new ExponentialMovingAverage { Length = SlowEma },
-				SignalMa = new ExponentialMovingAverage { Length = SignalMa }
+				Macd =
+				{
+					ShortMa = { Length = FastEma },
+					LongMa = { Length = SlowEma },
+				},
+				SignalMa = { Length = SignalMa }
 			};
-			
 			_macdHistSlope = new LinearRegression { Length = 2 }; // For calculating slope
 			
 			_prevSlopeValue = 0;

--- a/API/0290_MACD_Slope_Mean_Reversion/MacdSlopeMeanReversionStrategy.cs
+++ b/API/0290_MACD_Slope_Mean_Reversion/MacdSlopeMeanReversionStrategy.cs
@@ -151,13 +151,16 @@ namespace StockSharp.Samples.Strategies
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			// Initialize indicators
-			_macd = new MovingAverageConvergenceDivergence
-			{
-				FastMa = new ExponentialMovingAverage { Length = FastMacdPeriod },
-				SlowMa = new ExponentialMovingAverage { Length = SlowMacdPeriod },
-				SignalMa = new ExponentialMovingAverage { Length = SignalMacdPeriod }
-			};
 
+			_macd = new MovingAverageConvergenceDivergenceSignal
+			{
+				Macd =
+				{
+					ShortMa = { Length = FastMacdPeriod },
+					LongMa = { Length = SlowMacdPeriod },
+				},
+				SignalMa = { Length = SignalMacdPeriod }
+			};
 			// Initialize statistics variables
 			_sampleCount = 0;
 			_sumSlopes = 0;

--- a/API/0320_MACD_Hidden_Markov_Model/MacdHmmStrategy.cs
+++ b/API/0320_MACD_Hidden_Markov_Model/MacdHmmStrategy.cs
@@ -127,13 +127,16 @@ namespace StockSharp.Samples.Strategies
 			base.OnStarted(time);
 
 			// Create MACD indicator
-			_macd = new MovingAverageConvergenceDivergence
-			{
-				FastMa = new ExponentialMovingAverage { Length = MacdFast },
-				SlowMa = new ExponentialMovingAverage { Length = MacdSlow },
-				SignalMa = new ExponentialMovingAverage { Length = MacdSignal }
-			};
 
+			_macd = new MovingAverageConvergenceDivergenceSignal
+			{
+				Macd =
+				{
+					ShortMa = { Length = MacdFast },
+					LongMa = { Length = MacdSlow },
+				},
+				SignalMa = { Length = MacdSignal }
+			};
 			// Create subscription and bind indicator
 			var subscription = SubscribeCandles(CandleType);
 			

--- a/API/0339_MACD_Sentiment_Filter/MacdWithSentimentFilterStrategy.cs
+++ b/API/0339_MACD_Sentiment_Filter/MacdWithSentimentFilterStrategy.cs
@@ -139,13 +139,16 @@ namespace StockSharp.Samples.Strategies
 			base.OnStarted(time);
 			
 			// Create MACD indicator
-			var macd = new MovingAverageConvergenceDivergence
-			{
-				FastMa = new ExponentialMovingAverage { Length = MacdFast },
-				SlowMa = new ExponentialMovingAverage { Length = MacdSlow },
-				SignalMa = new ExponentialMovingAverage { Length = MacdSignal }
-			};
 			
+			var macd = new MovingAverageConvergenceDivergenceSignal
+			{
+				Macd =
+				{
+					ShortMa = { Length = MacdFast },
+					LongMa = { Length = MacdSlow },
+				},
+				SignalMa = { Length = MacdSignal }
+			};
 			// Initialize sentiment score
 			_sentimentScore = 0;
 			


### PR DESCRIPTION
## Summary
- replace uses of `MovingAverageConvergenceDivergence` with `MovingAverageConvergenceDivergenceSignal`
- update indicator initialization with read-only sub-indicators

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ee34819648323ad374a0d28f53463