### PR TITLE
Add multi-language links to strategy READMEs

### DIFF
--- a/API/0001_MA_CrossOver/README.md
+++ b/API/0001_MA_CrossOver/README.md
@@ -1,5 +1,6 @@
 # HMA Seasonal Divergence Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 This strategy combines the Hull Moving Average (HMA) with seasonal open interest clustering to find divergences between price and market positioning. It assumes that when price temporarily moves against the direction of rising open interest, a trend continuation is likely. The system is designed to trade both long and short, using the HMA slope to gauge momentum and the seasonal open interest data to measure participation levels.
 
 A trade setup occurs when the HMA changes relative to the previous bar while seasonal open interest confirms the move, but price prints in the opposite direction. This bullish or bearish divergence between price and positioning often signals the end of a short-term pullback within a larger trend. The strategy waits for these conditions before entering and places a volatility-based stop to manage risk.

--- a/API/0002_NDay_Breakout/README.md
+++ b/API/0002_NDay_Breakout/README.md
@@ -1,5 +1,6 @@
 # NDay Breakout
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 N-day high/low breakout strategy N-day breakout looks for new highs or lows over the given period. Entries occur when price pierces the latest N-day high or low, anticipating momentum. A moving-average filter and percentage stop manage exits.
 
 By waiting for the prior extreme to break, the system attempts to catch the start of a directional move. Filtering by a trend-following average helps avoid false signals that arise during consolidation.

--- a/API/0003_ADX_Trend/README.md
+++ b/API/0003_ADX_Trend/README.md
@@ -1,5 +1,6 @@
 # ADX Trend
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on Average Directional Index (ADX) trend The ADX Trend strategy gauges market strength using the ADX indicator. When ADX is above a threshold and price is on the correct side of its moving average, the system trades in that direction. Positions close once ADX weakens or the opposite setup appears.
 
 By waiting for a solid ADX reading, the approach only trades when momentum is firmly established. Stops typically use an ATR multiple so risk adjusts with volatility.

--- a/API/0004_Parabolic_SAR_Trend/README.md
+++ b/API/0004_Parabolic_SAR_Trend/README.md
@@ -1,5 +1,6 @@
 # Parabolic SAR Trend
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on Parabolic SAR indicator Parabolic SAR Trend follows the dots of the Parabolic SAR indicator. A flip of price from one side of the SAR to the other marks a potential trend change. If price crosses back, the trade is closed.
 
 Since the SAR dots trail price, they naturally provide an exit point when the trend shifts. The method trades both long and short without using additional stops beyond the SAR reversal.

--- a/API/0005_Donchian_Channel/README.md
+++ b/API/0005_Donchian_Channel/README.md
@@ -1,5 +1,6 @@
 # Donchian Channel
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on Donchian Channel
 
 Donchian Channel Breakout trades new highs and lows based on the channel range. A close beyond the upper band signals strength, while a drop below the lower band invites shorts. Exits occur when price returns to the midpoint.

--- a/API/0006_Tripple_MA/README.md
+++ b/API/0006_Tripple_MA/README.md
@@ -1,5 +1,6 @@
 # Tripple MA
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on Triple Moving Average crossover
 
 Triple MA aligns three moving averages to define direction. When the shortest average is above the middle and long averages a long entry occurs. The reverse alignment opens shorts, and a cross of the short and middle lines closes the trade.

--- a/API/0007_Keltner_Channel_Breakout/README.md
+++ b/API/0007_Keltner_Channel_Breakout/README.md
@@ -1,5 +1,6 @@
 # Keltner Channel Breakout
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on Keltner Channel breakout
 
 Keltner Channel Breakout uses volatility bands derived from ATR. Breakouts above the upper band or below the lower band trigger entries. Price moving back through the EMA center or hitting a stop exits the position.

--- a/API/0008_Hull_MA_Trend/README.md
+++ b/API/0008_Hull_MA_Trend/README.md
@@ -1,5 +1,6 @@
 # Hull MA Trend
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on Hull Moving Average trend
 
 The Hull MA Trend strategy monitors the slope of the Hull Moving Average. Rising slopes prompt longs and falling slopes prompt shorts, with an ATR trailing stop protecting each trade.

--- a/API/0009_MACD_Trend/README.md
+++ b/API/0009_MACD_Trend/README.md
@@ -1,5 +1,6 @@
 # MACD Trend
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on MACD indicator
 
 MACD Trend reacts to crossovers between the MACD line and its signal line. Bullish crosses initiate longs while bearish crosses start shorts. Opposite crosses or a stop close the trade.

--- a/API/0010_Super_Trend/README.md
+++ b/API/0010_Super_Trend/README.md
@@ -1,5 +1,6 @@
 # Super Trend
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on Supertrend indicator
 
 Super Trend calculates a dynamic line from ATR that flips between support and resistance. Price crossing above it turns the bias bullish, and crossing below turns it bearish. The trade ends when the line reverses.

--- a/API/0011_Ichimoku_Kumo_Breakout/README.md
+++ b/API/0011_Ichimoku_Kumo_Breakout/README.md
@@ -1,5 +1,6 @@
 # Ichimoku Kumo Breakout
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on Ichimoku Kumo (cloud) breakout
 
 This approach relies on Ichimoku cloud signals. Price breaking above the cloud with Tenkan-sen crossing over Kijun-sen triggers a buy, while the opposite break below the cloud starts a short. Positions are held until price returns through the cloud.

--- a/API/0012_Heikin_Ashi_Consecutive/README.md
+++ b/API/0012_Heikin_Ashi_Consecutive/README.md
@@ -1,5 +1,6 @@
 # Heikin Ashi Consecutive
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on consecutive Heikin Ashi candles
 
 Heikin Ashi Consecutive waits for several same-color Heikin Ashi candles to confirm momentum. After a run of bullish or bearish bars the strategy joins the move and exits on the first opposite candle or an ATR stop.

--- a/API/0013_DMI_Power_Move/README.md
+++ b/API/0013_DMI_Power_Move/README.md
@@ -1,5 +1,6 @@
 # DMI Power Move
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on DMI (Directional Movement Index) power moves
 
 DMI Power Move combines directional indicator differences with ADX to catch powerful trends. Trades enter when +DI markedly exceeds -DI (or vice versa) and ADX is strong. They exit when ADX fades or the DI spread narrows.

--- a/API/0014_TradingView_Supertrend_Flip/README.md
+++ b/API/0014_TradingView_Supertrend_Flip/README.md
@@ -1,5 +1,6 @@
 # TradingView Supertrend Flip
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on Supertrend indicator flips with volume confirmation
 
 TradingView Supertrend Flip emulates the popular indicator's color changes. A flip from red to green signals a long entry and green to red signals a short. The strategy exits on the next flip.

--- a/API/0015_Gann_Swing_Breakout/README.md
+++ b/API/0015_Gann_Swing_Breakout/README.md
@@ -1,5 +1,6 @@
 # Gann Swing Breakout
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on Gann Swing Breakout technique
 
 Gann Swing Breakout tracks swing highs and lows from Gann analysis. A breakout beyond the latest swing starts a trade in that direction and it stays open until an opposing swing is breached.

--- a/API/0016_RSI_Divergence/README.md
+++ b/API/0016_RSI_Divergence/README.md
@@ -1,5 +1,6 @@
 # RSI Divergence
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on RSI divergence
 
 RSI Divergence searches for price extremes unconfirmed by the RSI oscillator. A bullish divergence leads to a buy and a bearish divergence prompts a sell. The trade lasts until RSI reverses or a stop fires.

--- a/API/0017_Williams_R/README.md
+++ b/API/0017_Williams_R/README.md
@@ -1,5 +1,6 @@
 # Williams R
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on Williams %R indicator
 
 Williams %R identifies overbought and oversold zones. When the indicator rises above the upper threshold it signals potential weakness for shorts; readings below the lower threshold suggest longs. Positions close once %R moves toward neutral.

--- a/API/0018_ROC_Impulce/README.md
+++ b/API/0018_ROC_Impulce/README.md
@@ -1,5 +1,6 @@
 # ROC Impulce
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on Rate of Change (ROC) impulse
 
 ROC Impulse captures sudden bursts in the Rate of Change indicator. Sharp positive spikes lead to long trades and sharp negatives to short trades. When momentum fades back toward zero the position is closed.

--- a/API/0019_CCI_Breakout/README.md
+++ b/API/0019_CCI_Breakout/README.md
@@ -1,5 +1,6 @@
 # CCI Breakout
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on CCI (Commodity Channel Index) breakout
 
 CCI Breakout uses the Commodity Channel Index to spot powerful moves. Surges beyond positive or negative CCI thresholds generate entries. Exits happen when CCI retreats toward zero or an opposite signal forms.

--- a/API/0020_Momentum_Percentage/README.md
+++ b/API/0020_Momentum_Percentage/README.md
@@ -1,5 +1,6 @@
 # Momentum Percentage
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on price momentum percentage change
 
 Momentum Percentage tracks percent change in price. Trades trigger when momentum exceeds positive or negative levels and exit on the counter signal or a volatility stop.

--- a/API/0021_Bollinger_Squeeze/README.md
+++ b/API/0021_Bollinger_Squeeze/README.md
@@ -1,5 +1,6 @@
 # Bollinger Squeeze
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on Bollinger Bands squeeze
 
 Bollinger Squeeze waits for narrow band width indicating low volatility. A break outside the bands starts a trade in that direction and it exits when momentum fails or an opposite break appears.

--- a/API/0022_ADX_DI/README.md
+++ b/API/0022_ADX_DI/README.md
@@ -1,5 +1,6 @@
 # ADX DI
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on ADX and Directional Movement indicators
 
 ADX DI focuses on the crossing of +DI and -DI with rising ADX. A bullish cross of +DI over -DI coupled with strong ADX opens longs, while the opposite opens shorts. Positions close on a weakening ADX or opposite cross.

--- a/API/0023_Elder_Impulse/README.md
+++ b/API/0023_Elder_Impulse/README.md
@@ -1,5 +1,6 @@
 # Elder Impulse
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on Elder's Impulse System
 
 Elder Impulse combines EMA direction with MACD histogram color. Green bars above the EMA prompt longs, red bars below prompt shorts, and neutral bars signal exits.

--- a/API/0024_RSI_Laguerre/README.md
+++ b/API/0024_RSI_Laguerre/README.md
@@ -1,5 +1,6 @@
 # RSI Laguerre
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on Laguerre RSI
 
 Laguerre RSI smooths the standard RSI to reduce noise. The strategy buys when the Laguerre value crosses up from oversold and sells when it crosses down from overbought, exiting when it returns to mid-levels.

--- a/API/0025_Stochastic_RSI_Cross/README.md
+++ b/API/0025_Stochastic_RSI_Cross/README.md
@@ -1,5 +1,6 @@
 # Stochastic RSI Cross
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on Stochastic RSI crossover
 
 Stochastic RSI Cross watches the %K and %D lines of StochRSI. Bullish crosses near oversold levels trigger buys, bearish crosses near overbought trigger sells, and opposite crosses exit.

--- a/API/0026_RSI_Reversion/README.md
+++ b/API/0026_RSI_Reversion/README.md
@@ -1,5 +1,6 @@
 # RSI Reversion
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on RSI mean reversion
 
 RSI Reversion assumes price will revert after reaching extreme RSI values. When RSI falls below the lower threshold it buys; when above the upper threshold it sells. Positions close as RSI moves back toward neutral.

--- a/API/0027_Bollinger_Reversion/README.md
+++ b/API/0027_Bollinger_Reversion/README.md
@@ -1,5 +1,6 @@
 # Bollinger Reversion
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on Bollinger Bands mean reversion
 
 Bollinger Reversion fades moves outside the Bollinger Bands. Trades open against closes beyond the bands and close once price returns inside or hits a stop.

--- a/API/0028_ZScore/README.md
+++ b/API/0028_ZScore/README.md
@@ -1,5 +1,6 @@
 # ZScore
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on Z-Score indicator for mean reversion trading
 
 ZScore measures price deviation from a moving average. Extreme high or low z-scores suggest overextension and prompt trades in the opposite direction. The trade ends when the z-score normalizes.

--- a/API/0029_MA_Deviation/README.md
+++ b/API/0029_MA_Deviation/README.md
@@ -1,5 +1,6 @@
 # MA Deviation
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy that trades when price deviates significantly from its moving average
 
 MA Deviation enters when price deviates a set percentage from its moving average, anticipating a return to the mean. The position is exited when price converges back toward the average.

--- a/API/0030_VWAP_Reversion/README.md
+++ b/API/0030_VWAP_Reversion/README.md
@@ -1,5 +1,6 @@
 # VWAP Reversion
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 VWAP Reversion strategy that trades on deviations from Volume Weighted Average Price
 
 VWAP Reversion trades deviations from the volume-weighted average price. If price strays too far above or below VWAP, the strategy fades the move and exits on a snap back.

--- a/API/0031_Keltner_Reversion/README.md
+++ b/API/0031_Keltner_Reversion/README.md
@@ -1,5 +1,6 @@
 # Keltner Reversion
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy that trades on mean reversion using Keltner Channels
 
 Keltner Reversion fades pushes outside the Keltner Channel. Entries bet on a return toward the middle band, closing trades once price re-enters the channel or the stop is hit.

--- a/API/0032_ATR_Reversion/README.md
+++ b/API/0032_ATR_Reversion/README.md
@@ -1,5 +1,6 @@
 # ATR Reversion
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 ATR Reversion looks for sudden moves measured in multiples of Average True Range (ATR). When price surges beyond the ATR multiplier, the system expects a mean reversion.
 
 The strategy opens a trade opposite the direction of the spike and uses a moving average to judge momentum.

--- a/API/0033_MACD_Zero/README.md
+++ b/API/0033_MACD_Zero/README.md
@@ -1,5 +1,6 @@
 # MACD Zero Cross
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 This system trades momentum shifts when the Moving Average Convergence Divergence (MACD) histogram approaches the zero line. A rising MACD below zero or falling MACD above zero signals a potential reversal.
 
 The strategy waits for the MACD line to trend toward zero while still on the opposite side. Once momentum fades, it enters anticipating a swing in price.

--- a/API/0034_Low_Vol_Reversion/README.md
+++ b/API/0034_Low_Vol_Reversion/README.md
@@ -1,5 +1,6 @@
 # Low Volatility Reversion
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 This mean-reversion strategy activates only during quiet markets. It measures ATR over a lookback window and enters when volatility falls below a percentage of that average and price deviates from its moving average.
 
 By trading against small moves in calm conditions, it aims to capture snap backs without chasing large trends.

--- a/API/0035_Bollinger_B_Reversion/README.md
+++ b/API/0035_Bollinger_B_Reversion/README.md
@@ -1,5 +1,6 @@
 # Bollinger Percent B Reversion
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 This approach fades price extremes beyond the Bollinger Bands using the Percent B indicator. Moves above the upper band or below the lower band suggest overextension.
 
 When percent B is less than zero or greater than one, the system bets on a return to the middle of the band. An exit threshold closes trades once momentum normalizes.

--- a/API/0036_ATR_Expansion/README.md
+++ b/API/0036_ATR_Expansion/README.md
@@ -1,5 +1,6 @@
 # ATR Expansion Breakout
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 This strategy follows bursts of volatility using the Average True Range. When ATR is rising compared to the previous bar and price trades relative to a moving average, it looks to ride the breakout.
 
 Expansion of ATR implies a strong move is underway. Entries align with the direction of price relative to the moving average, while contractions in volatility trigger exits.

--- a/API/0037_VIX_Trigger/README.md
+++ b/API/0037_VIX_Trigger/README.md
@@ -1,5 +1,6 @@
 # VIX Trigger
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 VIX Trigger reacts to changes in the Volatility Index. A rising VIX signals fear and possible reversals in the underlying instrument. The strategy compares VIX direction with price relative to a moving average.
 
 When VIX increases and price is below the moving average, it buys expecting a recovery. Conversely, rising VIX with price above the average invites a short position.

--- a/API/0038_BB_Width/README.md
+++ b/API/0038_BB_Width/README.md
@@ -1,5 +1,6 @@
 # Bollinger Band Width Breakout
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Bollinger Band Width measures the spread between the upper and lower bands. Expanding width suggests volatility and possible trend formation. This strategy trades breakouts when the width is increasing.
 
 Price position relative to the middle band sets direction. A widening channel with price above the mid-band triggers longs, while a widening channel below it triggers shorts.

--- a/API/0039_HV_Breakout/README.md
+++ b/API/0039_HV_Breakout/README.md
@@ -1,5 +1,6 @@
 # Historical Volatility Breakout
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 This breakout method uses historical volatility to set dynamic thresholds. When price moves beyond a reference level by more than the current volatility, it indicates a potential trend.
 
 The strategy compares price to levels derived from standard deviation and a simple moving average. Breakouts above or below those levels trigger trades.

--- a/API/0040_ATR_Trailing/README.md
+++ b/API/0040_ATR_Trailing/README.md
@@ -1,5 +1,6 @@
 # ATR Trailing Stops
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 ATR Trailing uses an average true range multiple to trail stops behind open positions. Entries occur when price crosses a moving average, and the trailing stop adjusts with volatility.
 
 As price advances, the stop ratchets up (or down) based on the latest ATR reading, never retreating. This locks in gains as the trend persists.

--- a/API/0041_Vol_Adjusted_MA/README.md
+++ b/API/0041_Vol_Adjusted_MA/README.md
@@ -1,5 +1,6 @@
 # Volatility Adjusted Moving Average
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 This technique modifies a moving average band by a multiple of ATR. When price moves beyond the adjusted band, it indicates an accelerated trend.
 
 Long trades are opened above the upper band, shorts below the lower band. A cross back through the baseline moving average closes the position.

--- a/API/0042_IV_Spike/README.md
+++ b/API/0042_IV_Spike/README.md
@@ -1,5 +1,6 @@
 # Implied Volatility Spike
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 This strategy watches implied volatility for sudden jumps relative to the prior value. A strong spike paired with price trading against the moving average can signal a short-term reversal.
 
 When implied volatility increases by the configured threshold, the system enters in the opposite direction of the price move, expecting volatility to revert.

--- a/API/0043_VCP/README.md
+++ b/API/0043_VCP/README.md
@@ -1,5 +1,6 @@
 # Volatility Contraction Pattern
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 The VCP strategy looks for a sequence of narrowing price ranges. As each range contracts, energy builds for a breakout. The system measures range size and waits for a break above the highest high or below the lowest low.
 
 Once contraction is observed, a breakout beyond the recent extremes triggers a trade in that direction. Price crossing the moving average is used to manage exits.

--- a/API/0044_ATR_Range/README.md
+++ b/API/0044_ATR_Range/README.md
@@ -1,5 +1,6 @@
 # ATR Range Breakout
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 ATR Range Breakout measures price movement over a fixed number of bars and compares it with the average true range. When the move exceeds the ATR, a position is opened in the direction of the move.
 
 The strategy checks price every N bars and uses the moving average for exit signals. It aims to capture momentum when volatility expands beyond normal levels.

