### PR TITLE
Add Chinese README versions for strategies 31-60

### DIFF
--- a/API/0031_Keltner_Reversion/README_cn.md
+++ b/API/0031_Keltner_Reversion/README_cn.md
@@ -1,0 +1,29 @@
+# Keltner均值回归 (Keltner Reversion)
+
+当价格突破Keltner通道时做反向交易, 期望价格回到中轨。
+
+通道宽度随波动率调整, 止损基于ATR倍数。
+
+## 详情
+
+- **入场条件**: Signals based on RSI, ATR, Keltner.
+- **多空方向**: Both directions.
+- **出场条件**: Opposite signal or stop.
+- **止损**: Yes.
+- **默认值**:
+  - `EmaPeriod` = 20
+  - `AtrPeriod` = 14
+  - `AtrMultiplier` = 2.0m
+  - `StopLossAtrMultiplier` = 2.0m
+  - `CandleType` = TimeSpan.FromMinutes(5)
+- **过滤器**:
+  - 类别: Mean Reversion
+  - 方向: Both
+  - 指标: RSI, ATR, Keltner
+  - 止损: Yes
+  - 复杂度: Basic
+  - 时间框架: Intraday (5m)
+  - 季节性: No
+  - 神经网络: No
+  - 背离: No
+  - 风险等级: Medium

--- a/API/0032_ATR_Reversion/README_cn.md
+++ b/API/0032_ATR_Reversion/README_cn.md
@@ -1,0 +1,29 @@
+# ATR均值回归 (ATR Reversion)
+
+利用平均真实波幅(ATR)的异常波动寻找反转机会。
+
+在剧烈波动后按相反方向入场, 出场依据均线或ATR止损。
+
+## 详情
+
+- **入场条件**: Price move exceeds `AtrMultiplier` times ATR.
+- **多空方向**: Both directions.
+- **出场条件**: Price crosses moving average or stop.
+- **止损**: Yes.
+- **默认值**:
+  - `AtrPeriod` = 14
+  - `AtrMultiplier` = 2.0m
+  - `MAPeriod` = 20
+  - `StopLossPercent` = 2.0m
+  - `CandleType` = TimeSpan.FromMinutes(5)
+- **过滤器**:
+  - 类别: Mean Reversion
+  - 方向: Both
+  - 指标: ATR, MA
+  - 止损: Yes
+  - 复杂度: Basic
+  - 时间框架: Intraday
+  - 季节性: No
+  - 神经网络: No
+  - 背离: No
+  - 风险等级: Medium

--- a/API/0033_MACD_Zero/README_cn.md
+++ b/API/0033_MACD_Zero/README_cn.md
@@ -1,0 +1,29 @@
+# MACD零轴反转 (MACD Zero Cross)
+
+当MACD柱趋近零轴时捕捉动量反转。
+
+等待MACD减弱后入场, 交叉信号或止损离场。
+
+## 详情
+
+- **入场条件**: MACD trending toward zero from either side.
+- **多空方向**: Both directions.
+- **出场条件**: MACD crosses signal line or stop.
+- **止损**: Yes.
+- **默认值**:
+  - `FastPeriod` = 12
+  - `SlowPeriod` = 26
+  - `SignalPeriod` = 9
+  - `StopLossPercent` = 2.0m
+  - `CandleType` = TimeSpan.FromMinutes(5)
+- **过滤器**:
+  - 类别: Momentum
+  - 方向: Both
+  - 指标: MACD
+  - 止损: Yes
+  - 复杂度: Basic
+  - 时间框架: Intraday
+  - 季节性: No
+  - 神经网络: No
+  - 背离: No
+  - 风险等级: Medium

