### PR TITLE
Fix indicator processing using tabs

### DIFF
--- a/API/0155_VWAP_Volume/VwapVolumeStrategy.cs
+++ b/API/0155_VWAP_Volume/VwapVolumeStrategy.cs
@@ -138,8 +138,7 @@ namespace StockSharp.Samples.Strategies
 		private void ProcessCandle(ICandleMessage candle)
 		{
 			// Process volume with indicator
-			var volumeValue = new DecimalIndicatorValue(candle.TotalVolume);
-			var volumeMA = _volumeMA.Process(volumeValue).ToDecimal();
+			var volumeMA = _volumeMA.Process(candle.TotalVolume, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal();
 
 			// Calculate VWAP manually for the current candle
 			decimal vwap = 0;

--- a/API/0219_Statistical_Arbitrage/StatisticalArbitrageStrategy.cs
+++ b/API/0219_Statistical_Arbitrage/StatisticalArbitrageStrategy.cs
@@ -226,10 +226,9 @@ namespace StockSharp.Strategies
 			
 			// Store current price
 			_lastSecondPrice = candle.ClosePrice;
-			
+		
 			// Process through MA indicator
-			var secondValue = new DecimalIndicatorValue(candle.ClosePrice);
-			_secondMA.Process(secondValue);
+			_secondMA.Process(candle.ClosePrice, candle.ServerTime, candle.State == CandleStates.Finished);
 		}
 	}
 }

--- a/API/0251_MACD_Breakout/MacdBreakoutStrategy.cs
+++ b/API/0251_MACD_Breakout/MacdBreakoutStrategy.cs
@@ -207,9 +207,8 @@ namespace StockSharp.Samples.Strategies
 			var macdHistValue = macdValues[2];
 			
 			// Process indicators for MACD histogram
-			var macdHistInput = new DecimalIndicatorValue(macdHistValue);
-			var macdHistSmaValue = _macdHistSma.Process(macdHistInput).ToDecimal();
-			var macdHistStdDevValue = _macdHistStdDev.Process(macdHistInput).ToDecimal();
+			var macdHistSmaValue = _macdHistSma.Process(macdHistValue, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal();
+			var macdHistStdDevValue = _macdHistStdDev.Process(macdHistValue, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal();
 			
 			// Store previous values on first call
 			if (_prevMacdHistValue == 0 && _prevMacdHistSmaValue == 0)

--- a/API/0307_MACD_Adaptive_Histogram/MacdAdaptiveHistogramStrategy.cs
+++ b/API/0307_MACD_Adaptive_Histogram/MacdAdaptiveHistogramStrategy.cs
@@ -171,9 +171,8 @@ namespace StockSharp.Samples.Strategies
 					var histogram = macd - signal;
 					
 					// Process the histogram through the statistics indicators
-					var decimalValue = new DecimalIndicatorValue(histogram);
-					histAvg.Process(decimalValue);
-					histStdDev.Process(decimalValue);
+					histAvg.Process(histogram, macdValue.Time, macdValue.IsFinal);
+					histStdDev.Process(histogram, macdValue.Time, macdValue.IsFinal);
 				})
 				.Start();
 

--- a/API/0308_Ichimoku_Volume_Cluster/IchimokuVolumeClusterStrategy.cs
+++ b/API/0308_Ichimoku_Volume_Cluster/IchimokuVolumeClusterStrategy.cs
@@ -150,10 +150,9 @@ namespace StockSharp.Samples.Strategies
 			volumeSubscription
 				.BindEx(subscription, candle => {
 					var volume = candle.TotalVolume;
-					var volumeIndicatorValue = new DecimalIndicatorValue(volume);
-					
-					volumeAvg.Process(volumeIndicatorValue);
-					volumeStdDev.Process(volumeIndicatorValue);
+
+					volumeAvg.Process(volume, candle.ServerTime, candle.State == CandleStates.Finished);
+					volumeStdDev.Process(volume, candle.ServerTime, candle.State == CandleStates.Finished);
 				})
 				.Start();
 

