### PR TITLE
Add placeholder Chinese READMEs for strategies 140-188

### DIFF
--- a/API/0140_VWAP_RSI/README_cn.md
+++ b/API/0140_VWAP_RSI/README_cn.md
@@ -1,0 +1,3 @@
+# VWAP RSI Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0141_Donchian_Volume/README_cn.md
+++ b/API/0141_Donchian_Volume/README_cn.md
@@ -1,0 +1,3 @@
+# Donchian Volume Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0142_Keltner_Stochastic/README_cn.md
+++ b/API/0142_Keltner_Stochastic/README_cn.md
@@ -1,0 +1,3 @@
+# Keltner Stochastic Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0143_Parabolic_SAR_RSI/README_cn.md
+++ b/API/0143_Parabolic_SAR_RSI/README_cn.md
@@ -1,0 +1,3 @@
+# Parabolic Sar Rsi Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0144_Hull_MA_Volume/README_cn.md
+++ b/API/0144_Hull_MA_Volume/README_cn.md
@@ -1,0 +1,3 @@
+# Hull Ma Volume Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0145_ADX_Stochastic/README_cn.md
+++ b/API/0145_ADX_Stochastic/README_cn.md
@@ -1,0 +1,3 @@
+# Adx Stochastic Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0146_MACD_Volume/README_cn.md
+++ b/API/0146_MACD_Volume/README_cn.md
@@ -1,0 +1,3 @@
+# Macd Volume Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0147_Bollinger_Volume/README_cn.md
+++ b/API/0147_Bollinger_Volume/README_cn.md
@@ -1,0 +1,3 @@
+# Bollinger Volume Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0148_RSI_Stochastic/README_cn.md
+++ b/API/0148_RSI_Stochastic/README_cn.md
@@ -1,0 +1,3 @@
+# Rsi Stochastic Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0149_MA_ADX/README_cn.md
+++ b/API/0149_MA_ADX/README_cn.md
@@ -1,0 +1,3 @@
+# Ma Adx Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0150_VWAP_Stochastic/README_cn.md
+++ b/API/0150_VWAP_Stochastic/README_cn.md
@@ -1,0 +1,3 @@
+# Vwap Stochastic Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0151_Ichimoku_Volume/README_cn.md
+++ b/API/0151_Ichimoku_Volume/README_cn.md
@@ -1,0 +1,3 @@
+# Ichimoku Volume Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0152_Supertrend_RSI/README_cn.md
+++ b/API/0152_Supertrend_RSI/README_cn.md
@@ -1,0 +1,3 @@
+# Supertrend Rsi Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0153_Bollinger_ADX/README_cn.md
+++ b/API/0153_Bollinger_ADX/README_cn.md
@@ -1,0 +1,3 @@
+# Bollinger Adx Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0154_MA_CCI/README_cn.md
+++ b/API/0154_MA_CCI/README_cn.md
@@ -1,0 +1,3 @@
+# Ma Cci Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0155_VWAP_Volume/README_cn.md
+++ b/API/0155_VWAP_Volume/README_cn.md
@@ -1,0 +1,3 @@
+# Vwap Volume Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0156_Donchian_RSI/README_cn.md
+++ b/API/0156_Donchian_RSI/README_cn.md
@@ -1,0 +1,3 @@
+# Donchian Rsi Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0157_Keltner_Volume/README_cn.md
+++ b/API/0157_Keltner_Volume/README_cn.md
@@ -1,0 +1,3 @@
+# Keltner Volume Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0158_Parabolic_SAR_Stochastic/README_cn.md
+++ b/API/0158_Parabolic_SAR_Stochastic/README_cn.md
@@ -1,0 +1,3 @@
+# Parabolic Sar Stochastic Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0159_Hull_MA_RSI/README_cn.md
+++ b/API/0159_Hull_MA_RSI/README_cn.md
@@ -1,0 +1,3 @@
+# Hull Ma Rsi Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0160_ADX_Volume/README_cn.md
+++ b/API/0160_ADX_Volume/README_cn.md
@@ -1,0 +1,3 @@
+# Adx Volume Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0161_MACD_CCI/README_cn.md
+++ b/API/0161_MACD_CCI/README_cn.md
@@ -1,0 +1,3 @@
+# Macd Cci Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0162_Bollinger_CCI/README_cn.md
+++ b/API/0162_Bollinger_CCI/README_cn.md
@@ -1,0 +1,3 @@
+# Bollinger Cci Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0163_RSI_Williams_R/README_cn.md
+++ b/API/0163_RSI_Williams_R/README_cn.md
@@ -1,0 +1,3 @@
+# Rsi Williams R Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0164_MA_Williams_R/README_cn.md
+++ b/API/0164_MA_Williams_R/README_cn.md
@@ -1,0 +1,3 @@
+# Ma Williams R Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0165_VWAP_CCI/README_cn.md
+++ b/API/0165_VWAP_CCI/README_cn.md
@@ -1,0 +1,3 @@
+# Vwap Cci Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0166_Donchian_Stochastic/README_cn.md
+++ b/API/0166_Donchian_Stochastic/README_cn.md
@@ -1,0 +1,3 @@
+# Donchian Stochastic Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0167_Keltner_RSI/README_cn.md
+++ b/API/0167_Keltner_RSI/README_cn.md
@@ -1,0 +1,3 @@
+# Keltner Rsi Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0169_Hull_MA_Stochastic/README_cn.md
+++ b/API/0169_Hull_MA_Stochastic/README_cn.md
@@ -1,0 +1,3 @@
+# Hull Ma Stochastic Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0170_ADX_CCI/README_cn.md
+++ b/API/0170_ADX_CCI/README_cn.md
@@ -1,0 +1,3 @@
+# Adx Cci Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0171_MACD_Williams_R/README_cn.md
+++ b/API/0171_MACD_Williams_R/README_cn.md
@@ -1,0 +1,3 @@
+# Macd Williams R Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0172_Bollinger_Williams_R/README_cn.md
+++ b/API/0172_Bollinger_Williams_R/README_cn.md
@@ -1,0 +1,3 @@
+# Bollinger Williams R Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0174_MACD_VWAP/README_cn.md
+++ b/API/0174_MACD_VWAP/README_cn.md
@@ -1,0 +1,3 @@
+# Macd Vwap Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0175_RSI_Supertrend/README_cn.md
+++ b/API/0175_RSI_Supertrend/README_cn.md
@@ -1,0 +1,3 @@
+# Rsi Supertrend Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0176_ADX_Bollinger/README_cn.md
+++ b/API/0176_ADX_Bollinger/README_cn.md
@@ -1,0 +1,3 @@
+# Adx Bollinger Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0177_Ichimoku_Stochastic/README_cn.md
+++ b/API/0177_Ichimoku_Stochastic/README_cn.md
@@ -1,0 +1,3 @@
+# Ichimoku Stochastic Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0185_Supertrend_Stochastic/README_cn.md
+++ b/API/0185_Supertrend_Stochastic/README_cn.md
@@ -1,0 +1,3 @@
+# Supertrend Stochastic Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0187_Donchian_MACD/README_cn.md
+++ b/API/0187_Donchian_MACD/README_cn.md
@@ -1,0 +1,3 @@
+# Donchian Macd Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。

--- a/API/0188_Parabolic_SAR_Volume/README_cn.md
+++ b/API/0188_Parabolic_SAR_Volume/README_cn.md
@@ -1,0 +1,3 @@
+# Parabolic Sar Volume Strategy 策略 (中文)
+
+该文档的中文版本尚未完成，详细说明请参阅英文版 [README.md](README.md)。


### PR DESCRIPTION
## Summary
- add README_cn.md placeholders for strategies 0140–0188 under `API`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687190298e6083238a4a294568ef9863