--- a/API/0034_Low_Vol_Reversion/README_cn.md
+++ b/API/0034_Low_Vol_Reversion/README_cn.md
@@ -1,0 +1,30 @@
+# 低波动均值回归 (Low Volatility Reversion)
+
+仅在市场安静时启用, 当波动率低于平均水平且价格偏离均线时介入。
+
+目标是在平静环境下捕捉回归, 止损由ATR决定。
+
+## 详情
+
+- **入场条件**: Price away from moving average while ATR is below threshold.
+- **多空方向**: Both directions.
+- **出场条件**: Price returns to MA or stop triggers.
+- **止损**: Yes.
+- **默认值**:
+  - `MAPeriod` = 20
+  - `AtrPeriod` = 14
+  - `AtrLookbackPeriod` = 20
+  - `AtrThresholdPercent` = 50m
+  - `AtrMultiplier` = 2.0m
+  - `CandleType` = TimeSpan.FromMinutes(5)
+- **过滤器**:
+  - 类别: Mean Reversion
+  - 方向: Both
+  - 指标: ATR, MA
+  - 止损: Yes
+  - 复杂度: Intermediate
+  - 时间框架: Intraday
+  - 季节性: No
+  - 神经网络: No
+  - 背离: No
+  - 风险等级: Medium

--- a/API/0035_Bollinger_B_Reversion/README_cn.md
+++ b/API/0035_Bollinger_B_Reversion/README_cn.md
@@ -1,0 +1,29 @@
+# 布林百分比B回归 (Bollinger Percent B Reversion)
+
+利用Percent B指标在价格越界布林带时做回归。
+
+当Percent B超出0-1范围即进场, 达到阈值或止损退出。
+
+## 详情
+
+- **入场条件**: Percent B outside the 0–1 range.
+- **多空方向**: Both directions.
+- **出场条件**: Percent B crosses `ExitValue` or stop.
+- **止损**: Yes.
+- **默认值**:
+  - `BollingerPeriod` = 20
+  - `BollingerDeviation` = 2.0m
+  - `ExitValue` = 0.5m
+  - `StopLossPercent` = 2.0m
+  - `CandleType` = TimeSpan.FromMinutes(5)
+- **过滤器**:
+  - 类别: Mean Reversion
+  - 方向: Both
+  - 指标: Bollinger Bands
+  - 止损: Yes
+  - 复杂度: Basic
+  - 时间框架: Intraday
+  - 季节性: No
+  - 神经网络: No
+  - 背离: No
+  - 风险等级: Medium

--- a/API/0036_ATR_Expansion/README_cn.md
+++ b/API/0036_ATR_Expansion/README_cn.md
@@ -1,0 +1,28 @@
+# ATR扩张突破 (ATR Expansion Breakout)
+
+ATR上升表示波动爆发, 在价格相对均线方向突破时入场。
+
+ATR收缩则离场, 止损基于ATR倍数。
+
+## 详情
+
+- **入场条件**: ATR increasing and price above/below MA.
+- **多空方向**: Both directions.
+- **出场条件**: ATR contracts or stop is hit.
+- **止损**: Yes.
+- **默认值**:
+  - `AtrPeriod` = 14
+  - `MAPeriod` = 20
+  - `AtrMultiplier` = 2.0m
+  - `CandleType` = TimeSpan.FromMinutes(5)
+- **过滤器**:
+  - 类别: Breakout
+  - 方向: Both
+  - 指标: ATR, MA
+  - 止损: Yes
+  - 复杂度: Basic
+  - 时间框架: Intraday
+  - 季节性: No
+  - 神经网络: No
+  - 背离: No
+  - 风险等级: Medium

--- a/API/0037_VIX_Trigger/README_cn.md
+++ b/API/0037_VIX_Trigger/README_cn.md
@@ -1,0 +1,27 @@
+# VIX触发 (VIX Trigger)
+
+监控波动率指数VIX的变化。上升的VIX可能预示反转。
+
+结合价格与均线位置决定方向。
+
+## 详情
+
+- **入场条件**: VIX rising while price relative to MA triggers longs or shorts.
+- **多空方向**: Both directions.
+- **出场条件**: VIX falls or stop.
+- **止损**: Yes.
+- **默认值**:
+  - `MAPeriod` = 20
+  - `StopLossPercent` = 2.0m
+  - `CandleType` = TimeSpan.FromMinutes(5)
+- **过滤器**:
+  - 类别: Contrarian
+  - 方向: Both
+  - 指标: VIX, MA
+  - 止损: Yes
+  - 复杂度: Intermediate
+  - 时间框架: Intraday
+  - 季节性: No
+  - 神经网络: No
+  - 背离: No
+  - 风险等级: Medium

