### PR TITLE
Clean strategy README titles

### DIFF
--- a/API/0301_Adaptive_EMA_Breakout/README.md
+++ b/API/0301_Adaptive_EMA_Breakout/README.md
@@ -1,4 +1,4 @@
-# 301 Adaptive EMA Breakout
+# Adaptive EMA Breakout
 The **Adaptive EMA Breakout** strategy is built around Adaptive EMA breakout with trend confirmation.
 
 Signals trigger when its indicators confirms breakout opportunities on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0302_Volatility_Cluster_Breakout/README.md
+++ b/API/0302_Volatility_Cluster_Breakout/README.md
@@ -1,4 +1,4 @@
-# 302 Volatility Cluster Breakout
+# Volatility Cluster Breakout
 The **Volatility Cluster Breakout** strategy is built around breakouts during high volatility clusters.
 
 Signals trigger when its indicators confirms breakout opportunities on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0303_Seasonality_Adjusted_Momentum/README.md
+++ b/API/0303_Seasonality_Adjusted_Momentum/README.md
@@ -1,4 +1,4 @@
-# 303 Seasonality Adjusted Momentum
+# Seasonality Adjusted Momentum
 The **Seasonality Adjusted Momentum** strategy is built around momentum indicator adjusted with seasonality strength.
 
 Signals trigger when Seasonality confirms momentum shifts on daily data. This makes the method suitable for active traders.

--- a/API/0305_RSI_Dynamic_Overbought_Oversold/README.md
+++ b/API/0305_RSI_Dynamic_Overbought_Oversold/README.md
@@ -1,4 +1,4 @@
-# 305 RSI Dynamic Overbought Oversold
+# RSI Dynamic Overbought Oversold
 The **RSI Dynamic Overbought Oversold** strategy is built around RSI with dynamic overbought/oversold levels.
 
 Signals trigger when Overbought confirms trend changes on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0306_Bollinger_Volatility_Breakout/README.md
+++ b/API/0306_Bollinger_Volatility_Breakout/README.md
@@ -1,4 +1,4 @@
-# 306 Bollinger Volatility Breakout
+# Bollinger Volatility Breakout
 The **Bollinger Volatility Breakout** strategy is built around Bollinger Bands breakout with volatility confirmation.
 
 Signals trigger when Bollinger confirms breakout opportunities on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0307_MACD_Adaptive_Histogram/README.md
+++ b/API/0307_MACD_Adaptive_Histogram/README.md
@@ -1,4 +1,4 @@
-# 307 MACD Adaptive Histogram
+# MACD Adaptive Histogram
 The **MACD Adaptive Histogram** strategy is built around MACD with adaptive histogram threshold.
 
 Signals trigger when Histogram confirms trend changes on intraday (15m) data. This makes the method suitable for active traders.

--- a/API/0308_Ichimoku_Volume_Cluster/README.md
+++ b/API/0308_Ichimoku_Volume_Cluster/README.md
@@ -1,4 +1,4 @@
-# 308 Ichimoku Volume Cluster
+# Ichimoku Volume Cluster
 The **Ichimoku Volume Cluster** strategy is built around Ichimoku Cloud with volume cluster confirmation.
 
 Signals trigger when its indicators confirms trend changes on intraday (1h) data. This makes the method suitable for active traders.

--- a/API/0309_Supertrend_Momentum_Filter/README.md
+++ b/API/0309_Supertrend_Momentum_Filter/README.md
@@ -1,4 +1,4 @@
-# 309 Supertrend Momentum Filter
+# Supertrend Momentum Filter
 The **Supertrend Momentum Filter** strategy is built around Supertrend and Momentum indicators.
 
 Signals trigger when its indicators confirms filtered entries on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0310_Donchian_Volatility_Contraction/README.md
+++ b/API/0310_Donchian_Volatility_Contraction/README.md
@@ -1,4 +1,4 @@
-# 310 Donchian Volatility Contraction
+# Donchian Volatility Contraction
 The **Donchian Volatility Contraction** strategy is built around Donchian Channel breakout after volatility contraction.
 
 Signals trigger when Donchian confirms volatility contraction patterns on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0311_Keltner_RSI_Divergence/README.md
