### PR TITLE
Switch complex indicators to BindEx

### DIFF
--- a/API/0003_ADX_Trend/AdxTrendStrategy.cs
+++ b/API/0003_ADX_Trend/AdxTrendStrategy.cs
@@ -122,7 +122,7 @@ namespace StockSharp.Samples.Strategies
 			// Create subscription and bind indicators
 			var subscription = SubscribeCandles(CandleType);
 			subscription
-				.Bind(adx, ma, atr, ProcessCandle)
+				.BindEx(adx, ma, atr, ProcessCandle)
 				.Start();
 
 			// Setup chart visualization if available
@@ -143,7 +143,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal adxValue, decimal maValue, decimal atrValue)
+		private void ProcessCandle(ICandleMessage candle, IIndicatorValue adxValue, IIndicatorValue maValue, IIndicatorValue atrValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0005_Donchian_Channel/DonchianChannelStrategy.cs
+++ b/API/0005_Donchian_Channel/DonchianChannelStrategy.cs
@@ -75,7 +75,7 @@ namespace StockSharp.Samples.Strategies
 			// Create subscription and bind indicators
 			var subscription = SubscribeCandles(CandleType);
 			subscription
-				.Bind(donchian, ProcessCandle)
+				.BindEx(donchian, ProcessCandle)
 				.Start();
 
 			// Setup chart visualization if available
@@ -88,7 +88,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal midValue, decimal upperValue, decimal lowerValue)
+		private void ProcessCandle(ICandleMessage candle, IIndicatorValue midValue, IIndicatorValue upperValue, IIndicatorValue lowerValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0009_MACD_Trend/MacdTrendStrategy.cs
+++ b/API/0009_MACD_Trend/MacdTrendStrategy.cs
@@ -124,7 +124,7 @@ namespace StockSharp.Samples.Strategies
 			// Create subscription and bind indicator
 			var subscription = SubscribeCandles(CandleType);
 			subscription
-				.Bind(macd, ProcessCandle)
+				.BindEx(macd, ProcessCandle)
 				.Start();
 
 			// Setup chart visualization if available
@@ -143,7 +143,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal macdValue, decimal signalValue)
+		private void ProcessCandle(ICandleMessage candle, IIndicatorValue macdValue, IIndicatorValue signalValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0021_Bollinger_Squeeze/BollingerSqueezeStrategy.cs
+++ b/API/0021_Bollinger_Squeeze/BollingerSqueezeStrategy.cs
@@ -108,7 +108,7 @@ namespace StockSharp.Samples.Strategies
 			// Subscribe to candles and bind the indicator
 			var subscription = SubscribeCandles(CandleType);
 			subscription
-				.Bind(bollingerBands, ProcessCandle)
+				.BindEx(bollingerBands, ProcessCandle)
 				.Start();
 
 			// Setup chart visualization
@@ -121,7 +121,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal middleBand, decimal upperBand, decimal lowerBand)
+		private void ProcessCandle(ICandleMessage candle, IIndicatorValue middleBand, IIndicatorValue upperBand, IIndicatorValue lowerBand)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0023_Elder_Impulse/ElderImpulseStrategy.cs
+++ b/API/0023_Elder_Impulse/ElderImpulseStrategy.cs
@@ -144,7 +144,7 @@ namespace StockSharp.Samples.Strategies
 			
 			// Process candles with both indicators
 			subscription
-				.Bind(ema, macd, ProcessCandle)
+				.BindEx(ema, macd, ProcessCandle)
 				.Start();
 
 			// Enable position protection
