### PR TITLE
Clean up XML comments

### DIFF
--- a/API/0220_Volatility_Breakout/VolatilityBreakoutStrategy.cs
+++ b/API/0220_Volatility_Breakout/VolatilityBreakoutStrategy.cs
@@ -71,9 +71,7 @@ namespace StockSharp.Samples.Strategies
 				.SetDisplay("Candle Type", "Candle type for strategy", "Common");
 		}
 
-		/// <summary>
-		/// Returns working securities.
-		/// </summary>
+		/// <inheritdoc />
 		public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
 		{
 			return [(Security, CandleType)];

--- a/API/0221_Bollinger_Band_Squeeze/BollingerBandSqueezeStrategy.cs
+++ b/API/0221_Bollinger_Band_Squeeze/BollingerBandSqueezeStrategy.cs
@@ -89,9 +89,7 @@ namespace StockSharp.Samples.Strategies
 				.SetDisplay("Candle Type", "Candle type for strategy", "Common");
 		}
 
-		/// <summary>
-		/// Returns working securities.
-		/// </summary>
+		/// <inheritdoc />
 		public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
 		{
 			return [(Security, CandleType)];

--- a/API/0222_Cointegration_Pairs/CointegrationPairsStrategy.cs
+++ b/API/0222_Cointegration_Pairs/CointegrationPairsStrategy.cs
@@ -125,9 +125,7 @@ namespace StockSharp.Samples.Strategies
 				.SetDisplay("Candle Type", "Candle type for strategy", "Common");
 		}
 
-		/// <summary>
-		/// Returns working securities.
-		/// </summary>
+		/// <inheritdoc />
 		public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
 		{
 			return

--- a/API/0223_Momentum_Divergence/MomentumDivergenceStrategy.cs
+++ b/API/0223_Momentum_Divergence/MomentumDivergenceStrategy.cs
@@ -74,9 +74,7 @@ namespace StockSharp.Samples.Strategies
 				.SetDisplay("Candle Type", "Candle type for strategy", "Common");
 		}
 
-		/// <summary>
-		/// Returns working securities.
-		/// </summary>
+		/// <inheritdoc />
 		public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
 		{
 			return [(Security, CandleType)];

--- a/API/0224_ATR_Mean_Reversion/AtrMeanReversionStrategy.cs
+++ b/API/0224_ATR_Mean_Reversion/AtrMeanReversionStrategy.cs
@@ -85,9 +85,7 @@ namespace StockSharp.Samples.Strategies
 				.SetDisplay("Candle Type", "Candle type for strategy", "Common");
 		}
 
-		/// <summary>
-		/// Returns working securities.
-		/// </summary>
+		/// <inheritdoc />
 		public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
 		{
 			return [(Security, CandleType)];

--- a/API/0225_Kalman_Filter_Trend/KalmanFilterTrendStrategy.cs
+++ b/API/0225_Kalman_Filter_Trend/KalmanFilterTrendStrategy.cs
@@ -69,9 +69,7 @@ namespace StockSharp.Samples.Strategies
 				.SetDisplay("Candle Type", "Candle type for strategy", "Common");
 		}
 
-		/// <summary>
-		/// Returns working securities.
-		/// </summary>
+		/// <inheritdoc />
 		public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
 		{
 			return [(Security, CandleType)];

--- a/API/0226_Volatility_Adjusted_Mean_Reversion/VolatilityAdjustedMeanReversionStrategy.cs
+++ b/API/0226_Volatility_Adjusted_Mean_Reversion/VolatilityAdjustedMeanReversionStrategy.cs
@@ -70,9 +70,7 @@ namespace StockSharp.Samples.Strategies
 				.SetDisplay("Candle Type", "Candle type for strategy", "Common");
 		}
 
-		/// <summary>
-		/// Returns working securities.
-		/// </summary>
+		/// <inheritdoc />
 		public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
 		{
 			return [(Security, CandleType)];

--- a/API/0227_Hurst_Exponent_Trend/HurstExponentTrendStrategy.cs
+++ b/API/0227_Hurst_Exponent_Trend/HurstExponentTrendStrategy.cs
@@ -86,9 +86,7 @@ namespace StockSharp.Samples.Strategies
 				.SetDisplay("Candle Type", "Candle type for strategy", "Common");
 		}
 
-		/// <summary>
-		/// Returns working securities.
-		/// </summary>
+		/// <inheritdoc />
 		public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
 		{
 			return [(Security, CandleType)];


### PR DESCRIPTION
## Summary
- replace XML comments on several Strategy overrides with `<inheritdoc />`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fcf02357c8323a3ffe40717256dec