--- a/API/0045_Choppiness_Index_Breakout/README.md
+++ b/API/0045_Choppiness_Index_Breakout/README.md
@@ -1,5 +1,6 @@
 # Choppiness Index Breakout
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 The Choppiness Index gauges whether the market is trending or ranging. When the indicator drops below a threshold, it signals the start of a trend from a choppy environment.
 
 This strategy enters in the direction of price relative to its moving average when choppiness falls. It exits if choppiness rises back above a high threshold or a stop-loss hits.

--- a/API/0046_Volume_Spike/README.md
+++ b/API/0046_Volume_Spike/README.md
@@ -1,5 +1,6 @@
 # Volume Spike Trend
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Volume Spike Trend monitors sudden surges in traded volume. When current volume exceeds the recent average by a set multiplier, it signals strong participation.
 
 If volume spikes and price is above the moving average, the strategy buys; if volume spikes below the average, it sells short. Trades exit when volume falls back under the average or the stop-loss is reached.

--- a/API/0047_OBV_Breakout/README.md
+++ b/API/0047_OBV_Breakout/README.md
@@ -1,5 +1,6 @@
 # OBV Breakout
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 On-Balance Volume (OBV) tracks buying and selling pressure by accumulating volume. This strategy looks for OBV to break above a high or below a low over the lookback window while price confirms the move.
 
 A breakout in OBV suggests strong interest. The system goes long if OBV exceeds its previous maximum, or short if it breaks the minimum. Crossing the OBV moving average signals an exit.

--- a/API/0048_VWAP_Breakout/README.md
+++ b/API/0048_VWAP_Breakout/README.md
@@ -1,5 +1,6 @@
 # VWAP Breakout
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 VWAP Breakout looks for price to cross the Volume Weighted Average Price from the opposite side. A breakout above VWAP signals bullish pressure, while a drop below VWAP signals bearish sentiment.
 
 The strategy waits for a close on the other side of VWAP and then trades in that direction. Exits occur when price reverses back through VWAP.

--- a/API/0049_VWMA/README.md
+++ b/API/0049_VWMA/README.md
@@ -1,5 +1,6 @@
 # VWMA Cross
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 The Volume Weighted Moving Average (VWMA) emphasizes price levels with higher trading volume. This strategy trades crossovers between price and the VWMA.
 
 A close above VWMA after being below it generates a long entry, while a drop below VWMA prompts a short trade. Positions exit when price crosses back in the opposite direction.

--- a/API/0050_AD/README.md
+++ b/API/0050_AD/README.md
@@ -1,5 +1,6 @@
 # Accumulation/Distribution Trend
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 This strategy uses the Accumulation/Distribution (A/D) indicator to gauge buying and selling pressure. Rising A/D alongside price above the moving average signals accumulation, while falling A/D below the average indicates distribution.
 
 Trades are taken in the direction of the A/D trend relative to the moving average. A change in A/D direction acts as an exit signal.

--- a/API/0051_Volume_Weighted_Price_Breakout/README.md
+++ b/API/0051_Volume_Weighted_Price_Breakout/README.md
@@ -1,5 +1,6 @@
 # Volume Weighted Price Breakout
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 This strategy combines a moving average with a volume‑weighted moving average (VWMA). When price trades above the VWMA, it suggests buyers are dominant. A breakout occurs when price crosses the VWMA from the opposite side.
 
 Trades align with the VWMA direction and use the simple moving average as a higher‑level trend filter. Exits occur when price reverses relative to the moving average.

--- a/API/0052_Volume_Divergence/README.md
+++ b/API/0052_Volume_Divergence/README.md
@@ -1,5 +1,6 @@
 # Volume Divergence
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Volume Divergence looks for discrepancies between price movement and trading volume. If price falls but volume increases, it may signal accumulation; if price rises with strong volume, it may signal distribution.
 
 The strategy enters long when falling prices are accompanied by rising volume, and enters short when rising prices pair with heavy volume. Exits rely on a moving average crossover.

--- a/API/0053_Volume_MA_Cross/README.md
+++ b/API/0053_Volume_MA_Cross/README.md
@@ -1,5 +1,6 @@
 # Volume MA Cross
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 This strategy processes volume through fast and slow moving averages. When the fast volume MA crosses above the slow volume MA, it indicates increasing participation and triggers a long entry. A cross below signals weakness and initiates a short.
 
 Positions are closed when the opposite crossover occurs. Price is monitored with its own moving average to help filter trades.

--- a/API/0054_Cumulative_Delta_Breakout/README.md
+++ b/API/0054_Cumulative_Delta_Breakout/README.md
@@ -1,5 +1,6 @@
 # Cumulative Delta Breakout
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Cumulative Delta sums the difference between buy and sell volume. This strategy watches the running total and trades when it breaks above its highest value or below its lowest value within the lookback period.
 
 A break of cumulative delta often precedes price follow-through. The strategy closes trades when delta crosses back through zero or a stop-loss level.

--- a/API/0055_Volume_Surge/README.md
+++ b/API/0055_Volume_Surge/README.md
@@ -1,5 +1,6 @@
 # Volume Surge
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Volume Surge identifies unusually high volume relative to the moving average. When the ratio exceeds the defined multiplier, it signals strong interest and potential continuation in the direction of price relative to its moving average.
 
 Trades are initiated only on a surge and closed once volume falls back below average or when the stop-loss is reached.

--- a/API/0056_Double_Bottom/README.md
+++ b/API/0056_Double_Bottom/README.md
@@ -1,5 +1,6 @@
 # Double Bottom Pattern
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 This pattern-based strategy scans for two consecutive lows at roughly the same price separated by a set distance. After the second bottom forms, a bullish candle confirms the reversal.
 
 When confirmation occurs, the system buys with a stop below the pattern lows. The setup aims to capture sharp rebounds from exhausted selling.

--- a/API/0057_Double_Top/README.md
+++ b/API/0057_Double_Top/README.md
@@ -1,5 +1,6 @@
 # Double Top Pattern
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Double Top identifies two peaks separated by a number of bars with similar prices. After the second peak forms, a bearish candle confirms the reversal.
 
 The strategy sells short upon confirmation with a stop above the pattern highs, aiming to profit from a trend change after buyers are exhausted.

--- a/API/0058_RSI_Overbought_Oversold/README.md
+++ b/API/0058_RSI_Overbought_Oversold/README.md
@@ -1,5 +1,6 @@
 # RSI Overbought/Oversold
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 This system trades reversals using the Relative Strength Index. When RSI drops below the oversold level, it buys after closing any shorts. When RSI climbs above the overbought level, it sells after closing longs.
 
 Positions exit when RSI returns to a neutral zone or the stop-loss is reached.

--- a/API/0059_Hammer_Candle/README.md
+++ b/API/0059_Hammer_Candle/README.md
@@ -1,5 +1,6 @@
 # Hammer Candle Reversal
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Hammer candles often mark an intraday reversal after selling pressure subsides. This strategy looks for a hammer pattern and enters long, anticipating a rebound.
 
 The system requires a lower shadow at least twice the body and little upper shadow. Once identified, it buys with volume size and waits for profit or stop-loss.

--- a/API/0060_Shooting_Star/README.md
+++ b/API/0060_Shooting_Star/README.md
@@ -1,5 +1,6 @@
 # Shooting Star Pattern
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 The shooting star candlestick often appears after an advance and warns of a reversal. This strategy looks for a long upper shadow relative to the body with little lower shadow.
 
 If confirmation is required, the next candle must close lower before entering short. Otherwise the trade can be taken immediately. Stops are placed above the pattern high.

--- a/API/0061_MACD_Divergence/README.md
+++ b/API/0061_MACD_Divergence/README.md
@@ -1,5 +1,6 @@
 # MACD Divergence
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 MACD Divergence looks for disagreement between price action and the MACD indicator. Higher highs in price but lower highs in MACD suggest weakening momentum (bearish divergence), while lower lows in price and higher MACD lows hint at bullish reversal.
 
 After detecting divergence, the system waits for MACD to cross its signal line before entering. The trade is closed if MACD crosses back or the stop-loss triggers.

--- a/API/0062_Stochastic_Overbought_Oversold/README.md
+++ b/API/0062_Stochastic_Overbought_Oversold/README.md
@@ -1,5 +1,6 @@
 # Stochastic Overbought/Oversold Reversal
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The strategy reacts to extreme levels of the Stochastic Oscillator. When the %K line dives into oversold territory the system expects a bounce, whereas overbought readings can foreshadow a drop. The method runs on short intraday candles so signals arrive quickly.
 
 After subscribing to the selected timeframe it monitors the %K and %D lines. A bullish setup forms when %K falls below 20 and then begins to recover. Conversely, a bearish setup appears if %K rallies above 80 and starts to turn down. A fixed percent stop controls risk for either side.

--- a/API/0063_Engulfing_Bullish/README.md
+++ b/API/0063_Engulfing_Bullish/README.md
@@ -1,5 +1,6 @@
 # Bullish Engulfing Pattern Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 This setup looks for a sharp bullish reversal when a candle completely engulfs the prior bearish bar. Such a formation often ends a short-term decline and hints at renewed upward momentum. The optional downtrend filter counts consecutive red candles to confirm sellers are exhausted.
 
 During live operation the algorithm watches each incoming candle and keeps track of the previous bar. If the new candle closes higher than it opens and its body wraps around the prior bar, a long entry is triggered. The stop is placed just below the pattern low to cap risk.

--- a/API/0064_Engulfing_Bearish/README.md
+++ b/API/0064_Engulfing_Bearish/README.md
@@ -1,5 +1,6 @@
 # Bearish Engulfing Pattern Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 This pattern aims to capture the start of a bearish swing after a rally. A bearish engulfing occurs when a red candle completely swallows the prior bullish body. Counting a few consecutive up bars before the pattern ensures the market was previously rising.
 
 The algorithm stores each candle in sequence. If the new bar closes lower than it opens and its body engulfs the previous bullish bar, a short sale is executed. The stop-loss is positioned above the pattern high to limit exposure.

--- a/API/0065_Pinbar_Reversal/README.md
+++ b/API/0065_Pinbar_Reversal/README.md
@@ -1,5 +1,6 @@
 # Pinbar Reversal Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Pinbars highlight sudden rejections of price and can signal short-term turning points. This strategy measures the length of the candle's tail relative to its body, looking for long shadows that stick out from recent price action. A moving average filter helps trade in the direction of the underlying trend.
 
 During each candle update the system calculates upper and lower shadows and compares them to the body size. A bullish pinbar with a long lower wick may trigger a long entry if price is above the moving average. Likewise a bearish pinbar with an extended upper tail can initiate a short position in a downtrend. Stops are placed a fixed percentage from entry.

--- a/API/0066_Three_Bar_Reversal_Up/README.md
+++ b/API/0066_Three_Bar_Reversal_Up/README.md
@@ -1,5 +1,6 @@
 # Three-Bar Reversal Up Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 This pattern catches quick bullish turns after a short decline. It requires two consecutive down candles followed by a strong up candle that closes above the prior bar's high. The logic optionally checks that price was trending lower beforehand.
 
 The strategy keeps the last three candles in memory. Once the sequence matches the criteria and any downtrend filter is satisfied, a long position is opened. A volatility stop below the pattern low caps risk on the trade.

--- a/API/0067_Three_Bar_Reversal_Down/README.md
+++ b/API/0067_Three_Bar_Reversal_Down/README.md
@@ -1,5 +1,6 @@
 # Three-Bar Reversal Down Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 A mirror image of the bullish version, this setup looks for quick bearish reversals. After two strong up candles that push to new highs, a decisive bearish candle closes below the prior bar's low. A brief uptrend beforehand helps confirm buyer exhaustion.
 
 The algorithm tracks a rolling window of three candles. When the pattern appears and any uptrend requirement is met, a short position is taken with the stop above the pattern high. The rules are straightforward so signals occur immediately at candle close.

--- a/API/0068_CCI_Divergence/README.md
+++ b/API/0068_CCI_Divergence/README.md
@@ -1,5 +1,6 @@
 # CCI Divergence Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Commodity Channel Index divergences can foreshadow trend reversals when price moves in the opposite direction of the indicator. This strategy compares swing highs and lows in price to those of the CCI to identify hidden strength or weakness.
 
 On each candle the system updates recent price and CCI values, flagging bullish divergence when price makes a new low while CCI forms a higher low. Bearish divergence is the opposite. When a divergence aligns with oversold or overbought levels, a trade is opened with a volatility stop.

--- a/API/0069_Bollinger_Band_Reversal/README.md
+++ b/API/0069_Bollinger_Band_Reversal/README.md
@@ -1,5 +1,6 @@
 # Bollinger Band Reversal Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Price extremes outside the Bollinger Bands often snap back toward the middle band. This approach fades those extensions, buying dips below the lower band when the candle finishes green and selling rallies above the upper band after a red candle.
 
 The algorithm calculates Bollinger Bands on each bar and checks whether the close breaches the outer band. If a bullish candle closes below the lower band a long is opened; if a bearish candle closes above the upper band a short is taken. The stop relies on an ATR multiple while exits occur when price returns to the middle band.

--- a/API/0070_Morning_Star/README.md
+++ b/API/0070_Morning_Star/README.md
@@ -1,5 +1,6 @@
 # Morning Star Pattern Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Morning Star is a bullish candlestick formation that signals a potential bottom after a decline. It consists of a large bearish candle, a small indecisive candle, and a strong bullish candle that closes above the midpoint of the first bar.
 
 This strategy tracks sequences of three candles. When the pattern appears a long position is opened with a stop placed below the small middle candle. Exits occur once price rises above the high of the confirmation bar or if the stop is reached.

--- a/API/0071_Evening_Star/README.md
+++ b/API/0071_Evening_Star/README.md
@@ -1,5 +1,6 @@
 # Evening Star Pattern Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Evening Star mirrors the Morning Star but indicates a potential top. It begins with a strong bullish candle, followed by a small indecision candle, and ends with a bearish candle closing below the midpoint of the first bar.
 
 The algorithm watches sequences of three candles. When the pattern forms, it enters short with a stop above the small middle candle's high. Positions exit once price drops beneath the confirmation candle's low or if the stop is triggered.

--- a/API/0072_Doji_Reversal/README.md
+++ b/API/0072_Doji_Reversal/README.md
@@ -1,5 +1,6 @@
 # Doji Reversal Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Doji candles reflect a temporary balance of buyers and sellers. When a doji appears after a strong directional move it can precede a reversal as momentum fades. This strategy measures the candle body relative to its range to decide if a true doji formed.
 
 Once a doji is detected, the previous candles are checked for an uptrend or downtrend. A doji following a decline may trigger a long entry while one after a rise can open a short. Stops are placed at a percentage distance from the entry and exits occur if price breaks beyond the doji's extremes.

--- a/API/0073_Keltner_Channel_Reversal/README.md
+++ b/API/0073_Keltner_Channel_Reversal/README.md
@@ -1,5 +1,6 @@
 # Keltner Channel Reversal Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Volatility-based channels can highlight overextended moves. This method fades price when it pushes outside the Keltner Channel, anticipating a snap back toward the middle line. It uses an exponential moving average and ATR to size the channel width.
 
 As each candle completes, the strategy checks whether the close is beyond the upper or lower band and whether the candle direction agrees. Bullish candles closing below the lower band spark long entries, while bearish candles above the upper band prompt shorts. Positions exit once price crosses the middle band or when the ATR-based stop is reached.

--- a/API/0074_Williams_R_Divergence/README.md
+++ b/API/0074_Williams_R_Divergence/README.md
@@ -1,5 +1,6 @@
 # Williams %R Divergence Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Williams %R oscillator gauges overbought and oversold conditions. When price makes a new low but %R forms a higher low, or when price prints a new high but %R turns lower, momentum may reverse. This strategy hunts for such divergences at the extremes of the indicator.
 
 Every bar the system records the latest close and %R value to compare with the prior reading. A bullish divergence combined with an oversold level below -80 triggers a long entry, while a bearish divergence and a reading above -20 produces a short. Stops are set using a percentage of price.

--- a/API/0075_OBV_Divergence/README.md
+++ b/API/0075_OBV_Divergence/README.md
@@ -1,5 +1,6 @@
 # OBV Divergence Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 On-Balance Volume tracks cumulative trading volume with the idea that volume precedes price. When price forms a new high but OBV fails to confirm—or vice versa—a reversal may be brewing. This strategy uses that divergence to fade unsustainable moves.
 
 For each candle OBV is updated and compared with the prior reading. A bullish signal emerges if price makes a lower low while OBV prints a higher low. A bearish signal occurs when price rallies to a higher high but OBV lags. A moving average provides an exit point, while a percentage stop keeps losses controlled.

--- a/API/0076_Fibonacci_Retracement_Reversal/README.md
+++ b/API/0076_Fibonacci_Retracement_Reversal/README.md
@@ -1,5 +1,6 @@
 # Fibonacci Retracement Reversal Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Markets often retrace a portion of a prior move before resuming trend. This strategy identifies recent swing highs and lows and watches for price to test the 61.8% or 78.6% retracement levels. These areas frequently mark exhaustion points.
 
 The algorithm tracks swings over a rolling window and calculates Fibonacci levels between them. When price nears a key retracement and forms a candle in the direction of the original trend, a trade is opened with a stop placed a set percent away. Targets are around the 50% midpoint of the swing.

--- a/API/0077_Inside_Bar_Breakout/README.md
+++ b/API/0077_Inside_Bar_Breakout/README.md
@@ -1,5 +1,6 @@
 # Inside Bar Breakout Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 An inside bar forms when a candle's range is fully contained within the previous bar's high and low. It signals short-term indecision that can lead to a breakout once price clears the pattern. This strategy waits for that break and then trades in the direction of the expansion.
 
 Each new candle is compared with the one before it. If an inside bar appears, the system marks its high and low and watches for a close outside those levels. A bullish breakout opens a long position with a stop below the pattern low, while a bearish breakout triggers a short with a stop above the pattern high.

--- a/API/0078_Outside_Bar_Reversal/README.md
+++ b/API/0078_Outside_Bar_Reversal/README.md
@@ -1,5 +1,6 @@
 # Outside Bar Reversal Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 An outside bar occurs when a candle's range exceeds that of the previous candle, creating a brief surge of volatility. This strategy fades the move if the outside bar closes in the opposite direction of the prior trend, expecting a snap back toward equilibrium.
 
 When an outside bar forms, the algorithm determines whether the candle is bullish or bearish. A bullish outside bar after a decline opens a long position with a stop below the bar's low. A bearish outside bar after a rally triggers a short with a stop above its high. Trades exit if price subsequently breaks through that extreme.