+++ b/API/0311_Keltner_RSI_Divergence/README.md
@@ -1,4 +1,4 @@
-# 311 Keltner RSI Divergence
+# Keltner RSI Divergence
 The **Keltner RSI Divergence** strategy is built around Keltner Channel and RSI Divergence.
 
 Signals trigger when Keltner confirms divergence setups on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0312_Hull_MA_Volume_Spike/README.md
+++ b/API/0312_Hull_MA_Volume_Spike/README.md
@@ -1,4 +1,4 @@
-# 312 Hull MA Volume Spike
+# Hull MA Volume Spike
 The **Hull MA Volume Spike** strategy is built around Hull Moving Average with Volume Spike detection.
 
 Signals trigger when Spike confirms trend changes on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0313_VWAP_ADX_Trend_Strength/README.md
+++ b/API/0313_VWAP_ADX_Trend_Strength/README.md
@@ -1,4 +1,4 @@
-# 313 VWAP ADX Trend Strength
+# VWAP ADX Trend Strength
 The **VWAP ADX Trend Strength** strategy is built around VWAP with ADX Trend Strength.
 
 Signals trigger when its indicators confirms trend changes on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0314_Parabolic_SAR_Volatility_Expansion/README.md
+++ b/API/0314_Parabolic_SAR_Volatility_Expansion/README.md
@@ -1,4 +1,4 @@
-# 314 Parabolic SAR Volatility Expansion
+# Parabolic SAR Volatility Expansion
 The **Parabolic SAR Volatility Expansion** strategy is built around Parabolic SAR with Volatility Expansion detection.
 
 Signals trigger when Parabolic confirms trend changes on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0315_Stochastic_Dynamic_Zones/README.md
+++ b/API/0315_Stochastic_Dynamic_Zones/README.md
@@ -1,4 +1,4 @@
-# 315 Stochastic Dynamic Zones
+# Stochastic Dynamic Zones
 The **Stochastic Dynamic Zones** strategy is built around Stochastic Oscillator with Dynamic Overbought/Oversold Zones.
 
 Signals trigger when Stochastic confirms trend changes on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0316_ADX_Volume_Breakout/README.md
+++ b/API/0316_ADX_Volume_Breakout/README.md
@@ -1,4 +1,4 @@
-# 316 ADX Volume Breakout
+# ADX Volume Breakout
 The **ADX Volume Breakout** strategy is built around ADX with Volume Breakout.
 
 Signals trigger when its indicators confirms breakout opportunities on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0317_CCI_Volatility_Filter/README.md
+++ b/API/0317_CCI_Volatility_Filter/README.md
@@ -1,4 +1,4 @@
-# 317 CCI Volatility Filter
+# CCI Volatility Filter
 The **CCI Volatility Filter** strategy is built around CCI with Volatility Filter.
 
 Signals trigger when its indicators confirms filtered entries on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0318_Williams_R_Momentum/README.md
+++ b/API/0318_Williams_R_Momentum/README.md
@@ -1,4 +1,4 @@
-# 318 Williams R Momentum
+# Williams R Momentum
 The **Williams R Momentum** strategy is built around Williams %R with Momentum filter.
 
 Signals trigger when Williams confirms momentum shifts on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0319_Bollinger_K-Means_Cluster/README.md
+++ b/API/0319_Bollinger_K-Means_Cluster/README.md
@@ -1,4 +1,4 @@
-# 319 Bollinger K-Means Cluster
+# Bollinger K-Means Cluster
 The **Bollinger K-Means Cluster** strategy is built around Bollinger K-Means Cluster.
 
 Signals trigger when Bollinger confirms trend changes on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0320_MACD_Hidden_Markov_Model/README.md
+++ b/API/0320_MACD_Hidden_Markov_Model/README.md
@@ -1,4 +1,4 @@
-# 320 MACD Hidden Markov Model
+# MACD Hidden Markov Model
 The **MACD Hidden Markov Model** strategy is built around MACD Hidden Markov Model.
 
 Signals trigger when Markov confirms trend changes on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0321_Ichimoku_Hurst_Exponent/README.md
+++ b/API/0321_Ichimoku_Hurst_Exponent/README.md
@@ -1,4 +1,4 @@
-# 321 Ichimoku Hurst Exponent
+# Ichimoku Hurst Exponent
 The **Ichimoku Hurst Exponent** strategy is built around Ichimoku Kinko Hyo indicator with Hurst exponent filter.
 
 Signals trigger when Hurst confirms trend changes on intraday (15m) data. This makes the method suitable for active traders.