@@ -165,7 +165,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal emaValue, MacdSignalValue macdValue)
+		private void ProcessCandle(ICandleMessage candle, IIndicatorValue emaValue, IIndicatorValue macdValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0033_MACD_Zero/MacdZeroStrategy.cs
+++ b/API/0033_MACD_Zero/MacdZeroStrategy.cs
@@ -125,7 +125,7 @@ namespace StockSharp.Samples.Strategies
 			// Create subscription and bind MACD indicator
 			var subscription = SubscribeCandles(CandleType);
 			subscription
-				.Bind(macd, ProcessCandle)
+				.BindEx(macd, ProcessCandle)
 				.Start();
 
 			// Configure chart
@@ -147,7 +147,7 @@ namespace StockSharp.Samples.Strategies
 		/// <summary>
 		/// Process candle and check for MACD signals
 		/// </summary>
-		private void ProcessCandle(ICandleMessage candle, decimal macdValue, decimal signalValue)
+		private void ProcessCandle(ICandleMessage candle, IIndicatorValue macdValue, IIndicatorValue signalValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0062_Stochastic_Overbought_Oversold/StochOverboughtOversoldStrategy.cs
+++ b/API/0062_Stochastic_Overbought_Oversold/StochOverboughtOversoldStrategy.cs
@@ -103,7 +103,7 @@ namespace StockSharp.Samples.Strategies
 			var subscription = SubscribeCandles(CandleType);
 
 			subscription
-				.Bind(stochastic, ProcessCandle)
+				.BindEx(stochastic, ProcessCandle)
 				.Start();
 
 			// Setup stop loss/take profit protection
@@ -122,7 +122,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal kValue, decimal dValue)
+		private void ProcessCandle(ICandleMessage candle, IIndicatorValue kValue, IIndicatorValue dValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0090_Donchian_Reversal/DonchianReversalStrategy.cs
+++ b/API/0090_Donchian_Reversal/DonchianReversalStrategy.cs
@@ -98,7 +98,7 @@ namespace StockSharp.Samples.Strategies
 			
 			// Bind indicator and process candles
 			subscription
-				.Bind(donchian, ProcessCandle)
+				.BindEx(donchian, ProcessCandle)
 				.Start();
 				
 			// Setup chart visualization
@@ -118,7 +118,7 @@ namespace StockSharp.Samples.Strategies
 		/// <param name="upperBand">Upper band value.</param>
 		/// <param name="middleBand">Middle band value.</param>
 		/// <param name="lowerBand">Lower band value.</param>
-		private void ProcessCandle(ICandleMessage candle, decimal upperBand, decimal middleBand, decimal lowerBand)
+		private void ProcessCandle(ICandleMessage candle, IIndicatorValue upperBand, IIndicatorValue middleBand, IIndicatorValue lowerBand)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0091_MACD_Histogram_Reversal/MacdHistogramReversalStrategy.cs
+++ b/API/0091_MACD_Histogram_Reversal/MacdHistogramReversalStrategy.cs
@@ -135,7 +135,7 @@ namespace StockSharp.Samples.Strategies
 			
 			// Bind indicator and process candles
 			subscription
-				.Bind(macdHistogram, ProcessCandle)
+				.BindEx(macdHistogram, ProcessCandle)
 				.Start();
 				
 			// Setup chart visualization
@@ -153,7 +153,7 @@ namespace StockSharp.Samples.Strategies
 		/// </summary>
 		/// <param name="candle">Candle.</param>
 		/// <param name="histogramValue">MACD histogram value.</param>
-		private void ProcessCandle(ICandleMessage candle, decimal histogramValue)
+		private void ProcessCandle(ICandleMessage candle, IIndicatorValue histogramValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0093_Stochastic_Hook_Reversal/StochasticHookReversalStrategy.cs
+++ b/API/0093_Stochastic_Hook_Reversal/StochasticHookReversalStrategy.cs
@@ -176,7 +176,7 @@ namespace StockSharp.Samples.Strategies
 			
 			// Bind indicator and process candles
 			subscription
-				.Bind(stochastic, ProcessCandle)
+				.BindEx(stochastic, ProcessCandle)
 				.Start();
 				
 			// Setup chart visualization
@@ -195,7 +195,7 @@ namespace StockSharp.Samples.Strategies
 		/// <param name="candle">Candle.</param>
 		/// <param name="kValue">Stochastic %K value.</param>
 		/// <param name="dValue">Stochastic %D value.</param>
-		private void ProcessCandle(ICandleMessage candle, decimal kValue, decimal dValue)
+		private void ProcessCandle(ICandleMessage candle, IIndicatorValue kValue, IIndicatorValue dValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0103_Dark_Pool_Prints/DarkPoolPrintsStrategy.cs
+++ b/API/0103_Dark_Pool_Prints/DarkPoolPrintsStrategy.cs
@@ -118,7 +118,7 @@ namespace StockSharp.Samples.Strategies
 
 			// Bind indicators and processor
 			subscription
-				.Bind(_ma, _volumeAverage, _adx, _atr, ProcessCandle)
+				.BindEx(_ma, _volumeAverage, _adx, _atr, ProcessCandle)
 				.Start();
 
 			// Enable stop-loss protection
@@ -135,7 +135,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal ma, decimal volumeAvg, decimal adx, decimal atr)
+		private void ProcessCandle(ICandleMessage candle, IIndicatorValue ma, IIndicatorValue volumeAvg, IIndicatorValue adx, IIndicatorValue atr)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0111_Stochastic_Failure_Swing/StochasticFailureSwingStrategy.cs
+++ b/API/0111_Stochastic_Failure_Swing/StochasticFailureSwingStrategy.cs
@@ -155,7 +155,7 @@ namespace StockSharp.Samples.Strategies
 			
 			// Bind indicator and processor
 			subscription
-				.Bind(_stochastic, ProcessCandle)
+				.BindEx(_stochastic, ProcessCandle)
 				.Start();
 			
 			// Enable stop-loss protection

--- a/API/0131_MACD_RSI/MacdRsiStrategy.cs
+++ b/API/0131_MACD_RSI/MacdRsiStrategy.cs
@@ -177,7 +177,7 @@ namespace StockSharp.Strategies.Samples
 			
 			// When both indicators are ready, process the candle
 			subscription
-				.Bind(macd, rsi, ProcessCandle)
+				.BindEx(macd, rsi, ProcessCandle)
 				.Start();
 				
 			// Set up chart if available
@@ -205,7 +205,7 @@ namespace StockSharp.Strategies.Samples
 		/// <param name="macdValue">MACD line value.</param>
 		/// <param name="signalValue">MACD signal line value.</param>
 		/// <param name="rsiValue">RSI value.</param>
-		private void ProcessCandle(ICandleMessage candle, decimal macdValue, decimal signalValue, decimal rsiValue)
+		private void ProcessCandle(ICandleMessage candle, IIndicatorValue macdValue, IIndicatorValue signalValue, IIndicatorValue rsiValue)
 		{
 			if (candle.State != CandleStates.Finished)
 				return;

--- a/API/0138_MA_Stochastic/MaStochasticStrategy.cs
+++ b/API/0138_MA_Stochastic/MaStochasticStrategy.cs
@@ -174,7 +174,7 @@ namespace StockSharp.Samples.Strategies
 			var subscription = SubscribeCandles(CandleType);
 
 			subscription
-				.Bind(ma, stochastic, ProcessCandles)
+				.BindEx(ma, stochastic, ProcessCandles)
 				.Start();
 
 			// Setup position protection
@@ -197,7 +197,7 @@ namespace StockSharp.Samples.Strategies
 		/// <summary>
 		/// Process candles and indicator values.
 		/// </summary>
-		private void ProcessCandles(ICandleMessage candle, decimal maValue, decimal stochKValue)
+		private void ProcessCandles(ICandleMessage candle, IIndicatorValue maValue, IIndicatorValue stochKValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0141_Donchian_Volume/DonchianVolumeStrategy.cs
+++ b/API/0141_Donchian_Volume/DonchianVolumeStrategy.cs
@@ -138,7 +138,7 @@ namespace StockSharp.Samples.Strategies
 				.Start();
 
 			subscription
-				.Bind(donchianHigh, donchianLow, ProcessDonchian)
+				.BindEx(donchianHigh, donchianLow, ProcessDonchian)
 				.Start();
 
 			// Setup position protection
@@ -178,7 +178,7 @@ namespace StockSharp.Samples.Strategies
 		/// <summary>
 		/// Process Donchian Channel values.
 		/// </summary>
-		private void ProcessDonchian(ICandleMessage candle, decimal highestValue, decimal lowestValue)
+		private void ProcessDonchian(ICandleMessage candle, IIndicatorValue highestValue, IIndicatorValue lowestValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0142_Keltner_Stochastic/KeltnerStochasticStrategy.cs
+++ b/API/0142_Keltner_Stochastic/KeltnerStochasticStrategy.cs
@@ -227,7 +227,7 @@ namespace StockSharp.Samples.Strategies
 				.Start();
 
 			subscription
-				.Bind(stochastic, ProcessStochastic)
+				.BindEx(stochastic, ProcessStochastic)
 				.Start();
 
 			// Setup position protection
@@ -259,7 +259,7 @@ namespace StockSharp.Samples.Strategies
 		/// <summary>
 		/// Process Stochastic indicator values.
 		/// </summary>
-		private void ProcessStochastic(ICandleMessage candle, decimal stochKValue)
+		private void ProcessStochastic(ICandleMessage candle, IIndicatorValue stochKValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0146_MACD_Volume/MacdVolumeStrategy.cs
+++ b/API/0146_MACD_Volume/MacdVolumeStrategy.cs
@@ -176,7 +176,7 @@ namespace StockSharp.Samples.Strategies
 
 			// Bind MACD for trade decisions
 			subscription
-				.Bind(macd, ProcessMacd)
+				.BindEx(macd, ProcessMacd)
 				.Start();
 
 			// Setup position protection
@@ -209,7 +209,7 @@ namespace StockSharp.Samples.Strategies
 		/// <summary>
 		/// Process MACD indicator values.
 		/// </summary>
-		private void ProcessMacd(ICandleMessage candle, decimal macdValue, decimal signalValue)
+		private void ProcessMacd(ICandleMessage candle, IIndicatorValue macdValue, IIndicatorValue signalValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0148_RSI_Stochastic/RsiStochasticStrategy.cs
+++ b/API/0148_RSI_Stochastic/RsiStochasticStrategy.cs
@@ -205,7 +205,7 @@ namespace StockSharp.Samples.Strategies
 			var subscription = SubscribeCandles(CandleType);
 
 			subscription
-				.Bind(rsi, stochastic, ProcessIndicators)
+				.BindEx(rsi, stochastic, ProcessIndicators)
 				.Start();
 
 			// Setup position protection

--- a/API/0149_MA_ADX/MaAdxStrategy.cs
+++ b/API/0149_MA_ADX/MaAdxStrategy.cs
@@ -122,7 +122,7 @@ namespace StockSharp.Samples.Strategies
 
 			// Bind indicators to candles
 			subscription
-				.Bind(ma, adx, atr, ProcessCandle)
+				.BindEx(ma, adx, atr, ProcessCandle)
 				.Start();
 
 			// Enable stop-loss and take-profit
@@ -144,7 +144,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal maValue, decimal adxValue, decimal atrValue)
+		private void ProcessCandle(ICandleMessage candle, IIndicatorValue maValue, IIndicatorValue adxValue, IIndicatorValue atrValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0150_VWAP_Stochastic/VwapStochasticStrategy.cs
+++ b/API/0150_VWAP_Stochastic/VwapStochasticStrategy.cs
@@ -155,7 +155,7 @@ namespace StockSharp.Samples.Strategies
 
 			// Bind indicators to candles
 			subscription
-				.Bind(vwap, stochastic, ProcessCandle)
+				.BindEx(vwap, stochastic, ProcessCandle)
 				.Start();
 
 			// Enable stop-loss and take-profit protection
@@ -180,7 +180,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal vwapValue, decimal kValue)
+		private void ProcessCandle(ICandleMessage candle, IIndicatorValue vwapValue, IIndicatorValue kValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0156_Donchian_RSI/DonchianRsiStrategy.cs
+++ b/API/0156_Donchian_RSI/DonchianRsiStrategy.cs
@@ -139,7 +139,7 @@ namespace StockSharp.Samples.Strategies
 
 			// Bind indicators to candles
 			subscription
-				.Bind(donchian, rsi, ProcessCandle)
+				.BindEx(donchian, rsi, ProcessCandle)
 				.Start();
 
 			// Enable stop-loss
@@ -165,7 +165,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal middleBand, decimal upperBand, decimal lowerBand, decimal rsiValue)
+		private void ProcessCandle(ICandleMessage candle, IIndicatorValue middleBand, IIndicatorValue upperBand, IIndicatorValue lowerBand, IIndicatorValue rsiValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0158_Parabolic_SAR_Stochastic/ParabolicSarStochasticStrategy.cs
+++ b/API/0158_Parabolic_SAR_Stochastic/ParabolicSarStochasticStrategy.cs
@@ -174,7 +174,7 @@ namespace StockSharp.Samples.Strategies
 			
 			// Bind indicators to candles
 			subscription
-				.Bind(parabolicSar, stochastic, ProcessCandle)
+				.BindEx(parabolicSar, stochastic, ProcessCandle)
 				.Start();
 
 			// Setup chart visualization if available
@@ -198,7 +198,7 @@ namespace StockSharp.Samples.Strategies
 			// when price crosses SAR in the opposite direction
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal sarValue, decimal stochKValue)
+		private void ProcessCandle(ICandleMessage candle, IIndicatorValue sarValue, IIndicatorValue stochKValue)
 		{
 			if (candle.State != CandleStates.Finished)
 				return;

--- a/API/0160_ADX_Volume/AdxVolumeStrategy.cs
+++ b/API/0160_ADX_Volume/AdxVolumeStrategy.cs
@@ -122,7 +122,7 @@ namespace StockSharp.Samples.Strategies
 			
 			// Bind ADX indicator to candles
 			subscription
-				.Bind(adx, ProcessCandle)
+				.BindEx(adx, ProcessCandle)
 				.Start();
 
 			// Setup chart visualization if available
@@ -138,7 +138,7 @@ namespace StockSharp.Samples.Strategies
 			StartProtection(new(), StopLoss);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal adxValue, decimal diPlusValue, decimal diMinusValue)
+		private void ProcessCandle(ICandleMessage candle, IIndicatorValue adxValue, IIndicatorValue diPlusValue, IIndicatorValue diMinusValue)
 		{
 			if (candle.State != CandleStates.Finished)
 				return;

--- a/API/0161_MACD_CCI/MacdCciStrategy.cs
+++ b/API/0161_MACD_CCI/MacdCciStrategy.cs
@@ -161,7 +161,7 @@ namespace StockSharp.Samples.Strategies
 			
 			// Bind indicators to candles
 			subscription
-				.Bind(macd, cci, ProcessCandle)
+				.BindEx(macd, cci, ProcessCandle)
 				.Start();
 
 			// Setup chart visualization if available
@@ -185,7 +185,7 @@ namespace StockSharp.Samples.Strategies
 			StartProtection(new(), StopLoss);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal macdValue, decimal cciValue)
+		private void ProcessCandle(ICandleMessage candle, IIndicatorValue macdValue, IIndicatorValue cciValue)
 		{
 			if (candle.State != CandleStates.Finished)
 				return;

--- a/API/0166_Donchian_Stochastic/DonchianStochasticStrategy.cs
+++ b/API/0166_Donchian_Stochastic/DonchianStochasticStrategy.cs
@@ -150,7 +150,7 @@ namespace StockSharp.Samples.Strategies
 			var subscription = SubscribeCandles(CandleType);
 			
 			subscription
-				.Bind(_donchian, _stochastic, ProcessCandle)
+				.BindEx(_donchian, _stochastic, ProcessCandle)
 				.Start();
 
 			// Setup chart
@@ -171,9 +171,9 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		private void ProcessCandle(
-			ICandleMessage candle, 
-			(decimal upper, decimal middle, decimal lower) donchianValues, 
-			(decimal k, decimal d) stochValues)
+			ICandleMessage candle,
+			IIndicatorValue donchianValues,
+			IIndicatorValue stochValues)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0170_ADX_CCI/AdxCciStrategy.cs
+++ b/API/0170_ADX_CCI/AdxCciStrategy.cs
@@ -113,7 +113,7 @@ namespace StockSharp.Samples.Strategies
 			// Subscribe to candles and bind indicators
 			var subscription = SubscribeCandles(CandleType);
 			subscription
-				.Bind(adx, cci, ProcessCandle)
+				.BindEx(adx, cci, ProcessCandle)
 				.Start();
 
 			// Setup chart visualization if available
@@ -134,7 +134,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal adxValue, decimal cciValue)
+		private void ProcessCandle(ICandleMessage candle, IIndicatorValue adxValue, IIndicatorValue cciValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0171_MACD_Williams_R/MacdWilliamsRStrategy.cs
+++ b/API/0171_MACD_Williams_R/MacdWilliamsRStrategy.cs
@@ -148,7 +148,7 @@ namespace StockSharp.Samples.Strategies
 			// Subscribe to candles and bind indicators
 			var subscription = SubscribeCandles(CandleType);
 			subscription
-				.Bind(macd, williamsR, ProcessCandle)
+				.BindEx(macd, williamsR, ProcessCandle)
 				.Start();
 
 			// Setup chart visualization if available
@@ -169,7 +169,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal macdValue, decimal williamsRValue)
+		private void ProcessCandle(ICandleMessage candle, IIndicatorValue macdValue, IIndicatorValue williamsRValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0174_MACD_VWAP/MacdVwapStrategy.cs
+++ b/API/0174_MACD_VWAP/MacdVwapStrategy.cs
@@ -132,7 +132,7 @@ namespace StockSharp.Samples.Strategies
 			// Subscribe to candles and bind indicators
 			var subscription = SubscribeCandles(CandleType);
 			subscription
-				.Bind(macd, vwap, ProcessCandle)
+				.BindEx(macd, vwap, ProcessCandle)
 				.Start();
 
 			// Setup chart visualization if available
@@ -146,7 +146,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal macdValue, decimal vwapValue)
+		private void ProcessCandle(ICandleMessage candle, IIndicatorValue macdValue, IIndicatorValue vwapValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0177_Ichimoku_Stochastic/IchimokuStochasticStrategy.cs
+++ b/API/0177_Ichimoku_Stochastic/IchimokuStochasticStrategy.cs
@@ -160,7 +160,7 @@ namespace StockSharp.Samples.Strategies
 			var subscription = SubscribeCandles(CandleType);
 			
 			subscription
-				.Bind(ichimoku, stochastic, ProcessCandle)
+				.BindEx(ichimoku, stochastic, ProcessCandle)
 				.Start();
 
 			// Setup chart visualization if available
@@ -181,7 +181,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal ichimokuValue, decimal stochasticValue)
+		private void ProcessCandle(ICandleMessage candle, IIndicatorValue ichimokuValue, IIndicatorValue stochasticValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0193_Supertrend_ADX/SupertrendAdxStrategy.cs
+++ b/API/0193_Supertrend_ADX/SupertrendAdxStrategy.cs
@@ -132,7 +132,7 @@ namespace StockSharp.Samples.Strategies
 
 			// Process candles with Supertrend and ADX indicators
 			subscription
-				.Bind(supertrend, adx, ProcessCandle)
+				.BindEx(supertrend, adx, ProcessCandle)
 				.Start();
 
 			// Setup chart visualization if available
@@ -146,7 +146,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal supertrendValue, decimal adxValue)
+		private void ProcessCandle(ICandleMessage candle, IIndicatorValue supertrendValue, IIndicatorValue adxValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0214_Bollinger_Supertrend/BollingerSupertrendStrategy.cs
+++ b/API/0214_Bollinger_Supertrend/BollingerSupertrendStrategy.cs
@@ -135,7 +135,7 @@ namespace StockSharp.Strategies
 			
 			// Bind Bollinger indicator to candle subscription
 			subscription
-				.Bind(_bollinger, _atr, ProcessCandle)
+				.BindEx(_bollinger, _atr, ProcessCandle)
 				.Start();
 			
 			// Setup chart if available
@@ -148,7 +148,7 @@ namespace StockSharp.Strategies
 			}
 		}
 		
-		private void ProcessCandle(ICandleMessage candle, decimal bollingerValue, decimal atrValue)
+		private void ProcessCandle(ICandleMessage candle, IIndicatorValue bollingerValue, IIndicatorValue atrValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0251_MACD_Breakout/MacdBreakoutStrategy.cs
+++ b/API/0251_MACD_Breakout/MacdBreakoutStrategy.cs
@@ -163,7 +163,7 @@ namespace StockSharp.Samples.Strategies
 			var subscription = SubscribeCandles(CandleType);
 			
 			subscription
-				.Bind(_macd, ProcessCandle)
+				.BindEx(_macd, ProcessCandle)
 				.Start();
 
 			// Enable position protection

--- a/API/0268_Stochastic_Slope_Breakout/StochasticSlopeBreakoutStrategy.cs
+++ b/API/0268_Stochastic_Slope_Breakout/StochasticSlopeBreakoutStrategy.cs
@@ -163,7 +163,7 @@ namespace StockSharp.Samples.Strategies
 
 			var subscription = SubscribeCandles(CandleType);
 			subscription
-				.Bind(_stochastic, ProcessCandle)
+				.BindEx(_stochastic, ProcessCandle)
 				.Start();
 
 			// Setup chart visualization if available

--- a/API/0271_MACD_Slope_Breakout/MacdSlopeBreakoutStrategy.cs
+++ b/API/0271_MACD_Slope_Breakout/MacdSlopeBreakoutStrategy.cs
@@ -147,7 +147,7 @@ namespace StockSharp.Samples.Strategies
 			// Create subscription and bind indicator
 			var subscription = SubscribeCandles(CandleType);
 			subscription
-				.Bind(_macd, ProcessCandle)
+				.BindEx(_macd, ProcessCandle)
 				.Start();
 			
 			// Setup chart visualization
@@ -163,7 +163,7 @@ namespace StockSharp.Samples.Strategies
 			StartProtection(new(), new Unit(StopLossPercent, UnitTypes.Percent));
 		}
 		
-		private void ProcessCandle(ICandleMessage candle, decimal macdValue, decimal signalValue)
+		private void ProcessCandle(ICandleMessage candle, IIndicatorValue macdValue, IIndicatorValue signalValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0287_Stochastic_Slope_Mean_Reversion/StochasticSlopeMeanReversionStrategy.cs
+++ b/API/0287_Stochastic_Slope_Mean_Reversion/StochasticSlopeMeanReversionStrategy.cs
@@ -164,7 +164,7 @@ namespace StockSharp.Samples.Strategies
 			var subscription = SubscribeCandles(CandleType);
 			
 			subscription
-				.Bind(stochastic, ProcessCandle)
+				.BindEx(stochastic, ProcessCandle)
 				.Start();
 
 			// Start position protection
@@ -183,7 +183,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal kValue, decimal dValue)
+		private void ProcessCandle(ICandleMessage candle, IIndicatorValue kValue, IIndicatorValue dValue)
 		{
 			if (candle.State != CandleStates.Finished)
 				return;

--- a/API/0290_MACD_Slope_Mean_Reversion/MacdSlopeMeanReversionStrategy.cs
+++ b/API/0290_MACD_Slope_Mean_Reversion/MacdSlopeMeanReversionStrategy.cs
@@ -170,7 +170,7 @@ namespace StockSharp.Samples.Strategies
 			// Create subscription and bind indicator
 			var subscription = SubscribeCandles(CandleType);
 			subscription
-				.Bind(_macd, ProcessCandle)
+				.BindEx(_macd, ProcessCandle)
 				.Start();
 
 			// Set up chart visualization if available
@@ -190,7 +190,7 @@ namespace StockSharp.Samples.Strategies
 			base.OnStarted(time);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal macdValue, decimal signalValue)
+		private void ProcessCandle(ICandleMessage candle, IIndicatorValue macdValue, IIndicatorValue signalValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0291_ADX_Slope_Mean_Reversion/AdxSlopeMeanReversionStrategy.cs
+++ b/API/0291_ADX_Slope_Mean_Reversion/AdxSlopeMeanReversionStrategy.cs
@@ -133,7 +133,7 @@ namespace StockSharp.Samples.Strategies
 			// Create subscription and bind indicator
 			var subscription = SubscribeCandles(CandleType);
 			subscription
-				.Bind(_adx, ProcessCandle)
+				.BindEx(_adx, ProcessCandle)
 				.Start();
 
 			// Set up chart visualization if available
@@ -153,7 +153,7 @@ namespace StockSharp.Samples.Strategies
 			base.OnStarted(time);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal adxValue)
+		private void ProcessCandle(ICandleMessage candle, IIndicatorValue adxValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0306_Bollinger_Volatility_Breakout/BollingerVolatilityBreakoutStrategy.cs
+++ b/API/0306_Bollinger_Volatility_Breakout/BollingerVolatilityBreakoutStrategy.cs
@@ -140,7 +140,7 @@ namespace StockSharp.Samples.Strategies
 			
 			// Bind main indicators to subscription
 			subscription
-				.Bind(bollingerBands, atr, ProcessCandle)
+				.BindEx(bollingerBands, atr, ProcessCandle)
 				.Start();
 				
 			// Setup additional processing for ATR-based indicators
@@ -171,7 +171,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal bbMiddle, decimal bbUpper, decimal bbLower, decimal atrValue)
+		private void ProcessCandle(ICandleMessage candle, IIndicatorValue bbMiddle, IIndicatorValue bbUpper, IIndicatorValue bbLower, IIndicatorValue atrValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0307_MACD_Adaptive_Histogram/MacdAdaptiveHistogramStrategy.cs
+++ b/API/0307_MACD_Adaptive_Histogram/MacdAdaptiveHistogramStrategy.cs
@@ -160,7 +160,7 @@ namespace StockSharp.Samples.Strategies
 			
 			// Bind MACD to subscription
 			subscription
-				.Bind(macdLine, ProcessCandle)
+				.BindEx(macdLine, ProcessCandle)
 				.Start();
 				
 			// Create a special subscription for histogram statistics
@@ -196,7 +196,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, Tuple<decimal, decimal, decimal> macdValues)
+		private void ProcessCandle(ICandleMessage candle, IIndicatorValue macdValues)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0320_MACD_Hidden_Markov_Model/MacdHmmStrategy.cs
+++ b/API/0320_MACD_Hidden_Markov_Model/MacdHmmStrategy.cs
@@ -141,7 +141,7 @@ namespace StockSharp.Samples.Strategies
 			var subscription = SubscribeCandles(CandleType);
 			
 			subscription
-				.Bind(_macd, ProcessCandle)
+				.BindEx(_macd, ProcessCandle)
 				.Start();
 
 			// Setup chart visualization if available
@@ -160,7 +160,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 		
-		private void ProcessCandle(ICandleMessage candle, decimal macdValue, decimal signalValue)
+		private void ProcessCandle(ICandleMessage candle, IIndicatorValue macdValue, IIndicatorValue signalValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0323_Donchian_Seasonal_Filter/DonchianSeasonalStrategy.cs
+++ b/API/0323_Donchian_Seasonal_Filter/DonchianSeasonalStrategy.cs
@@ -126,7 +126,7 @@ namespace StockSharp.Samples.Strategies
 			var subscription = SubscribeCandles(CandleType);
 			
 			subscription
-				.Bind(_donchian, ProcessCandle)
+				.BindEx(_donchian, ProcessCandle)
 				.Start();
 
 			// Setup chart visualization if available
@@ -145,7 +145,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 		
-		private void ProcessCandle(ICandleMessage candle, decimal upperBand, decimal middleBand, decimal lowerBand)
+		private void ProcessCandle(ICandleMessage candle, IIndicatorValue upperBand, IIndicatorValue middleBand, IIndicatorValue lowerBand)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0332_Donchian_Hurst_Exponent/DonchianHurstExponentStrategy.cs
+++ b/API/0332_Donchian_Hurst_Exponent/DonchianHurstExponentStrategy.cs
@@ -126,7 +126,7 @@ namespace StockSharp.Samples.Strategies
 
 			// Bind indicators to subscription and start
 			subscription
-				.Bind(donchian, ProcessDonchianChannel)
+				.BindEx(donchian, ProcessDonchianChannel)
 				.BindEx(fractalDimension, ProcessFractalDimension)
 				.Start();
 
@@ -146,7 +146,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessDonchianChannel(ICandleMessage candle, decimal upperBand, decimal lowerBand, decimal middleBand)
+		private void ProcessDonchianChannel(ICandleMessage candle, IIndicatorValue upperBand, IIndicatorValue lowerBand, IIndicatorValue middleBand)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0339_MACD_Sentiment_Filter/MacdWithSentimentFilterStrategy.cs
+++ b/API/0339_MACD_Sentiment_Filter/MacdWithSentimentFilterStrategy.cs
@@ -155,7 +155,7 @@ namespace StockSharp.Samples.Strategies
 			// Subscribe to candles and bind indicator
 			var subscription = SubscribeCandles(CandleType);
 			subscription
-				.Bind(macd, ProcessCandle)
+				.BindEx(macd, ProcessCandle)
 				.Start();
 			
 			// Create chart visualization if available
@@ -177,7 +177,7 @@ namespace StockSharp.Samples.Strategies
 		/// <summary>
 		/// Process each candle and MACD values.
 		/// </summary>
-		private void ProcessCandle(ICandleMessage candle, decimal macd, decimal signal)
+		private void ProcessCandle(ICandleMessage candle, IIndicatorValue macd, IIndicatorValue signal)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0342_Donchian_Sentiment_Spike/DonchianSentimentStrategy.cs
+++ b/API/0342_Donchian_Sentiment_Spike/DonchianSentimentStrategy.cs
@@ -138,7 +138,7 @@ namespace StockSharp.Samples.Strategies
 			var subscription = SubscribeCandles(CandleType);
 			
 			subscription
-				.Bind(donchian, ProcessCandle)
+				.BindEx(donchian, ProcessCandle)
 				.Start();
 			
 			// Create chart visualization if available

--- a/API/0348_Stochastic_Implied_Volatility_Skew/StochasticImpliedVolatilitySkewStrategy.cs
+++ b/API/0348_Stochastic_Implied_Volatility_Skew/StochasticImpliedVolatilitySkewStrategy.cs
@@ -145,7 +145,7 @@ namespace StockSharp.Samples.Strategies
 			// Create subscription and bind indicators
 			var subscription = SubscribeCandles(CandleType);
 			subscription
-				.Bind(_stochastic, ProcessCandle)
+				.BindEx(_stochastic, ProcessCandle)
 				.Start();
 
 			// Setup chart visualization
@@ -164,7 +164,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal stochK, decimal stochD)
+		private void ProcessCandle(ICandleMessage candle, IIndicatorValue stochK, IIndicatorValue stochD)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)


### PR DESCRIPTION
## Summary
- revert previous BindEx changes
- reapply BindEx only for MACD, Stochastic, ADX, Bollinger and Donchian
- update handler signatures to use `IIndicatorValue`
- preserve indentation using tabs

## Testing
- `dotnet test -v minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686578d306e88323a4587714bd93fd41