--- a/API/0310_Donchian_Volatility_Contraction/DonchianVolatilityContractionStrategy.cs
+++ b/API/0310_Donchian_Volatility_Contraction/DonchianVolatilityContractionStrategy.cs
@@ -128,10 +128,8 @@ namespace StockSharp.Samples.Strategies
 					_currentDcWidth = highPrice - lowPrice;
 					
 					// Process SMA and StdDev for the channel width
-					var smaInput = new DecimalIndicatorValue(_currentDcWidth);
-					var smaValue = sma.Process(smaInput);
-					var stdDevInput = new DecimalIndicatorValue(_currentDcWidth);
-					var stdDevValue = standardDeviation.Process(stdDevInput);
+					var smaValue = sma.Process(_currentDcWidth, candle.ServerTime, candle.State == CandleStates.Finished);
+					var stdDevValue = standardDeviation.Process(_currentDcWidth, candle.ServerTime, candle.State == CandleStates.Finished);
 					
 					_avgDcWidth = smaValue.ToDecimal();
 					_stdDevDcWidth = stdDevValue.ToDecimal();

--- a/API/0312_Hull_MA_Volume_Spike/HullMaWithVolumeSpikeStrategy.cs
+++ b/API/0312_Hull_MA_Volume_Spike/HullMaWithVolumeSpikeStrategy.cs
@@ -110,9 +110,8 @@ namespace StockSharp.Samples.Strategies
 				.BindEx(hma, (candle, hmaValue) => 
 				{
 					// Process volume indicators
-					var volumeValue = new DecimalIndicatorValue(candle.TotalVolume);
-					var volumeSmaValue = volumeSma.Process(volumeValue);
-					var volumeStdDevValue = volumeStdDev.Process(volumeValue);
+					var volumeSmaValue = volumeSma.Process(candle.TotalVolume, candle.ServerTime, candle.State == CandleStates.Finished);
+					var volumeStdDevValue = volumeStdDev.Process(candle.TotalVolume, candle.ServerTime, candle.State == CandleStates.Finished);
 					
 					// Process the strategy logic
 					ProcessStrategy(

--- a/API/0315_Stochastic_Dynamic_Zones/StochasticWithDynamicZonesStrategy.cs
+++ b/API/0315_Stochastic_Dynamic_Zones/StochasticWithDynamicZonesStrategy.cs
@@ -151,9 +151,8 @@ namespace StockSharp.Samples.Strategies
 					var stochK = stochValue.ToDecimal();
 					
 					// Calculate dynamic zones
-					var stochKInput = new DecimalIndicatorValue(stochK);
-					var stochKAvg = stochSma.Process(stochKInput).ToDecimal();
-					var stochKStdDev = stochStdDev.Process(stochKInput).ToDecimal();
+					var stochKAvg = stochSma.Process(stochK, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal();
+					var stochKStdDev = stochStdDev.Process(stochK, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal();
 					
 					var dynamicOversold = stochKAvg - (StandardDeviationFactor * stochKStdDev);
 					var dynamicOverbought = stochKAvg + (StandardDeviationFactor * stochKStdDev);

--- a/API/0318_Williams_R_Momentum/WilliamsPercentRWithMomentumStrategy.cs
+++ b/API/0318_Williams_R_Momentum/WilliamsPercentRWithMomentumStrategy.cs
@@ -118,8 +118,7 @@ namespace StockSharp.Samples.Strategies
 				.Bind(williamsR, momentum, (candle, williamsRValue, momentumValue) =>
 				{
 					// Calculate momentum average
-					var momentumInput = new DecimalIndicatorValue(momentumValue);
-					var momentumAvg = momentumSma.Process(momentumInput).ToDecimal();
+					var momentumAvg = momentumSma.Process(momentumValue, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal();
 					
 					// Process the strategy logic
 					ProcessStrategy(candle, williamsRValue, momentumValue, momentumAvg);


### PR DESCRIPTION
## Summary
- re-indent strategy logic with tab-only alignment for SMA/StdDev processing
- process decimal values directly with candle metadata

## Testing
- `dotnet test -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ef8f02f688323a70765356bf86c7b