--- a/API/0322_Supertrend_RSI_Divergence/README.md
+++ b/API/0322_Supertrend_RSI_Divergence/README.md
@@ -1,4 +1,4 @@
-# 322 Supertrend RSI Divergence
+# Supertrend RSI Divergence
 The **Supertrend RSI Divergence** strategy is built around that uses Supertrend indicator along with RSI divergence to identify trading opportunities.
 
 Signals trigger when Divergence confirms divergence setups on intraday (15m) data. This makes the method suitable for active traders.

--- a/API/0323_Donchian_Seasonal_Filter/README.md
+++ b/API/0323_Donchian_Seasonal_Filter/README.md
@@ -1,4 +1,4 @@
-# 323 Donchian Seasonal Filter
+# Donchian Seasonal Filter
 The **Donchian Seasonal Filter** strategy is built around Donchian Channels with seasonal filter.
 
 Signals trigger when Donchian confirms filtered entries on intraday (15m) data. This makes the method suitable for active traders.

--- a/API/0324_Keltner_Kalman_Filter/README.md
+++ b/API/0324_Keltner_Kalman_Filter/README.md
@@ -1,4 +1,4 @@
-# 324 Keltner Kalman Filter
+# Keltner Kalman Filter
 The **Keltner Kalman Filter** strategy is built around combining Keltner Channels with a Kalman Filter to identify trends and trade opportunities.
 
 Signals trigger when Keltner confirms filtered entries on intraday (15m) data. This makes the method suitable for active traders.

--- a/API/0325_Hull_MA_Volatility_Contraction/README.md
+++ b/API/0325_Hull_MA_Volatility_Contraction/README.md
@@ -1,4 +1,4 @@
-# 325 Hull MA Volatility Contraction
+# Hull MA Volatility Contraction
 The **Hull MA Volatility Contraction** strategy is built around Hull Moving Average with volatility contraction filter.
 
 Signals trigger when its indicators confirms volatility contraction patterns on intraday (15m) data. This makes the method suitable for active traders.

--- a/API/0326_VWAP_Stochastic_Divergence/README.md
+++ b/API/0326_VWAP_Stochastic_Divergence/README.md
@@ -1,4 +1,4 @@
-# 326 VWAP Stochastic Divergence
+# VWAP Stochastic Divergence
 The **VWAP Stochastic Divergence** strategy is built around combining VWAP with ADX trend strength indicator.
 
 Signals trigger when Stochastic confirms divergence setups on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0327_Parabolic_SAR_Hurst_Filter/README.md
+++ b/API/0327_Parabolic_SAR_Hurst_Filter/README.md
@@ -1,4 +1,4 @@
-# 327 Parabolic SAR Hurst Filter
+# Parabolic SAR Hurst Filter
 The **Parabolic SAR Hurst Filter** strategy is built around Parabolic SAR Hurst Filter.
 
 Signals trigger when Parabolic confirms filtered entries on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0328_Bollinger_Kalman_Filter/README.md
+++ b/API/0328_Bollinger_Kalman_Filter/README.md
@@ -1,4 +1,4 @@
-# 328 Bollinger Kalman Filter
+# Bollinger Kalman Filter
 The **Bollinger Kalman Filter** strategy is built around Bollinger Kalman Filter.
 
 Signals trigger when Bollinger confirms filtered entries on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0329_MACD_Volume_Cluster/README.md
+++ b/API/0329_MACD_Volume_Cluster/README.md
@@ -1,4 +1,4 @@
-# 329 MACD Volume Cluster
+# MACD Volume Cluster
 The **MACD Volume Cluster** strategy is built around MACD Volume Cluster.
 
 Signals trigger when its indicators confirms trend changes on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0330_Ichimoku_Volatility_Contraction/README.md
+++ b/API/0330_Ichimoku_Volatility_Contraction/README.md
@@ -1,4 +1,4 @@
-# 330 Ichimoku Volatility Contraction
+# Ichimoku Volatility Contraction
 The **Ichimoku Volatility Contraction** strategy is built around Ichimoku Volatility Contraction.
 
 Signals trigger when its indicators confirms volatility contraction patterns on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0332_Donchian_Hurst_Exponent/README.md