--- a/API/0079_Trendline_Bounce/README.md
+++ b/API/0079_Trendline_Bounce/README.md
@@ -1,5 +1,6 @@
 # Trendline Bounce Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Markets often respect trendlines drawn across prior swing highs or lows. This strategy automatically fits regression lines to recent price action and looks for candles that bounce from those lines in the direction of the dominant trend.
 
 Recent candles are stored to calculate upward or downward sloping support and resistance lines. When price nears a trendline and a candle confirms the bounce while staying on the correct side of a moving average, the system enters a trade. The stop is set using a percentage of price and an exit occurs on a cross of the moving average.

--- a/API/0080_Pivot_Point_Reversal/README.md
+++ b/API/0080_Pivot_Point_Reversal/README.md
@@ -1,5 +1,6 @@
 # Pivot Point Reversal Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Daily pivot points and their support and resistance levels often act as turning points for intraday price action. This strategy calculates the classic floor-trader pivots from the prior day's high, low and close, then looks for candles bouncing off S1 or R1.
 
 When price approaches support level S1 and forms a bullish candle, a long entry is taken. If price tests resistance level R1 and prints a bearish candle, a short is opened. Trades exit upon reaching the central pivot or if the protective stop is hit.

--- a/API/0081_VWAP_Bounce/README.md
+++ b/API/0081_VWAP_Bounce/README.md
@@ -1,5 +1,6 @@
 # VWAP Bounce Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Volume Weighted Average Price (VWAP) is a popular intraday benchmark. When price deviates significantly from VWAP and then prints a candle back toward it, a brief reversion move often follows. This strategy trades those bounces.
 
 For each bar the current VWAP is computed. If a bullish candle closes below VWAP the system goes long; if a bearish candle closes above VWAP it goes short. A fixed stop-loss percentage manages risk, and positions are typically held only until an opposite signal forms or the stop is reached.

--- a/API/0082_Volume_Exhaustion/README.md
+++ b/API/0082_Volume_Exhaustion/README.md
@@ -1,5 +1,6 @@
 # Volume Exhaustion Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Sharp spikes in volume often signal the end of a move as traders rush to exit or enter positions. This strategy measures current volume against an average to spot exhaustion. When combined with candle direction and a moving average filter it can pinpoint reversal entries.
 
 Each candle updates the average volume. If the new bar's volume exceeds this average by a set multiplier and the candle closes in the direction opposite the prevailing trend, the system enters a trade. A stop based on ATR protects the position.

--- a/API/0083_ADX_Weakening/README.md
+++ b/API/0083_ADX_Weakening/README.md
@@ -1,5 +1,6 @@
 # ADX Weakening Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Average Directional Index measures trend strength. When ADX begins to decline it often signals that the current move is losing momentum. This system trades against that weakening trend when price is on the opposite side of a simple moving average.
 
 For each bar the strategy computes ADX and an MA. If ADX decreases compared to the prior value and price is above the MA, a long entry is placed. If ADX falls while price is below the MA, it goes short. A fixed stop-loss protects the position.

--- a/API/0084_ATR_Exhaustion/README.md
+++ b/API/0084_ATR_Exhaustion/README.md
@@ -1,5 +1,6 @@
 # ATR Exhaustion Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 A sudden surge in Average True Range indicates expanding volatility that can quickly fade. This strategy looks for ATR readings that spike above a moving average by a configurable multiplier. When coupled with a reversal candle it aims to capture the subsequent contraction.
 
 Each bar updates ATR and its own average. If ATR exceeds the average by the multiplier and the candle closes opposite the prior move, a trade is opened. The stop-loss uses an ATR multiple as well, anchoring risk to current volatility levels.

--- a/API/0085_Ichimoku_Tenkan/README.md
+++ b/API/0085_Ichimoku_Tenkan/README.md
@@ -1,5 +1,6 @@
 # Ichimoku Tenkan/Kijun Cross Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Ichimoku indicators provide a full trend-following system. This approach focuses on the Tenkan-sen crossing the Kijun-sen while price trades relative to the Kumo cloud. A bullish cross above the cloud signals trend continuation higher, whereas a bearish cross below the cloud suggests weakness.
 
 During operation the strategy calculates the Ichimoku components on each bar. When Tenkan rises above Kijun and price sits above the cloud, a long trade is initiated with a stop near Kijun. A cross in the opposite direction below the cloud triggers a short with a similar stop placement.

--- a/API/0086_Heikin_Ashi_Reversal/README.md
+++ b/API/0086_Heikin_Ashi_Reversal/README.md
@@ -1,5 +1,6 @@
 # Heikin-Ashi Reversal Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Heikin-Ashi candles smooth noise and highlight trend direction. A shift from a series of bearish HA candles to a bullish one, or vice versa, can indicate a change in momentum. This strategy trades those color flips and uses a percentage stop for protection.
 
 The logic calculates Heikin-Ashi values from regular candles. When the HA close crosses above the HA open after a bearish sequence, a long is taken. A cross below after a bullish run opens a short. The stop is placed a fixed percentage away from entry.

--- a/API/0087_Parabolic_SAR_Reversal/README.md
+++ b/API/0087_Parabolic_SAR_Reversal/README.md
@@ -1,5 +1,6 @@
 # Parabolic SAR Reversal Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Parabolic SAR indicator places dots above or below price to signal trend direction. When the dots flip sides, it may mark the end of the previous move. This strategy enters trades on that switch, expecting a short-term reversal.
 
 A running Parabolic SAR value is maintained for each candle. If the indicator moves from above price to below, a long position is opened. If it flips from below to above, a short trade is executed. The method does not use an explicit profit target and typically relies on discretionary exit or trailing stops outside the sample code.

--- a/API/0088_Supertrend_Reversal/README.md
+++ b/API/0088_Supertrend_Reversal/README.md
@@ -1,5 +1,6 @@
 # Supertrend Reversal Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Supertrend indicator combines ATR and price to produce trailing support or resistance. When the Supertrend line flips from above to below price or vice versa, it suggests a potential trend change. This strategy trades those flips.
 
 On each candle an ATR-based calculation updates the Supertrend level. A switch from above price to below triggers a long entry, while a move from below to above creates a short. The code sample omits explicit stops, so exits are discretionary or managed by a separate risk module.

--- a/API/0089_Hull_MA_Reversal/README.md
+++ b/API/0089_Hull_MA_Reversal/README.md
@@ -1,5 +1,6 @@
 # Hull MA Reversal Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Hull Moving Average responds quickly to price changes while remaining smooth. A change in its direction can foreshadow a short-term reversal. This strategy monitors consecutive Hull MA values and trades when the slope flips.
 
 When the moving average transitions from falling to rising, a long position is opened. A shift from rising to falling initiates a short. Risk is controlled using an ATR-based stop placed beyond the recent candle.

--- a/API/0090_Donchian_Reversal/README.md
+++ b/API/0090_Donchian_Reversal/README.md
@@ -1,5 +1,6 @@
 # Donchian Channel Reversal Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Donchian Channels mark recent highs and lows over a chosen period. Prices that pierce those boundaries and then reverse can signal exhaustion. This strategy watches for closes back inside the channel after a brief breakout.
 
 If the previous close was below the lower band and the current close moves back above it, a long trade is taken. Conversely, if the prior close was above the upper band and price falls back inside, a short is opened. A percentage stop manages risk in both cases.

--- a/API/0091_MACD_Histogram_Reversal/README.md
+++ b/API/0091_MACD_Histogram_Reversal/README.md
@@ -1,5 +1,6 @@
 # MACD Histogram Reversal Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The MACD histogram represents the difference between the MACD line and its signal line. Crosses above or below zero often mark shifts in momentum. This strategy trades those zero-line crosses and manages risk with a percent stop.
 
 On each candle the MACD histogram is computed. When it transitions from negative to positive, a long position is opened. A flip from positive to negative triggers a short sale. Because the strategy only looks for the zero crossover, trades are straightforward and typically short term.

--- a/API/0092_RSI_Hook_Reversal/README.md
+++ b/API/0092_RSI_Hook_Reversal/README.md
@@ -1,5 +1,6 @@
 # RSI Hook Reversal Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The RSI Hook Reversal tries to catch short-term turning points when the RSI exits an extreme.
 After an overbought or oversold push the indicator often "hooks" back toward the midline before price reacts.
 

--- a/API/0093_Stochastic_Hook_Reversal/README.md
+++ b/API/0093_Stochastic_Hook_Reversal/README.md
@@ -1,5 +1,6 @@
 # Stochastic Hook Reversal Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Stochastic Hook Reversal watches the %K line for a hook out of overbought or oversold territory.
 After stretching to an extreme the oscillator often curls back, indicating momentum is waning.
 

--- a/API/0094_CCI_Hook_Reversal/README.md
+++ b/API/0094_CCI_Hook_Reversal/README.md
@@ -1,5 +1,6 @@
 # CCI Hook Reversal Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The CCI Hook Reversal uses the Commodity Channel Index as a trigger when it hooks away from an extreme reading.
 After the indicator pushes above +100 or below -100 it often snaps back quickly as momentum stalls.
 

--- a/API/0095_Williams_R_Hook_Reversal/README.md
+++ b/API/0095_Williams_R_Hook_Reversal/README.md
@@ -1,5 +1,6 @@
 # Williams %R Hook Reversal Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Williams %R Hook Reversal follows the Williams %R indicator as it quickly snaps back from an extreme.
 When the reading moves above -20 or below -80 and then hooks toward the center, the prior thrust is likely exhausted.
 

--- a/API/0096_Three_White_Soldiers/README.md
+++ b/API/0096_Three_White_Soldiers/README.md
@@ -1,5 +1,6 @@
 # Three White Soldiers Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Three White Soldiers pattern is a classic bullish reversal consisting of three consecutive strong up candles.
 After a downtrend, this sequence often marks the start of a sustained move higher as buying pressure overwhelms sellers.
 

--- a/API/0097_Three_Black_Crows/README.md
+++ b/API/0097_Three_Black_Crows/README.md
@@ -1,5 +1,6 @@
 # Three Black Crows Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Three Black Crows is the bearish counterpart to Three White Soldiers, consisting of three long down candles after an advance.
 The pattern suggests that sellers have seized control as each close lands near the session low.
 

--- a/API/0098_Gap_Fill_Reversal/README.md
+++ b/API/0098_Gap_Fill_Reversal/README.md
@@ -1,5 +1,6 @@
 # Gap Fill Reversal Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Gap Fill Reversal takes advantage of overnight gaps that quickly retrace during the next session.
 When price gaps away from the prior close but immediately moves back to fill that void, it often signals an exhaustion of the initial move.
 

--- a/API/0099_Tweezer_Bottom/README.md
+++ b/API/0099_Tweezer_Bottom/README.md
@@ -1,5 +1,6 @@
 # Tweezer Bottom Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Tweezer Bottom is a two-candle reversal pattern that appears after a decline.
 Both candles share a similar low, signaling that sellers failed to push beyond that level.
 

--- a/API/0100_Tweezer_Top/README.md
+++ b/API/0100_Tweezer_Top/README.md
@@ -1,5 +1,6 @@
 # Tweezer Top Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Tweezer Top mirrors the bottom version but appears after an advance.
 Two candles share nearly the same high, showing that buyers could not push beyond a certain level.
 

--- a/API/0101_Harami_Bullish/README.md
+++ b/API/0101_Harami_Bullish/README.md
@@ -1,5 +1,6 @@
 # Bullish Harami Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Bullish Harami is a two-candle pattern where a small body is contained within the range of the prior bearish candle.
 It hints that selling momentum has stalled and buyers may step back in.
 

--- a/API/0102_Harami_Bearish/README.md
+++ b/API/0102_Harami_Bearish/README.md
@@ -1,5 +1,6 @@
 # Bearish Harami Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Bearish Harami is the inverse of the bullish version, appearing after an upswing.
 Here a small candle forms completely inside the prior bullish bar, hinting that upward momentum is stalling.
 

--- a/API/0103_Dark_Pool_Prints/README.md
+++ b/API/0103_Dark_Pool_Prints/README.md
@@ -1,5 +1,6 @@
 # Dark Pool Prints Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Dark Pool Prints tracks large off-exchange transactions that often precede sharp moves once the activity is revealed.
 Unusual volume hitting the tape can signal institutional positioning that hasn't yet impacted the regular market.
 

--- a/API/0104_Rejection_Candle/README.md
+++ b/API/0104_Rejection_Candle/README.md
@@ -1,5 +1,6 @@
 # Rejection Candle Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 A Rejection Candle forms when price probes a level but fails to hold beyond it, leaving a long wick and small body.
 Such candles indicate an attempt to move in one direction was firmly rejected by the market.
 

--- a/API/0105_False_Breakout_Trap/README.md
+++ b/API/0105_False_Breakout_Trap/README.md
@@ -1,5 +1,6 @@
 # False Breakout Trap Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The False Breakout Trap aims to capitalize on breaks that fail to hold beyond key support or resistance.
 Traders often jump into a breakout only to see price quickly reverse, leaving them trapped.
 

--- a/API/0106_Spring_Reversal/README.md
+++ b/API/0106_Spring_Reversal/README.md
@@ -1,5 +1,6 @@
 # Spring Reversal Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Spring Reversal is a Wyckoff concept where price briefly breaks support and then springs back above it.
 This shakeout traps late sellers and often marks the beginning of an uptrend.
 

--- a/API/0107_Upthrust_Reversal/README.md
+++ b/API/0107_Upthrust_Reversal/README.md
@@ -1,5 +1,6 @@
 # Upthrust Reversal Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Upthrust Reversal is the bearish companion to the spring and occurs when price briefly breaks above resistance but quickly falls back.
 The move flushes out late buyers before reversing lower.
 

--- a/API/0108_Wyckoff_Accumulation/README.md
+++ b/API/0108_Wyckoff_Accumulation/README.md
@@ -1,5 +1,6 @@
 # Wyckoff Accumulation Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Wyckoff Accumulation describes a basing phase where large interests quietly build positions after a decline.
 Volume and price action form a series of tests of support followed by higher lows, hinting at growing demand.
 

--- a/API/0109_Wyckoff_Distribution/README.md
+++ b/API/0109_Wyckoff_Distribution/README.md
@@ -1,5 +1,6 @@
 # Wyckoff Distribution Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Wyckoff Distribution is a topping phase characterized by heavy selling into rallies and tests of resistance.
 Volume often expands on down moves and contracts on bounces, suggesting large interests are liquidating positions.
 

--- a/API/0110_RSI_Failure_Swing/README.md
+++ b/API/0110_RSI_Failure_Swing/README.md
@@ -1,5 +1,6 @@
 # RSI Failure Swing Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 RSI Failure Swing is a classic reversal technique where the RSI forms a higher low in oversold territory or a lower high in overbought territory.
 This failure to reach a new extreme often precedes a change in trend.
 

--- a/API/0111_Stochastic_Failure_Swing/README.md
+++ b/API/0111_Stochastic_Failure_Swing/README.md
@@ -1,5 +1,6 @@
 # Stochastic Failure Swing Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Stochastic Failure Swing monitors the oscillator for a lower high above 80 or a higher low below 20.
 When the indicator fails to reach a new extreme and then reverses, it often signals a trend shift.
 

--- a/API/0112_CCI_Failure_Swing/README.md
+++ b/API/0112_CCI_Failure_Swing/README.md
@@ -1,5 +1,6 @@
 # CCI Failure Swing Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The CCI Failure Swing is based on the Commodity Channel Index forming a lower high above +100 or a higher low below -100.
 This inability to make a new extreme often signals the end of the prior trend.
 

--- a/API/0113_Bullish_Abandoned_Baby/README.md
+++ b/API/0113_Bullish_Abandoned_Baby/README.md
@@ -1,5 +1,6 @@
 # Bullish Abandoned Baby Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Bullish Abandoned Baby is a rare three-candle pattern featuring a gap down doji followed by a gap up.
 This formation leaves the middle candle "abandoned" and often precedes a sharp reversal higher.
 

--- a/API/0114_Bearish_Abandoned_Baby/README.md
+++ b/API/0114_Bearish_Abandoned_Baby/README.md
@@ -1,5 +1,6 @@
 # Bearish Abandoned Baby Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Bearish Abandoned Baby mirrors the bullish version but signals a potential top.
 It features a gap up doji followed by a gap down, leaving the middle candle isolated above the prior range.
 

--- a/API/0115_Volume_Climax_Reversal/README.md
+++ b/API/0115_Volume_Climax_Reversal/README.md
@@ -1,5 +1,6 @@
 # Volume Climax Reversal Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Volume Climax Reversal seeks turning points marked by extremely high volume after a strong trend.
 Such climactic spikes suggest exhaustion as the last buyers or sellers rush in before momentum fades.
 

--- a/API/0116_Day_of_Week/README.md
+++ b/API/0116_Day_of_Week/README.md
@@ -1,5 +1,6 @@
 # Day of Week Effect Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Day of Week Effect exploits tendencies for markets to exhibit recurring behavior on specific weekdays.
 Some indices show consistent strength midweek while Monday or Friday can be relatively weak.
 

--- a/API/0117_Month_of_Year/README.md
+++ b/API/0117_Month_of_Year/README.md
@@ -1,5 +1,6 @@
 # Month of Year Effect Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Month of Year Effect captures performance differences observed in various months.
 For example, equities often rally in November and December but can be weak during September.
 

--- a/API/0118_Turnaround_Tuesday/README.md
+++ b/API/0118_Turnaround_Tuesday/README.md
@@ -1,5 +1,6 @@
 # Turnaround Tuesday Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Turnaround Tuesday refers to the tendency for markets that sold off on Monday to rebound the next day.
 The effect is often attributed to traders overreacting after the weekend and then reversing course.
 

--- a/API/0119_End_of_Month_Strength/README.md
+++ b/API/0119_End_of_Month_Strength/README.md
@@ -1,5 +1,6 @@
 # End of Month Strength Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 End of Month Strength observes that equities often rally during the last few trading days as portfolio managers adjust holdings.
 Buying pressure tied to window dressing can create a reliable upward bias ahead of the monthly close.
 

--- a/API/0120_First_Day_of_Month/README.md
+++ b/API/0120_First_Day_of_Month/README.md
@@ -1,5 +1,6 @@
 # First Day of Month Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Many markets exhibit a bullish bias on the first trading day of the month as new capital flows into funds.
 Traders attempt to front-run this effect by buying at the prior month's close or early in the session.
 

--- a/API/0121_Santa_Claus_Rally/README.md
+++ b/API/0121_Santa_Claus_Rally/README.md
@@ -1,5 +1,6 @@
 # Santa Claus Rally Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Santa Claus Rally describes the tendency for stocks to rise in the final week of December through the first two trading days of January.
 Holiday optimism and year-end positioning can fuel this short burst of strength.
 

--- a/API/0122_January_Effect/README.md
+++ b/API/0122_January_Effect/README.md
@@ -1,5 +1,6 @@
 # January Effect Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The January Effect observes that small-cap stocks often outperform early in the year, possibly due to tax-loss selling in December.
 Traders attempt to capture this tendency by buying in late December and selling after the first few weeks of January.
 

--- a/API/0123_Monday_Weakness/README.md
+++ b/API/0123_Monday_Weakness/README.md
@@ -1,5 +1,6 @@
 # Monday Weakness Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Monday Weakness notes that equities often open lower after the weekend as traders digest news and reposition.
 Short-term bearish pressure can appear at the start of the week before markets stabilize.
 

