### PR TITLE
Add Chinese README translations for strategies 0310-0350

### DIFF
--- a/API/0310_Donchian_Volatility_Contraction/README_zh.md
+++ b/API/0310_Donchian_Volatility_Contraction/README_zh.md
@@ -1,0 +1,29 @@
+# Donchian Volatility Contraction
+
+**Donchian Volatility Contraction** 策略基于 Donchian Channel breakout after volatility contraction。
+
+当 Donchian confirms volatility contraction patterns 在日内（5m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 DonchianPeriod, AtrPeriod 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `DonchianPeriod = 20`
+  - `AtrPeriod = 14`
+  - `VolatilityFactor = 2.0m`
+  - `CandleType = TimeSpan.FromMinutes(5).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: Donchian
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (5m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/0311_Keltner_RSI_Divergence/README_zh.md
+++ b/API/0311_Keltner_RSI_Divergence/README_zh.md
@@ -1,0 +1,30 @@
+# Keltner RSI Divergence
+
+**Keltner RSI Divergence** 策略基于 Keltner Channel and RSI Divergence。
+
+当 Keltner confirms divergence setups 在日内（5m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 EmaPeriod, AtrPeriod 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `EmaPeriod = 20`
+  - `AtrPeriod = 14`
+  - `AtrMultiplier = 2.0m`
+  - `RsiPeriod = 14`
+  - `CandleType = TimeSpan.FromMinutes(5).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: Keltner, Divergence
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (5m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 是
+  - 风险等级: 中等

--- a/API/0312_Hull_MA_Volume_Spike/README_zh.md
+++ b/API/0312_Hull_MA_Volume_Spike/README_zh.md
@@ -1,0 +1,29 @@
+# Hull MA Volume Spike
+
+**Hull MA Volume Spike** 策略基于 Hull Moving Average with Volume Spike detection。
+
+当 Spike confirms trend changes 在日内（5m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 HmaPeriod, VolumeAvgPeriod 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `HmaPeriod = 9`
+  - `VolumeAvgPeriod = 20`
+  - `VolumeThresholdFactor = 2.0m`
+  - `CandleType = TimeSpan.FromMinutes(5).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: Spike
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (5m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/0313_VWAP_ADX_Trend_Strength/README_zh.md
+++ b/API/0313_VWAP_ADX_Trend_Strength/README_zh.md
@@ -1,0 +1,28 @@
+# VWAP ADX Trend Strength
+
+**VWAP ADX Trend Strength** 策略基于 VWAP with ADX Trend Strength。
+
+当 its indicators confirms trend changes 在日内（5m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 AdxPeriod, AdxThreshold 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `AdxPeriod = 14`
+  - `AdxThreshold = 25m`
+  - `CandleType = TimeSpan.FromMinutes(5).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: multiple indicators
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (5m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/0314_Parabolic_SAR_Volatility_Expansion/README_zh.md
+++ b/API/0314_Parabolic_SAR_Volatility_Expansion/README_zh.md
@@ -1,0 +1,30 @@
+# Parabolic SAR Volatility Expansion
+
+**Parabolic SAR Volatility Expansion** 策略基于 Parabolic SAR with Volatility Expansion detection。
+
+当 Parabolic confirms trend changes 在日内（5m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 SarAf, SarMaxAf 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `SarAf = 0.02m`
+  - `SarMaxAf = 0.2m`
+  - `AtrPeriod = 14`
+  - `VolatilityExpansionFactor = 2.0m`
+  - `CandleType = TimeSpan.FromMinutes(5).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: Parabolic
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (5m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/0315_Stochastic_Dynamic_Zones/README_zh.md
+++ b/API/0315_Stochastic_Dynamic_Zones/README_zh.md
@@ -1,0 +1,31 @@
+# Stochastic Dynamic Zones
+
+**Stochastic Dynamic Zones** 策略基于 Stochastic Oscillator with Dynamic Overbought/Oversold Zones。
+
+当 Stochastic confirms trend changes 在日内（5m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 StochPeriod, StochKPeriod 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `StochPeriod = 14`
+  - `StochKPeriod = 3`
+  - `StochDPeriod = 3`
+  - `LookbackPeriod = 20`
+  - `StandardDeviationFactor = 2.0m`
+  - `CandleType = TimeSpan.FromMinutes(5).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: Stochastic
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (5m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/0316_ADX_Volume_Breakout/README_zh.md
+++ b/API/0316_ADX_Volume_Breakout/README_zh.md
@@ -1,0 +1,30 @@
+# ADX Volume Breakout
+
+**ADX Volume Breakout** 策略基于 ADX with Volume Breakout。
+
+当 its indicators confirms breakout opportunities 在日内（5m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 AdxPeriod, AdxThreshold 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `AdxPeriod = 14`
+  - `AdxThreshold = 25m`
+  - `VolumeAvgPeriod = 20`
+  - `VolumeThresholdFactor = 2.0m`
+  - `CandleType = TimeSpan.FromMinutes(5).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: multiple indicators
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (5m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/0317_CCI_Volatility_Filter/README_zh.md
+++ b/API/0317_CCI_Volatility_Filter/README_zh.md
@@ -1,0 +1,30 @@
+# CCI Volatility Filter
+
+**CCI Volatility Filter** 策略基于 CCI with Volatility Filter。
+
+当 its indicators confirms filtered entries 在日内（5m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 CciPeriod, AtrPeriod 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `CciPeriod = 20`
+  - `AtrPeriod = 14`
+  - `CciOversold = -100m`
+  - `CciOverbought = 100m`
+  - `CandleType = TimeSpan.FromMinutes(5).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: multiple indicators
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (5m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/0318_Williams_R_Momentum/README_zh.md
+++ b/API/0318_Williams_R_Momentum/README_zh.md
@@ -1,0 +1,30 @@
+# Williams R Momentum
+
+**Williams R Momentum** 策略基于 Williams %R with Momentum filter。
+
+当 Williams confirms momentum shifts 在日内（5m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 WilliamsRPeriod, MomentumPeriod 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `WilliamsRPeriod = 14`
+  - `MomentumPeriod = 14`
+  - `WilliamsROversold = -80m`
+  - `WilliamsROverbought = -20m`
+  - `CandleType = TimeSpan.FromMinutes(5).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: Williams, R
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (5m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/0319_Bollinger_K-Means_Cluster/README_zh.md
+++ b/API/0319_Bollinger_K-Means_Cluster/README_zh.md
@@ -1,0 +1,29 @@
+# Bollinger K-Means Cluster
+
+**Bollinger K-Means Cluster** 策略基于 Bollinger K-Means Cluster。
+
+当 Bollinger confirms trend changes 在日内（5m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 BollingerLength, BollingerDeviation 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `BollingerLength = 20`
+  - `BollingerDeviation = 2.0m`
+  - `CandleType = TimeSpan.FromMinutes(5).TimeFrame()`
+  - `KMeansHistoryLength = 50`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: Bollinger
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (5m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/0320_MACD_Hidden_Markov_Model/README_zh.md
+++ b/API/0320_MACD_Hidden_Markov_Model/README_zh.md
@@ -1,0 +1,30 @@
+# MACD Hidden Markov Model
+
+**MACD Hidden Markov Model** 策略基于 MACD Hidden Markov Model。
+
+当 Markov confirms trend changes 在日内（5m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 MacdFast, MacdSlow 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `MacdFast = 12`
+  - `MacdSlow = 26`
+  - `MacdSignal = 9`
+  - `CandleType = TimeSpan.FromMinutes(5).TimeFrame()`
+  - `HmmHistoryLength = 100`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: Markov
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (5m)
+  - 季节性: 否
+  - 神经网络: 是
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/0321_Ichimoku_Hurst_Exponent/README_zh.md
+++ b/API/0321_Ichimoku_Hurst_Exponent/README_zh.md
@@ -1,0 +1,31 @@
+# Ichimoku Hurst Exponent
+
+**Ichimoku Hurst Exponent** 策略基于 Ichimoku Kinko Hyo indicator with Hurst exponent filter。
+
+当 Hurst confirms trend changes 在日内（15m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 TenkanPeriod, KijunPeriod 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `TenkanPeriod = 9`
+  - `KijunPeriod = 26`
+  - `SenkouSpanBPeriod = 52`
+  - `HurstPeriod = 100`
+  - `HurstThreshold = 0.5m`
+  - `CandleType = TimeSpan.FromMinutes(15).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: Hurst, Exponent
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (15m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/0322_Supertrend_RSI_Divergence/README_zh.md
+++ b/API/0322_Supertrend_RSI_Divergence/README_zh.md
@@ -1,0 +1,29 @@
+# Supertrend RSI Divergence
+
+**Supertrend RSI Divergence** 策略基于 that uses Supertrend indicator along with RSI divergence to identify trading opportunities。
+
+当 Divergence confirms divergence setups 在日内（15m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 SupertrendPeriod, SupertrendMultiplier 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `SupertrendPeriod = 10`
+  - `SupertrendMultiplier = 3.0m`
+  - `RsiPeriod = 14`
+  - `CandleType = TimeSpan.FromMinutes(15).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: Divergence
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (15m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 是
+  - 风险等级: 中等

--- a/API/0323_Donchian_Seasonal_Filter/README_zh.md
+++ b/API/0323_Donchian_Seasonal_Filter/README_zh.md
@@ -1,0 +1,28 @@
+# Donchian Seasonal Filter
+
+**Donchian Seasonal Filter** 策略基于 Donchian Channels with seasonal filter。
+
+当 Donchian confirms filtered entries 在日内（15m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 DonchianPeriod, SeasonalThreshold 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `DonchianPeriod = 20`
+  - `SeasonalThreshold = 0.5m`
+  - `CandleType = TimeSpan.FromMinutes(15).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: Donchian, Seasonal
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (15m)
+  - 季节性: 是
+  - 神经网络: 否
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/0324_Keltner_Kalman_Filter/README_zh.md
+++ b/API/0324_Keltner_Kalman_Filter/README_zh.md
@@ -1,0 +1,31 @@
+# Keltner Kalman Filter
+
+**Keltner Kalman Filter** 策略基于 combining Keltner Channels with a Kalman Filter to identify trends and trade opportunities。
+
+当 Keltner confirms filtered entries 在日内（15m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 EmaPeriod, AtrPeriod 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `EmaPeriod = 20`
+  - `AtrPeriod = 14`
+  - `AtrMultiplier = 2.0m`
+  - `KalmanProcessNoise = 0.01m`
+  - `KalmanMeasurementNoise = 0.1m`
+  - `CandleType = TimeSpan.FromMinutes(15).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: Keltner
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (15m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/0325_Hull_MA_Volatility_Contraction/README_zh.md
+++ b/API/0325_Hull_MA_Volatility_Contraction/README_zh.md
@@ -1,0 +1,29 @@
+# Hull MA Volatility Contraction
+
+**Hull MA Volatility Contraction** 策略基于 Hull Moving Average with volatility contraction filter。
+
+当 its indicators confirms volatility contraction patterns 在日内（15m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 HmaPeriod, AtrPeriod 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `HmaPeriod = 9`
+  - `AtrPeriod = 14`
+  - `VolatilityContractionFactor = 2.0m`
+  - `CandleType = TimeSpan.FromMinutes(15).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: multiple indicators
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (15m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/0326_VWAP_Stochastic_Divergence/README_zh.md
+++ b/API/0326_VWAP_Stochastic_Divergence/README_zh.md
@@ -1,0 +1,29 @@
+# VWAP Stochastic Divergence
+
+**VWAP Stochastic Divergence** 策略基于 combining VWAP with ADX trend strength indicator。
+
+当 Stochastic confirms divergence setups 在日内（5m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 AdxPeriod, AdxThreshold 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `AdxPeriod = 14`
+  - `AdxThreshold = 25m`
+  - `AdxExitThreshold = 20m`
+  - `CandleType = TimeSpan.FromMinutes(5).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: Stochastic, Divergence
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (5m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 是
+  - 风险等级: 中等

--- a/API/0327_Parabolic_SAR_Hurst_Filter/README_zh.md
+++ b/API/0327_Parabolic_SAR_Hurst_Filter/README_zh.md
@@ -1,0 +1,29 @@
+# Parabolic SAR Hurst Filter
+
+**Parabolic SAR Hurst Filter** 策略基于 Parabolic SAR Hurst Filter。
+
+当 Parabolic confirms filtered entries 在日内（5m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 SarAccelerationFactor, SarMaxAccelerationFactor 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `SarAccelerationFactor = 0.02m`
+  - `SarMaxAccelerationFactor = 0.2m`
+  - `HurstPeriod = 100`
+  - `CandleType = TimeSpan.FromMinutes(5).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: Parabolic, Hurst
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (5m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/0328_Bollinger_Kalman_Filter/README_zh.md
+++ b/API/0328_Bollinger_Kalman_Filter/README_zh.md
@@ -1,0 +1,30 @@
+# Bollinger Kalman Filter
+
+**Bollinger Kalman Filter** 策略基于 Bollinger Kalman Filter。
+
+当 Bollinger confirms filtered entries 在日内（5m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 BollingerLength, BollingerDeviation 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `BollingerLength = 20`
+  - `BollingerDeviation = 2.0m`
+  - `KalmanQ = 0.01m`
+  - `KalmanR = 0.1m`
+  - `CandleType = TimeSpan.FromMinutes(5).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: Bollinger
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (5m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/0329_MACD_Volume_Cluster/README_zh.md
+++ b/API/0329_MACD_Volume_Cluster/README_zh.md
@@ -1,0 +1,31 @@
+# MACD Volume Cluster
+
+**MACD Volume Cluster** 策略基于 MACD Volume Cluster。
+
+当 its indicators confirms trend changes 在日内（5m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 FastMacdPeriod, SlowMacdPeriod 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `FastMacdPeriod = 12`
+  - `SlowMacdPeriod = 26`
+  - `MacdSignalPeriod = 9`
+  - `VolumePeriod = 20`
+  - `VolumeDeviationFactor = 2.0m`
+  - `CandleType = TimeSpan.FromMinutes(5).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: multiple indicators
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (5m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/0330_Ichimoku_Volatility_Contraction/README_zh.md
+++ b/API/0330_Ichimoku_Volatility_Contraction/README_zh.md
@@ -1,0 +1,31 @@
+# Ichimoku Volatility Contraction
+
+**Ichimoku Volatility Contraction** 策略基于 Ichimoku Volatility Contraction。
+
+当 its indicators confirms volatility contraction patterns 在日内（5m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 TenkanPeriod, KijunPeriod 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `TenkanPeriod = 9`
+  - `KijunPeriod = 26`
+  - `SenkouSpanBPeriod = 52`
+  - `AtrPeriod = 14`
+  - `DeviationFactor = 2.0m`
+  - `CandleType = TimeSpan.FromMinutes(5).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: multiple indicators
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (5m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/0332_Donchian_Hurst_Exponent/README_zh.md
+++ b/API/0332_Donchian_Hurst_Exponent/README_zh.md
@@ -1,0 +1,30 @@
+# Donchian Hurst Exponent
+
+**Donchian Hurst Exponent** 策略基于 that trades based on Donchian Channel breakouts with Hurst Exponent filter。
+
+当 Donchian confirms trend changes 在日内（5m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 DonchianPeriod, HurstPeriod 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `DonchianPeriod = 20`
+  - `HurstPeriod = 100`
+  - `HurstThreshold = 0.5m`
+  - `StopLossPercent = 2m`
+  - `CandleType = TimeSpan.FromMinutes(5).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: Donchian, Hurst, Exponent
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (5m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/0333_Keltner_Seasonal_Filter/README_zh.md
+++ b/API/0333_Keltner_Seasonal_Filter/README_zh.md
@@ -1,0 +1,30 @@
+# Keltner Seasonal Filter
+
+**Keltner Seasonal Filter** 策略基于 that trades based on Keltner Channel breakouts with seasonal bias filter。
+
+当 Keltner confirms filtered entries 在日内（5m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 EmaPeriod, AtrPeriod 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `EmaPeriod = 20`
+  - `AtrPeriod = 14`
+  - `AtrMultiplier = 2m`
+  - `SeasonalThreshold = 0.5m`
+  - `CandleType = TimeSpan.FromMinutes(5).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: Keltner, Seasonal
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (5m)
+  - 季节性: 是
+  - 神经网络: 否
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/0334_Hull_MA_K-Means_Cluster/README_zh.md
+++ b/API/0334_Hull_MA_K-Means_Cluster/README_zh.md
@@ -1,0 +1,29 @@
+# Hull MA K-Means Cluster
+
+**Hull MA K-Means Cluster** 策略基于 that trades based on Hull Moving Average direction with K-Means clustering for market state detection。
+
+当 its indicators confirms trend changes 在日内（5m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 HullPeriod, ClusterDataLength 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `HullPeriod = 9`
+  - `ClusterDataLength = 50`
+  - `RsiPeriod = 14`
+  - `CandleType = TimeSpan.FromMinutes(5).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: multiple indicators
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (5m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/0335_VWAP_Hidden_Markov_Model/README_zh.md
+++ b/API/0335_VWAP_Hidden_Markov_Model/README_zh.md
@@ -1,0 +1,28 @@
+# VWAP Hidden Markov Model
+
+**VWAP Hidden Markov Model** 策略基于 that trades based on VWAP with Hidden Markov Model for market state detection。
+
+当 Markov confirms trend changes 在日内（5m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 HmmDataLength, StopLossPercent 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `HmmDataLength = 100`
+  - `StopLossPercent = 2m`
+  - `CandleType = TimeSpan.FromMinutes(5).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: Markov
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (5m)
+  - 季节性: 否
+  - 神经网络: 是
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/0336_Parabolic_SAR_RSI_Divergence/README_zh.md
+++ b/API/0336_Parabolic_SAR_RSI_Divergence/README_zh.md
@@ -1,0 +1,29 @@
+# Parabolic SAR RSI Divergence
+
+**Parabolic SAR RSI Divergence** 策略基于 that trades based on Parabolic SAR signals when RSI shows divergence from price。
+
+当 Parabolic confirms divergence setups 在日内（5m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 SarAccelerationFactor, SarMaxAccelerationFactor 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `SarAccelerationFactor = 0.02m`
+  - `SarMaxAccelerationFactor = 0.2m`
+  - `RsiPeriod = 14`
+  - `CandleType = TimeSpan.FromMinutes(5).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: Parabolic, Divergence
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (5m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 是
+  - 风险等级: 中等

--- a/API/0337_Adaptive_RSI_Volume_Filter/README_zh.md
+++ b/API/0337_Adaptive_RSI_Volume_Filter/README_zh.md
@@ -1,0 +1,30 @@
+# Adaptive RSI Volume Filter
+
+**Adaptive RSI Volume Filter** 策略基于 that trades based on Adaptive RSI with volume confirmation。
+
+当 its indicators confirms filtered entries 在日内（5m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 MinRsiPeriod, MaxRsiPeriod 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `MinRsiPeriod = 10`
+  - `MaxRsiPeriod = 20`
+  - `AtrPeriod = 14`
+  - `VolumeLookback = 20`
+  - `CandleType = TimeSpan.FromMinutes(5).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: multiple indicators
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (5m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/0338_Adaptive_Bollinger_Breakout/README_zh.md
+++ b/API/0338_Adaptive_Bollinger_Breakout/README_zh.md
@@ -1,0 +1,31 @@
+# Adaptive Bollinger Breakout
+
+**Adaptive Bollinger Breakout** 策略基于 that trades based on breakouts of Bollinger Bands with adaptively adjusted parameters。
+
+当 Bollinger confirms breakout opportunities 在日内（5m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 MinBollingerPeriod, MaxBollingerPeriod 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `MinBollingerPeriod = 10`
+  - `MaxBollingerPeriod = 30`
+  - `MinBollingerDeviation = 1.5m`
+  - `MaxBollingerDeviation = 2.5m`
+  - `AtrPeriod = 14`
+  - `CandleType = TimeSpan.FromMinutes(5).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: Bollinger
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (5m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/0339_MACD_Sentiment_Filter/README_zh.md
+++ b/API/0339_MACD_Sentiment_Filter/README_zh.md
@@ -1,0 +1,31 @@
+# MACD Sentiment Filter
+
+**MACD Sentiment Filter** 策略基于 MACD Sentiment Filter。
+
+当 its indicators confirms filtered entries 在日内（15m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 MacdFast, MacdSlow 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `MacdFast = 12`
+  - `MacdSlow = 26`
+  - `MacdSignal = 9`
+  - `Threshold = 0.5m`
+  - `StopLoss = 2m`
+  - `CandleType = TimeSpan.FromMinutes(15).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: multiple indicators
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (15m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/0340_Ichimoku_Implied_Volatility/README_zh.md
+++ b/API/0340_Ichimoku_Implied_Volatility/README_zh.md
@@ -1,0 +1,30 @@
+# Ichimoku Implied Volatility
+
+**Ichimoku Implied Volatility** 策略基于 Ichimoku Implied Volatility。
+
+当 its indicators confirms trend changes 在日内（15m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 TenkanPeriod, KijunPeriod 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `TenkanPeriod = 9`
+  - `KijunPeriod = 26`
+  - `SenkouSpanBPeriod = 52`
+  - `IVPeriod = 20`
+  - `CandleType = TimeSpan.FromMinutes(15).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: multiple indicators
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (15m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/0341_Supertrend_Put_Call_Ratio/README_zh.md
+++ b/API/0341_Supertrend_Put_Call_Ratio/README_zh.md
@@ -1,0 +1,30 @@
+# Supertrend Put Call Ratio
+
+**Supertrend Put Call Ratio** 策略基于 Supertrend Put Call Ratio。
+
+当 its indicators confirms trend changes 在日内（15m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 Period, Multiplier 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `Period = 10`
+  - `Multiplier = 3m`
+  - `PCRPeriod = 20`
+  - `PCRMultiplier = 2m`
+  - `CandleType = TimeSpan.FromMinutes(15).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: multiple indicators
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (15m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/0342_Donchian_Sentiment_Spike/README_zh.md
+++ b/API/0342_Donchian_Sentiment_Spike/README_zh.md
@@ -1,0 +1,30 @@
+# Donchian Sentiment Spike
+
+**Donchian Sentiment Spike** 策略基于 Donchian Sentiment Spike。
+
+当 Donchian confirms trend changes 在日内（15m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 DonchianPeriod, SentimentPeriod 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `DonchianPeriod = 20`
+  - `SentimentPeriod = 20`
+  - `SentimentMultiplier = 2m`
+  - `StopLoss = 2m`
+  - `CandleType = TimeSpan.FromMinutes(15).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: Donchian, Spike
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (15m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/0343_Keltner_Reinforcement_Learning_Signal/README_zh.md
+++ b/API/0343_Keltner_Reinforcement_Learning_Signal/README_zh.md
@@ -1,0 +1,30 @@
+# Keltner Reinforcement Learning Signal
+
+**Keltner Reinforcement Learning Signal** 策略基于 Keltner Reinforcement Learning Signal。
+
+当 Keltner confirms trend changes 在日内（15m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 EmaPeriod, AtrPeriod 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `EmaPeriod = 20`
+  - `AtrPeriod = 14`
+  - `AtrMultiplier = 2m`
+  - `StopLossAtr = 2m`
+  - `CandleType = TimeSpan.FromMinutes(15).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: Keltner, Reinforcement
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (15m)
+  - 季节性: 否
+  - 神经网络: 是
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/0344_Hull_MA_Implied_Volatility_Breakout/README_zh.md
+++ b/API/0344_Hull_MA_Implied_Volatility_Breakout/README_zh.md
@@ -1,0 +1,30 @@
+# Hull MA Implied Volatility Breakout
+
+**Hull MA Implied Volatility Breakout** 策略基于 Hull MA Implied Volatility Breakout。
+
+当 its indicators confirms breakout opportunities 在日内（15m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 HmaPeriod, IVPeriod 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `HmaPeriod = 9`
+  - `IVPeriod = 20`
+  - `IVMultiplier = 2m`
+  - `StopLossAtr = 2m`
+  - `CandleType = TimeSpan.FromMinutes(15).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: multiple indicators
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (15m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/0345_VWAP_Behavioral_Bias_Filter/README_zh.md
+++ b/API/0345_VWAP_Behavioral_Bias_Filter/README_zh.md
@@ -1,0 +1,29 @@
+# VWAP Behavioral Bias Filter
+
+**VWAP Behavioral Bias Filter** 策略基于 VWAP Behavioral Bias Filter。
+
+当 Behavioral confirms filtered entries 在日内（5m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 BiasThreshold, BiasWindowSize 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `BiasThreshold = 0.5m`
+  - `BiasWindowSize = 20`
+  - `StopLoss = 2m`
+  - `CandleType = TimeSpan.FromMinutes(5).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: Behavioral, Bias
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (5m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/0346_Parabolic_SAR_Sentiment_Divergence/README_zh.md
+++ b/API/0346_Parabolic_SAR_Sentiment_Divergence/README_zh.md
@@ -1,0 +1,28 @@
+# Parabolic SAR Sentiment Divergence
+
+**Parabolic SAR Sentiment Divergence** 策略基于 Parabolic SAR Sentiment Divergence。
+
+当 Parabolic confirms divergence setups 在日内（5m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 StartAf, MaxAf 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `StartAf = 0.02m`
+  - `MaxAf = 0.2m`
+  - `CandleType = TimeSpan.FromMinutes(5).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: Parabolic, Divergence
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (5m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 是
+  - 风险等级: 中等

--- a/API/0347_RSI_Option_Open_Interest/README_zh.md
+++ b/API/0347_RSI_Option_Open_Interest/README_zh.md
@@ -1,0 +1,30 @@
+# RSI Option Open Interest
+
+**RSI Option Open Interest** 策略基于 RSI Option Open Interest。
+
+当 Option confirms trend changes 在日内（5m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 RsiPeriod, CandleType 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `RsiPeriod = 14`
+  - `CandleType = TimeSpan.FromMinutes(5).TimeFrame()`
+  - `OiPeriod = 20`
+  - `OiDeviationFactor = 2m`
+  - `StopLoss = 2m`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: Option, Open, Interest
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (5m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/0348_Stochastic_Implied_Volatility_Skew/README_zh.md
+++ b/API/0348_Stochastic_Implied_Volatility_Skew/README_zh.md
@@ -1,0 +1,31 @@
+# Stochastic Implied Volatility Skew
+
+**Stochastic Implied Volatility Skew** 策略基于 Stochastic Implied Volatility Skew。
+
+当 Stochastic confirms trend changes 在日内（5m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 StochLength, StochK 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `StochLength = 14`
+  - `StochK = 3`
+  - `StochD = 3`
+  - `IvPeriod = 20`
+  - `StopLoss = 2m`
+  - `CandleType = TimeSpan.FromMinutes(5).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: Stochastic, Skew
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (5m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/0349_ADX_Sentiment_Momentum/README_zh.md
+++ b/API/0349_ADX_Sentiment_Momentum/README_zh.md
@@ -1,0 +1,30 @@
+# ADX Sentiment Momentum
+
+**ADX Sentiment Momentum** 策略基于 ADX Sentiment Momentum。
+
+当 its indicators confirms momentum shifts 在日内（5m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 AdxPeriod, AdxThreshold 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `AdxPeriod = 14`
+  - `AdxThreshold = 25m`
+  - `SentimentPeriod = 5`
+  - `StopLoss = 2m`
+  - `CandleType = TimeSpan.FromMinutes(5).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: multiple indicators
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (5m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/0350_CCI_Put_Call_Ratio_Divergence/README_zh.md
+++ b/API/0350_CCI_Put_Call_Ratio_Divergence/README_zh.md
@@ -1,0 +1,28 @@
+# CCI Put Call Ratio Divergence
+
+**CCI Put Call Ratio Divergence** 策略基于 CCI Put Call Ratio Divergence。
+
+当 Divergence confirms divergence setups 在日内（5m）数据上得到确认时触发信号，适合积极交易者。
+
+止损依赖于 ATR 倍数以及 CciPeriod, AtrMultiplier 等参数，可根据需要调整以平衡风险与收益。
+
+## 详情
+- **入场条件**：参见指标条件实现.
+- **多空方向**：双向.
+- **退出条件**：反向信号或止损逻辑.
+- **止损**：是，基于指标计算.
+- **默认值**:
+  - `CciPeriod = 20`
+  - `AtrMultiplier = 2m`
+  - `CandleType = TimeSpan.FromMinutes(5).TimeFrame()`
+- **过滤器**:
+  - 分类: 趋势跟随
+  - 方向: 双向
+  - 指标: Divergence
+  - 止损: 是
+  - 复杂度: 中等
+  - 时间框架: 日内 (5m)
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 是
+  - 风险等级: 中等


### PR DESCRIPTION
## Summary
- add README_zh.md translations for API strategies 0310 through 0350

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871909b2ff08323aabe68c5846903e8