--- a/API/0038_BB_Width/README_cn.md
+++ b/API/0038_BB_Width/README_cn.md
@@ -1,0 +1,28 @@
+# 布林带宽突破 (Bollinger Band Width Breakout)
+
+带宽扩大表明波动增加并可能形成趋势。
+
+价格位于中轨之上时看多, 之下看空。
+
+## 详情
+
+- **入场条件**: Band width expanding and price relative to middle band.
+- **多空方向**: Both directions.
+- **出场条件**: Band width contracts or stop.
+- **止损**: Yes.
+- **默认值**:
+  - `BollingerPeriod` = 20
+  - `BollingerDeviation` = 2.0m
+  - `AtrMultiplier` = 2.0m
+  - `CandleType` = TimeSpan.FromMinutes(5)
+- **过滤器**:
+  - 类别: Breakout
+  - 方向: Both
+  - 指标: Bollinger Bands, ATR
+  - 止损: Yes
+  - 复杂度: Basic
+  - 时间框架: Intraday
+  - 季节性: No
+  - 神经网络: No
+  - 背离: No
+  - 风险等级: Medium

--- a/API/0039_HV_Breakout/README_cn.md
+++ b/API/0039_HV_Breakout/README_cn.md
@@ -1,0 +1,28 @@
+# 历史波动率突破 (Historical Volatility Breakout)
+
+利用历史波动率设定动态阈值, 突破该阈值表明新趋势。
+
+根据标准差和均线生成的水平进行交易。
+
+## 详情
+
+- **入场条件**: Price breaks above or below HV-based level.
+- **多空方向**: Both directions.
+- **出场条件**: Price crosses MA or stop.
+- **止损**: Yes.
+- **默认值**:
+  - `HvPeriod` = 20
+  - `MAPeriod` = 20
+  - `StopLossPercent` = 2.0m
+  - `CandleType` = TimeSpan.FromMinutes(5)
+- **过滤器**:
+  - 类别: Breakout
+  - 方向: Both
+  - 指标: HV, MA
+  - 止损: Yes
+  - 复杂度: Intermediate
+  - 时间框架: Intraday
+  - 季节性: No
+  - 神经网络: No
+  - 背离: No
+  - 风险等级: Medium

--- a/API/0040_ATR_Trailing/README_cn.md
+++ b/API/0040_ATR_Trailing/README_cn.md
@@ -1,0 +1,28 @@
+# ATR跟踪止损 (ATR Trailing Stops)
+
+以ATR倍数跟随价格设置止损。
+
+价格穿越均线时入场, 止损随波动率移动。
+
+## 详情
+
+- **入场条件**: Price above or below MA.
+- **多空方向**: Both directions.
+- **出场条件**: Trailing stop hit or price crosses MA.
+- **止损**: Yes.
+- **默认值**:
+  - `AtrPeriod` = 14
+  - `AtrMultiplier` = 3.0m
+  - `MAPeriod` = 20
+  - `CandleType` = TimeSpan.FromMinutes(5)
+- **过滤器**:
+  - 类别: Trend
+  - 方向: Both
+  - 指标: ATR, MA
+  - 止损: Yes
+  - 复杂度: Intermediate
+  - 时间框架: Intraday
+  - 季节性: No
+  - 神经网络: No
+  - 背离: No
+  - 风险等级: Medium

--- a/API/0041_Vol_Adjusted_MA/README_cn.md
+++ b/API/0041_Vol_Adjusted_MA/README_cn.md
@@ -1,0 +1,28 @@
+# 波动率调节均线 (Volatility Adjusted Moving Average)
+
+在均线上下添加ATR倍数带。
+
+价格突破带上缘做多, 突破下缘做空, 回到均线平仓。
+
+## 详情
+
+- **入场条件**: Price breaks above or below MA ± ATR multiplier.
+- **多空方向**: Both directions.
+- **出场条件**: Price crosses MA or stop.
+- **止损**: Yes.
+- **默认值**:
+  - `MAPeriod` = 20
+  - `ATRPeriod` = 14
+  - `ATRMultiplier` = 2.0m
+  - `CandleType` = TimeSpan.FromMinutes(5)
+- **过滤器**:
+  - 类别: Trend
+  - 方向: Both
+  - 指标: MA, ATR
+  - 止损: Yes
+  - 复杂度: Intermediate
+  - 时间框架: Intraday
+  - 季节性: No
+  - 神经网络: No
+  - 背离: No
+  - 风险等级: Medium