--- a/API/0124_Pre-Holiday_Strength/README.md
+++ b/API/0124_Pre-Holiday_Strength/README.md
@@ -1,5 +1,6 @@
 # Pre-Holiday Strength Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Pre-Holiday Strength refers to the bullish tendency just before major market holidays when volume is lighter and sentiment optimistic.
 Traders often position ahead of the break, pushing prices higher in the final session or two.
 

--- a/API/0125_Post-Holiday_Weakness/README.md
+++ b/API/0125_Post-Holiday_Weakness/README.md
@@ -1,5 +1,6 @@
 # Post-Holiday Weakness Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Post-Holiday Weakness is the tendency for prices to drift lower immediately after a major holiday when volume remains thin.
 With many participants still away, counter-trend moves can gain traction.
 

--- a/API/0126_Quarterly_Expiry/README.md
+++ b/API/0126_Quarterly_Expiry/README.md
@@ -1,5 +1,6 @@
 # Quarterly Expiry Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Quarterly Expiry weeks see futures and options contracts roll over, often creating volatility as positions are closed or rolled.
 Price swings can accelerate as hedges are adjusted and liquidity temporarily dries up.
 

--- a/API/0127_Open_Drive/README.md
+++ b/API/0127_Open_Drive/README.md
@@ -1,5 +1,6 @@
 # Open Drive Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Open Drive refers to strong directional movement right from the opening bell, often after an overnight news catalyst.
 Traders look for heavy volume and sustained momentum in the first few minutes.
 

--- a/API/0128_Midday_Reversal/README.md
+++ b/API/0128_Midday_Reversal/README.md
@@ -1,5 +1,6 @@
 # Midday Reversal Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Midday Reversal seeks turning points that occur around lunchtime when morning trends often exhaust.
 Liquidity typically dries up mid-session, leading to reversals as traders square positions.
 

--- a/API/0129_Overnight_Gap/README.md
+++ b/API/0129_Overnight_Gap/README.md
@@ -1,5 +1,6 @@
 # Overnight Gap Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Overnight Gap plays the open when price gaps significantly from the prior close due to news or after-hours activity.
 Large gaps often retrace partially as traders digest the move.
 

--- a/API/0130_Lunch_Break_Fade/README.md
+++ b/API/0130_Lunch_Break_Fade/README.md
@@ -1,5 +1,6 @@
 # Lunch Break Fade Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Lunch Break Fade targets reversals that develop during the slow midday period.
 After the morning session, trends often pause or pull back as volume dries up around lunchtime.
 

--- a/API/0131_MACD_RSI/README.md
+++ b/API/0131_MACD_RSI/README.md
@@ -1,5 +1,6 @@
 # MACD RSI Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 MACD RSI combines momentum from the Moving Average Convergence Divergence with overbought/oversold readings from RSI.
 When both indicators align, the probability of a sustained move increases.
 

--- a/API/0132_Bollinger_Stochastic/README.md
+++ b/API/0132_Bollinger_Stochastic/README.md
@@ -1,5 +1,6 @@
 # Bollinger Stochastic Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Bollinger Stochastic pairs Bollinger Bands with the stochastic oscillator to identify overextended moves.
 Price touching the outer band while the oscillator is in an extreme zone suggests a possible snap back.
 

--- a/API/0133_MA_Volume/README.md
+++ b/API/0133_MA_Volume/README.md
@@ -1,5 +1,6 @@
 # MA Volume Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 MA Volume combines a moving average trend filter with volume surges to time entries.
 Rising volume alongside price above the average signals strong accumulation; falling volume below the average indicates distribution.
 

--- a/API/0134_ADX_MACD/README.md
+++ b/API/0134_ADX_MACD/README.md
@@ -1,5 +1,6 @@
 # ADX MACD Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 ADX MACD blends trend strength from the Average Directional Index with momentum shifts from MACD.
 When ADX is rising, breakouts have a higher chance of continuing, especially if MACD crosses in the same direction.
 

--- a/API/0135_Ichimoku_RSI/README.md
+++ b/API/0135_Ichimoku_RSI/README.md
@@ -1,5 +1,6 @@
 # Ichimoku RSI Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Ichimoku RSI uses Ichimoku cloud levels to define trend direction while RSI pinpoints short-term pullbacks.
 Trades align with the cloud, entering when RSI recovers from oversold in an uptrend or falls from overbought in a downtrend.
 

--- a/API/0136_Supertrend_Volume/README.md
+++ b/API/0136_Supertrend_Volume/README.md
@@ -1,5 +1,6 @@
 # Supertrend Volume Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Supertrend Volume augments the Supertrend indicator with volume confirmation.
 Rising volume during a Supertrend flip strengthens the likelihood of a new impulse move.
 

--- a/API/0137_Bollinger_RSI/README.md
+++ b/API/0137_Bollinger_RSI/README.md
@@ -1,5 +1,6 @@
 # Bollinger RSI Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Bollinger RSI combines Bollinger Band overextension with RSI momentum signals.
 When price closes outside the bands but RSI shows divergence, a reversal is often near.
 

--- a/API/0138_MA_Stochastic/README.md
+++ b/API/0138_MA_Stochastic/README.md
@@ -1,5 +1,6 @@
 # MA Stochastic Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 MA Stochastic uses a moving average trend filter with stochastic oscillator pullbacks.
 When price trends above the average and the stochastic dips into oversold, the system prepares to buy the next upturn.
 

--- a/API/0139_ATR_MACD/README.md
+++ b/API/0139_ATR_MACD/README.md
@@ -1,5 +1,6 @@
 # ATR MACD Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 ATR MACD uses volatility from the Average True Range to adjust position size while trading MACD crossovers.
 Larger ATR readings result in smaller trade size, keeping risk consistent across market regimes.
 

--- a/API/0140_VWAP_RSI/README.md
+++ b/API/0140_VWAP_RSI/README.md
@@ -1,5 +1,6 @@
 # VWAP RSI Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 VWAP RSI uses the volume-weighted average price to gauge fair value during the session while RSI shows momentum extremes.
 Trades are taken when price stretches away from VWAP and RSI reaches overbought or oversold levels.
 

--- a/API/0141_Donchian_Volume/README.md
+++ b/API/0141_Donchian_Volume/README.md
@@ -1,5 +1,6 @@
 # Donchian Volume Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Donchian Volume uses Donchian channel breakouts confirmed by rising volume to initiate trades.
 A move outside the channel on strong volume suggests the start of a new trend.
 

--- a/API/0142_Keltner_Stochastic/README.md
+++ b/API/0142_Keltner_Stochastic/README.md
@@ -1,5 +1,6 @@
 # Keltner Stochastic Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy that combines Keltner Channels and Stochastic Oscillator.
 Enters positions when price reaches Keltner Channel boundaries and Stochastic confirms oversold/overbought conditions.
 

--- a/API/0143_Parabolic_SAR_RSI/README.md
+++ b/API/0143_Parabolic_SAR_RSI/README.md
@@ -1,5 +1,6 @@
 # Parabolic Sar Rsi Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy that combines Parabolic SAR for trend direction and RSI for entry confirmation with oversold/overbought conditions.
 
 Here the Parabolic SAR outlines the prevailing trend and RSI measures exhaustion. Trades are opened once both indicators signal the same direction.

--- a/API/0144_Hull_MA_Volume/README.md
+++ b/API/0144_Hull_MA_Volume/README.md
@@ -1,5 +1,6 @@
 # Hull Ma Volume Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy that uses Hull Moving Average for trend direction and volume confirmation for trade entries.
 
 The Hull moving average smooths out noise, and rising volume confirms conviction. Entries occur when price moves with the Hull slope backed by a volume surge.

--- a/API/0145_ADX_Stochastic/README.md
+++ b/API/0145_ADX_Stochastic/README.md
@@ -1,5 +1,6 @@
 # Adx Stochastic Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy that combines ADX (Average Directional Index) for trend strength and Stochastic Oscillator for entry timing with oversold/overbought conditions.
 
 ADX highlights trend strength while Stochastic pinpoints pullbacks. Long or short signals appear when momentum turns while ADX stays high.

--- a/API/0146_MACD_Volume/README.md
+++ b/API/0146_MACD_Volume/README.md
@@ -1,5 +1,6 @@
 # Macd Volume Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy combining MACD (Moving Average Convergence Divergence) with volume confirmation. Enters positions when MACD line crosses the Signal line and confirms with increased volume.
 
 MACD crossovers are filtered by an increase in volume to confirm momentum. Buy signals come on bullish crosses with expanding volume; sells do the opposite.

--- a/API/0147_Bollinger_Volume/README.md
+++ b/API/0147_Bollinger_Volume/README.md
@@ -1,5 +1,6 @@
 # Bollinger Volume Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy that uses Bollinger Bands breakouts with volume confirmation.
 Enters positions when price breaks above/below Bollinger Bands with increased volume.
 

--- a/API/0148_RSI_Stochastic/README.md
+++ b/API/0148_RSI_Stochastic/README.md
@@ -1,5 +1,6 @@
 # Rsi Stochastic Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy that combines RSI and Stochastic Oscillator for double confirmation of oversold and overbought conditions.
 
 RSI provides a broader momentum view, while Stochastic gives faster signals near extremes. Trades flip as the oscillator crosses levels within the RSI context.

--- a/API/0149_MA_ADX/README.md
+++ b/API/0149_MA_ADX/README.md
@@ -1,5 +1,6 @@
 # Ma Adx Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on MA and ADX indicators. Enters position when price crosses MA with strong trend.
 
 The moving average dictates the trend, and ADX verifies whether it's strong enough to trade. Entries follow price crossings of the MA when ADX exceeds a threshold.

--- a/API/0150_VWAP_Stochastic/README.md
+++ b/API/0150_VWAP_Stochastic/README.md
@@ -1,5 +1,6 @@
 # Vwap Stochastic Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy combining VWAP and Stochastic indicators. Buys when price is below VWAP and Stochastic is oversold. Sells when price is above VWAP and Stochastic is overbought.
 
 VWAP marks the average trading level and Stochastic shows overbought or oversold conditions. Longs trigger below VWAP with a rising oscillator, shorts above VWAP with a falling one.

--- a/API/0151_Ichimoku_Volume/README.md
+++ b/API/0151_Ichimoku_Volume/README.md
@@ -1,5 +1,6 @@
 # Ichimoku Volume Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Implementation of strategy #151 - Ichimoku + Volume. Buy when price is above Kumo cloud, Tenkan-sen is above Kijun-sen, and volume is above average. Sell when price is below Kumo cloud, Tenkan-sen is below Kijun-sen, and volume is above average.
 
 Ichimoku components define the directional bias while surging volume confirms interest. Trades open when price aligns with the cloud and volume picks up.

--- a/API/0152_Supertrend_RSI/README.md
+++ b/API/0152_Supertrend_RSI/README.md
@@ -1,5 +1,6 @@
 # Supertrend Rsi Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Implementation of strategy #152 - Supertrend + RSI. Buy when price is above Supertrend and RSI is below 30 (oversold). Sell when price is below Supertrend and RSI is above 70 (overbought).
 
 The Supertrend indicator shows the current trend, and RSI spots when price is stretched. Orders follow the Supertrend direction once RSI reaches an extreme.

--- a/API/0153_Bollinger_ADX/README.md
+++ b/API/0153_Bollinger_ADX/README.md
@@ -1,5 +1,6 @@
 # Bollinger Adx Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy combining Bollinger Bands and ADX indicators. Looks for breakouts with strong trend confirmation.
 
 Price movements outside Bollinger bands are filtered through ADX for strength. Trades engage when a band break coincides with high ADX.

--- a/API/0154_MA_CCI/README.md
+++ b/API/0154_MA_CCI/README.md
@@ -1,5 +1,6 @@
 # Ma Cci Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy combining Moving Average and CCI indicators. Buys when price is above MA and CCI is oversold. Sells when price is below MA and CCI is overbought.
 
 A moving average guides the trend while CCI looks for deviations from that average. Entries happen on CCI extremes in the direction of the MA.

--- a/API/0155_VWAP_Volume/README.md
+++ b/API/0155_VWAP_Volume/README.md
@@ -1,5 +1,6 @@
 # Vwap Volume Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy combining VWAP and Volume indicators. Buys/sells on VWAP breakouts confirmed by above-average volume.
 
 This strategy references VWAP to gauge value and requires volume confirmation before trades. The idea is to join moves backed by strong participation.

--- a/API/0156_Donchian_RSI/README.md
+++ b/API/0156_Donchian_RSI/README.md
@@ -1,5 +1,6 @@
 # Donchian Rsi Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy combining Donchian Channels and RSI indicators. Buys on Donchian breakouts when RSI confirms trend is not overextended.
 
 Donchian channels identify breakout levels, while RSI checks whether momentum supports the move. Positions follow when a breakout aligns with RSI direction.

--- a/API/0157_Keltner_Volume/README.md
+++ b/API/0157_Keltner_Volume/README.md
@@ -1,5 +1,6 @@
 # Keltner Volume Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Implementation of strategy #157 - Keltner Channels + Volume. Buy when price breaks above upper Keltner Channel with above average volume. Sell when price breaks below lower Keltner Channel with above average volume.
 
 Keltner Channel boundaries define potential reversals, and increased volume signals conviction. The system trades when price touches a band with volume expanding.

--- a/API/0158_Parabolic_SAR_Stochastic/README.md
+++ b/API/0158_Parabolic_SAR_Stochastic/README.md
@@ -1,5 +1,6 @@
 # Parabolic Sar Stochastic Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Implementation of strategy #158 - Parabolic SAR + Stochastic. Buy when price is above SAR and Stochastic %K is below 20 (oversold). Sell when price is below SAR and Stochastic %K is above 80 (overbought).
 
 Parabolic SAR supplies the trend and Stochastic refines entry on pullbacks. Signals flip when SAR changes side.

--- a/API/0159_Hull_MA_RSI/README.md
+++ b/API/0159_Hull_MA_RSI/README.md
@@ -1,5 +1,6 @@
 # Hull Ma Rsi Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Implementation of strategy #159 - Hull Moving Average + RSI. Buy when HMA is rising and RSI is below 30 (oversold). Sell when HMA is falling and RSI is above 70 (overbought).
 
 Hull MA provides a smoothed trend line and RSI highlights momentum divergences. Trades occur when RSI turns at extremes while price follows the Hull direction.

--- a/API/0160_ADX_Volume/README.md
+++ b/API/0160_ADX_Volume/README.md
@@ -1,5 +1,6 @@
 # Adx Volume Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Implementation of strategy #160 - ADX + Volume. Enter trades when ADX is above threshold with above average volume. Direction determined by DI+ and DI- comparison.
 
 High ADX denotes a strong trend and volume spikes confirm commitment. Entries are made when both indicators show strength together.

--- a/API/0161_MACD_CCI/README.md
+++ b/API/0161_MACD_CCI/README.md
@@ -1,5 +1,6 @@
 # Macd Cci Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Implementation of strategy #161 - MACD + CCI. Buy when MACD is above Signal line and CCI is below -100 (oversold). Sell when MACD is below Signal line and CCI is above 100 (overbought).
 
 MACD swings highlight momentum shifts; CCI helps time pullback entries in that direction. Both long and short trades are possible.

--- a/API/0162_Bollinger_CCI/README.md
+++ b/API/0162_Bollinger_CCI/README.md
@@ -1,5 +1,6 @@
 # Bollinger Cci Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Implementation of strategy #162 - Bollinger Bands + CCI. Buy when price is below lower Bollinger Band and CCI is below -100 (oversold). Sell when price is above upper Bollinger Band and CCI is above 100 (overbought).
 
 Bollinger bands map volatility limits, and CCI measures the distance from the mean. Breaks beyond a band with CCI confirmation trigger trades.

--- a/API/0163_RSI_Williams_R/README.md
+++ b/API/0163_RSI_Williams_R/README.md
@@ -1,5 +1,6 @@
 # Rsi Williams R Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Implementation of strategy #163 - RSI + Williams %R. Buy when RSI is below 30 and Williams %R is below -80 (double oversold condition). Sell when RSI is above 70 and Williams %R is above -20 (double overbought condition).
 
 RSI outlines the overall momentum, while Williams %R gives a quicker signal of reversal. Trades act on agreement between the two oscillators.

--- a/API/0164_MA_Williams_R/README.md
+++ b/API/0164_MA_Williams_R/README.md
@@ -1,5 +1,6 @@
 # Ma Williams R Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Implementation of strategy #164 - MA + Williams %R. Buy when price is above MA and Williams %R is below -80 (oversold). Sell when price is below MA and Williams %R is above -20 (overbought).
 
 The moving average shows the prevailing trend direction. Williams %R looks for overbought or oversold points relative to that trend.

--- a/API/0165_VWAP_CCI/README.md
+++ b/API/0165_VWAP_CCI/README.md
@@ -1,5 +1,6 @@
 # Vwap Cci Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Implementation of strategy #165 - VWAP + CCI. Buy when price is below VWAP and CCI is below -100 (oversold). Sell when price is above VWAP and CCI is above 100 (overbought).
 
 VWAP acts as a value benchmark, and CCI highlights momentum moves away from it. Entries favor strong CCI readings relative to VWAP.

--- a/API/0166_Donchian_Stochastic/README.md
+++ b/API/0166_Donchian_Stochastic/README.md
@@ -1,5 +1,6 @@
 # Donchian Stochastic Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Donchian Channel + Stochastic strategy. Strategy enters the market when the price breaks out of Donchian Channel with Stochastic confirming oversold/overbought conditions.
 
 Breakouts beyond the Donchian channel are confirmed with Stochastic momentum. Trades start as soon as price escapes the range and the oscillator agrees.

--- a/API/0167_Keltner_RSI/README.md
+++ b/API/0167_Keltner_RSI/README.md
@@ -1,5 +1,6 @@
 # Keltner Rsi Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy combining Keltner Channels and RSI indicators. Looks for mean reversion opportunities when price touches channel boundaries and RSI confirms oversold/overbought conditions.
 
 Keltner Channels map recent volatility while RSI measures momentum extremes. Entries occur when RSI supports a move beyond the channel.

--- a/API/0169_Hull_MA_Stochastic/README.md
+++ b/API/0169_Hull_MA_Stochastic/README.md
@@ -1,5 +1,6 @@
 # Hull Ma Stochastic Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Hull Moving Average + Stochastic Oscillator strategy. Strategy enters when HMA trend direction changes with Stochastic confirming oversold/overbought conditions.
 
 Hull MA quickly reveals trend direction. Stochastic waits for a dip or rally within that trend to trigger the trade.

--- a/API/0170_ADX_CCI/README.md
+++ b/API/0170_ADX_CCI/README.md
@@ -1,5 +1,6 @@
 # Adx Cci Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on ADX and CCI indicators. Enters long when ADX > 25 and CCI is oversold (< -100) Enters short when ADX > 25 and CCI is overbought (> 100)
 
 ADX assesses whether a trend has strength and CCI identifies entry timing after pullbacks. Longs and shorts follow the ADX direction.