+++ b/API/0332_Donchian_Hurst_Exponent/README.md
@@ -1,4 +1,4 @@
-# 332 Donchian Hurst Exponent
+# Donchian Hurst Exponent
 The **Donchian Hurst Exponent** strategy is built around that trades based on Donchian Channel breakouts with Hurst Exponent filter.
 
 Signals trigger when Donchian confirms trend changes on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0333_Keltner_Seasonal_Filter/README.md
+++ b/API/0333_Keltner_Seasonal_Filter/README.md
@@ -1,4 +1,4 @@
-# 333 Keltner Seasonal Filter
+# Keltner Seasonal Filter
 The **Keltner Seasonal Filter** strategy is built around that trades based on Keltner Channel breakouts with seasonal bias filter.
 
 Signals trigger when Keltner confirms filtered entries on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0334_Hull_MA_K-Means_Cluster/README.md
+++ b/API/0334_Hull_MA_K-Means_Cluster/README.md
@@ -1,4 +1,4 @@
-# 334 Hull MA K-Means Cluster
+# Hull MA K-Means Cluster
 The **Hull MA K-Means Cluster** strategy is built around that trades based on Hull Moving Average direction with K-Means clustering for market state detection.
 
 Signals trigger when its indicators confirms trend changes on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0335_VWAP_Hidden_Markov_Model/README.md
+++ b/API/0335_VWAP_Hidden_Markov_Model/README.md
@@ -1,4 +1,4 @@
-# 335 VWAP Hidden Markov Model
+# VWAP Hidden Markov Model
 The **VWAP Hidden Markov Model** strategy is built around that trades based on VWAP with Hidden Markov Model for market state detection.
 
 Signals trigger when Markov confirms trend changes on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0336_Parabolic_SAR_RSI_Divergence/README.md
+++ b/API/0336_Parabolic_SAR_RSI_Divergence/README.md
@@ -1,4 +1,4 @@
-# 336 Parabolic SAR RSI Divergence
+# Parabolic SAR RSI Divergence
 The **Parabolic SAR RSI Divergence** strategy is built around that trades based on Parabolic SAR signals when RSI shows divergence from price.
 
 Signals trigger when Parabolic confirms divergence setups on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0337_Adaptive_RSI_Volume_Filter/README.md
+++ b/API/0337_Adaptive_RSI_Volume_Filter/README.md
@@ -1,4 +1,4 @@
-# 337 Adaptive RSI Volume Filter
+# Adaptive RSI Volume Filter
 The **Adaptive RSI Volume Filter** strategy is built around that trades based on Adaptive RSI with volume confirmation.
 
 Signals trigger when its indicators confirms filtered entries on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0338_Adaptive_Bollinger_Breakout/README.md
+++ b/API/0338_Adaptive_Bollinger_Breakout/README.md
@@ -1,4 +1,4 @@
-# 338 Adaptive Bollinger Breakout
+# Adaptive Bollinger Breakout
 The **Adaptive Bollinger Breakout** strategy is built around that trades based on breakouts of Bollinger Bands with adaptively adjusted parameters.
 
 Signals trigger when Bollinger confirms breakout opportunities on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0339_MACD_Sentiment_Filter/README.md
+++ b/API/0339_MACD_Sentiment_Filter/README.md
@@ -1,4 +1,4 @@
-# 339 MACD Sentiment Filter
+# MACD Sentiment Filter
 The **MACD Sentiment Filter** strategy is built around MACD Sentiment Filter.
 
 Signals trigger when its indicators confirms filtered entries on intraday (15m) data. This makes the method suitable for active traders.

--- a/API/0340_Ichimoku_Implied_Volatility/README.md
+++ b/API/0340_Ichimoku_Implied_Volatility/README.md
@@ -1,4 +1,4 @@
-# 340 Ichimoku Implied Volatility
+# Ichimoku Implied Volatility
 The **Ichimoku Implied Volatility** strategy is built around Ichimoku Implied Volatility.
 
 Signals trigger when its indicators confirms trend changes on intraday (15m) data. This makes the method suitable for active traders.

--- a/API/0341_Supertrend_Put_Call_Ratio/README.md
+++ b/API/0341_Supertrend_Put_Call_Ratio/README.md
@@ -1,4 +1,4 @@
-# 341 Supertrend Put Call Ratio
+# Supertrend Put Call Ratio
 The **Supertrend Put Call Ratio** strategy is built around Supertrend Put Call Ratio.
 
 Signals trigger when its indicators confirms trend changes on intraday (15m) data. This makes the method suitable for active traders.