--- a/API/0042_IV_Spike/README_cn.md
+++ b/API/0042_IV_Spike/README_cn.md
@@ -1,0 +1,28 @@
+# 隐含波动飙升 (Implied Volatility Spike)
+
+监控隐含波动率急剧上升并与均线方向相反时做短期反转。
+
+波动率超过阈值时逆势入场, 期待回落。
+
+## 详情
+
+- **入场条件**: IV spike above `IVSpikeThreshold` and price relative to MA.
+- **多空方向**: Both directions.
+- **出场条件**: IV declines or stop.
+- **止损**: Yes.
+- **默认值**:
+  - `MAPeriod` = 20
+  - `IVPeriod` = 20
+  - `IVSpikeThreshold` = 1.5m
+  - `CandleType` = TimeSpan.FromMinutes(5)
+- **过滤器**:
+  - 类别: Volatility
+  - 方向: Both
+  - 指标: IV, MA
+  - 止损: Yes
+  - 复杂度: Intermediate
+  - 时间框架: Intraday
+  - 季节性: No
+  - 神经网络: No
+  - 背离: No
+  - 风险等级: Medium

--- a/API/0043_VCP/README_cn.md
+++ b/API/0043_VCP/README_cn.md
@@ -1,0 +1,27 @@
+# 波动收缩形态 (Volatility Contraction Pattern)
+
+寻找一系列逐渐收窄的价格区间, 为爆发行情蓄势。
+
+突破区间高点或低点时入场。
+
+## 详情
+
+- **入场条件**: Range contraction then breakout of recent high/low.
+- **多空方向**: Both directions.
+- **出场条件**: Price crosses MA or stop.
+- **止损**: Yes.
+- **默认值**:
+  - `MAPeriod` = 20
+  - `LookbackPeriod` = 20
+  - `CandleType` = TimeSpan.FromMinutes(5)
+- **过滤器**:
+  - 类别: Breakout
+  - 方向: Both
+  - 指标: Range, MA
+  - 止损: Yes
+  - 复杂度: Intermediate
+  - 时间框架: Intraday
+  - 季节性: No
+  - 神经网络: No
+  - 背离: No
+  - 风险等级: Medium

--- a/API/0044_ATR_Range/README_cn.md
+++ b/API/0044_ATR_Range/README_cn.md
@@ -1,0 +1,28 @@
+# ATR区间突破 (ATR Range Breakout)
+
+价格移动超过ATR平均值时顺势开仓。
+
+突破方向决定多空, 反向或止损离场。
+
+## 详情
+
+- **入场条件**: Price moves more than ATR over the lookback period.
+- **多空方向**: Both directions.
+- **出场条件**: Price crosses MA or stop.
+- **止损**: Yes.
+- **默认值**:
+  - `MAPeriod` = 20
+  - `ATRPeriod` = 14
+  - `LookbackPeriod` = 5
+  - `CandleType` = TimeSpan.FromMinutes(5)
+- **过滤器**:
+  - 类别: Breakout
+  - 方向: Both
+  - 指标: ATR, MA
+  - 止损: Yes
+  - 复杂度: Basic
+  - 时间框架: Intraday
+  - 季节性: No
+  - 神经网络: No
+  - 背离: No
+  - 风险等级: Medium

--- a/API/0045_Choppiness_Index_Breakout/README_cn.md
+++ b/API/0045_Choppiness_Index_Breakout/README_cn.md
@@ -1,0 +1,29 @@
+# 震荡指数突破 (Choppiness Index Breakout)
+
+利用Choppiness Index判断市场从震荡转向趋势。
+
+指标低于阈值时跟随新趋势进入。
+
+## 详情
+
+- **入场条件**: Choppiness below `ChoppinessThreshold` with price above/below MA.
+- **多空方向**: Both directions.
+- **出场条件**: Choppiness above `HighChoppinessThreshold` or stop.
+- **止损**: Yes.
+- **默认值**:
+  - `MAPeriod` = 20
+  - `ChoppinessPeriod` = 14
+  - `ChoppinessThreshold` = 38.2m
+  - `HighChoppinessThreshold` = 61.8m
+  - `CandleType` = TimeSpan.FromMinutes(5)
+- **过滤器**:
+  - 类别: Breakout
+  - 方向: Both
+  - 指标: Choppiness, MA
+  - 止损: Yes
+  - 复杂度: Intermediate
+  - 时间框架: Intraday
+  - 季节性: No
+  - 神经网络: No
+  - 背离: No
+  - 风险等级: Medium

