### PR TITLE
Refactor Stochastic initialization

### DIFF
--- a/API/0111_Stochastic_Failure_Swing/StochasticFailureSwingStrategy.cs
+++ b/API/0111_Stochastic_Failure_Swing/StochasticFailureSwingStrategy.cs
@@ -140,8 +140,8 @@ namespace StockSharp.Samples.Strategies
 			// Initialize indicators
 			_stochastic = new StochasticOscillator
 			{
-				KPeriod = KPeriod,
-				DPeriod = DPeriod,
+				K = { Length = KPeriod },
+				D = { Length = DPeriod },
 				Slowing = Slowing
 			};
 			

--- a/API/0138_MA_Stochastic/MaStochasticStrategy.cs
+++ b/API/0138_MA_Stochastic/MaStochasticStrategy.cs
@@ -166,9 +166,8 @@ namespace StockSharp.Samples.Strategies
 
 			var stochastic = new StochasticOscillator
 			{
-				Length = StochPeriod,
-				KPeriod = StochK,
-				DPeriod = StochD
+				K = { Length = StochK },
+				D = { Length = StochD },
 			};
 
 			// Create subscription and bind indicators

--- a/API/0142_Keltner_Stochastic/KeltnerStochasticStrategy.cs
+++ b/API/0142_Keltner_Stochastic/KeltnerStochasticStrategy.cs
@@ -211,9 +211,8 @@ namespace StockSharp.Samples.Strategies
 
 			var stochastic = new StochasticOscillator
 			{
-				Length = StochPeriod,
-				KPeriod = StochK,
-				DPeriod = StochD
+				K = { Length = StochK },
+				D = { Length = StochD },
 			};
 
 			// Create subscription and bind indicators

--- a/API/0148_RSI_Stochastic/RsiStochasticStrategy.cs
+++ b/API/0148_RSI_Stochastic/RsiStochasticStrategy.cs
@@ -197,9 +197,8 @@ namespace StockSharp.Samples.Strategies
 
 			var stochastic = new StochasticOscillator
 			{
-				Length = StochPeriod,
-				KPeriod = StochK,
-				DPeriod = StochD
+				K = { Length = StochK },
+				D = { Length = StochD },
 			};
 
 			// Create subscription and bind indicators

--- a/API/0150_VWAP_Stochastic/VwapStochasticStrategy.cs
+++ b/API/0150_VWAP_Stochastic/VwapStochasticStrategy.cs
@@ -146,9 +146,8 @@ namespace StockSharp.Samples.Strategies
 			var vwap = new VWAP();
 			var stochastic = new StochasticOscillator
 			{
-				Length = StochPeriod,
-				K = StochKPeriod,
-				D = StochDPeriod
+				K = { Length = StochKPeriod },
+				D = { Length = StochDPeriod },
 			};
 
 			// Create subscription

--- a/API/0158_Parabolic_SAR_Stochastic/ParabolicSarStochasticStrategy.cs
+++ b/API/0158_Parabolic_SAR_Stochastic/ParabolicSarStochasticStrategy.cs
@@ -161,9 +161,8 @@ namespace StockSharp.Samples.Strategies
 
 			var stochastic = new StochasticOscillator
 			{
-				KPeriod = StochK,
-				DPeriod = StochD,
-				Период = StochPeriod
+				K = { Length = StochK },
+				D = { Length = StochD },
 			};
 
 			// Reset state

--- a/API/0169_Hull_MA_Stochastic/HullStochasticStrategy.cs
+++ b/API/0169_Hull_MA_Stochastic/HullStochasticStrategy.cs
@@ -141,9 +141,8 @@ namespace StockSharp.Samples.Strategies
 
 			_stochastic = new StochasticOscillator
 			{
-				K = StochK,
-				D = StochD,
-				KPeriod = StochPeriod
+				K = { Length = StochK },
+				D = { Length = StochD },
 			};
 
 			_atr = new AverageTrueRange { Length = 14 };