--- a/API/0342_Donchian_Sentiment_Spike/README.md
+++ b/API/0342_Donchian_Sentiment_Spike/README.md
@@ -1,4 +1,4 @@
-# 342 Donchian Sentiment Spike
+# Donchian Sentiment Spike
 The **Donchian Sentiment Spike** strategy is built around Donchian Sentiment Spike.
 
 Signals trigger when Donchian confirms trend changes on intraday (15m) data. This makes the method suitable for active traders.

--- a/API/0343_Keltner_Reinforcement_Learning_Signal/README.md
+++ b/API/0343_Keltner_Reinforcement_Learning_Signal/README.md
@@ -1,4 +1,4 @@
-# 343 Keltner Reinforcement Learning Signal
+# Keltner Reinforcement Learning Signal
 The **Keltner Reinforcement Learning Signal** strategy is built around Keltner Reinforcement Learning Signal.
 
 Signals trigger when Keltner confirms trend changes on intraday (15m) data. This makes the method suitable for active traders.

--- a/API/0344_Hull_MA_Implied_Volatility_Breakout/README.md
+++ b/API/0344_Hull_MA_Implied_Volatility_Breakout/README.md
@@ -1,4 +1,4 @@
-# 344 Hull MA Implied Volatility Breakout
+# Hull MA Implied Volatility Breakout
 The **Hull MA Implied Volatility Breakout** strategy is built around Hull MA Implied Volatility Breakout.
 
 Signals trigger when its indicators confirms breakout opportunities on intraday (15m) data. This makes the method suitable for active traders.

--- a/API/0345_VWAP_Behavioral_Bias_Filter/README.md
+++ b/API/0345_VWAP_Behavioral_Bias_Filter/README.md
@@ -1,4 +1,4 @@
-# 345 VWAP Behavioral Bias Filter
+# VWAP Behavioral Bias Filter
 The **VWAP Behavioral Bias Filter** strategy is built around VWAP Behavioral Bias Filter.
 
 Signals trigger when Behavioral confirms filtered entries on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0346_Parabolic_SAR_Sentiment_Divergence/README.md
+++ b/API/0346_Parabolic_SAR_Sentiment_Divergence/README.md
@@ -1,4 +1,4 @@
-# 346 Parabolic SAR Sentiment Divergence
+# Parabolic SAR Sentiment Divergence
 The **Parabolic SAR Sentiment Divergence** strategy is built around Parabolic SAR Sentiment Divergence.
 
 Signals trigger when Parabolic confirms divergence setups on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0347_RSI_Option_Open_Interest/README.md
+++ b/API/0347_RSI_Option_Open_Interest/README.md
@@ -1,4 +1,4 @@
-# 347 RSI Option Open Interest
+# RSI Option Open Interest
 The **RSI Option Open Interest** strategy is built around RSI Option Open Interest.
 
 Signals trigger when Option confirms trend changes on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0348_Stochastic_Implied_Volatility_Skew/README.md
+++ b/API/0348_Stochastic_Implied_Volatility_Skew/README.md
@@ -1,4 +1,4 @@
-# 348 Stochastic Implied Volatility Skew
+# Stochastic Implied Volatility Skew
 The **Stochastic Implied Volatility Skew** strategy is built around Stochastic Implied Volatility Skew.
 
 Signals trigger when Stochastic confirms trend changes on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0349_ADX_Sentiment_Momentum/README.md
+++ b/API/0349_ADX_Sentiment_Momentum/README.md
@@ -1,4 +1,4 @@
-# 349 ADX Sentiment Momentum
+# ADX Sentiment Momentum
 The **ADX Sentiment Momentum** strategy is built around ADX Sentiment Momentum.
 
 Signals trigger when its indicators confirms momentum shifts on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0350_CCI_Put_Call_Ratio_Divergence/README.md
+++ b/API/0350_CCI_Put_Call_Ratio_Divergence/README.md
@@ -1,4 +1,4 @@
-# 350 CCI Put Call Ratio Divergence
+# CCI Put Call Ratio Divergence
 The **CCI Put Call Ratio Divergence** strategy is built around CCI Put Call Ratio Divergence.
 
 Signals trigger when Divergence confirms divergence setups on intraday (5m) data. This makes the method suitable for active traders.


### PR DESCRIPTION
## Summary
- remove numeric prefixes from strategy titles in API README files

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68712f791d608323bfa719e9537d7c96