--- a/API/0046_Volume_Spike/README_cn.md
+++ b/API/0046_Volume_Spike/README_cn.md
@@ -1,0 +1,28 @@
+# 成交量激增趋势 (Volume Spike Trend)
+
+当成交量超过平均值乘以倍数时表明强烈参与。
+
+顺着价格与均线方向开仓。
+
+## 详情
+
+- **入场条件**: Volume change exceeds `VolumeSpikeMultiplier` times average.
+- **多空方向**: Both directions.
+- **出场条件**: Volume drops below average or stop.
+- **止损**: Yes.
+- **默认值**:
+  - `MAPeriod` = 20
+  - `VolAvgPeriod` = 20
+  - `VolumeSpikeMultiplier` = 2.0m
+  - `CandleType` = TimeSpan.FromMinutes(5)
+- **过滤器**:
+  - 类别: Breakout
+  - 方向: Both
+  - 指标: Volume, MA
+  - 止损: Yes
+  - 复杂度: Basic
+  - 时间框架: Intraday
+  - 季节性: No
+  - 神经网络: No
+  - 背离: No
+  - 风险等级: Medium

--- a/API/0047_OBV_Breakout/README_cn.md
+++ b/API/0047_OBV_Breakout/README_cn.md
@@ -1,0 +1,27 @@
+# OBV突破 (OBV Breakout)
+
+观察能量潮(OBV)突破历史高点或低点并由价格确认。
+
+跟随OBV方向交易。
+
+## 详情
+
+- **入场条件**: OBV surpasses highest or lowest value in lookback period.
+- **多空方向**: Both directions.
+- **出场条件**: OBV crosses its MA or stop.
+- **止损**: Yes.
+- **默认值**:
+  - `LookbackPeriod` = 20
+  - `OBVMAPeriod` = 20
+  - `CandleType` = TimeSpan.FromMinutes(5)
+- **过滤器**:
+  - 类别: Breakout
+  - 方向: Both
+  - 指标: OBV, MA
+  - 止损: Yes
+  - 复杂度: Intermediate
+  - 时间框架: Intraday
+  - 季节性: No
+  - 神经网络: No
+  - 背离: No
+  - 风险等级: Medium

--- a/API/0048_VWAP_Breakout/README_cn.md
+++ b/API/0048_VWAP_Breakout/README_cn.md
@@ -1,0 +1,25 @@
+# VWAP突破 (VWAP Breakout)
+
+价格从另一侧穿越成交量加权平均价(VWAP)时视为突破。
+
+回穿VWAP或止损退出。
+
+## 详情
+
+- **入场条件**: Price closes on the opposite side of VWAP.
+- **多空方向**: Both directions.
+- **出场条件**: Price crosses back through VWAP or stop.
+- **止损**: Yes.
+- **默认值**:
+  - `CandleType` = TimeSpan.FromMinutes(5)
+- **过滤器**:
+  - 类别: Breakout
+  - 方向: Both
+  - 指标: VWAP
+  - 止损: Yes
+  - 复杂度: Basic
+  - 时间框架: Intraday
+  - 季节性: No
+  - 神经网络: No
+  - 背离: No
+  - 风险等级: Medium

--- a/API/0049_VWMA/README_cn.md
+++ b/API/0049_VWMA/README_cn.md
@@ -1,0 +1,26 @@
+# VWMA交叉 (VWMA Cross)
+
+成交量加权移动平均(VWMA)强调高量价格。
+
+价格与VWMA交叉产生信号, 反向交叉离场。
+
+## 详情
+
+- **入场条件**: Price crosses VWMA from below or above.
+- **多空方向**: Both directions.
+- **出场条件**: Reverse crossover or stop.
+- **止损**: Yes.
+- **默认值**:
+  - `VWMAPeriod` = 14
+  - `CandleType` = TimeSpan.FromMinutes(5)
+- **过滤器**:
+  - 类别: Trend
+  - 方向: Both
+  - 指标: VWMA
+  - 止损: Yes
+  - 复杂度: Basic
+  - 时间框架: Intraday
+  - 季节性: No
+  - 神经网络: No
+  - 背离: No
+  - 风险等级: Medium

