### PR TITLE
Use nullable decimals with Bind handlers

### DIFF
--- a/API/0002_NDay_Breakout/NdayBreakoutStrategy.cs
+++ b/API/0002_NDay_Breakout/NdayBreakoutStrategy.cs
@@ -135,7 +135,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal highestValue, decimal lowestValue, decimal maValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? highestValue, decimal? lowestValue, decimal? maValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0004_Parabolic_SAR_Trend/ParabolicSarTrendStrategy.cs
+++ b/API/0004_Parabolic_SAR_Trend/ParabolicSarTrendStrategy.cs
@@ -105,7 +105,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal sarValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? sarValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0006_Tripple_MA/TripleMAStrategy.cs
+++ b/API/0006_Tripple_MA/TripleMAStrategy.cs
@@ -139,7 +139,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal shortMaValue, decimal middleMaValue, decimal longMaValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? shortMaValue, decimal? middleMaValue, decimal? longMaValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0008_Hull_MA_Trend/HullMaTrendStrategy.cs
+++ b/API/0008_Hull_MA_Trend/HullMaTrendStrategy.cs
@@ -122,7 +122,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal hmaValue, decimal atrValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? hmaValue, decimal? atrValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0010_Super_Trend/SupertrendStrategy.cs
+++ b/API/0010_Super_Trend/SupertrendStrategy.cs
@@ -104,7 +104,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal atrValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? atrValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0014_TradingView_Supertrend_Flip/TradingviewSupertrendFlipStrategy.cs
+++ b/API/0014_TradingView_Supertrend_Flip/TradingviewSupertrendFlipStrategy.cs
@@ -124,7 +124,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal atrValue, decimal volumeAvgValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? atrValue, decimal? volumeAvgValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0015_Gann_Swing_Breakout/GannSwingBreakoutStrategy.cs
+++ b/API/0015_Gann_Swing_Breakout/GannSwingBreakoutStrategy.cs
@@ -113,7 +113,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal maValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? maValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0018_ROC_Impulce/RocImpulseStrategy.cs
+++ b/API/0018_ROC_Impulce/RocImpulseStrategy.cs
@@ -110,7 +110,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal rocValue, decimal atrValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? rocValue, decimal? atrValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0020_Momentum_Percentage/MomentumPercentageStrategy.cs
+++ b/API/0020_Momentum_Percentage/MomentumPercentageStrategy.cs
@@ -117,7 +117,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal momentumValue, decimal smaValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? momentumValue, decimal? smaValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0028_ZScore/ZScoreStrategy.cs
+++ b/API/0028_ZScore/ZScoreStrategy.cs
@@ -154,7 +154,7 @@ namespace StockSharp.Samples.Strategies
 		/// <summary>
 		/// Process candle and calculate Z-Score
 		/// </summary>