--- a/API/0177_Ichimoku_Stochastic/IchimokuStochasticStrategy.cs
+++ b/API/0177_Ichimoku_Stochastic/IchimokuStochasticStrategy.cs
@@ -152,9 +152,8 @@ namespace StockSharp.Samples.Strategies
 
 			var stochastic = new StochasticOscillator
 			{
-				Length = StochPeriod,
-				KPeriod = StochK,
-				DPeriod = StochD
+				K = { Length = StochK },
+				D = { Length = StochD },
 			};
 
 			// Subscribe to candles and bind indicators

--- a/API/0248_Stochastic_Breakout/StochasticBreakoutStrategy.cs
+++ b/API/0248_Stochastic_Breakout/StochasticBreakoutStrategy.cs
@@ -131,9 +131,8 @@ namespace StockSharp.Samples.Strategies
 			// Initialize indicators
 			_stochastic = new StochasticOscillator
 			{
-				KPeriod = StochasticPeriod,
-				KSmoothing = KPeriod,
-				DPeriod = DPeriod
+				K = { Length = StochasticPeriod },
+				D = { Length = DPeriod },
 			};
 
 			_stochAverage = new SimpleMovingAverage { Length = LookbackPeriod };

--- a/API/0268_Stochastic_Slope_Breakout/StochasticSlopeBreakoutStrategy.cs
+++ b/API/0268_Stochastic_Slope_Breakout/StochasticSlopeBreakoutStrategy.cs
@@ -149,9 +149,8 @@ namespace StockSharp.Samples.Strategies
 		{
 			_stochastic = new StochasticOscillator
 			{
-				K = KPeriod,
-				D = DPeriod,
-				Length = StochPeriod
+				K = { Length = KPeriod },
+				D = { Length = DPeriod },
 			};
 			
 			_prevStochKValue = 0;

--- a/API/0287_Stochastic_Slope_Mean_Reversion/StochasticSlopeMeanReversionStrategy.cs
+++ b/API/0287_Stochastic_Slope_Mean_Reversion/StochasticSlopeMeanReversionStrategy.cs
@@ -156,9 +156,8 @@ namespace StockSharp.Samples.Strategies
 			// Create Stochastic indicator
 			var stochastic = new StochasticOscillator
 			{
-				Length = StochPeriod,
-				KPeriod = StochKPeriod,
-				DPeriod = StochDPeriod
+				K = { Length = StochKPeriod },
+				D = { Length = StochDPeriod },
 			};
 
 			// Subscribe to candles and bind indicator

--- a/API/0315_Stochastic_Dynamic_Zones/StochasticWithDynamicZonesStrategy.cs
+++ b/API/0315_Stochastic_Dynamic_Zones/StochasticWithDynamicZonesStrategy.cs
@@ -133,9 +133,8 @@ namespace StockSharp.Samples.Strategies
 			// Create indicators
 			var stochastic = new StochasticOscillator
 			{
-				K = StochKPeriod,
-				D = StochDPeriod,
-				Length = StochPeriod
+				K = { Length = StochKPeriod },
+				D = { Length = StochDPeriod },
 			};
 			
 			var stochSma = new SimpleMovingAverage { Length = LookbackPeriod };

--- a/API/0348_Stochastic_Implied_Volatility_Skew/StochasticImpliedVolatilitySkewStrategy.cs
+++ b/API/0348_Stochastic_Implied_Volatility_Skew/StochasticImpliedVolatilitySkewStrategy.cs
@@ -128,9 +128,8 @@ namespace StockSharp.Samples.Strategies
 			// Create Stochastic Oscillator
 			_stochastic = new StochasticOscillator
 			{
-				Length = StochLength,
-				K = StochK,
-				D = StochD
+				K = { Length = StochK },
+				D = { Length = StochD },
 			};
 
 			// Create IV Skew SMA


### PR DESCRIPTION
## Summary
- update StochasticOscillator usage to init readonly K and D components
- restore tab-based indentation

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fc6946c9083238a515f9f7c9875d8