--- a/API/0050_AD/README_cn.md
+++ b/API/0050_AD/README_cn.md
@@ -1,0 +1,26 @@
+# AD趋势 (Accumulation/Distribution Trend)
+
+利用累计/派发指标判定买卖压力。
+
+指标与价格相符时顺势交易, 指标转向则退出。
+
+## 详情
+
+- **入场条件**: A/D rising with price above MA or falling below MA.
+- **多空方向**: Both directions.
+- **出场条件**: A/D reverses or stop.
+- **止损**: Yes.
+- **默认值**:
+  - `MAPeriod` = 20
+  - `CandleType` = TimeSpan.FromMinutes(5)
+- **过滤器**:
+  - 类别: Trend
+  - 方向: Both
+  - 指标: A/D, MA
+  - 止损: Yes
+  - 复杂度: Basic
+  - 时间框架: Intraday
+  - 季节性: No
+  - 神经网络: No
+  - 背离: No
+  - 风险等级: Medium

--- a/API/0051_Volume_Weighted_Price_Breakout/README_cn.md
+++ b/API/0051_Volume_Weighted_Price_Breakout/README_cn.md
@@ -1,0 +1,27 @@
+# 量价加权突破 (Volume Weighted Price Breakout)
+
+结合简单均线与VWMA, 当价格从另一侧穿越VWMA视为突破。
+
+价格反向穿越均线时离场。
+
+## 详情
+
+- **入场条件**: Price above or below VWMA with MA confirmation.
+- **多空方向**: Both directions.
+- **出场条件**: Price crosses MA in opposite direction or stop.
+- **止损**: Yes.
+- **默认值**:
+  - `MAPeriod` = 20
+  - `VWAPPeriod` = 20
+  - `CandleType` = TimeSpan.FromMinutes(5)
+- **过滤器**:
+  - 类别: Breakout
+  - 方向: Both
+  - 指标: VWMA, MA
+  - 止损: Yes
+  - 复杂度: Intermediate
+  - 时间框架: Intraday
+  - 季节性: No
+  - 神经网络: No
+  - 背离: No
+  - 风险等级: Medium

--- a/API/0052_Volume_Divergence/README_cn.md
+++ b/API/0052_Volume_Divergence/README_cn.md
@@ -1,0 +1,27 @@
+# 成交量背离 (Volume Divergence)
+
+寻找价格走势与成交量不一致的情况。
+
+量增价跌视为吸筹, 量增价涨视为派发, 依此做多或做空。
+
+## 详情
+
+- **入场条件**: Price and volume moving in opposite directions.
+- **多空方向**: Both directions.
+- **出场条件**: Price crosses MA or stop.
+- **止损**: Yes.
+- **默认值**:
+  - `MAPeriod` = 20
+  - `ATRPeriod` = 14
+  - `CandleType` = TimeSpan.FromMinutes(5)
+- **过滤器**:
+  - 类别: Divergence
+  - 方向: Both
+  - 指标: Volume, MA
+  - 止损: Yes
+  - 复杂度: Intermediate
+  - 时间框架: Intraday
+  - 季节性: No
+  - 神经网络: No
+  - 背离: Yes
+  - 风险等级: Medium

--- a/API/0053_Volume_MA_Cross/README_cn.md
+++ b/API/0053_Volume_MA_Cross/README_cn.md
@@ -1,0 +1,27 @@
+# 成交量均线交叉 (Volume MA Cross)
+
+利用成交量快慢均线交叉判断参与度变化。
+
+快线向上穿越做多, 向下穿越做空, 反向交叉离场。
+
+## 详情
+
+- **入场条件**: Fast volume MA crosses slow volume MA.
+- **多空方向**: Both directions.
+- **出场条件**: Reverse crossover or stop.
+- **止损**: Yes.
+- **默认值**:
+  - `FastVolumeMALength` = 10
+  - `SlowVolumeMALength` = 50
+  - `CandleType` = TimeSpan.FromMinutes(5)
+- **过滤器**:
+  - 类别: Momentum
+  - 方向: Both
+  - 指标: Volume MA
+  - 止损: Yes
+  - 复杂度: Intermediate
+  - 时间框架: Intraday
+  - 季节性: No
+  - 神经网络: No
+  - 背离: No
+  - 风险等级: Medium