-		private void ProcessCandle(ICandleMessage candle, decimal maValue, decimal stdDevValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? maValue, decimal? stdDevValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0029_MA_Deviation/MaDeviationStrategy.cs
+++ b/API/0029_MA_Deviation/MaDeviationStrategy.cs
@@ -130,7 +130,7 @@ namespace StockSharp.Samples.Strategies
 		/// <summary>
 		/// Process candle and check for MA deviation signals
 		/// </summary>
-		private void ProcessCandle(ICandleMessage candle, decimal maValue, decimal atrValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? maValue, decimal? atrValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0030_VWAP_Reversion/VwapReversionStrategy.cs
+++ b/API/0030_VWAP_Reversion/VwapReversionStrategy.cs
@@ -104,7 +104,7 @@ namespace StockSharp.Samples.Strategies
 		/// <summary>
 		/// Process candle and check for VWAP deviation signals
 		/// </summary>
-		private void ProcessCandle(ICandleMessage candle, decimal vwapValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? vwapValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0031_Keltner_Reversion/KeltnerReversionStrategy.cs
+++ b/API/0031_Keltner_Reversion/KeltnerReversionStrategy.cs
@@ -130,7 +130,7 @@ namespace StockSharp.Samples.Strategies
 		/// <summary>
 		/// Process candle and check for Keltner Channel signals
 		/// </summary>
-		private void ProcessCandle(ICandleMessage candle, decimal emaValue, decimal atrValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? emaValue, decimal? atrValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0032_ATR_Reversion/AtrReversionStrategy.cs
+++ b/API/0032_ATR_Reversion/AtrReversionStrategy.cs
@@ -141,7 +141,7 @@ namespace StockSharp.Samples.Strategies
 		/// <summary>
 		/// Process candle and check for ATR-based signals
 		/// </summary>
-		private void ProcessCandle(ICandleMessage candle, decimal atrValue, decimal smaValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? atrValue, decimal? smaValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0034_Low_Vol_Reversion/LowVolReversionStrategy.cs
+++ b/API/0034_Low_Vol_Reversion/LowVolReversionStrategy.cs
@@ -152,7 +152,7 @@ namespace StockSharp.Samples.Strategies
 		/// <summary>
 		/// Process candle and check for low volatility mean reversion signals
 		/// </summary>
-		private void ProcessCandle(ICandleMessage candle, decimal smaValue, decimal atrValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? smaValue, decimal? atrValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0036_ATR_Expansion/AtrExpansionStrategy.cs
+++ b/API/0036_ATR_Expansion/AtrExpansionStrategy.cs
@@ -120,7 +120,7 @@ namespace StockSharp.Samples.Strategies
 		/// <summary>
 		/// Process candle and check for ATR expansion signals
 		/// </summary>
-		private void ProcessCandle(ICandleMessage candle, decimal atrValue, decimal smaValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? atrValue, decimal? smaValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0037_VIX_Trigger/VixTriggerStrategy.cs
+++ b/API/0037_VIX_Trigger/VixTriggerStrategy.cs
@@ -166,7 +166,7 @@ namespace StockSharp.Samples.Strategies
 		/// <summary>
 		/// Process main security candle and check for trading signals
 		/// </summary>
-		private void ProcessMainCandle(ICandleMessage candle, decimal smaValue)
+		private void ProcessMainCandle(ICandleMessage candle, decimal? smaValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0039_HV_Breakout/HvBreakoutStrategy.cs
+++ b/API/0039_HV_Breakout/HvBreakoutStrategy.cs
@@ -130,7 +130,7 @@ namespace StockSharp.Samples.Strategies
 		/// <summary>
 		/// Process candle and check for HV breakout signals
 		/// </summary>
-		private void ProcessCandle(ICandleMessage candle, decimal stdDevValue, decimal smaValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? stdDevValue, decimal? smaValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0040_ATR_Trailing/AtrTrailingStrategy.cs
+++ b/API/0040_ATR_Trailing/AtrTrailingStrategy.cs
@@ -122,7 +122,7 @@ namespace StockSharp.Samples.Strategies
 		/// <summary>
 		/// Process candle and manage positions with ATR-based trailing stops
 		/// </summary>
-		private void ProcessCandle(ICandleMessage candle, decimal atrValue, decimal smaValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? atrValue, decimal? smaValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0041_Vol_Adjusted_MA/VolAdjustedMaStrategy.cs
+++ b/API/0041_Vol_Adjusted_MA/VolAdjustedMaStrategy.cs
@@ -126,7 +126,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal maValue, decimal atrValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? maValue, decimal? atrValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0042_IV_Spike/IvSpikeStrategy.cs
+++ b/API/0042_IV_Spike/IvSpikeStrategy.cs
@@ -126,7 +126,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal maValue, decimal ivValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? maValue, decimal? ivValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0043_VCP/VcpStrategy.cs
+++ b/API/0043_VCP/VcpStrategy.cs
@@ -111,7 +111,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal highestValue, decimal lowestValue, decimal maValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? highestValue, decimal? lowestValue, decimal? maValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0044_ATR_Range/AtrRangeStrategy.cs
+++ b/API/0044_ATR_Range/AtrRangeStrategy.cs
@@ -128,7 +128,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal maValue, decimal atrValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? maValue, decimal? atrValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0045_Choppiness_Index_Breakout/ChoppinessIndexBreakoutStrategy.cs
+++ b/API/0045_Choppiness_Index_Breakout/ChoppinessIndexBreakoutStrategy.cs
@@ -143,7 +143,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal maValue, decimal choppinessValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? maValue, decimal? choppinessValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0046_Volume_Spike/VolumeSpikeStrategy.cs
+++ b/API/0046_Volume_Spike/VolumeSpikeStrategy.cs
@@ -126,7 +126,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal maValue, decimal volumeMAValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? maValue, decimal? volumeMAValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0047_OBV_Breakout/ObvBreakoutStrategy.cs
+++ b/API/0047_OBV_Breakout/ObvBreakoutStrategy.cs
@@ -153,7 +153,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal obvValue, decimal obvMAValue, decimal highestValue, decimal lowestValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? obvValue, decimal? obvMAValue, decimal? highestValue, decimal? lowestValue)
 		{
 			// Check if strategy is ready to trade
 			if (!IsFormedAndOnlineAndAllowTrading())

--- a/API/0050_AD/ADStrategy.cs
+++ b/API/0050_AD/ADStrategy.cs
@@ -98,7 +98,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal maValue, decimal adValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? maValue, decimal? adValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0051_Volume_Weighted_Price_Breakout/VolumeWeightedPriceBreakoutStrategy.cs
+++ b/API/0051_Volume_Weighted_Price_Breakout/VolumeWeightedPriceBreakoutStrategy.cs
@@ -107,7 +107,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal maValue, decimal vwmaValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? maValue, decimal? vwmaValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0055_Volume_Surge/VolumeSurgeStrategy.cs
+++ b/API/0055_Volume_Surge/VolumeSurgeStrategy.cs
@@ -125,7 +125,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal maValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? maValue)
 		{
 			var volumeMAValue = _volumeMA.Process(candle.TotalVolume, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal();
 

--- a/API/0061_MACD_Divergence/MacdDivergenceStrategy.cs
+++ b/API/0061_MACD_Divergence/MacdDivergenceStrategy.cs
@@ -248,7 +248,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessDivergenceSignals(ICandleMessage candle, decimal macdLine, decimal signalLine)
+		private void ProcessDivergenceSignals(ICandleMessage candle, decimal? macdLine, decimal? signalLine)
 		{
 			// Entry signals based on detected divergences
 			if (_bullishDivergence && Position <= 0 && macdLine > signalLine)

--- a/API/0065_Pinbar_Reversal/PinbarReversalStrategy.cs
+++ b/API/0065_Pinbar_Reversal/PinbarReversalStrategy.cs
@@ -149,7 +149,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal maValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? maValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0066_Three_Bar_Reversal_Up/ThreeBarReversalUpStrategy.cs
+++ b/API/0066_Three_Bar_Reversal_Up/ThreeBarReversalUpStrategy.cs
@@ -126,7 +126,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal lowestValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? lowestValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0067_Three_Bar_Reversal_Down/ThreeBarReversalDownStrategy.cs
+++ b/API/0067_Three_Bar_Reversal_Down/ThreeBarReversalDownStrategy.cs
@@ -126,7 +126,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal highestValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? highestValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0068_CCI_Divergence/CciDivergenceStrategy.cs
+++ b/API/0068_CCI_Divergence/CciDivergenceStrategy.cs
@@ -168,7 +168,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal cciValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? cciValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)
@@ -231,7 +231,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessDivergenceSignals(ICandleMessage candle, decimal cciValue)
+		private void ProcessDivergenceSignals(ICandleMessage candle, decimal? cciValue)
 		{
 			// Entry signals based on detected divergences
 			if (_bullishDivergence && Position <= 0 && cciValue < OversoldLevel)

--- a/API/0074_Williams_R_Divergence/WilliamsPercentRDivergenceStrategy.cs
+++ b/API/0074_Williams_R_Divergence/WilliamsPercentRDivergenceStrategy.cs
@@ -135,7 +135,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal williamsRValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? williamsRValue)
 		{
 			if (candle.State != CandleStates.Finished)
 				return;

--- a/API/0075_OBV_Divergence/ObvDivergenceStrategy.cs
+++ b/API/0075_OBV_Divergence/ObvDivergenceStrategy.cs
@@ -139,7 +139,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal obvValue, decimal maValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? obvValue, decimal? maValue)
 		{
 			if (candle.State != CandleStates.Finished)
 				return;

--- a/API/0079_Trendline_Bounce/TrendlineBounceStrategy.cs
+++ b/API/0079_Trendline_Bounce/TrendlineBounceStrategy.cs
@@ -160,7 +160,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal maPrice)
+		private void ProcessCandle(ICandleMessage candle, decimal? maPrice)
 		{
 			if (candle.State != CandleStates.Finished)
 				return;
@@ -265,7 +265,7 @@ namespace StockSharp.Samples.Strategies
 			intercept = (sumY - slope * sumX) / n;
 		}
 
-		private void CheckForTrendlineBounces(ICandleMessage candle, decimal maPrice)
+		private void CheckForTrendlineBounces(ICandleMessage candle, decimal? maPrice)
 		{
 			if (_recentCandles.Count < 3)
 				return;

--- a/API/0082_Volume_Exhaustion/VolumeExhaustionStrategy.cs
+++ b/API/0082_Volume_Exhaustion/VolumeExhaustionStrategy.cs
@@ -138,7 +138,7 @@ namespace StockSharp.Samples.Strategies
 		/// <param name="maValue">Moving average value.</param>
 		/// <param name="atrValue">ATR value.</param>
 		/// <param name="volumeAvgValue">Volume average value.</param>
-		private void ProcessCandle(ICandleMessage candle, decimal maValue, decimal atrValue, decimal volumeAvgValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? maValue, decimal? atrValue, decimal? volumeAvgValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0087_Parabolic_SAR_Reversal/ParabolicSarReversalStrategy.cs
+++ b/API/0087_Parabolic_SAR_Reversal/ParabolicSarReversalStrategy.cs
@@ -111,7 +111,7 @@ namespace StockSharp.Samples.Strategies
 		/// </summary>
 		/// <param name="candle">Candle.</param>
 		/// <param name="sarValue">Parabolic SAR value.</param>
-		private void ProcessCandle(ICandleMessage candle, decimal sarValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? sarValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0088_Supertrend_Reversal/SupertrendReversalStrategy.cs
+++ b/API/0088_Supertrend_Reversal/SupertrendReversalStrategy.cs
@@ -114,7 +114,7 @@ namespace StockSharp.Samples.Strategies
 		/// </summary>
 		/// <param name="candle">Candle.</param>
 		/// <param name="atrValue">ATR value.</param>
-		private void ProcessCandle(ICandleMessage candle, decimal atrValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? atrValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0089_Hull_MA_Reversal/HullMaReversalStrategy.cs
+++ b/API/0089_Hull_MA_Reversal/HullMaReversalStrategy.cs
@@ -112,7 +112,7 @@ namespace StockSharp.Samples.Strategies
 		/// <param name="candle">Candle.</param>
 		/// <param name="hmaValue">Hull MA value.</param>
 		/// <param name="atrValue">ATR value.</param>
-		private void ProcessCandle(ICandleMessage candle, decimal hmaValue, decimal atrValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? hmaValue, decimal? atrValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0092_RSI_Hook_Reversal/RsiHookReversalStrategy.cs
+++ b/API/0092_RSI_Hook_Reversal/RsiHookReversalStrategy.cs
@@ -160,7 +160,7 @@ namespace StockSharp.Samples.Strategies
 		/// </summary>
 		/// <param name="candle">Candle.</param>
 		/// <param name="rsiValue">RSI value.</param>
-		private void ProcessCandle(ICandleMessage candle, decimal rsiValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? rsiValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0094_CCI_Hook_Reversal/CciHookReversalStrategy.cs
+++ b/API/0094_CCI_Hook_Reversal/CciHookReversalStrategy.cs
@@ -145,7 +145,7 @@ namespace StockSharp.Samples.Strategies
 		/// </summary>
 		/// <param name="candle">Candle.</param>
 		/// <param name="cciValue">CCI value.</param>
-		private void ProcessCandle(ICandleMessage candle, decimal cciValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? cciValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0095_Williams_R_Hook_Reversal/WilliamsRHookReversalStrategy.cs
+++ b/API/0095_Williams_R_Hook_Reversal/WilliamsRHookReversalStrategy.cs
@@ -160,7 +160,7 @@ namespace StockSharp.Samples.Strategies
 		/// </summary>
 		/// <param name="candle">Candle.</param>
 		/// <param name="willRValue">Williams %R value.</param>
-		private void ProcessCandle(ICandleMessage candle, decimal willRValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? willRValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0096_Three_White_Soldiers/ThreeWhiteSoldiersStrategy.cs
+++ b/API/0096_Three_White_Soldiers/ThreeWhiteSoldiersStrategy.cs
@@ -109,7 +109,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal maValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? maValue)
 		{
 			if (candle.State != CandleStates.Finished)
 				return;

--- a/API/0097_Three_Black_Crows/ThreeBlackCrowsStrategy.cs
+++ b/API/0097_Three_Black_Crows/ThreeBlackCrowsStrategy.cs
@@ -109,7 +109,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal maValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? maValue)
 		{
 			if (candle.State != CandleStates.Finished)
 				return;

--- a/API/0105_False_Breakout_Trap/FalseBreakoutTrapStrategy.cs
+++ b/API/0105_False_Breakout_Trap/FalseBreakoutTrapStrategy.cs
@@ -126,7 +126,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal ma, decimal highest, decimal lowest)
+		private void ProcessCandle(ICandleMessage candle, decimal? ma, decimal? highest, decimal? lowest)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0106_Spring_Reversal/SpringReversalStrategy.cs
+++ b/API/0106_Spring_Reversal/SpringReversalStrategy.cs
@@ -118,7 +118,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal ma, decimal lowest)
+		private void ProcessCandle(ICandleMessage candle, decimal? ma, decimal? lowest)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0107_Upthrust_Reversal/UpthrustReversalStrategy.cs
+++ b/API/0107_Upthrust_Reversal/UpthrustReversalStrategy.cs
@@ -118,7 +118,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal ma, decimal highest)
+		private void ProcessCandle(ICandleMessage candle, decimal? ma, decimal? highest)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0108_Wyckoff_Accumulation/WyckoffAccumulationStrategy.cs
+++ b/API/0108_Wyckoff_Accumulation/WyckoffAccumulationStrategy.cs
@@ -155,7 +155,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal ma, decimal volumeAvg, decimal highest, decimal lowest)
+		private void ProcessCandle(ICandleMessage candle, decimal? ma, decimal? volumeAvg, decimal? highest, decimal? lowest)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0109_Wyckoff_Distribution/WyckoffDistributionStrategy.cs
+++ b/API/0109_Wyckoff_Distribution/WyckoffDistributionStrategy.cs
@@ -155,7 +155,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal ma, decimal volumeAvg, decimal highest, decimal lowest)
+		private void ProcessCandle(ICandleMessage candle, decimal? ma, decimal? volumeAvg, decimal? highest, decimal? lowest)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0110_RSI_Failure_Swing/RsiFailureSwingStrategy.cs
+++ b/API/0110_RSI_Failure_Swing/RsiFailureSwingStrategy.cs
@@ -138,7 +138,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal rsiValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? rsiValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0115_Volume_Climax_Reversal/VolumeClimaxReversalStrategy.cs
+++ b/API/0115_Volume_Climax_Reversal/VolumeClimaxReversalStrategy.cs
@@ -131,7 +131,7 @@ namespace StockSharp.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal maValue, decimal atrValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? maValue, decimal? atrValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0116_Day_of_Week/DayOfWeekStrategy.cs
+++ b/API/0116_Day_of_Week/DayOfWeekStrategy.cs
@@ -97,7 +97,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal maValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? maValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0117_Month_of_Year/MonthOfYearStrategy.cs
+++ b/API/0117_Month_of_Year/MonthOfYearStrategy.cs
@@ -97,7 +97,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal maValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? maValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0118_Turnaround_Tuesday/TurnaroundTuesdayStrategy.cs
+++ b/API/0118_Turnaround_Tuesday/TurnaroundTuesdayStrategy.cs
@@ -103,7 +103,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal maValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? maValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0119_End_of_Month_Strength/EndOfMonthStrengthStrategy.cs
+++ b/API/0119_End_of_Month_Strength/EndOfMonthStrengthStrategy.cs
@@ -97,7 +97,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal maValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? maValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0120_First_Day_of_Month/FirstDayOfMonthStrategy.cs
+++ b/API/0120_First_Day_of_Month/FirstDayOfMonthStrategy.cs
@@ -97,7 +97,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal maValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? maValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0121_Santa_Claus_Rally/SantaClausRallyStrategy.cs
+++ b/API/0121_Santa_Claus_Rally/SantaClausRallyStrategy.cs
@@ -98,7 +98,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal maValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? maValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0122_January_Effect/JanuaryEffectStrategy.cs
+++ b/API/0122_January_Effect/JanuaryEffectStrategy.cs
@@ -97,7 +97,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal maValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? maValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0123_Monday_Weakness/MondayWeaknessStrategy.cs
+++ b/API/0123_Monday_Weakness/MondayWeaknessStrategy.cs
@@ -98,7 +98,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal maValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? maValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0124_Pre-Holiday_Strength/PreHolidayStrengthStrategy.cs
+++ b/API/0124_Pre-Holiday_Strength/PreHolidayStrengthStrategy.cs
@@ -114,7 +114,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal maValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? maValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0125_Post-Holiday_Weakness/PostHolidayWeaknessStrategy.cs
+++ b/API/0125_Post-Holiday_Weakness/PostHolidayWeaknessStrategy.cs
@@ -114,7 +114,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal maValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? maValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0126_Quarterly_Expiry/QuarterlyExpiryStrategy.cs
+++ b/API/0126_Quarterly_Expiry/QuarterlyExpiryStrategy.cs
@@ -97,7 +97,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal maValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? maValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0127_Open_Drive/OpenDriveStrategy.cs
+++ b/API/0127_Open_Drive/OpenDriveStrategy.cs
@@ -126,7 +126,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal smaValue, decimal atrValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? smaValue, decimal? atrValue)
 		{
 			// Skip if we don't have the previous close price yet
 			if (_prevClosePrice == 0)

--- a/API/0129_Overnight_Gap/OvernightGapStrategy.cs
+++ b/API/0129_Overnight_Gap/OvernightGapStrategy.cs
@@ -101,7 +101,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal maValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? maValue)
 		{
 			// Skip if we don't have previous close price yet
 			if (_prevClosePrice == 0)

--- a/API/0136_Supertrend_Volume/SupertrendVolumeStrategy.cs
+++ b/API/0136_Supertrend_Volume/SupertrendVolumeStrategy.cs
@@ -155,7 +155,7 @@ namespace StockSharp.Strategies.Samples
 		/// </summary>
 		/// <param name="candle">Candle to process.</param>
 		/// <param name="atrValue">ATR value.</param>
-		private void ProcessCandle(ICandleMessage candle, decimal atrValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? atrValue)
 		{
 			if (candle.State != CandleStates.Finished)
 				return;
@@ -219,7 +219,7 @@ namespace StockSharp.Strategies.Samples
 		/// </summary>
 		/// <param name="candle">Candle to process.</param>
 		/// <param name="atrValue">ATR value.</param>
-		private void CalculateSupertrend(ICandleMessage candle, decimal atrValue)
+		private void CalculateSupertrend(ICandleMessage candle, decimal? atrValue)
 		{
 			// Calculate basic price
 			var basicPrice = (candle.HighPrice + candle.LowPrice) / 2;

--- a/API/0140_VWAP_RSI/VwapRsiStrategy.cs
+++ b/API/0140_VWAP_RSI/VwapRsiStrategy.cs
@@ -146,7 +146,7 @@ namespace StockSharp.Samples.Strategies
 		/// <summary>
 		/// Process candles and indicator values.
 		/// </summary>
-		private void ProcessCandles(ICandleMessage candle, decimal vwapValue, decimal rsiValue)
+		private void ProcessCandles(ICandleMessage candle, decimal? vwapValue, decimal? rsiValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0143_Parabolic_SAR_RSI/ParabolicSarRsiStrategy.cs
+++ b/API/0143_Parabolic_SAR_RSI/ParabolicSarRsiStrategy.cs
@@ -165,7 +165,7 @@ namespace StockSharp.Samples.Strategies
 		/// <summary>
 		/// Process candles and indicator values.
 		/// </summary>
-		private void ProcessCandles(ICandleMessage candle, decimal sarValue, decimal rsiValue)
+		private void ProcessCandles(ICandleMessage candle, decimal? sarValue, decimal? rsiValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0144_Hull_MA_Volume/HullMaVolumeStrategy.cs
+++ b/API/0144_Hull_MA_Volume/HullMaVolumeStrategy.cs
@@ -192,7 +192,7 @@ namespace StockSharp.Samples.Strategies
 		/// <summary>
 		/// Process Hull MA and ATR indicator values.
 		/// </summary>
-		private void ProcessHullAndAtr(ICandleMessage candle, decimal hullValue, decimal atrValue)
+		private void ProcessHullAndAtr(ICandleMessage candle, decimal? hullValue, decimal? atrValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0152_Supertrend_RSI/SupertrendRsiStrategy.cs
+++ b/API/0152_Supertrend_RSI/SupertrendRsiStrategy.cs
@@ -164,7 +164,7 @@ namespace StockSharp.Samples.Strategies
 			// through the Supertrend indicator crossovers)
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal supertrendValue, decimal rsiValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? supertrendValue, decimal? rsiValue)
 		{
 			if (candle.State != CandleStates.Finished)
 				return;

--- a/API/0154_MA_CCI/MaCciStrategy.cs
+++ b/API/0154_MA_CCI/MaCciStrategy.cs
@@ -159,7 +159,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal maValue, decimal cciValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? maValue, decimal? cciValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0157_Keltner_Volume/KeltnerVolumeStrategy.cs
+++ b/API/0157_Keltner_Volume/KeltnerVolumeStrategy.cs
@@ -162,7 +162,7 @@ namespace StockSharp.Samples.Strategies
 			StartProtection(new(), StopLoss);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal emaValue, decimal atrValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? emaValue, decimal? atrValue)
 		{
 			if (candle.State != CandleStates.Finished)
 				return;

--- a/API/0159_Hull_MA_RSI/HullMaRsiStrategy.cs
+++ b/API/0159_Hull_MA_RSI/HullMaRsiStrategy.cs
@@ -157,7 +157,7 @@ namespace StockSharp.Samples.Strategies
 			StartProtection(new(), StopLoss);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal hmaValue, decimal rsiValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? hmaValue, decimal? rsiValue)
 		{
 			if (candle.State != CandleStates.Finished)
 				return;

--- a/API/0164_MA_Williams_R/MaWilliamsRStrategy.cs
+++ b/API/0164_MA_Williams_R/MaWilliamsRStrategy.cs
@@ -185,7 +185,7 @@ namespace StockSharp.Samples.Strategies
 			StartProtection(new(), StopLoss);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal maValue, decimal williamsRValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? maValue, decimal? williamsRValue)
 		{
 			if (candle.State != CandleStates.Finished)
 				return;

--- a/API/0165_VWAP_CCI/VwapCciStrategy.cs
+++ b/API/0165_VWAP_CCI/VwapCciStrategy.cs
@@ -134,7 +134,7 @@ namespace StockSharp.Samples.Strategies
 			StartProtection(new(), StopLoss);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal vwapValue, decimal cciValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? vwapValue, decimal? cciValue)
 		{
 			if (candle.State != CandleStates.Finished)
 				return;

--- a/API/0167_Keltner_RSI/KeltnerRsiStrategy.cs
+++ b/API/0167_Keltner_RSI/KeltnerRsiStrategy.cs
@@ -201,7 +201,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal emaValue, decimal atrValue, decimal rsiValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? emaValue, decimal? atrValue, decimal? rsiValue)
 		{
 			// Skip if indicators are not formed yet
 			if (!_ema.IsFormed || !_atr.IsFormed || !_rsi.IsFormed)

--- a/API/0175_RSI_Supertrend/RsiSupertrendStrategy.cs
+++ b/API/0175_RSI_Supertrend/RsiSupertrendStrategy.cs
@@ -142,7 +142,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal rsiValue, decimal atrValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? rsiValue, decimal? atrValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0188_Parabolic_SAR_Volume/ParabolicSarVolumeStrategy.cs
+++ b/API/0188_Parabolic_SAR_Volume/ParabolicSarVolumeStrategy.cs
@@ -156,7 +156,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessSarSignal(ICandleMessage candle, decimal sarValue)
+		private void ProcessSarSignal(ICandleMessage candle, decimal? sarValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0201_VWAP_Williams_R/VwapWilliamsRStrategy.cs
+++ b/API/0201_VWAP_Williams_R/VwapWilliamsRStrategy.cs
@@ -101,7 +101,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal vwapValue, decimal williamsRValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? vwapValue, decimal? williamsRValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0204_Parabolic_SAR_CCI/ParabolicSarCciStrategy.cs
+++ b/API/0204_Parabolic_SAR_CCI/ParabolicSarCciStrategy.cs
@@ -115,7 +115,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal sarValue, decimal cciValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? sarValue, decimal? cciValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0205_Hull_MA_CCI/HullMaCciStrategy.cs
+++ b/API/0205_Hull_MA_CCI/HullMaCciStrategy.cs
@@ -131,7 +131,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessIndicators(ICandleMessage candle, decimal hullValue, decimal cciValue, decimal atrValue)
+		private void ProcessIndicators(ICandleMessage candle, decimal? hullValue, decimal? cciValue, decimal? atrValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0207_RSI_Hull_MA/RsiHullMaStrategy.cs
+++ b/API/0207_RSI_Hull_MA/RsiHullMaStrategy.cs
@@ -131,7 +131,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessIndicators(ICandleMessage candle, decimal rsiValue, decimal hullValue, decimal atrValue)
+		private void ProcessIndicators(ICandleMessage candle, decimal? rsiValue, decimal? hullValue, decimal? atrValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0209_Volume_Supertrend/VolumeSupertrendStrategy.cs
+++ b/API/0209_Volume_Supertrend/VolumeSupertrendStrategy.cs
@@ -188,7 +188,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessSignals(ICandleMessage candle, decimal currentVolume, decimal volumeAvg, 
+		private void ProcessSignals(ICandleMessage candle, decimal? currentVolume, decimal? volumeAvg, 
 			decimal supertrendValue, int supertrendDirection)
 		{
 			// Skip unfinished candles

--- a/API/0211_CCI_VWAP/CciVwapStrategy.cs
+++ b/API/0211_CCI_VWAP/CciVwapStrategy.cs
@@ -129,7 +129,7 @@ namespace StockSharp.Strategies
 			}
 		}
 		
-		private void ProcessCandle(ICandleMessage candle, decimal cciValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? cciValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0213_MA_Parabolic_SAR/MaParabolicSarStrategy.cs
+++ b/API/0213_MA_Parabolic_SAR/MaParabolicSarStrategy.cs
@@ -156,7 +156,7 @@ namespace StockSharp.Strategies
 			StartProtection(TakeValue, StopValue);
 		}
 		
-		private void ProcessCandle(ICandleMessage candle, decimal maValue, decimal sarValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? maValue, decimal? sarValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0219_Statistical_Arbitrage/StatisticalArbitrageStrategy.cs
+++ b/API/0219_Statistical_Arbitrage/StatisticalArbitrageStrategy.cs
@@ -139,7 +139,7 @@ namespace StockSharp.Strategies
 			}
 		}
 		
-		private void ProcessFirstSecurityCandle(ICandleMessage candle, decimal firstMAValue)
+		private void ProcessFirstSecurityCandle(ICandleMessage candle, decimal? firstMAValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0220_Volatility_Breakout/VolatilityBreakoutStrategy.cs
+++ b/API/0220_Volatility_Breakout/VolatilityBreakoutStrategy.cs
@@ -112,7 +112,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal smaValue, decimal atrValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? smaValue, decimal? atrValue)
 		{
 			if (candle.State != CandleStates.Finished)
 				return;

--- a/API/0223_Momentum_Divergence/MomentumDivergenceStrategy.cs
+++ b/API/0223_Momentum_Divergence/MomentumDivergenceStrategy.cs
@@ -118,7 +118,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal momentumValue, decimal smaValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? momentumValue, decimal? smaValue)
 		{
 			if (candle.State != CandleStates.Finished)
 				return;

--- a/API/0224_ATR_Mean_Reversion/AtrMeanReversionStrategy.cs
+++ b/API/0224_ATR_Mean_Reversion/AtrMeanReversionStrategy.cs
@@ -123,7 +123,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal smaValue, decimal atrValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? smaValue, decimal? atrValue)
 		{
 			if (candle.State != CandleStates.Finished)
 				return;

--- a/API/0225_Kalman_Filter_Trend/KalmanFilterTrendStrategy.cs
+++ b/API/0225_Kalman_Filter_Trend/KalmanFilterTrendStrategy.cs
@@ -111,7 +111,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal kalmanValue, decimal atrValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? kalmanValue, decimal? atrValue)
 		{
 			if (candle.State != CandleStates.Finished)
 				return;

--- a/API/0226_Volatility_Adjusted_Mean_Reversion/VolatilityAdjustedMeanReversionStrategy.cs
+++ b/API/0226_Volatility_Adjusted_Mean_Reversion/VolatilityAdjustedMeanReversionStrategy.cs
@@ -111,7 +111,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal smaValue, decimal atrValue, decimal stdDevValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? smaValue, decimal? atrValue, decimal? stdDevValue)
 		{
 			if (candle.State != CandleStates.Finished)
 				return;

--- a/API/0227_Hurst_Exponent_Trend/HurstExponentTrendStrategy.cs
+++ b/API/0227_Hurst_Exponent_Trend/HurstExponentTrendStrategy.cs
@@ -123,7 +123,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal hurstValue, decimal smaValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? hurstValue, decimal? smaValue)
 		{
 			if (candle.State != CandleStates.Finished)
 				return;

--- a/API/0228_Hurst_Exponent_Reversion/HurstExponentReversionStrategy.cs
+++ b/API/0228_Hurst_Exponent_Reversion/HurstExponentReversionStrategy.cs
@@ -121,7 +121,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal smaValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? smaValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)
@@ -160,7 +160,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private decimal CalculateSimplifiedHurst(ICandleMessage candle)
+		private decimal? CalculateSimplifiedHurst(ICandleMessage candle)
 		{
 			// This is a simplified placeholder implementation
 			// A real Hurst exponent would require more complex calculations

--- a/API/0229_Autocorrelation_Reversal/AutocorrelationReversionStrategy.cs
+++ b/API/0229_Autocorrelation_Reversal/AutocorrelationReversionStrategy.cs
@@ -126,7 +126,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal smaValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? smaValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0235_VWAP_Mean_Reversion/VwapMeanReversionStrategy.cs
+++ b/API/0235_VWAP_Mean_Reversion/VwapMeanReversionStrategy.cs
@@ -111,7 +111,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessATR(ICandleMessage candle, decimal atr)
+		private void ProcessATR(ICandleMessage candle, decimal? atr)
 		{
 			if (candle.State != CandleStates.Finished)
 				return;

--- a/API/0236_RSI_Mean_Reversion/RsiMeanReversionStrategy.cs
+++ b/API/0236_RSI_Mean_Reversion/RsiMeanReversionStrategy.cs
@@ -129,7 +129,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessRsi(ICandleMessage candle, decimal rsiValue)
+		private void ProcessRsi(ICandleMessage candle, decimal? rsiValue)
 		{
 			if (candle.State != CandleStates.Finished)
 				return;

--- a/API/0246_VWAP_Breakout/VwapBreakoutStrategy.cs
+++ b/API/0246_VWAP_Breakout/VwapBreakoutStrategy.cs
@@ -112,7 +112,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal atr)
+		private void ProcessCandle(ICandleMessage candle, decimal? atr)
 		{
 			if (candle.State != CandleStates.Finished)
 				return;

--- a/API/0247_RSI_Breakout/RsiBreakoutStrategy.cs
+++ b/API/0247_RSI_Breakout/RsiBreakoutStrategy.cs
@@ -133,7 +133,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessRsi(ICandleMessage candle, decimal rsiValue)
+		private void ProcessRsi(ICandleMessage candle, decimal? rsiValue)
 		{
 			if (candle.State != CandleStates.Finished)
 				return;

--- a/API/0260_Supertrend_Distance_Breakout/SupertrendDistanceBreakoutStrategy.cs
+++ b/API/0260_Supertrend_Distance_Breakout/SupertrendDistanceBreakoutStrategy.cs
@@ -154,7 +154,7 @@ namespace StockSharp.Samples.Strategies
 			base.OnStarted(time);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal supertrendPrice)
+		private void ProcessCandle(ICandleMessage candle, decimal? supertrendPrice)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0261_Parabolic_SAR_Distance_Breakout/ParabolicSarDistanceBreakoutStrategy.cs
+++ b/API/0261_Parabolic_SAR_Distance_Breakout/ParabolicSarDistanceBreakoutStrategy.cs
@@ -156,7 +156,7 @@ namespace StockSharp.Samples.Strategies
 			base.OnStarted(time);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal sarValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? sarValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0262_Hull_MA_Slope_Breakout/HullMaSlopeBreakoutStrategy.cs
+++ b/API/0262_Hull_MA_Slope_Breakout/HullMaSlopeBreakoutStrategy.cs
@@ -150,7 +150,7 @@ namespace StockSharp.Samples.Strategies
 			base.OnStarted(time);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal hullValue, decimal atrValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? hullValue, decimal? atrValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0263_MA_Slope_Breakout/MaSlopeBreakoutStrategy.cs
+++ b/API/0263_MA_Slope_Breakout/MaSlopeBreakoutStrategy.cs
@@ -148,7 +148,7 @@ namespace StockSharp.Samples.Strategies
 			base.OnStarted(time);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal maValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? maValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0264_EMA_Slope_Breakout/EmaSlopeBreakoutStrategy.cs
+++ b/API/0264_EMA_Slope_Breakout/EmaSlopeBreakoutStrategy.cs
@@ -148,7 +148,7 @@ namespace StockSharp.Samples.Strategies
 			base.OnStarted(time);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal emaValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? emaValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0265_Volatility_Adjusted_Momentum/VolatilityAdjustedMomentumStrategy.cs
+++ b/API/0265_Volatility_Adjusted_Momentum/VolatilityAdjustedMomentumStrategy.cs
@@ -163,7 +163,7 @@ namespace StockSharp.Samples.Strategies
 			base.OnStarted(time);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal momentumValue, decimal atrValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? momentumValue, decimal? atrValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0266_VWAP_Slope_Breakout/VwapSlopeBreakoutStrategy.cs
+++ b/API/0266_VWAP_Slope_Breakout/VwapSlopeBreakoutStrategy.cs
@@ -133,7 +133,7 @@ namespace StockSharp.Samples.Strategies
 			base.OnStarted(time);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal vwapValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? vwapValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0267_RSI_Slope_Breakout/RsiSlopeBreakoutStrategy.cs
+++ b/API/0267_RSI_Slope_Breakout/RsiSlopeBreakoutStrategy.cs
@@ -148,7 +148,7 @@ namespace StockSharp.Samples.Strategies
 			base.OnStarted(time);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal rsiValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? rsiValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0269_CCI_Slope_Breakout/CciSlopeBreakoutStrategy.cs
+++ b/API/0269_CCI_Slope_Breakout/CciSlopeBreakoutStrategy.cs
@@ -129,7 +129,7 @@ namespace StockSharp.Samples.Strategies
 			StartProtection(new(), new Unit(StopLossPercent, UnitTypes.Percent));
 		}
 		
-		private void ProcessCandle(ICandleMessage candle, decimal cciValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? cciValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0270_Williams_R_Slope_Breakout/WilliamsRSlopeBreakoutStrategy.cs
+++ b/API/0270_Williams_R_Slope_Breakout/WilliamsRSlopeBreakoutStrategy.cs
@@ -129,7 +129,7 @@ namespace StockSharp.Samples.Strategies
 			StartProtection(new(), new Unit(StopLossPercent, UnitTypes.Percent));
 		}
 		
-		private void ProcessCandle(ICandleMessage candle, decimal williamsRValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? williamsRValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0274_Volume_Slope_Breakout/VolumeSlopeBreakoutStrategy.cs
+++ b/API/0274_Volume_Slope_Breakout/VolumeSlopeBreakoutStrategy.cs
@@ -138,7 +138,7 @@ namespace StockSharp.Samples.Strategies
 			StartProtection(new(), new Unit(StopLossPercent, UnitTypes.Percent));
 		}
 		
-		private void ProcessCandle(ICandleMessage candle, decimal volumeValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? volumeValue)
 		{
 			// Check if strategy is ready to trade
 			if (!IsFormedAndOnlineAndAllowTrading())

--- a/API/0275_OBV_Slope_Breakout/ObvSlopeBreakoutStrategy.cs
+++ b/API/0275_OBV_Slope_Breakout/ObvSlopeBreakoutStrategy.cs
@@ -142,7 +142,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessObv(ICandleMessage candle, decimal obvValue)
+		private void ProcessObv(ICandleMessage candle, decimal? obvValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0283_MA_Slope_Mean_Reversion/MaSlopeMeanReversionStrategy.cs
+++ b/API/0283_MA_Slope_Mean_Reversion/MaSlopeMeanReversionStrategy.cs
@@ -149,7 +149,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal maValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? maValue)
 		{
 			if (candle.State != CandleStates.Finished)
 				return;

--- a/API/0284_EMA_Slope_Mean_Reversion/EmaSlopeMeanReversionStrategy.cs
+++ b/API/0284_EMA_Slope_Mean_Reversion/EmaSlopeMeanReversionStrategy.cs
@@ -149,7 +149,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal emaValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? emaValue)
 		{
 			if (candle.State != CandleStates.Finished)
 				return;

--- a/API/0285_VWAP_Slope_Mean_Reversion/VwapSlopeMeanReversionStrategy.cs
+++ b/API/0285_VWAP_Slope_Mean_Reversion/VwapSlopeMeanReversionStrategy.cs
@@ -134,7 +134,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal vwapValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? vwapValue)
 		{
 			if (candle.State != CandleStates.Finished)
 				return;

--- a/API/0286_RSI_Slope_Mean_Reversion/RsiSlopeMeanReversionStrategy.cs
+++ b/API/0286_RSI_Slope_Mean_Reversion/RsiSlopeMeanReversionStrategy.cs
@@ -149,7 +149,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal rsiValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? rsiValue)
 		{
 			if (candle.State != CandleStates.Finished)
 				return;

--- a/API/0288_CCI_Slope_Mean_Reversion/CciSlopeMeanReversionStrategy.cs
+++ b/API/0288_CCI_Slope_Mean_Reversion/CciSlopeMeanReversionStrategy.cs
@@ -149,7 +149,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal cciValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? cciValue)
 		{
 			if (candle.State != CandleStates.Finished)
 				return;

--- a/API/0292_ATR_Slope_Mean_Reversion/AtrSlopeMeanReversionStrategy.cs
+++ b/API/0292_ATR_Slope_Mean_Reversion/AtrSlopeMeanReversionStrategy.cs
@@ -148,7 +148,7 @@ namespace StockSharp.Samples.Strategies
 			base.OnStarted(time);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal atrValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? atrValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0295_Pairs_Trading_Volatility_Filter/PairsTradingVolatilityFilterStrategy.cs
+++ b/API/0295_Pairs_Trading_Volatility_Filter/PairsTradingVolatilityFilterStrategy.cs
@@ -213,7 +213,7 @@ namespace StockSharp.Strategies
 			return price1 / price2;
 		}
 		
-		private void ProcessSecurity1Candle(ICandleMessage candle, decimal atrValue)
+		private void ProcessSecurity1Candle(ICandleMessage candle, decimal? atrValue)
 		{
 			if (candle.State != CandleStates.Finished)
 				return;

--- a/API/0300_Hurst_Exponent_Volatility_Filter/HurstVolatilityFilterStrategy.cs
+++ b/API/0300_Hurst_Exponent_Volatility_Filter/HurstVolatilityFilterStrategy.cs
@@ -161,7 +161,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal smaValue, decimal atrValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? smaValue, decimal? atrValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)
@@ -188,7 +188,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 		
-		private decimal CalculateHurstExponentValue(ICandleMessage candle)
+		private decimal? CalculateHurstExponentValue(ICandleMessage candle)
 		{
 			// In a real implementation, this would use R/S analysis or other methods
 			// to calculate the Hurst exponent. For this example, we'll use a placeholder

--- a/API/0302_Volatility_Cluster_Breakout/VolatilityClusterBreakoutStrategy.cs
+++ b/API/0302_Volatility_Cluster_Breakout/VolatilityClusterBreakoutStrategy.cs
@@ -141,7 +141,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal smaValue, decimal stdDevValue, decimal atrValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? smaValue, decimal? stdDevValue, decimal? atrValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0303_Seasonality_Adjusted_Momentum/SeasonalityAdjustedMomentumStrategy.cs
+++ b/API/0303_Seasonality_Adjusted_Momentum/SeasonalityAdjustedMomentumStrategy.cs
@@ -146,7 +146,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal momentumValue, decimal momentumAvgValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? momentumValue, decimal? momentumAvgValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0305_RSI_Dynamic_Overbought_Oversold/RsiDynamicOverboughtOversoldStrategy.cs
+++ b/API/0305_RSI_Dynamic_Overbought_Oversold/RsiDynamicOverboughtOversoldStrategy.cs
@@ -142,7 +142,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal rsiValue, decimal priceSmaValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? rsiValue, decimal? priceSmaValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0310_Donchian_Volatility_Contraction/DonchianWithVolatilityContractionStrategy.cs
+++ b/API/0310_Donchian_Volatility_Contraction/DonchianWithVolatilityContractionStrategy.cs
@@ -154,7 +154,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessStrategy(ICandleMessage candle, decimal donchianHigh, decimal donchianLow, decimal atrValue)
+		private void ProcessStrategy(ICandleMessage candle, decimal? donchianHigh, decimal? donchianLow, decimal? atrValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0311_Keltner_RSI_Divergence/KeltnerWithRsiDivergenceStrategy.cs
+++ b/API/0311_Keltner_RSI_Divergence/KeltnerWithRsiDivergenceStrategy.cs
@@ -145,7 +145,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal emaValue, decimal atrValue, decimal rsiValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? emaValue, decimal? atrValue, decimal? rsiValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0312_Hull_MA_Volume_Spike/HullMaWithVolumeSpikeStrategy.cs
+++ b/API/0312_Hull_MA_Volume_Spike/HullMaWithVolumeSpikeStrategy.cs
@@ -140,7 +140,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessStrategy(ICandleMessage candle, decimal hmaValue, decimal volume, decimal volumeAvg, decimal volumeStdDev)
+		private void ProcessStrategy(ICandleMessage candle, decimal? hmaValue, decimal? volume, decimal? volumeAvg, decimal? volumeStdDev)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0314_Parabolic_SAR_Volatility_Expansion/ParabolicSarWithVolatilityExpansionStrategy.cs
+++ b/API/0314_Parabolic_SAR_Volatility_Expansion/ParabolicSarWithVolatilityExpansionStrategy.cs
@@ -151,7 +151,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessStrategy(ICandleMessage candle, decimal sarValue, decimal atrValue, decimal atrAvg, decimal atrStdDev)
+		private void ProcessStrategy(ICandleMessage candle, decimal? sarValue, decimal? atrValue, decimal? atrAvg, decimal? atrStdDev)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0315_Stochastic_Dynamic_Zones/StochasticWithDynamicZonesStrategy.cs
+++ b/API/0315_Stochastic_Dynamic_Zones/StochasticWithDynamicZonesStrategy.cs
@@ -177,7 +177,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessStrategy(ICandleMessage candle, decimal stochK, decimal dynamicOversold, decimal dynamicOverbought)
+		private void ProcessStrategy(ICandleMessage candle, decimal? stochK, decimal? dynamicOversold, decimal? dynamicOverbought)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0316_ADX_Volume_Breakout/AdxWithVolumeBreakoutStrategy.cs
+++ b/API/0316_ADX_Volume_Breakout/AdxWithVolumeBreakoutStrategy.cs
@@ -154,7 +154,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessStrategy(ICandleMessage candle, decimal adx, decimal diPlus, decimal diMinus, decimal volume, decimal volumeAvg, decimal volumeStdDev)
+		private void ProcessStrategy(ICandleMessage candle, decimal? adx, decimal? diPlus, decimal? diMinus, decimal? volume, decimal? volumeAvg, decimal? volumeStdDev)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0317_CCI_Volatility_Filter/CciWithVolatilityFilterStrategy.cs
+++ b/API/0317_CCI_Volatility_Filter/CciWithVolatilityFilterStrategy.cs
@@ -142,7 +142,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessStrategy(ICandleMessage candle, decimal cciValue, decimal atrValue, decimal atrAvg)
+		private void ProcessStrategy(ICandleMessage candle, decimal? cciValue, decimal? atrValue, decimal? atrAvg)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0318_Williams_R_Momentum/WilliamsPercentRWithMomentumStrategy.cs
+++ b/API/0318_Williams_R_Momentum/WilliamsPercentRWithMomentumStrategy.cs
@@ -142,7 +142,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessStrategy(ICandleMessage candle, decimal williamsRValue, decimal momentumValue, decimal momentumAvg)
+		private void ProcessStrategy(ICandleMessage candle, decimal? williamsRValue, decimal? momentumValue, decimal? momentumAvg)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0319_Bollinger_K-Means_Cluster/BollingerKmeansStrategy.cs
+++ b/API/0319_Bollinger_K-Means_Cluster/BollingerKmeansStrategy.cs
@@ -213,7 +213,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 		
-		private void UpdateClusterData(ICandleMessage candle, decimal rsi)
+		private void UpdateClusterData(ICandleMessage candle, decimal? rsi)
 		{
 			// Add current values to the data series
 			_priceValues.Add(candle.ClosePrice);

--- a/API/0322_Supertrend_RSI_Divergence/SupertrendRsiDivergenceStrategy.cs
+++ b/API/0322_Supertrend_RSI_Divergence/SupertrendRsiDivergenceStrategy.cs
@@ -139,7 +139,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 		
-		private void ProcessCandle(ICandleMessage candle, decimal supertrendValue, decimal rsiValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? supertrendValue, decimal? rsiValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0324_Keltner_Kalman_Filter/KeltnerKalmanStrategy.cs
+++ b/API/0324_Keltner_Kalman_Filter/KeltnerKalmanStrategy.cs
@@ -178,7 +178,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal emaValue, decimal atrValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? emaValue, decimal? atrValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0325_Hull_MA_Volatility_Contraction/HullMaVolatilityContractionStrategy.cs
+++ b/API/0325_Hull_MA_Volatility_Contraction/HullMaVolatilityContractionStrategy.cs
@@ -139,7 +139,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 		
-		private void ProcessCandle(ICandleMessage candle, decimal hmaValue, decimal atrValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? hmaValue, decimal? atrValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0334_Hull_MA_K-Means_Cluster/HullKmeansClusterStrategy.cs
+++ b/API/0334_Hull_MA_K-Means_Cluster/HullKmeansClusterStrategy.cs
@@ -152,7 +152,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal hullValue, decimal rsiValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? hullValue, decimal? rsiValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)
@@ -199,7 +199,7 @@ namespace StockSharp.Samples.Strategies
 			_lastPrice = candle.ClosePrice;
 		}
 
-		private void UpdateFeatureData(ICandleMessage candle, decimal rsiValue)
+		private void UpdateFeatureData(ICandleMessage candle, decimal? rsiValue)
 		{
 			// Calculate price change percentage
 			if (_lastPrice != 0)

--- a/API/0335_VWAP_Hidden_Markov_Model/VwapHiddenMarkovModelStrategy.cs
+++ b/API/0335_VWAP_Hidden_Markov_Model/VwapHiddenMarkovModelStrategy.cs
@@ -126,7 +126,7 @@ namespace StockSharp.Samples.Strategies
 			);
 		}
 
-		private void ProcessVwap(ICandleMessage candle, decimal vwapValue)
+		private void ProcessVwap(ICandleMessage candle, decimal? vwapValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0336_Parabolic_SAR_RSI_Divergence/ParabolicSarRsiDivergenceStrategy.cs
+++ b/API/0336_Parabolic_SAR_RSI_Divergence/ParabolicSarRsiDivergenceStrategy.cs
@@ -127,7 +127,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessSignals(ICandleMessage candle, decimal sarValue, decimal rsiValue)
+		private void ProcessSignals(ICandleMessage candle, decimal? sarValue, decimal? rsiValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0341_Supertrend_Put_Call_Ratio/SupertrendWithPutCallRatioStrategy.cs
+++ b/API/0341_Supertrend_Put_Call_Ratio/SupertrendWithPutCallRatioStrategy.cs
@@ -155,7 +155,7 @@ namespace StockSharp.Samples.Strategies
 		/// <summary>
 		/// Process each candle and Supertrend value.
 		/// </summary>
-		private void ProcessCandle(ICandleMessage candle, decimal supertrendValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? supertrendValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0343_Keltner_Reinforcement_Learning_Signal/KeltnerWithRLSignalStrategy.cs
+++ b/API/0343_Keltner_Reinforcement_Learning_Signal/KeltnerWithRLSignalStrategy.cs
@@ -247,7 +247,7 @@ namespace StockSharp.Samples.Strategies
 		/// This is a simplified RL model (Q-learning) for demonstration.
 		/// In a real system, this would likely be a more sophisticated model.
 		/// </summary>
-		private void UpdateRLSignal(ICandleMessage candle, decimal ema, decimal atr)
+		private void UpdateRLSignal(ICandleMessage candle, decimal? ema, decimal? atr)
 		{
 			// Features for RL decision:
 			// 1. Price position relative to EMA

--- a/API/0344_Hull_MA_Implied_Volatility_Breakout/HullMAWithImpliedVolatilityBreakoutStrategy.cs
+++ b/API/0344_Hull_MA_Implied_Volatility_Breakout/HullMAWithImpliedVolatilityBreakoutStrategy.cs
@@ -159,7 +159,7 @@ namespace StockSharp.Samples.Strategies
 		/// <summary>
 		/// Process each candle with HMA and ATR values.
 		/// </summary>
-		private void ProcessCandle(ICandleMessage candle, decimal hmaValue, decimal atrValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? hmaValue, decimal? atrValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0345_VWAP_Behavioral_Bias_Filter/VwapWithBehavioralBiasFilterStrategy.cs
+++ b/API/0345_VWAP_Behavioral_Bias_Filter/VwapWithBehavioralBiasFilterStrategy.cs
@@ -143,7 +143,7 @@ namespace StockSharp.Samples.Strategies
 		/// <summary>
 		/// Process each candle and VWAP value.
 		/// </summary>
-		private void ProcessCandle(ICandleMessage candle, decimal vwapValue)
+		private void ProcessCandle(ICandleMessage candle, decimal? vwapValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)

--- a/API/0349_ADX_Sentiment_Momentum/AdxSentimentMomentumStrategy.cs
+++ b/API/0349_ADX_Sentiment_Momentum/AdxSentimentMomentumStrategy.cs
@@ -209,7 +209,7 @@ namespace StockSharp.Samples.Strategies
 			_sentimentMomentum = _currentSentiment - _prevSentiment;
 		}
 
-		private decimal SimulateSentiment(ICandleMessage candle)
+		private decimal? SimulateSentiment(ICandleMessage candle)
 		{
 			// Base sentiment on price movement (up = positive sentiment, down = negative sentiment)
 			var priceUp = candle.OpenPrice < candle.ClosePrice;

--- a/API/0350_CCI_Put_Call_Ratio_Divergence/CciPutcallRatioDivergenceStrategy.cs
+++ b/API/0350_CCI_Put_Call_Ratio_Divergence/CciPutcallRatioDivergenceStrategy.cs
@@ -117,7 +117,7 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 
-		private void ProcessCandle(ICandleMessage candle, decimal cci, decimal atr)
+		private void ProcessCandle(ICandleMessage candle, decimal? cci, decimal? atr)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)


### PR DESCRIPTION
## Summary
- make handler parameters nullable decimals when bound via `Bind`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68692180ccdc8323b777da0e1f9dfac6