--- a/API/0171_MACD_Williams_R/README.md
+++ b/API/0171_MACD_Williams_R/README.md
@@ -1,5 +1,6 @@
 # Macd Williams R Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on MACD and Williams %R indicators. Enters long when MACD > Signal and Williams %R is oversold (< -80) Enters short when MACD < Signal and Williams %R is overbought (> -20)
 
 MACD indicates the larger momentum shift, while Williams %R pinpoints near-term reversals. Both signals must line up to initiate a trade.

--- a/API/0172_Bollinger_Williams_R/README.md
+++ b/API/0172_Bollinger_Williams_R/README.md
@@ -1,5 +1,6 @@
 # Bollinger Williams R Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on Bollinger Bands and Williams %R indicators. Enters long when price is at lower band and Williams %R is oversold (< -80) Enters short when price is at upper band and Williams %R is overbought (> -20)
 
 Bollinger bands expose volatility breakouts and Williams %R ensures momentum is extreme. Positions open when price closes outside a band with a matching Williams %R reading.

--- a/API/0174_MACD_VWAP/README.md
+++ b/API/0174_MACD_VWAP/README.md
@@ -1,5 +1,6 @@
 # Macd Vwap Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on MACD and VWAP indicators. Enters long when MACD > Signal and price > VWAP Enters short when MACD < Signal and price < VWAP
 
 MACD momentum is gauged relative to the VWAP line. Long trades look for MACD strength below VWAP, whereas shorts take form above it.

--- a/API/0175_RSI_Supertrend/README.md
+++ b/API/0175_RSI_Supertrend/README.md
@@ -1,5 +1,6 @@
 # Rsi Supertrend Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on RSI and Supertrend indicators. Enters long when RSI is oversold (< 30) and price is above Supertrend Enters short when RSI is overbought (> 70) and price is below Supertrend
 
 The RSI oscillator defines momentum extremes while Supertrend points to the prevailing direction. Trades occur when RSI aligns with the Supertrend color.

--- a/API/0176_ADX_Bollinger/README.md
+++ b/API/0176_ADX_Bollinger/README.md
@@ -1,5 +1,6 @@
 # Adx Bollinger Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on ADX and Bollinger Bands indicators. Enters long when ADX > 25 and price breaks above upper Bollinger band Enters short when ADX > 25 and price breaks below lower Bollinger band
 
 Bollinger band breaches filtered with ADX ensure price is breaking out with force. The system trades in the direction of the breakout.

--- a/API/0177_Ichimoku_Stochastic/README.md
+++ b/API/0177_Ichimoku_Stochastic/README.md
@@ -1,5 +1,6 @@
 # Ichimoku Stochastic Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on Ichimoku Cloud and Stochastic Oscillator indicators.
 Enters long when price is above Kumo (cloud), Tenkan > Kijun, and Stochastic is oversold (< 20) Enters short when price is below Kumo, Tenkan < Kijun, and Stochastic is overbought (> 80)
 

--- a/API/0185_Supertrend_Stochastic/README.md
+++ b/API/0185_Supertrend_Stochastic/README.md
@@ -1,5 +1,6 @@
 # Supertrend Stochastic Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Supertrend + Stochastic strategy. Strategy enters trades when Supertrend indicates trend direction and Stochastic confirms with oversold/overbought conditions.
 
 Supertrend marks the trend, and Stochastic points out temporary counter moves. Entries happen once Stochastic exits oversold or overbought against the trend.

--- a/API/0187_Donchian_MACD/README.md
+++ b/API/0187_Donchian_MACD/README.md
@@ -1,5 +1,6 @@
 # Donchian Macd Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy combining Donchian Channel breakout with MACD trend confirmation.
 
 The strategy waits for a Donchian breakout and verifies momentum with MACD. Long or short trades ride the move once MACD agrees.

--- a/API/0188_Parabolic_SAR_Volume/README.md
+++ b/API/0188_Parabolic_SAR_Volume/README.md
@@ -1,5 +1,6 @@
 # Parabolic Sar Volume Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy that combines Parabolic SAR with volume confirmation. Enters trades when price crosses the Parabolic SAR with above-average volume.
 
 Parabolic SAR identifies trend shifts, and higher volume validates the signal. Trades commence when the SAR flip comes with expanding volume.

--- a/API/0190_VWAP_ADX/README.md
+++ b/API/0190_VWAP_ADX/README.md
@@ -1,5 +1,6 @@
 # Vwap Adx Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on VWAP and ADX indicators. Enters long when price is above VWAP and ADX > 25. Enters short when price is below VWAP and ADX > 25. Exits when ADX < 20.
 
 VWAP acts as the session benchmark, and ADX measures conviction. Entries appear when price departs from VWAP with ADX showing strength.

--- a/API/0193_Supertrend_ADX/README.md
+++ b/API/0193_Supertrend_ADX/README.md
@@ -1,5 +1,6 @@
 # Supertrend Adx Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on Supertrend indicator and ADX for trend strength confirmation. Entry criteria: Long: Price > Supertrend && ADX > 25 (uptrend with strong movement) Short: Price < Supertrend && ADX > 25 (downtrend with strong movement) Exit criteria: Long: Price < Supertrend (price falls below Supertrend) Short: Price > Supertrend (price rises above Supertrend)
 
 Supertrend provides a volatility-adjusted path while ADX confirms the power of the move. Trades take place when both indicators line up.

--- a/API/0194_Keltner_MACD/README.md
+++ b/API/0194_Keltner_MACD/README.md
@@ -1,5 +1,6 @@
 # Keltner Macd Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on Keltner Channels and MACD. Enters long when price breaks above upper Keltner Channel with MACD > Signal. Enters short when price breaks below lower Keltner Channel with MACD < Signal. Exits when MACD crosses its signal line in the opposite direction.
 
 Keltner Channel breakouts serve as the trigger, and MACD momentum filters the direction. The strategy initiates trades once both signals align.

--- a/API/0197_Hull_MA_ADX/README.md
+++ b/API/0197_Hull_MA_ADX/README.md
@@ -1,5 +1,6 @@
 # Hull Ma Adx Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on Hull Moving Average and ADX. Enters long when HMA increases and ADX > 25 (strong trend). Enters short when HMA decreases and ADX > 25 (strong trend). Exits when ADX < 20 (weakening trend).
 
 Hull MA shows the trend, while ADX confirms its intensity. Entries follow the Hull slope when ADX indicates strength.

--- a/API/0198_VWAP_MACD/README.md
+++ b/API/0198_VWAP_MACD/README.md
@@ -1,5 +1,6 @@
 # Vwap Macd Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on VWAP and MACD. Enters long when price is above VWAP and MACD > Signal. Enters short when price is below VWAP and MACD < Signal. Exits when MACD crosses its signal line in the opposite direction.
 
 VWAP guides intraday value, and MACD crossovers reveal momentum shifts. Trades are launched as MACD turns near the VWAP level.

--- a/API/0200_Ichimoku_ADX/README.md
+++ b/API/0200_Ichimoku_ADX/README.md
@@ -1,5 +1,6 @@
 # Ichimoku Adx Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 Strategy based on Ichimoku Cloud and ADX indicators. Entry criteria:
 Long: Price > Kumo (cloud) && Tenkan > Kijun && ADX > 25 (uptrend with strong movement) Short: Price < Kumo (cloud) && Tenkan < Kijun && ADX > 25 (downtrend with strong movement) Exit criteria: Long: Price < Kumo (price falls below cloud) Short: Price > Kumo (price rises above cloud)
 

--- a/API/0201_VWAP_Williams_R/README.md
+++ b/API/0201_VWAP_Williams_R/README.md
@@ -1,5 +1,6 @@
 # VWAP Williams R Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 The VWAP Williams %R strategy focuses on intraday reversion around the Volume Weighted Average Price. It observes when price drifts away from VWAP while the Williams %R oscillator reaches oversold or overbought territory. The assumption is that extreme readings near VWAP often lead to a snapback toward the mean.
 
 When the oscillator drops below -80 and price trades under VWAP, the setup implies selling pressure is fading and a rebound may follow. Conversely, a reading above -20 while price is positioned above VWAP warns that buyers are exhausted and a pullback is likely. The strategy opens trades in the direction of a potential return to VWAP and watches for that move to complete.

--- a/API/0202_Donchian_CCI/README.md
+++ b/API/0202_Donchian_CCI/README.md
@@ -1,5 +1,6 @@
 # Donchian CCI Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 This strategy uses Donchian CCI indicators to generate signals.
 Long entry occurs when Price > Donchian Upper && CCI < -100 (breakout up with oversold conditions). Short entry occurs when Price < Donchian Lower && CCI > 100 (breakout down with overbought conditions).
 It is suitable for traders seeking opportunities in mixed markets.

--- a/API/0203_Keltner_Williams_R/README.md
+++ b/API/0203_Keltner_Williams_R/README.md
@@ -1,5 +1,6 @@
 # Keltner Williams R Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 This strategy uses Keltner Williams R indicators to generate signals.
 Long entry occurs when Price < lower Keltner band && Williams %R < -80 (oversold at lower band). Short entry occurs when Price > upper Keltner band && Williams %R > -20 (overbought at upper band).
 It is suitable for traders seeking opportunities in mixed markets.

--- a/API/0204_Parabolic_SAR_CCI/README.md
+++ b/API/0204_Parabolic_SAR_CCI/README.md
@@ -1,5 +1,6 @@
 # Parabolic SAR CCI Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 This strategy uses Parabolic SAR CCI indicators to generate signals.
 Long entry occurs when Price > SAR && CCI < -100 (trend up with oversold conditions). Short entry occurs when Price < SAR && CCI > 100 (trend down with overbought conditions).
 It is suitable for traders seeking opportunities in mixed markets.

--- a/API/0205_Hull_MA_CCI/README.md
+++ b/API/0205_Hull_MA_CCI/README.md
@@ -1,5 +1,6 @@
 # Hull MA CCI Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 This strategy uses Hull MA CCI indicators to generate signals.
 Long entry occurs when HMA(t) > HMA(t-1) && CCI < -100 (HMA rising with oversold conditions). Short entry occurs when HMA(t) < HMA(t-1) && CCI > 100 (HMA falling with overbought conditions).
 It is suitable for traders seeking opportunities in mixed markets.

--- a/API/0206_MACD_Bollinger/README.md
+++ b/API/0206_MACD_Bollinger/README.md
@@ -1,5 +1,6 @@
 # MACD Bollinger Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 This strategy uses MACD Bollinger indicators to generate signals.
 Long entry occurs when MACD > Signal && Price < BB_lower (trend up with oversold conditions). Short entry occurs when MACD < Signal && Price > BB_upper (trend down with overbought conditions).
 It is suitable for traders seeking opportunities in mixed markets.

--- a/API/0207_RSI_Hull_MA/README.md
+++ b/API/0207_RSI_Hull_MA/README.md
@@ -1,5 +1,6 @@
 # RSI Hull MA Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 This strategy uses RSI Hull MA indicators to generate signals.
 Long entry occurs when RSI < 30 && HMA(t) > HMA(t-1) (oversold with rising HMA). Short entry occurs when RSI > 70 && HMA(t) < HMA(t-1) (overbought with falling HMA).
 It is suitable for traders seeking opportunities in mixed markets.

--- a/API/0208_Stochastic_Keltner/README.md
+++ b/API/0208_Stochastic_Keltner/README.md
@@ -1,5 +1,6 @@
 # Stochastic Keltner Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 This strategy uses Stochastic Keltner indicators to generate signals.
 Long entry occurs when Stoch %K < 20 && Price < Keltner lower band (oversold at lower band). Short entry occurs when Stoch %K > 80 && Price > Keltner upper band (overbought at upper band).
 It is suitable for traders seeking opportunities in mixed markets.

--- a/API/0209_Volume_Supertrend/README.md
+++ b/API/0209_Volume_Supertrend/README.md
@@ -1,5 +1,6 @@
 # Volume Supertrend Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 This strategy uses Volume Supertrend indicators to generate signals.
 Long entry occurs when Volume > Avg(Volume) && Price > Supertrend (volume surge with uptrend). Short entry occurs when Volume > Avg(Volume) && Price < Supertrend (volume surge with downtrend).
 It is suitable for traders seeking opportunities in trend markets.

--- a/API/0210_ADX_Donchian/README.md
+++ b/API/0210_ADX_Donchian/README.md
@@ -1,5 +1,6 @@
 # ADX Donchian Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 This strategy uses ADX Donchian indicators to generate signals.
 Long entry occurs when ADX > AdxThreshold && Price >= upperBorder (strong trend with breakout up). Short entry occurs when ADX > AdxThreshold && Price <= lowerBorder (strong trend with breakout down).
 It is suitable for traders seeking opportunities in mixed markets.

--- a/API/0211_CCI_VWAP/README.md
+++ b/API/0211_CCI_VWAP/README.md
@@ -1,5 +1,6 @@
 # CCI VWAP Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 The CCI VWAP approach attempts to capture intraday reversals when momentum and price align away from the volume weighted average price. By observing the Commodity Channel Index alongside the VWAP level, the system measures the strength of recent swings relative to a fair value benchmark.
 
 A buy setup emerges when the CCI falls below -100 and the market trades beneath VWAP, signalling that selling pressure may be exhausted. A short occurs when the CCI rises above +100 with price above VWAP, highlighting a stretched rally vulnerable to a setback. Positions are closed once price reclaims the VWAP in the opposite direction.

--- a/API/0212_Williams_R_Ichimoku/README.md
+++ b/API/0212_Williams_R_Ichimoku/README.md
@@ -1,5 +1,6 @@
 # Williams R Ichimoku Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 This setup combines the momentum extremes of Williams %R with the trend structure defined by the Ichimoku Cloud. The idea is to join strong moves only when price sits on the favourable side of the cloud and the short term lines confirm the bias.
 
 A long opportunity appears when the oscillator drops below -80 while price holds above the cloud and Tenkan-sen crosses above Kijun-sen. A short signal occurs when %R climbs above -20 with price below the cloud and Tenkan-sen under Kijun-sen. The position remains open until price crosses the opposite side of the cloud.

--- a/API/0213_MA_Parabolic_SAR/README.md
+++ b/API/0213_MA_Parabolic_SAR/README.md
@@ -1,5 +1,6 @@
 # MA Parabolic SAR Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 The MA Parabolic SAR strategy attempts to capture sustained trends while using a trailing stop for risk control. A simple moving average determines the prevailing direction and the Parabolic SAR dots provide entry timing and stop placement. When both indicators align, the system assumes momentum is strong enough to follow.
 
 A long position is opened when the closing price sits above the moving average and the Parabolic SAR dots flip below the market. A short position is taken when price is below the average and the SAR dots flip above price, signalling downward pressure. The strategy exits once price crosses the SAR in the opposite direction, locking in profits or limiting losses.

--- a/API/0214_Bollinger_Supertrend/README.md
+++ b/API/0214_Bollinger_Supertrend/README.md
@@ -1,5 +1,6 @@
 # Bollinger Supertrend Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 This strategy blends Bollinger Bands with the Supertrend indicator to pinpoint entries during strong directional moves. Bollinger Bands gauge volatility expansion while the Supertrend line tracks the overall trend and acts as a trailing stop.
 
 A long trade triggers when price closes above the upper Bollinger Band and remains above the Supertrend line, confirming momentum and trend alignment. A short trade occurs when price closes below the lower band while staying under the Supertrend level. Trades are exited once price crosses back through the Supertrend, indicating momentum has faded.

--- a/API/0215_RSI_Donchian/README.md
+++ b/API/0215_RSI_Donchian/README.md
@@ -1,5 +1,6 @@
 # RSI Donchian Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 The RSI Donchian strategy looks for momentum extremes that coincide with breakouts of the Donchian Channel. The relative strength index gauges overbought and oversold conditions while the channel defines recent price highs and lows.
 
 A buy signal appears when the RSI dips below 30 and price breaks above the Donchian upper band. A short signal forms when the RSI rises above 70 and price falls through the lower band. Exits occur once price moves back to the Donchian middle line, signalling a return to balance.

--- a/API/0216_Mean_Reversion/README.md
+++ b/API/0216_Mean_Reversion/README.md
@@ -1,5 +1,6 @@
 # Mean Reversion Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 This statistical approach looks for short-term extremes in price relative to its recent average. The strategy uses a moving average to define fair value and measures the deviation from that mean through a standard deviation calculation.
 
 Trades are opened when price pushes a set distance from the average. A dip below the lower band triggers a long entry, anticipating a rebound toward the mean, while a rally above the upper band prompts a short. Once price touches the moving average again, any open position is closed.

--- a/API/0217_Pairs_Trading/README.md
+++ b/API/0217_Pairs_Trading/README.md
@@ -1,5 +1,6 @@
 # Pairs Trading Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 This pairs trading strategy monitors the price spread between two correlated instruments. By comparing the spread to its historical mean and standard deviation, the system attempts to exploit temporary divergences that eventually revert.
 
 A long spread is entered when the spread drops below its mean by more than the specified deviation multiplier. This means buying the first asset and selling the second. A short spread does the opposite when the spread rises above the mean by the same amount. Positions are closed once the spread returns to the average level.

--- a/API/0218_ZScore_Reversal/README.md
+++ b/API/0218_ZScore_Reversal/README.md
@@ -1,5 +1,6 @@
 # ZScore Reversal Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 The ZScore Reversal strategy measures how far price deviates from a moving average in terms of standard deviations. The resulting Z-Score highlights statistically stretched conditions that may snap back toward the mean.
 
 A trade is opened long when the Z-Score falls below a negative threshold, signalling an oversold market. A short trade is taken when the Z-Score rises above the positive threshold. The position is closed once the Z-Score crosses back through zero, indicating price has normalized.

--- a/API/0219_Statistical_Arbitrage/README.md
+++ b/API/0219_Statistical_Arbitrage/README.md
@@ -1,5 +1,6 @@
 # Statistical Arbitrage Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 This statistical arbitrage approach trades a pair of related securities based on their relative positioning around moving averages. By comparing each asset to its own average, the strategy seeks to exploit short-term dislocations that should converge over time.
 
 A long position is initiated when the first asset trades below its moving average while the second asset trades above its own average. A short position occurs when the first asset is above its average and the second is below. Positions are closed when the first asset crosses back through its moving average, signalling the spread has normalized.

--- a/API/0220_Volatility_Breakout/README.md
+++ b/API/0220_Volatility_Breakout/README.md
@@ -1,5 +1,6 @@
 # Volatility Breakout Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 The Volatility Breakout strategy seeks strong directional moves when price escapes from its average range. By measuring the distance from a simple moving average using the Average True Range, the algorithm defines breakout thresholds that scale with volatility.
 
 A buy order is triggered when the close rises above the SMA by more than `Multiplier` times the ATR. A sell signal appears when the close falls below the SMA by the same distance. Positions remain open until an opposite breakout occurs or a protective stop is hit.