--- a/API/0054_Cumulative_Delta_Breakout/README_cn.md
+++ b/API/0054_Cumulative_Delta_Breakout/README_cn.md
@@ -1,0 +1,26 @@
+# 累积差分突破 (Cumulative Delta Breakout)
+
+累积买卖量差突破历史区间时入场。
+
+当差分回到零或止损触发时退出。
+
+## 详情
+
+- **入场条件**: Cumulative delta exceeds highest or lowest value in lookback.
+- **多空方向**: Both directions.
+- **出场条件**: Delta crosses zero or stop.
+- **止损**: Yes.
+- **默认值**:
+  - `LookbackPeriod` = 20
+  - `CandleType` = TimeSpan.FromMinutes(5)
+- **过滤器**:
+  - 类别: Breakout
+  - 方向: Both
+  - 指标: Cumulative Delta
+  - 止损: Yes
+  - 复杂度: Intermediate
+  - 时间框架: Intraday
+  - 季节性: No
+  - 神经网络: No
+  - 背离: No
+  - 风险等级: Medium

--- a/API/0055_Volume_Surge/README_cn.md
+++ b/API/0055_Volume_Surge/README_cn.md
@@ -1,0 +1,28 @@
+# 成交量激增 (Volume Surge)
+
+监控成交量远高于均值的情况, 表示市场强烈兴趣。
+
+激增时顺趋势开仓, 成交量回落或止损退出。
+
+## 详情
+
+- **入场条件**: Volume ratio above `VolumeSurgeMultiplier`.
+- **多空方向**: Both directions.
+- **出场条件**: Volume drops below average or stop.
+- **止损**: Yes.
+- **默认值**:
+  - `MAPeriod` = 20
+  - `VolumeAvgPeriod` = 20
+  - `VolumeSurgeMultiplier` = 2.0m
+  - `CandleType` = TimeSpan.FromMinutes(5)
+- **过滤器**:
+  - 类别: Breakout
+  - 方向: Both
+  - 指标: Volume
+  - 止损: Yes
+  - 复杂度: Basic
+  - 时间框架: Intraday
+  - 季节性: No
+  - 神经网络: No
+  - 背离: No
+  - 风险等级: Medium

--- a/API/0056_Double_Bottom/README_cn.md
+++ b/API/0056_Double_Bottom/README_cn.md
@@ -1,0 +1,28 @@
+# 双底形态 (Double Bottom Pattern)
+
+侦测两次相近低点形成的反转形态。
+
+第二个低点后出现看涨蜡烛确认后买入。
+
+## 详情
+
+- **入场条件**: Two bottoms form within `SimilarityPercent` after `Distance` bars.
+- **多空方向**: Long only.
+- **出场条件**: Price fails or stop-loss.
+- **止损**: Yes.
+- **默认值**:
+  - `Distance` = 5
+  - `SimilarityPercent` = 2.0m
+  - `CandleType` = TimeSpan.FromMinutes(15)
+  - `StopLossPercent` = 1.0m
+- **过滤器**:
+  - 类别: Pattern
+  - 方向: Long
+  - 指标: Price Action
+  - 止损: Yes
+  - 复杂度: Intermediate
+  - 时间框架: Intraday
+  - 季节性: No
+  - 神经网络: No
+  - 背离: Yes
+  - 风险等级: Medium