--- a/API/0221_Bollinger_Band_Squeeze/README.md
+++ b/API/0221_Bollinger_Band_Squeeze/README.md
@@ -1,5 +1,6 @@
 # Bollinger Band Squeeze Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 This setup monitors the width of the Bollinger Bands to detect periods of low volatility. When the bands contract relative to their recent average, it signals a potential volatility expansion is near.
 
 Once a squeeze is identified, the strategy waits for price to break outside the bands. A close above the upper band initiates a long, while a close below the lower band opens a short. The trade is closed if price returns toward the middle of the bands or if a stop-loss is triggered.

--- a/API/0222_Cointegration_Pairs/README.md
+++ b/API/0222_Cointegration_Pairs/README.md
@@ -1,5 +1,6 @@
 # Cointegration Pairs Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 This strategy trades two assets that share a long-term cointegration relationship. By calculating the residual between the first asset and a beta-adjusted second asset, it looks for deviations that historically revert back to equilibrium.
 
 A long position buys the first asset and sells the second when the residual z-score drops below `-EntryThreshold`. A short position sells the first and buys the second when the z-score rises above the threshold. Positions are closed once the spread normalizes toward zero.

--- a/API/0223_Momentum_Divergence/README.md
+++ b/API/0223_Momentum_Divergence/README.md
@@ -1,5 +1,6 @@
 # Momentum Divergence Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 The Momentum Divergence strategy compares momentum readings with price direction to spot early signs of a reversal. Divergences occur when price makes a new extreme yet the momentum indicator fails to confirm, hinting at weakening strength.
 
 A bullish setup happens when price records a lower low while the momentum oscillator prints a higher low. A bearish setup forms when price pushes to a higher high but momentum fails to follow. Positions are closed when momentum crosses back through zero or the divergence is invalidated.

--- a/API/0224_ATR_Mean_Reversion/README.md
+++ b/API/0224_ATR_Mean_Reversion/README.md
@@ -1,5 +1,6 @@
 # ATR Mean Reversion Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 The ATR Mean Reversion strategy measures how far price travels away from a moving average relative to recent volatility. The Average True Range (ATR) provides an adaptive gauge so thresholds expand during active periods and contract when markets quiet down.
 
 A long setup occurs when price closes below the moving average by more than `Multiplier` times the ATR. A short setup appears when price closes above the moving average by the same distance. Positions are exited once price returns to the moving average.

--- a/API/0225_Kalman_Filter_Trend/README.md
+++ b/API/0225_Kalman_Filter_Trend/README.md
@@ -1,5 +1,6 @@
 # Kalman Filter Trend Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 This trend-following method uses a Kalman filter to smooth price fluctuations and estimate the underlying direction. The filter dynamically adapts to market noise, offering a refined view of trend strength compared to standard moving averages.
 
 A long position is opened when the closing price rises above the Kalman filter estimate. Conversely, a short position is taken when the close drops below the filter value. Because the filter updates on every bar, trades flip whenever price crosses the line, providing continuous participation in trending markets.

--- a/API/0226_Volatility_Adjusted_Mean_Reversion/README.md
+++ b/API/0226_Volatility_Adjusted_Mean_Reversion/README.md
@@ -1,5 +1,6 @@
 # Volatility Adjusted Mean Reversion Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 This variation of mean reversion scales entry thresholds by the ratio of ATR to standard deviation. When volatility increases relative to typical noise, the distance needed to trigger a trade grows, helping avoid premature signals during chaotic swings.
 
 A long position opens when price falls below the moving average by more than the adjusted threshold. A short position opens when price rises above the average by the same measure. Positions exit once price closes back near the average level.

--- a/API/0227_Hurst_Exponent_Trend/README.md
+++ b/API/0227_Hurst_Exponent_Trend/README.md
@@ -1,5 +1,6 @@
 # Hurst Exponent Trend Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 This system uses the Hurst exponent to determine whether the market is exhibiting trending behaviour. Values above the threshold indicate persistence, while values below suggest noise or mean reversion. A moving average provides additional direction confirmation.
 
 The strategy buys when the Hurst exponent is greater than the threshold and price closes above the moving average. It sells short when the Hurst exponent is high and price closes below the average. If the Hurst exponent drops below the threshold, existing positions are closed to avoid trading in choppy markets.

--- a/API/0228_Hurst_Exponent_Reversion/README.md
+++ b/API/0228_Hurst_Exponent_Reversion/README.md
@@ -1,5 +1,6 @@
 # Hurst Exponent Reversion Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 This approach uses the Hurst exponent to detect when a market is behaving in a mean-reverting manner. Values below 0.5 suggest price tends to return toward its average, creating opportunities to fade extremes.
 
 A long position is opened when the Hurst exponent is below 0.5 and price closes under a moving average. A short position occurs when the Hurst value is below 0.5 and price closes above the average. Positions exit when price returns to the average line or the Hurst exponent rises above the threshold.

--- a/API/0229_Autocorrelation_Reversal/README.md
+++ b/API/0229_Autocorrelation_Reversal/README.md
@@ -1,5 +1,6 @@
 # Autocorrelation Reversal Strategy
-
+[Русский](README_ru.md) | [中文](README_cn.md)
+ 
 This strategy analyzes short-term price autocorrelation to gauge whether recent moves are likely to reverse. Negative autocorrelation suggests successive price changes tend to alternate direction, creating mean-reverting conditions.
 
 When the calculated autocorrelation falls below the threshold and price is below a moving average, the system buys in anticipation of a bounce. If autocorrelation is negative and price is above the average, a short position is opened. Exits occur once price crosses the average or autocorrelation rises above the threshold.

--- a/API/0230_Delta_Neutral_Arbitrage/README.md
+++ b/API/0230_Delta_Neutral_Arbitrage/README.md
@@ -1,5 +1,6 @@
 # Delta Neutral Arbitrage Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 This arbitrage strategy trades the spread between two correlated assets while keeping the combined position close to delta neutral. By balancing a long position in one asset against a short in another, it attempts to profit from mean reversion in the spread rather than market direction.
 
 A long spread is entered when the z-score of the price difference falls below `-EntryThreshold`. The first asset is bought and the second is sold in equal size. A short spread does the reverse when the z-score rises above the positive threshold. The trade is closed once the spread returns to the moving average.

--- a/API/0231_Volatility_Skew_Arbitrage/README.md
+++ b/API/0231_Volatility_Skew_Arbitrage/README.md
@@ -1,5 +1,6 @@
 # Volatility Skew Arbitrage Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 This options-based strategy observes the difference in implied volatility between two strikes. When the skew diverges from its historical average by a large margin, it opens a position expecting the skew to revert.
 
 A long skew trade buys the cheaper-volatility option and sells the expensive one when the skew exceeds `Threshold` standard deviations above the mean. A short skew trade does the opposite when the skew falls below the mean by the same amount. Positions are closed when the skew moves back toward its average level.

--- a/API/0232_Correlation_Breakout/README.md
+++ b/API/0232_Correlation_Breakout/README.md
@@ -1,5 +1,6 @@
 # Correlation Breakout Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 This strategy monitors the rolling correlation between two assets. When correlation deviates sharply from its normal range, it may signal shifting relationships that produce tradeable trends.
 
 A long position buys the first asset and sells the second when correlation plunges below the average by more than `Threshold` standard deviations. A short position does the reverse when correlation spikes above the average. Trades are closed once correlation returns toward its mean.

--- a/API/0233_Beta_Neutral_Arbitrage/README.md
+++ b/API/0233_Beta_Neutral_Arbitrage/README.md
@@ -1,5 +1,6 @@
 # Beta Neutral Arbitrage Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 This strategy seeks to exploit pricing differences between two securities while neutralizing overall market beta. By adjusting positions based on each asset's beta to a common index, the portfolio aims to remain insensitive to broad market moves.
 
 A long spread goes long the asset with lower beta-adjusted price and shorts the other when the spread deviates beyond two standard deviations. A short spread does the reverse when the spread is above the mean. Trades are closed once the beta-adjusted spread reverts toward its average.

--- a/API/0235_VWAP_Mean_Reversion/README.md
+++ b/API/0235_VWAP_Mean_Reversion/README.md
@@ -1,5 +1,6 @@
 # VWAP Mean Reversion Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 This strategy fades moves away from the volume weighted average price. ATR is used to gauge how far price must deviate from VWAP before a reversal trade is considered.
 
 A long position opens when price drops below VWAP by more than `K` times the ATR. A short is taken when price rallies above VWAP by the same amount. Trades exit as soon as price returns to the VWAP line.

--- a/API/0236_RSI_Mean_Reversion/README.md
+++ b/API/0236_RSI_Mean_Reversion/README.md
@@ -1,5 +1,6 @@
 # RSI Mean Reversion Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 This strategy tracks the relative strength index and measures its distance from an average level. When RSI deviates by more than a multiple of its recent standard deviation, the algorithm expects a snap back toward the mean.
 
 A long trade is opened when RSI falls below the lower band defined by the average minus `Multiplier` times the standard deviation. A short trade is taken when RSI rises above the upper band. Exits occur when RSI returns to its moving average.

--- a/API/0237_Stochastic_Mean_Reversion/README.md
+++ b/API/0237_Stochastic_Mean_Reversion/README.md
@@ -1,5 +1,6 @@
 # Stochastic Mean Reversion Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 This strategy measures the Stochastic oscillator against its own moving average to locate overextended swings. When %K moves several standard deviations away from its mean, the expectation is for the indicator to drift back toward typical values.
 
 A long trade is placed when Stochastic %K falls below the lower band defined by the average minus `Multiplier` times the standard deviation. A short trade occurs when %K exceeds the upper band. Positions are closed once %K crosses back through its average line.

--- a/API/0238_CCI_Mean_Reversion/README.md
+++ b/API/0238_CCI_Mean_Reversion/README.md
@@ -1,5 +1,6 @@
 # CCI Mean Reversion Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Commodity Channel Index (CCI) measures how far price moves from its statistical average. This strategy enters when CCI deviates from its own mean by a large margin, expecting a snap back once momentum fades.
 
 A long trade occurs when CCI drops below the average minus `DeviationMultiplier` times the standard deviation. A short trade is opened when CCI rises above the average plus that multiplier. The position exits when CCI crosses back through the mean value.

--- a/API/0239_Williams_R_Mean_Reversion/README.md
+++ b/API/0239_Williams_R_Mean_Reversion/README.md
@@ -1,5 +1,6 @@
 # Williams R Mean Reversion Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Williams %R oscillates between 0 and -100 to show when price closes near the extremes of its recent range. This strategy fades those extremes once the indicator stretches far from its own average.
 
 A long trade triggers when Williams %R falls below the average minus `DeviationMultiplier` times the standard deviation. A short trade is taken when it rises above the average plus that multiplier. Exits occur when Williams %R moves back toward its average level.

--- a/API/0240_MACD_Mean_Reversion/README.md
+++ b/API/0240_MACD_Mean_Reversion/README.md
@@ -1,5 +1,6 @@
 # MACD Mean Reversion Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 This method tracks the MACD histogram relative to its own average. Extreme histogram readings often revert once momentum subsides. By monitoring the difference between MACD and its signal line, the strategy finds overextended moves.
 
 A long position is entered when the MACD histogram falls below the mean by `DeviationMultiplier` standard deviations. A short position is opened when the histogram rises above the mean by the same amount. The trade is closed when the histogram crosses back through its average.

--- a/API/0241_ADX_Mean_Reversion/README.md
+++ b/API/0241_ADX_Mean_Reversion/README.md
@@ -1,5 +1,6 @@
 # ADX Mean Reversion Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 Here the Average Directional Index (ADX) measures overall trend strength. When ADX is low, the market lacks direction and prices tend to oscillate around a mean value. This strategy exploits that behaviour by trading deviations of ADX from its moving average.
 
 A long trade is entered when ADX drops below the average minus `DeviationMultiplier` times the standard deviation and price is below the moving average. A short trade is opened when ADX spikes above the upper band and price is above the average. Positions are closed when ADX reverts toward its average.

--- a/API/0242_Volatility_Mean_Reversion/README.md
+++ b/API/0242_Volatility_Mean_Reversion/README.md
@@ -1,5 +1,6 @@
 # Volatility Mean Reversion Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 This approach trades around fluctuations in market volatility. When the ATR deviates markedly from its moving average, it suggests volatility has become unusually high or low and may revert.
 
 The strategy goes long when ATR drops below the average minus `DeviationMultiplier` times the standard deviation and price is below the moving average. It shorts when ATR exceeds the upper band and price is above the average. Positions exit once ATR returns toward its mean level.

--- a/API/0243_Volume_Mean_Reversion/README.md
+++ b/API/0243_Volume_Mean_Reversion/README.md
@@ -1,5 +1,6 @@
 # Volume Mean Reversion Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 This system looks for unusually high or low trading volume relative to its historical average. Significant volume spikes often revert as activity normalizes, offering potential fade trades.
 
 A long entry is made when volume drops below the average minus `DeviationMultiplier` times the standard deviation and price is below the moving average. A short entry occurs when volume rises above the upper band with price above the average. Trades exit once volume returns toward its mean level.

--- a/API/0244_OBV_Mean_Reversion/README.md
+++ b/API/0244_OBV_Mean_Reversion/README.md
@@ -1,5 +1,6 @@
 # OBV Mean Reversion Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 On Balance Volume (OBV) tracks cumulative volume flow to determine whether buyers or sellers are dominant. This strategy waits for OBV to diverge sharply from its average and then trades in anticipation of a return to typical levels.
 
 A buy signal occurs when OBV falls below its average minus `Multiplier` times the standard deviation and price is below the moving average. A sell signal is generated when OBV rises above the upper band with price above the average. Positions close when OBV crosses back through its mean line.

--- a/API/0245_Momentum_Breakout/README.md
+++ b/API/0245_Momentum_Breakout/README.md
@@ -1,5 +1,6 @@
 # Momentum Breakout Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 This breakout system looks for sudden surges in momentum relative to its historical average. When momentum readings exceed the average by a large margin, price may be starting a fast directional move.
 
 The strategy buys when momentum rises above the average plus `Multiplier` times its standard deviation. A short is initiated when momentum falls below the average minus the same multiplier. Positions are closed once momentum returns toward its mean.

--- a/API/0247_RSI_Breakout/README.md
+++ b/API/0247_RSI_Breakout/README.md
@@ -1,5 +1,6 @@
 # RSI Breakout Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The RSI Breakout strategy looks for momentum bursts when the Relative Strength Index pushes beyond its typical range. By measuring RSI deviations from its moving average, the system aims to catch new trends as they begin.
 
 A long position is opened when RSI closes above the average plus `Multiplier` times the standard deviation. A short position is taken when RSI falls below the average minus that multiplier. Positions are closed once RSI crosses back through its average value.

--- a/API/0248_Stochastic_Breakout/README.md
+++ b/API/0248_Stochastic_Breakout/README.md
@@ -1,5 +1,6 @@
 # Stochastic Breakout Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 This breakout approach monitors the Stochastic oscillator for sharp moves away from its recent average. When the %K line breaks above or below a volatility-adjusted threshold, it signals a burst of momentum that may start a trend.
 
 A long position is triggered when %K crosses above the upper threshold after a period of contraction. A short position is taken when %K breaks below the lower threshold. The trade is closed when the oscillator drifts back toward its average or hits a protective stop.

--- a/API/0250_Williams_R_Breakout/README.md
+++ b/API/0250_Williams_R_Breakout/README.md
@@ -1,5 +1,6 @@
 # Williams R Breakout Strategy
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 This strategy seeks momentum bursts by watching Williams %R relative to its historical average. When the oscillator pushes far beyond typical readings, it may signal the start of a strong move.
 
 A long position is opened when %R climbs above the average plus `Multiplier` times an estimated standard deviation. A short position is taken when %R drops below the average minus the same multiplier. The trade closes once %R returns toward its average or a stop-loss is hit.

--- a/API/0251_MACD_Breakout/README.md
+++ b/API/0251_MACD_Breakout/README.md
@@ -1,5 +1,6 @@
 # MACD Breakout
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The MACD Breakout strategy watches the MACD for sudden expansions. When readings jump beyond their normal range, price often starts a new move.
 
 A position opens once the indicator pierces a band derived from recent data and a deviation multiplier. Long and short trades are possible with a stop attached.

--- a/API/0252_ADX_Breakout/README.md
+++ b/API/0252_ADX_Breakout/README.md
@@ -1,5 +1,6 @@
 # ADX Breakout
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The ADX Breakout strategy monitors the ADX for strong expansions. When readings jump beyond their typical range, price often starts a new move.
 
 A position opens once the indicator pierces a band derived from recent data and a deviation multiplier. Long and short trades are possible with a stop attached.

--- a/API/0254_Volume_Breakout/README.md
+++ b/API/0254_Volume_Breakout/README.md
@@ -1,5 +1,6 @@
 # Volume Breakout
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Volume Breakout strategy observes the Volume for rapid expansions. When readings jump beyond their average range, price often starts a new move.
 
 A position opens once the indicator pierces a band derived from recent data and a deviation multiplier. Long and short trades are possible with a stop attached.

--- a/API/0256_Bollinger_Band_Width_Breakout/README.md
+++ b/API/0256_Bollinger_Band_Width_Breakout/README.md
@@ -1,5 +1,6 @@
 # Bollinger Band Width Breakout
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Bollinger Band Width Breakout strategy tracks the Bollinger for strong expansions. When readings jump beyond their normal range, price often starts a new move.
 
 A position opens once the indicator pierces a band derived from recent data and a deviation multiplier. Long and short trades are possible with a stop attached.

--- a/API/0257_Keltner_Channel_Width_Breakout/README.md
+++ b/API/0257_Keltner_Channel_Width_Breakout/README.md
@@ -1,5 +1,6 @@
 # Keltner Channel Width Breakout
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Keltner Channel Width Breakout strategy observes the Keltner for rapid expansions. When readings jump beyond their typical range, price often starts a new move.
 
 A position opens once the indicator pierces a band derived from recent data and a deviation multiplier. Long and short trades are possible with a stop attached.

--- a/API/0258_Donchian_Channel_Width_Breakout/README.md
+++ b/API/0258_Donchian_Channel_Width_Breakout/README.md
@@ -1,5 +1,6 @@
 # Donchian Channel Width Breakout
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Donchian Channel Width Breakout strategy observes the Donchian for sharp expansions. When readings jump beyond their average range, price often starts a new move.
 
 A position opens once the indicator pierces a band derived from recent data and a deviation multiplier. Long and short trades are possible with a stop attached.

--- a/API/0259_Ichimoku_Cloud_Width_Breakout/README.md
+++ b/API/0259_Ichimoku_Cloud_Width_Breakout/README.md
@@ -1,5 +1,6 @@
 # Ichimoku Cloud Width Breakout
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Ichimoku Cloud Width Breakout strategy watches the Ichimoku for sharp expansions. When readings jump beyond their average range, price often starts a new move.
 
 A position opens once the indicator pierces a band derived from recent data and a deviation multiplier. Long and short trades are possible with a stop attached.