--- a/API/0057_Double_Top/README_cn.md
+++ b/API/0057_Double_Top/README_cn.md
@@ -1,0 +1,28 @@
+# 双顶形态 (Double Top Pattern)
+
+侦测两次相近高点形成的反转形态。
+
+第二个高点后出现看跌蜡烛确认后卖出。
+
+## 详情
+
+- **入场条件**: Two tops within `SimilarityPercent` after `Distance` bars.
+- **多空方向**: Short only.
+- **出场条件**: Price rallies or stop-loss.
+- **止损**: Yes.
+- **默认值**:
+  - `Distance` = 5
+  - `SimilarityPercent` = 2.0m
+  - `CandleType` = TimeSpan.FromMinutes(15)
+  - `StopLossPercent` = 1.0m
+- **过滤器**:
+  - 类别: Pattern
+  - 方向: Short
+  - 指标: Price Action
+  - 止损: Yes
+  - 复杂度: Intermediate
+  - 时间框架: Intraday
+  - 季节性: No
+  - 神经网络: No
+  - 背离: Yes
+  - 风险等级: Medium

--- a/API/0058_RSI_Overbought_Oversold/README_cn.md
+++ b/API/0058_RSI_Overbought_Oversold/README_cn.md
@@ -1,0 +1,30 @@
+# RSI超买超卖 (RSI Overbought/Oversold)
+
+当RSI跌破超卖水平时买入, 升破超买水平时卖出。
+
+RSI回到中性区或止损则退出。
+
+## 详情
+
+- **入场条件**: RSI below `OversoldLevel` or above `OverboughtLevel`.
+- **多空方向**: Both directions.
+- **出场条件**: RSI crosses `NeutralLevel` or stop.
+- **止损**: Yes.
+- **默认值**:
+  - `RsiPeriod` = 14
+  - `OverboughtLevel` = 70
+  - `OversoldLevel` = 30
+  - `NeutralLevel` = 50
+  - `CandleType` = TimeSpan.FromMinutes(5)
+  - `StopLossPercent` = 2.0m
+- **过滤器**:
+  - 类别: Oscillator
+  - 方向: Both
+  - 指标: RSI
+  - 止损: Yes
+  - 复杂度: Basic
+  - 时间框架: Intraday
+  - 季节性: No
+  - 神经网络: No
+  - 背离: Yes
+  - 风险等级: Medium

--- a/API/0059_Hammer_Candle/README_cn.md
+++ b/API/0059_Hammer_Candle/README_cn.md
@@ -1,0 +1,25 @@
+# 锤形反转 (Hammer Candle Reversal)
+
+锤头线通常预示盘中反转, 下影线至少为实体两倍。
+
+识别后做多, 止损在形态低点。
+
+## 详情
+
+- **入场条件**: Hammer candle detected.
+- **多空方向**: Long only.
+- **出场条件**: Stop-loss or discretionary exit.
+- **止损**: Yes.
+- **默认值**:
+  - `CandleType` = TimeSpan.FromMinutes(5)
+- **过滤器**:
+  - 类别: Pattern
+  - 方向: Long
+  - 指标: Candlestick
+  - 止损: Yes
+  - 复杂度: Basic
+  - 时间框架: Intraday
+  - 季节性: No
+  - 神经网络: No
+  - 背离: No
+  - 风险等级: Medium

--- a/API/0060_Shooting_Star/README_cn.md
+++ b/API/0060_Shooting_Star/README_cn.md
@@ -1,0 +1,28 @@
+# 射击之星形态 (Shooting Star Pattern)
+
+射击之星在上升后出现, 长上影表示可能反转。
+
+若需要确认, 下一根蜡烛收低再进空, 止损在形态高点。
+
+## 详情
+
+- **入场条件**: Shooting star detected and confirmation if enabled.
+- **多空方向**: Short only.
+- **出场条件**: Stop-loss or discretionary exit.
+- **止损**: Yes.
+- **默认值**:
+  - `ShadowToBodyRatio` = 2.0m
+  - `CandleType` = TimeSpan.FromMinutes(15)
+  - `StopLossPercent` = 1.0m
+  - `ConfirmationRequired` = true
+- **过滤器**:
+  - 类别: Pattern
+  - 方向: Short
+  - 指标: Candlestick
+  - 止损: Yes
+  - 复杂度: Intermediate
+  - 时间框架: Intraday
+  - 季节性: No
+  - 神经网络: No
+  - 背离: No
+  - 风险等级: Medium


### PR DESCRIPTION
## Summary
- add `README_cn.md` files with Chinese translations for strategies 31 through 60

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68718fdf29f48323abe2e9d290ef74d8