--- a/API/0260_Supertrend_Distance_Breakout/README.md
+++ b/API/0260_Supertrend_Distance_Breakout/README.md
@@ -1,5 +1,6 @@
 # Supertrend Distance Breakout
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Supertrend Distance Breakout strategy watches the Supertrend for sharp expansions. When readings jump beyond their average range, price often starts a new move.
 
 A position opens once the indicator pierces a band derived from recent data and a deviation multiplier. Long and short trades are possible with a stop attached.

--- a/API/0261_Parabolic_SAR_Distance_Breakout/README.md
+++ b/API/0261_Parabolic_SAR_Distance_Breakout/README.md
@@ -1,5 +1,6 @@
 # Parabolic SAR Distance Breakout
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Parabolic SAR Distance Breakout strategy watches the Parabolic for rapid expansions. When readings jump beyond their recent range, price often starts a new move.
 
 A position opens once the indicator pierces a band derived from recent data and a deviation multiplier. Long and short trades are possible with a stop attached.

--- a/API/0262_Hull_MA_Slope_Breakout/README.md
+++ b/API/0262_Hull_MA_Slope_Breakout/README.md
@@ -1,5 +1,6 @@
 # Hull MA Slope Breakout
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Hull MA Slope Breakout strategy tracks the rate of change of the Hull. An unusually steep slope hints that a new trend is forming.
 
 Entries occur when slope exceeds its typical level by a multiple of standard deviation, taking trades in the direction of acceleration with a protective stop.

--- a/API/0263_MA_Slope_Breakout/README.md
+++ b/API/0263_MA_Slope_Breakout/README.md
@@ -1,5 +1,6 @@
 # MA Slope Breakout
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The MA Slope Breakout strategy watches the rate of change of the MA. An unusually steep slope hints that a new trend is forming.
 
 Entries occur when slope exceeds its typical level by a multiple of standard deviation, taking trades in the direction of acceleration with a protective stop.

--- a/API/0264_EMA_Slope_Breakout/README.md
+++ b/API/0264_EMA_Slope_Breakout/README.md
@@ -1,5 +1,6 @@
 # EMA Slope Breakout
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The EMA Slope Breakout strategy observes the rate of change of the EMA. An unusually steep slope hints that a new trend is forming.
 
 Entries occur when slope exceeds its typical level by a multiple of standard deviation, taking trades in the direction of acceleration with a protective stop.

--- a/API/0265_Volatility_Adjusted_Momentum/README.md
+++ b/API/0265_Volatility_Adjusted_Momentum/README.md
@@ -1,5 +1,6 @@
 # Volatility Adjusted Momentum
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Volatility Adjusted Momentum strategy monitors the Volatility for rapid expansions. When readings jump beyond their average range, price often starts a new move.
 
 A position opens once the indicator pierces a band derived from recent data and a deviation multiplier. Long and short trades are possible with a stop attached.

--- a/API/0266_VWAP_Slope_Breakout/README.md
+++ b/API/0266_VWAP_Slope_Breakout/README.md
@@ -1,5 +1,6 @@
 # VWAP Slope Breakout
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The VWAP Slope Breakout strategy observes the rate of change of the VWAP. An unusually steep slope hints that a new trend is forming.
 
 Entries occur when slope exceeds its typical level by a multiple of standard deviation, taking trades in the direction of acceleration with a protective stop.

--- a/API/0267_RSI_Slope_Breakout/README.md
+++ b/API/0267_RSI_Slope_Breakout/README.md
@@ -1,5 +1,6 @@
 # RSI Slope Breakout
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The RSI Slope Breakout strategy observes the rate of change of the RSI. An unusually steep slope hints that a new trend is forming.
 
 Entries occur when slope exceeds its typical level by a multiple of standard deviation, taking trades in the direction of acceleration with a protective stop.

--- a/API/0268_Stochastic_Slope_Breakout/README.md
+++ b/API/0268_Stochastic_Slope_Breakout/README.md
@@ -1,5 +1,6 @@
 # Stochastic Slope Breakout
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Stochastic Slope Breakout strategy tracks the rate of change of the Stochastic. An unusually steep slope hints that a new trend is forming.
 
 Entries occur when slope exceeds its typical level by a multiple of standard deviation, taking trades in the direction of acceleration with a protective stop.

--- a/API/0269_CCI_Slope_Breakout/README.md
+++ b/API/0269_CCI_Slope_Breakout/README.md
@@ -1,5 +1,6 @@
 # CCI Slope Breakout
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The CCI Slope Breakout strategy monitors the rate of change of the CCI. An unusually steep slope hints that a new trend is forming.
 
 Entries occur when slope exceeds its typical level by a multiple of standard deviation, taking trades in the direction of acceleration with a protective stop.

--- a/API/0270_Williams_R_Slope_Breakout/README.md
+++ b/API/0270_Williams_R_Slope_Breakout/README.md
@@ -1,5 +1,6 @@
 # Williams R Slope Breakout
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Williams R Slope Breakout strategy monitors the rate of change of the Williams. An unusually steep slope hints that a new trend is forming.
 
 Entries occur when slope exceeds its typical level by a multiple of standard deviation, taking trades in the direction of acceleration with a protective stop.

--- a/API/0271_MACD_Slope_Breakout/README.md
+++ b/API/0271_MACD_Slope_Breakout/README.md
@@ -1,5 +1,6 @@
 # MACD Slope Breakout
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The MACD Slope Breakout strategy tracks the rate of change of the MACD. An unusually steep slope hints that a new trend is forming.
 
 Entries occur when slope exceeds its typical level by a multiple of standard deviation, taking trades in the direction of acceleration with a protective stop.

--- a/API/0272_ADX_Slope_Breakout/README.md
+++ b/API/0272_ADX_Slope_Breakout/README.md
@@ -1,5 +1,6 @@
 # ADX Slope Breakout
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The ADX Slope Breakout strategy tracks the rate of change of the ADX. An unusually steep slope hints that a new trend is forming.
 
 Entries occur when slope exceeds its typical level by a multiple of standard deviation, taking trades in the direction of acceleration with a protective stop.

--- a/API/0273_ATR_Slope_Breakout/README.md
+++ b/API/0273_ATR_Slope_Breakout/README.md
@@ -1,5 +1,6 @@
 # ATR Slope Breakout
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The ATR Slope Breakout strategy watches the rate of change of the ATR. An unusually steep slope hints that a new trend is forming.
 
 Entries occur when slope exceeds its typical level by a multiple of standard deviation, taking trades in the direction of acceleration with a protective stop.

--- a/API/0274_Volume_Slope_Breakout/README.md
+++ b/API/0274_Volume_Slope_Breakout/README.md
@@ -1,5 +1,6 @@
 # Volume Slope Breakout
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Volume Slope Breakout strategy tracks the rate of change of the Volume. An unusually steep slope hints that a new trend is forming.
 
 Entries occur when slope exceeds its typical level by a multiple of standard deviation, taking trades in the direction of acceleration with a protective stop.

--- a/API/0275_OBV_Slope_Breakout/README.md
+++ b/API/0275_OBV_Slope_Breakout/README.md
@@ -1,5 +1,6 @@
 # OBV Slope Breakout
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The OBV Slope Breakout strategy watches the rate of change of the OBV. An unusually steep slope hints that a new trend is forming.
 
 Entries occur when slope exceeds its typical level by a multiple of standard deviation, taking trades in the direction of acceleration with a protective stop.

--- a/API/0276_Bollinger_Width_Mean_Reversion/README.md
+++ b/API/0276_Bollinger_Width_Mean_Reversion/README.md
@@ -1,5 +1,6 @@
 # Bollinger Width Mean Reversion
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Bollinger Width Mean Reversion strategy focuses on extreme readings of the Bollinger to exploit reversion. Wide departures from the average level rarely last.
 
 Trades trigger when the indicator swings far from its mean and then begins to reverse. Both long and short setups include a protective stop.

--- a/API/0277_Keltner_Width_Mean_Reversion/README.md
+++ b/API/0277_Keltner_Width_Mean_Reversion/README.md
@@ -1,5 +1,6 @@
 # Keltner Width Mean Reversion
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Keltner Width Mean Reversion strategy focuses on extreme readings of the Keltner to exploit reversion. Wide departures from the normal level rarely last.
 
 Trades trigger when the indicator swings far from its mean and then begins to reverse. Both long and short setups include a protective stop.

--- a/API/0278_Donchian_Width_Mean_Reversion/README.md
+++ b/API/0278_Donchian_Width_Mean_Reversion/README.md
@@ -1,5 +1,6 @@
 # Donchian Width Mean Reversion
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Donchian Width Mean Reversion strategy focuses on extreme readings of the Donchian to exploit reversion. Wide departures from the normal level rarely last.
 
 Trades trigger when the indicator swings far from its mean and then begins to reverse. Both long and short setups include a protective stop.

--- a/API/0279_Ichimoku_Cloud_Width_Mean_Reversion/README.md
+++ b/API/0279_Ichimoku_Cloud_Width_Mean_Reversion/README.md
@@ -1,5 +1,6 @@
 # Ichimoku Cloud Width Mean Reversion
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Ichimoku Cloud Width Mean Reversion strategy focuses on extreme readings of the Ichimoku to exploit reversion. Wide departures from the normal level rarely last.
 
 Trades trigger when the indicator swings far from its mean and then begins to reverse. Both long and short setups include a protective stop.

--- a/API/0280_Supertrend_Distance_Mean_Reversion/README.md
+++ b/API/0280_Supertrend_Distance_Mean_Reversion/README.md
@@ -1,5 +1,6 @@
 # Supertrend Distance Mean Reversion
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Supertrend Distance Mean Reversion strategy focuses on extreme readings of the Supertrend to exploit reversion. Wide departures from the normal level rarely last.
 
 Trades trigger when the indicator swings far from its mean and then begins to reverse. Both long and short setups include a protective stop.

--- a/API/0281_Parabolic_SAR_Distance_Mean_Reversion/README.md
+++ b/API/0281_Parabolic_SAR_Distance_Mean_Reversion/README.md
@@ -1,5 +1,6 @@
 # Parabolic SAR Distance Mean Reversion
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Parabolic SAR Distance Mean Reversion strategy focuses on extreme readings of the Parabolic to exploit reversion. Wide departures from the normal level rarely last.
 
 Trades trigger when the indicator swings far from its mean and then begins to reverse. Both long and short setups include a protective stop.

--- a/API/0282_Hull_MA_Slope_Mean_Reversion/README.md
+++ b/API/0282_Hull_MA_Slope_Mean_Reversion/README.md
@@ -1,5 +1,6 @@
 # Hull MA Slope Mean Reversion
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Hull MA Slope Mean Reversion strategy focuses on extreme readings of the Hull to exploit reversion. Wide departures from the normal level rarely last.
 
 Trades trigger when the indicator swings far from its mean and then begins to reverse. Both long and short setups include a protective stop.

--- a/API/0283_MA_Slope_Mean_Reversion/README.md
+++ b/API/0283_MA_Slope_Mean_Reversion/README.md
@@ -1,5 +1,6 @@
 # MA Slope Mean Reversion
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The MA Slope Mean Reversion strategy focuses on extreme readings of the MA to exploit reversion. Wide departures from the recent level rarely last.
 
 Trades trigger when the indicator swings far from its mean and then begins to reverse. Both long and short setups include a protective stop.

--- a/API/0284_EMA_Slope_Mean_Reversion/README.md
+++ b/API/0284_EMA_Slope_Mean_Reversion/README.md
@@ -1,5 +1,6 @@
 # EMA Slope Mean Reversion
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The EMA Slope Mean Reversion strategy focuses on extreme readings of the EMA to exploit reversion. Wide departures from the recent level rarely last.
 
 Trades trigger when the indicator swings far from its mean and then begins to reverse. Both long and short setups include a protective stop.

--- a/API/0285_VWAP_Slope_Mean_Reversion/README.md
+++ b/API/0285_VWAP_Slope_Mean_Reversion/README.md
@@ -1,5 +1,6 @@
 # VWAP Slope Mean Reversion
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The VWAP Slope Mean Reversion strategy focuses on extreme readings of the VWAP to exploit reversion. Wide departures from the normal level rarely last.
 
 Trades trigger when the indicator swings far from its mean and then begins to reverse. Both long and short setups include a protective stop.

--- a/API/0286_RSI_Slope_Mean_Reversion/README.md
+++ b/API/0286_RSI_Slope_Mean_Reversion/README.md
@@ -1,5 +1,6 @@
 # RSI Slope Mean Reversion
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The RSI Slope Mean Reversion strategy focuses on extreme readings of the RSI to exploit reversion. Wide departures from the average level rarely last.
 
 Trades trigger when the indicator swings far from its mean and then begins to reverse. Both long and short setups include a protective stop.

--- a/API/0287_Stochastic_Slope_Mean_Reversion/README.md
+++ b/API/0287_Stochastic_Slope_Mean_Reversion/README.md
@@ -1,5 +1,6 @@
 # Stochastic Slope Mean Reversion
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Stochastic Slope Mean Reversion strategy focuses on extreme readings of the Stochastic to exploit reversion. Wide departures from the normal level rarely last.
 
 Trades trigger when the indicator swings far from its mean and then begins to reverse. Both long and short setups include a protective stop.

--- a/API/0288_CCI_Slope_Mean_Reversion/README.md
+++ b/API/0288_CCI_Slope_Mean_Reversion/README.md
@@ -1,5 +1,6 @@
 # CCI Slope Mean Reversion
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The CCI Slope Mean Reversion strategy focuses on extreme readings of the CCI to exploit reversion. Wide departures from the typical level rarely last.
 
 Trades trigger when the indicator swings far from its mean and then begins to reverse. Both long and short setups include a protective stop.

--- a/API/0289_Williams_R_Slope_Mean_Reversion/README.md
+++ b/API/0289_Williams_R_Slope_Mean_Reversion/README.md
@@ -1,5 +1,6 @@
 # Williams R Slope Mean Reversion
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Williams R Slope Mean Reversion strategy focuses on extreme readings of the Williams to exploit reversion. Wide departures from the normal level rarely last.
 
 Trades trigger when the indicator swings far from its mean and then begins to reverse. Both long and short setups include a protective stop.

--- a/API/0290_MACD_Slope_Mean_Reversion/README.md
+++ b/API/0290_MACD_Slope_Mean_Reversion/README.md
@@ -1,5 +1,6 @@
 # MACD Slope Mean Reversion
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The MACD Slope Mean Reversion strategy focuses on extreme readings of the MACD to exploit reversion. Wide departures from the normal level rarely last.
 
 Trades trigger when the indicator swings far from its mean and then begins to reverse. Both long and short setups include a protective stop.

--- a/API/0291_ADX_Slope_Mean_Reversion/README.md
+++ b/API/0291_ADX_Slope_Mean_Reversion/README.md
@@ -1,5 +1,6 @@
 # ADX Slope Mean Reversion
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The ADX Slope Mean Reversion strategy focuses on extreme readings of the ADX to exploit reversion. Wide departures from the average level rarely last.
 
 Trades trigger when the indicator swings far from its mean and then begins to reverse. Both long and short setups include a protective stop.

--- a/API/0292_ATR_Slope_Mean_Reversion/README.md
+++ b/API/0292_ATR_Slope_Mean_Reversion/README.md
@@ -1,5 +1,6 @@
 # ATR Slope Mean Reversion
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The ATR Slope Mean Reversion strategy focuses on extreme readings of the ATR to exploit reversion. Wide departures from the normal level rarely last.
 
 Trades trigger when the indicator swings far from its mean and then begins to reverse. Both long and short setups include a protective stop.

--- a/API/0293_Volume_Slope_Mean_Reversion/README.md
+++ b/API/0293_Volume_Slope_Mean_Reversion/README.md
@@ -1,5 +1,6 @@
 # Volume Slope Mean Reversion
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Volume Slope Mean Reversion strategy focuses on extreme readings of the Volume to exploit reversion. Wide departures from the typical level rarely last.
 
 Trades trigger when the indicator swings far from its mean and then begins to reverse. Both long and short setups include a protective stop.

--- a/API/0294_OBV_Slope_Mean_Reversion/README.md
+++ b/API/0294_OBV_Slope_Mean_Reversion/README.md
@@ -1,5 +1,6 @@
 # OBV Slope Mean Reversion
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The OBV Slope Mean Reversion strategy focuses on extreme readings of the OBV to exploit reversion. Wide departures from the normal level rarely last.
 
 Trades trigger when the indicator swings far from its mean and then begins to reverse. Both long and short setups include a protective stop.

--- a/API/0295_Pairs_Trading_Volatility_Filter/README.md
+++ b/API/0295_Pairs_Trading_Volatility_Filter/README.md
@@ -1,5 +1,6 @@
 # Pairs Trading Volatility Filter
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Pairs Trading Volatility Filter strategy uses the Pairs alongside volatility filters. It enters trades only when specified conditions align.
 
 Signals require the indicator to surpass a threshold while volatility meets predefined criteria. Positions can be long or short with built-in stops.

--- a/API/0296_Z-Score_Volume_Filter/README.md
+++ b/API/0296_Z-Score_Volume_Filter/README.md
@@ -1,5 +1,6 @@
 # Z-Score Volume Filter
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Z-Score Volume Filter strategy uses the Z-Score alongside volatility filters. It enters trades only when specified conditions align.
 
 Signals require the indicator to surpass a threshold while volatility meets predefined criteria. Positions can be long or short with built-in stops.

--- a/API/0298_Correlation_Mean_Reversion/README.md
+++ b/API/0298_Correlation_Mean_Reversion/README.md
@@ -1,5 +1,6 @@
 # Correlation Mean Reversion
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Correlation Mean Reversion strategy focuses on extreme readings of the Correlation to exploit reversion. Wide departures from the typical level rarely last.
 
 Trades trigger when the indicator swings far from its mean and then begins to reverse. Both long and short setups include a protective stop.

--- a/API/0299_Beta_Adjusted_Pairs_Trading/README.md
+++ b/API/0299_Beta_Adjusted_Pairs_Trading/README.md
@@ -1,5 +1,6 @@
 # Beta Adjusted Pairs Trading
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Beta Adjusted Pairs Trading strategy uses the Beta alongside volatility filters. It enters trades only when specified conditions align.
 
 Signals require the indicator to surpass a threshold while volatility meets predefined criteria. Positions can be long or short with built-in stops.

--- a/API/0300_Hurst_Exponent_Volatility_Filter/README.md
+++ b/API/0300_Hurst_Exponent_Volatility_Filter/README.md
@@ -1,5 +1,6 @@
 # Hurst Exponent Volatility Filter
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The Hurst Exponent Volatility Filter strategy uses the Hurst alongside volatility filters. It enters trades only when specified conditions align.
 
 Signals require the indicator to surpass a threshold while volatility meets predefined criteria. Positions can be long or short with built-in stops.

--- a/API/0301_Adaptive_EMA_Breakout/README.md
+++ b/API/0301_Adaptive_EMA_Breakout/README.md
@@ -1,5 +1,6 @@
 # Adaptive EMA Breakout
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **Adaptive EMA Breakout** strategy is built around Adaptive EMA breakout with trend confirmation.
 
 Signals trigger when its indicators confirms breakout opportunities on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0302_Volatility_Cluster_Breakout/README.md
+++ b/API/0302_Volatility_Cluster_Breakout/README.md
@@ -1,5 +1,6 @@
 # Volatility Cluster Breakout
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **Volatility Cluster Breakout** strategy is built around breakouts during high volatility clusters.
 
 Signals trigger when its indicators confirms breakout opportunities on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0303_Seasonality_Adjusted_Momentum/README.md
+++ b/API/0303_Seasonality_Adjusted_Momentum/README.md
@@ -1,5 +1,6 @@
 # Seasonality Adjusted Momentum
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **Seasonality Adjusted Momentum** strategy is built around momentum indicator adjusted with seasonality strength.
 
 Signals trigger when Seasonality confirms momentum shifts on daily data. This makes the method suitable for active traders.

--- a/API/0305_RSI_Dynamic_Overbought_Oversold/README.md
+++ b/API/0305_RSI_Dynamic_Overbought_Oversold/README.md
@@ -1,5 +1,6 @@
 # RSI Dynamic Overbought Oversold
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **RSI Dynamic Overbought Oversold** strategy is built around RSI with dynamic overbought/oversold levels.
 
 Signals trigger when Overbought confirms trend changes on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0306_Bollinger_Volatility_Breakout/README.md
+++ b/API/0306_Bollinger_Volatility_Breakout/README.md
@@ -1,5 +1,6 @@
 # Bollinger Volatility Breakout
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **Bollinger Volatility Breakout** strategy is built around Bollinger Bands breakout with volatility confirmation.
 
 Signals trigger when Bollinger confirms breakout opportunities on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0307_MACD_Adaptive_Histogram/README.md
+++ b/API/0307_MACD_Adaptive_Histogram/README.md
@@ -1,5 +1,6 @@
 # MACD Adaptive Histogram
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **MACD Adaptive Histogram** strategy is built around MACD with adaptive histogram threshold.
 
 Signals trigger when Histogram confirms trend changes on intraday (15m) data. This makes the method suitable for active traders.

--- a/API/0308_Ichimoku_Volume_Cluster/README.md
+++ b/API/0308_Ichimoku_Volume_Cluster/README.md
@@ -1,5 +1,6 @@
 # Ichimoku Volume Cluster
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **Ichimoku Volume Cluster** strategy is built around Ichimoku Cloud with volume cluster confirmation.
 
 Signals trigger when its indicators confirms trend changes on intraday (1h) data. This makes the method suitable for active traders.

--- a/API/0309_Supertrend_Momentum_Filter/README.md
+++ b/API/0309_Supertrend_Momentum_Filter/README.md
@@ -1,5 +1,6 @@
 # Supertrend Momentum Filter
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **Supertrend Momentum Filter** strategy is built around Supertrend and Momentum indicators.
 
 Signals trigger when its indicators confirms filtered entries on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0310_Donchian_Volatility_Contraction/README.md
+++ b/API/0310_Donchian_Volatility_Contraction/README.md
@@ -1,5 +1,6 @@
 # Donchian Volatility Contraction
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **Donchian Volatility Contraction** strategy is built around Donchian Channel breakout after volatility contraction.
 
 Signals trigger when Donchian confirms volatility contraction patterns on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0311_Keltner_RSI_Divergence/README.md
+++ b/API/0311_Keltner_RSI_Divergence/README.md
@@ -1,5 +1,6 @@
 # Keltner RSI Divergence
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **Keltner RSI Divergence** strategy is built around Keltner Channel and RSI Divergence.
 
 Signals trigger when Keltner confirms divergence setups on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0312_Hull_MA_Volume_Spike/README.md
+++ b/API/0312_Hull_MA_Volume_Spike/README.md
@@ -1,5 +1,6 @@
 # Hull MA Volume Spike
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **Hull MA Volume Spike** strategy is built around Hull Moving Average with Volume Spike detection.
 
 Signals trigger when Spike confirms trend changes on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0313_VWAP_ADX_Trend_Strength/README.md
+++ b/API/0313_VWAP_ADX_Trend_Strength/README.md
@@ -1,5 +1,6 @@
 # VWAP ADX Trend Strength
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **VWAP ADX Trend Strength** strategy is built around VWAP with ADX Trend Strength.
 
 Signals trigger when its indicators confirms trend changes on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0314_Parabolic_SAR_Volatility_Expansion/README.md
+++ b/API/0314_Parabolic_SAR_Volatility_Expansion/README.md
@@ -1,5 +1,6 @@
 # Parabolic SAR Volatility Expansion
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **Parabolic SAR Volatility Expansion** strategy is built around Parabolic SAR with Volatility Expansion detection.
 
 Signals trigger when Parabolic confirms trend changes on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0315_Stochastic_Dynamic_Zones/README.md
+++ b/API/0315_Stochastic_Dynamic_Zones/README.md
@@ -1,5 +1,6 @@
 # Stochastic Dynamic Zones
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **Stochastic Dynamic Zones** strategy is built around Stochastic Oscillator with Dynamic Overbought/Oversold Zones.
 
 Signals trigger when Stochastic confirms trend changes on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0316_ADX_Volume_Breakout/README.md
+++ b/API/0316_ADX_Volume_Breakout/README.md
@@ -1,5 +1,6 @@
 # ADX Volume Breakout
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **ADX Volume Breakout** strategy is built around ADX with Volume Breakout.
 
 Signals trigger when its indicators confirms breakout opportunities on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0317_CCI_Volatility_Filter/README.md
+++ b/API/0317_CCI_Volatility_Filter/README.md
@@ -1,5 +1,6 @@
 # CCI Volatility Filter
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **CCI Volatility Filter** strategy is built around CCI with Volatility Filter.
 
 Signals trigger when its indicators confirms filtered entries on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0318_Williams_R_Momentum/README.md
+++ b/API/0318_Williams_R_Momentum/README.md
@@ -1,5 +1,6 @@
 # Williams R Momentum
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **Williams R Momentum** strategy is built around Williams %R with Momentum filter.
 
 Signals trigger when Williams confirms momentum shifts on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0319_Bollinger_K-Means_Cluster/README.md
+++ b/API/0319_Bollinger_K-Means_Cluster/README.md
@@ -1,5 +1,6 @@
 # Bollinger K-Means Cluster
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **Bollinger K-Means Cluster** strategy is built around Bollinger K-Means Cluster.
 
 Signals trigger when Bollinger confirms trend changes on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0320_MACD_Hidden_Markov_Model/README.md
+++ b/API/0320_MACD_Hidden_Markov_Model/README.md
@@ -1,5 +1,6 @@
 # MACD Hidden Markov Model
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **MACD Hidden Markov Model** strategy is built around MACD Hidden Markov Model.
 
 Signals trigger when Markov confirms trend changes on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0321_Ichimoku_Hurst_Exponent/README.md
+++ b/API/0321_Ichimoku_Hurst_Exponent/README.md
@@ -1,5 +1,6 @@
 # Ichimoku Hurst Exponent
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **Ichimoku Hurst Exponent** strategy is built around Ichimoku Kinko Hyo indicator with Hurst exponent filter.
 
 Signals trigger when Hurst confirms trend changes on intraday (15m) data. This makes the method suitable for active traders.

--- a/API/0322_Supertrend_RSI_Divergence/README.md
+++ b/API/0322_Supertrend_RSI_Divergence/README.md
@@ -1,5 +1,6 @@
 # Supertrend RSI Divergence
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **Supertrend RSI Divergence** strategy is built around that uses Supertrend indicator along with RSI divergence to identify trading opportunities.
 
 Signals trigger when Divergence confirms divergence setups on intraday (15m) data. This makes the method suitable for active traders.

--- a/API/0323_Donchian_Seasonal_Filter/README.md
+++ b/API/0323_Donchian_Seasonal_Filter/README.md
@@ -1,5 +1,6 @@
 # Donchian Seasonal Filter
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **Donchian Seasonal Filter** strategy is built around Donchian Channels with seasonal filter.
 
 Signals trigger when Donchian confirms filtered entries on intraday (15m) data. This makes the method suitable for active traders.

--- a/API/0324_Keltner_Kalman_Filter/README.md
+++ b/API/0324_Keltner_Kalman_Filter/README.md
@@ -1,5 +1,6 @@
 # Keltner Kalman Filter
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **Keltner Kalman Filter** strategy is built around combining Keltner Channels with a Kalman Filter to identify trends and trade opportunities.
 
 Signals trigger when Keltner confirms filtered entries on intraday (15m) data. This makes the method suitable for active traders.

--- a/API/0325_Hull_MA_Volatility_Contraction/README.md
+++ b/API/0325_Hull_MA_Volatility_Contraction/README.md
@@ -1,5 +1,6 @@
 # Hull MA Volatility Contraction
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **Hull MA Volatility Contraction** strategy is built around Hull Moving Average with volatility contraction filter.
 
 Signals trigger when its indicators confirms volatility contraction patterns on intraday (15m) data. This makes the method suitable for active traders.

--- a/API/0326_VWAP_Stochastic_Divergence/README.md
+++ b/API/0326_VWAP_Stochastic_Divergence/README.md
@@ -1,5 +1,6 @@
 # VWAP Stochastic Divergence
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **VWAP Stochastic Divergence** strategy is built around combining VWAP with ADX trend strength indicator.
 
 Signals trigger when Stochastic confirms divergence setups on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0327_Parabolic_SAR_Hurst_Filter/README.md
+++ b/API/0327_Parabolic_SAR_Hurst_Filter/README.md
@@ -1,5 +1,6 @@
 # Parabolic SAR Hurst Filter
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **Parabolic SAR Hurst Filter** strategy is built around Parabolic SAR Hurst Filter.
 
 Signals trigger when Parabolic confirms filtered entries on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0328_Bollinger_Kalman_Filter/README.md
+++ b/API/0328_Bollinger_Kalman_Filter/README.md
@@ -1,5 +1,6 @@
 # Bollinger Kalman Filter
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **Bollinger Kalman Filter** strategy is built around Bollinger Kalman Filter.
 
 Signals trigger when Bollinger confirms filtered entries on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0329_MACD_Volume_Cluster/README.md
+++ b/API/0329_MACD_Volume_Cluster/README.md
@@ -1,5 +1,6 @@
 # MACD Volume Cluster
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **MACD Volume Cluster** strategy is built around MACD Volume Cluster.
 
 Signals trigger when its indicators confirms trend changes on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0330_Ichimoku_Volatility_Contraction/README.md
+++ b/API/0330_Ichimoku_Volatility_Contraction/README.md
@@ -1,5 +1,6 @@
 # Ichimoku Volatility Contraction
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **Ichimoku Volatility Contraction** strategy is built around Ichimoku Volatility Contraction.
 
 Signals trigger when its indicators confirms volatility contraction patterns on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0332_Donchian_Hurst_Exponent/README.md
+++ b/API/0332_Donchian_Hurst_Exponent/README.md
@@ -1,5 +1,6 @@
 # Donchian Hurst Exponent
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **Donchian Hurst Exponent** strategy is built around that trades based on Donchian Channel breakouts with Hurst Exponent filter.
 
 Signals trigger when Donchian confirms trend changes on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0333_Keltner_Seasonal_Filter/README.md
+++ b/API/0333_Keltner_Seasonal_Filter/README.md
@@ -1,5 +1,6 @@
 # Keltner Seasonal Filter
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **Keltner Seasonal Filter** strategy is built around that trades based on Keltner Channel breakouts with seasonal bias filter.
 
 Signals trigger when Keltner confirms filtered entries on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0334_Hull_MA_K-Means_Cluster/README.md
+++ b/API/0334_Hull_MA_K-Means_Cluster/README.md
@@ -1,5 +1,6 @@
 # Hull MA K-Means Cluster
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **Hull MA K-Means Cluster** strategy is built around that trades based on Hull Moving Average direction with K-Means clustering for market state detection.
 
 Signals trigger when its indicators confirms trend changes on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0335_VWAP_Hidden_Markov_Model/README.md
+++ b/API/0335_VWAP_Hidden_Markov_Model/README.md
@@ -1,5 +1,6 @@
 # VWAP Hidden Markov Model
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **VWAP Hidden Markov Model** strategy is built around that trades based on VWAP with Hidden Markov Model for market state detection.
 
 Signals trigger when Markov confirms trend changes on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0336_Parabolic_SAR_RSI_Divergence/README.md
+++ b/API/0336_Parabolic_SAR_RSI_Divergence/README.md
@@ -1,5 +1,6 @@
 # Parabolic SAR RSI Divergence
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **Parabolic SAR RSI Divergence** strategy is built around that trades based on Parabolic SAR signals when RSI shows divergence from price.
 
 Signals trigger when Parabolic confirms divergence setups on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0337_Adaptive_RSI_Volume_Filter/README.md
+++ b/API/0337_Adaptive_RSI_Volume_Filter/README.md
@@ -1,5 +1,6 @@
 # Adaptive RSI Volume Filter
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **Adaptive RSI Volume Filter** strategy is built around that trades based on Adaptive RSI with volume confirmation.
 
 Signals trigger when its indicators confirms filtered entries on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0338_Adaptive_Bollinger_Breakout/README.md
+++ b/API/0338_Adaptive_Bollinger_Breakout/README.md
@@ -1,5 +1,6 @@
 # Adaptive Bollinger Breakout
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **Adaptive Bollinger Breakout** strategy is built around that trades based on breakouts of Bollinger Bands with adaptively adjusted parameters.
 
 Signals trigger when Bollinger confirms breakout opportunities on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0339_MACD_Sentiment_Filter/README.md
+++ b/API/0339_MACD_Sentiment_Filter/README.md
@@ -1,5 +1,6 @@
 # MACD Sentiment Filter
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **MACD Sentiment Filter** strategy is built around MACD Sentiment Filter.
 
 Signals trigger when its indicators confirms filtered entries on intraday (15m) data. This makes the method suitable for active traders.

--- a/API/0340_Ichimoku_Implied_Volatility/README.md
+++ b/API/0340_Ichimoku_Implied_Volatility/README.md
@@ -1,5 +1,6 @@
 # Ichimoku Implied Volatility
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **Ichimoku Implied Volatility** strategy is built around Ichimoku Implied Volatility.
 
 Signals trigger when its indicators confirms trend changes on intraday (15m) data. This makes the method suitable for active traders.

--- a/API/0341_Supertrend_Put_Call_Ratio/README.md
+++ b/API/0341_Supertrend_Put_Call_Ratio/README.md
@@ -1,5 +1,6 @@
 # Supertrend Put Call Ratio
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **Supertrend Put Call Ratio** strategy is built around Supertrend Put Call Ratio.
 
 Signals trigger when its indicators confirms trend changes on intraday (15m) data. This makes the method suitable for active traders.

--- a/API/0342_Donchian_Sentiment_Spike/README.md
+++ b/API/0342_Donchian_Sentiment_Spike/README.md
@@ -1,5 +1,6 @@
 # Donchian Sentiment Spike
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **Donchian Sentiment Spike** strategy is built around Donchian Sentiment Spike.
 
 Signals trigger when Donchian confirms trend changes on intraday (15m) data. This makes the method suitable for active traders.

--- a/API/0343_Keltner_Reinforcement_Learning_Signal/README.md
+++ b/API/0343_Keltner_Reinforcement_Learning_Signal/README.md
@@ -1,5 +1,6 @@
 # Keltner Reinforcement Learning Signal
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **Keltner Reinforcement Learning Signal** strategy is built around Keltner Reinforcement Learning Signal.
 
 Signals trigger when Keltner confirms trend changes on intraday (15m) data. This makes the method suitable for active traders.

--- a/API/0344_Hull_MA_Implied_Volatility_Breakout/README.md
+++ b/API/0344_Hull_MA_Implied_Volatility_Breakout/README.md
@@ -1,5 +1,6 @@
 # Hull MA Implied Volatility Breakout
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **Hull MA Implied Volatility Breakout** strategy is built around Hull MA Implied Volatility Breakout.
 
 Signals trigger when its indicators confirms breakout opportunities on intraday (15m) data. This makes the method suitable for active traders.

--- a/API/0345_VWAP_Behavioral_Bias_Filter/README.md
+++ b/API/0345_VWAP_Behavioral_Bias_Filter/README.md
@@ -1,5 +1,6 @@
 # VWAP Behavioral Bias Filter
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **VWAP Behavioral Bias Filter** strategy is built around VWAP Behavioral Bias Filter.
 
 Signals trigger when Behavioral confirms filtered entries on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0346_Parabolic_SAR_Sentiment_Divergence/README.md
+++ b/API/0346_Parabolic_SAR_Sentiment_Divergence/README.md
@@ -1,5 +1,6 @@
 # Parabolic SAR Sentiment Divergence
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **Parabolic SAR Sentiment Divergence** strategy is built around Parabolic SAR Sentiment Divergence.
 
 Signals trigger when Parabolic confirms divergence setups on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0347_RSI_Option_Open_Interest/README.md
+++ b/API/0347_RSI_Option_Open_Interest/README.md
@@ -1,5 +1,6 @@
 # RSI Option Open Interest
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **RSI Option Open Interest** strategy is built around RSI Option Open Interest.
 
 Signals trigger when Option confirms trend changes on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0348_Stochastic_Implied_Volatility_Skew/README.md
+++ b/API/0348_Stochastic_Implied_Volatility_Skew/README.md
@@ -1,5 +1,6 @@
 # Stochastic Implied Volatility Skew
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **Stochastic Implied Volatility Skew** strategy is built around Stochastic Implied Volatility Skew.
 
 Signals trigger when Stochastic confirms trend changes on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0349_ADX_Sentiment_Momentum/README.md
+++ b/API/0349_ADX_Sentiment_Momentum/README.md
@@ -1,5 +1,6 @@
 # ADX Sentiment Momentum
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **ADX Sentiment Momentum** strategy is built around ADX Sentiment Momentum.
 
 Signals trigger when its indicators confirms momentum shifts on intraday (5m) data. This makes the method suitable for active traders.

--- a/API/0350_CCI_Put_Call_Ratio_Divergence/README.md
+++ b/API/0350_CCI_Put_Call_Ratio_Divergence/README.md
@@ -1,5 +1,6 @@
 # CCI Put Call Ratio Divergence
-
+[Русский](README_ru.md) | [中文](README_zh.md)
+ 
 The **CCI Put Call Ratio Divergence** strategy is built around CCI Put Call Ratio Divergence.
 
 Signals trigger when Divergence confirms divergence setups on intraday (5m) data. This makes the method suitable for active traders.


### PR DESCRIPTION
## Summary
- link each strategy README to Russian (`README_ru.md`) and Chinese translations

## Testing
- `dotnet test --no-build` *(fails: command not found)*
- `apt-get update` *(fails: repository signatures unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68778b90c12c83238e3124a214212ca9