### PR TITLE
Remove strategy numbers from comments

### DIFF
--- a/API/0069_Bollinger_Band_Reversal/BollingerBandReversalStrategy.cs
+++ b/API/0069_Bollinger_Band_Reversal/BollingerBandReversalStrategy.cs
@@ -9,7 +9,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Strategy #69: Bollinger Band Reversal strategy.
+	/// Bollinger Band Reversal strategy.
 	/// The strategy enters long position when price is below the lower Bollinger Band and the candle is bullish,
 	/// enters short position when price is above the upper Bollinger Band and the candle is bearish.
 	/// </summary>

--- a/API/0070_Morning_Star/MorningStarStrategy.cs
+++ b/API/0070_Morning_Star/MorningStarStrategy.cs
@@ -8,7 +8,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Strategy #70: Morning Star candle pattern strategy.
+	/// Morning Star candle pattern strategy.
 	/// The strategy looks for a Morning Star pattern - first bearish candle, second small candle (doji), third bullish candle that closes above the midpoint of the first.
 	/// </summary>
 	public class MorningStarStrategy : Strategy

--- a/API/0071_Evening_Star/EveningStarStrategy.cs
+++ b/API/0071_Evening_Star/EveningStarStrategy.cs
@@ -8,7 +8,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Strategy #71: Evening Star candle pattern strategy.
+	/// Evening Star candle pattern strategy.
 	/// The strategy looks for an Evening Star pattern - first bullish candle, second small candle (doji), third bearish candle that closes below the midpoint of the first.
 	/// </summary>
 	public class EveningStarStrategy : Strategy

--- a/API/0072_Doji_Reversal/DojiReversalStrategy.cs
+++ b/API/0072_Doji_Reversal/DojiReversalStrategy.cs
@@ -8,7 +8,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Strategy #72: Doji Reversal strategy.
+	/// Doji Reversal strategy.
 	/// The strategy looks for doji candlestick patterns after a trend and takes a reversal position.
 	/// </summary>
 	public class DojiReversalStrategy : Strategy

--- a/API/0073_Keltner_Channel_Reversal/KeltnerChannelReversalStrategy.cs
+++ b/API/0073_Keltner_Channel_Reversal/KeltnerChannelReversalStrategy.cs
@@ -9,7 +9,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Strategy #73: Keltner Channel Reversal strategy.
+	/// Keltner Channel Reversal strategy.
 	/// The strategy enters long when price is below lower Keltner Channel and a bullish candle appears,
 	/// enters short when price is above upper Keltner Channel and a bearish candle appears.
 	/// </summary>

--- a/API/0073_Keltner_Channel_Reversal/keltner_channel_reversal_strategy.py
+++ b/API/0073_Keltner_Channel_Reversal/keltner_channel_reversal_strategy.py
@@ -19,7 +19,7 @@ from StockSharp.Algo.Strategies import Strategy
 
 class keltner_channel_reversal_strategy(Strategy):
     """
-    Strategy #73: Keltner Channel Reversal strategy.
+    Keltner Channel Reversal strategy.
     The strategy enters long when price is below lower Keltner Channel and a bullish candle appears,
     enters short when price is above upper Keltner Channel and a bearish candle appears.
     

--- a/API/0074_Williams_R_Divergence/WilliamsPercentRDivergenceStrategy.cs
+++ b/API/0074_Williams_R_Divergence/WilliamsPercentRDivergenceStrategy.cs
@@ -9,7 +9,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Strategy #74: Williams %R Divergence strategy.
+	/// Williams %R Divergence strategy.
 	/// The strategy looks for divergences between price and Williams %R indicator to identify potential reversal points.
 	/// </summary>
 	public class WilliamsPercentRDivergenceStrategy : Strategy

--- a/API/0074_Williams_R_Divergence/williams_r_strategy.py
+++ b/API/0074_Williams_R_Divergence/williams_r_strategy.py
@@ -18,7 +18,7 @@ from StockSharp.Algo.Strategies import Strategy
 
 class williams_percent_r_divergence_strategy(Strategy):
     """
-    Strategy #74: Williams %R Divergence strategy.
+    Williams %R Divergence strategy.
     The strategy looks for divergences between price and Williams %R indicator to identify potential reversal points.
     
     See more examples: https://github.com/StockSharp/AlgoTrading

--- a/API/0075_OBV_Divergence/ObvDivergenceStrategy.cs
+++ b/API/0075_OBV_Divergence/ObvDivergenceStrategy.cs
@@ -9,7 +9,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Strategy #75: OBV (On-Balance Volume) Divergence strategy.
+	/// OBV (On-Balance Volume) Divergence strategy.
 	/// The strategy uses divergence between price and OBV indicator to identify potential reversal points.
 	/// </summary>
 	public class OBVDivergenceStrategy : Strategy

--- a/API/0075_OBV_Divergence/obv_strategy.py
+++ b/API/0075_OBV_Divergence/obv_strategy.py
@@ -19,7 +19,7 @@ from StockSharp.Algo.Strategies import Strategy
 
 class obv_divergence_strategy(Strategy):
     """
-    Strategy #75: OBV (On-Balance Volume) Divergence strategy.
+    OBV (On-Balance Volume) Divergence strategy.
     The strategy uses divergence between price and OBV indicator to identify potential reversal points.
     
     See more examples: https://github.com/StockSharp/AlgoTrading

--- a/API/0076_Fibonacci_Retracement_Reversal/FibonacciRetracementReversalStrategy.cs
+++ b/API/0076_Fibonacci_Retracement_Reversal/FibonacciRetracementReversalStrategy.cs
@@ -9,7 +9,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Strategy #76: Fibonacci Retracement Reversal strategy.
+	/// Fibonacci Retracement Reversal strategy.
 	/// The strategy identifies significant swings in price and looks for reversals at key Fibonacci retracement levels.
 	/// </summary>
 	public class FibonacciRetracementReversalStrategy : Strategy

--- a/API/0076_Fibonacci_Retracement_Reversal/fibonacci_strategy.py
+++ b/API/0076_Fibonacci_Retracement_Reversal/fibonacci_strategy.py
@@ -17,7 +17,7 @@ from StockSharp.Algo.Strategies import Strategy
 
 class fibonacci_retracement_reversal_strategy(Strategy):
     """
-    Strategy #76: Fibonacci Retracement Reversal strategy.
+    Fibonacci Retracement Reversal strategy.
     The strategy identifies significant swings in price and looks for reversals at key Fibonacci retracement levels.
     
     See more examples: https://github.com/StockSharp/AlgoTrading

--- a/API/0077_Inside_Bar_Breakout/InsideBarBreakoutStrategy.cs
+++ b/API/0077_Inside_Bar_Breakout/InsideBarBreakoutStrategy.cs
@@ -8,7 +8,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Strategy #77: Inside Bar Breakout strategy.
+	/// Inside Bar Breakout strategy.
 	/// The strategy looks for inside bar patterns (a bar with high lower than the previous bar's high and low higher than the previous bar's low)
 	/// and enters positions on breakouts of the inside bar's high or low.
 	/// </summary>

--- a/API/0077_Inside_Bar_Breakout/inside_bar_strategy.py
+++ b/API/0077_Inside_Bar_Breakout/inside_bar_strategy.py
@@ -17,7 +17,7 @@ from StockSharp.Algo.Strategies import Strategy
 
 class inside_bar_breakout_strategy(Strategy):
     """
-    Strategy #77: Inside Bar Breakout strategy.
+    Inside Bar Breakout strategy.
     The strategy looks for inside bar patterns (a bar with high lower than the previous bar's high and low higher than the previous bar's low)
     and enters positions on breakouts of the inside bar's high or low.
     

--- a/API/0078_Outside_Bar_Reversal/OutsideBarReversalStrategy.cs
+++ b/API/0078_Outside_Bar_Reversal/OutsideBarReversalStrategy.cs
@@ -8,7 +8,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Strategy #78: Outside Bar Reversal strategy.
+	/// Outside Bar Reversal strategy.
 	/// The strategy looks for outside bar patterns (a bar with higher high and lower low than the previous bar)
 	/// and takes positions based on the direction (bullish or bearish) of the outside bar.
 	/// </summary>

--- a/API/0078_Outside_Bar_Reversal/outside_bar_strategy.py
+++ b/API/0078_Outside_Bar_Reversal/outside_bar_strategy.py
@@ -17,7 +17,7 @@ from StockSharp.Algo.Strategies import Strategy
 
 class outside_bar_reversal_strategy(Strategy):
     """
-    Strategy #78: Outside Bar Reversal strategy.
+    Outside Bar Reversal strategy.
     The strategy looks for outside bar patterns (a bar with higher high and lower low than the previous bar)
     and takes positions based on the direction (bullish or bearish) of the outside bar.
     

--- a/API/0079_Trendline_Bounce/TrendlineBounceStrategy.cs
+++ b/API/0079_Trendline_Bounce/TrendlineBounceStrategy.cs
@@ -10,7 +10,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Strategy #79: Trendline Bounce strategy.
+	/// Trendline Bounce strategy.
 	/// The strategy automatically identifies trendlines by connecting highs or lows
 	/// and enters positions when price bounces off a trendline with confirmation.
 	/// </summary>

--- a/API/0079_Trendline_Bounce/trendline_strategy.py
+++ b/API/0079_Trendline_Bounce/trendline_strategy.py
@@ -21,7 +21,7 @@ from StockSharp.Algo.Strategies import Strategy
 
 class trendline_bounce_strategy(Strategy):
     """
-    Strategy #79: Trendline Bounce strategy.
+    Trendline Bounce strategy.
     The strategy automatically identifies trendlines by connecting highs or lows
     and enters positions when price bounces off a trendline with confirmation.
     

--- a/API/0080_Pivot_Point_Reversal/PivotPointReversalStrategy.cs
+++ b/API/0080_Pivot_Point_Reversal/PivotPointReversalStrategy.cs
@@ -9,7 +9,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Strategy #80: Pivot Point Reversal strategy.
+	/// Pivot Point Reversal strategy.
 	/// The strategy calculates daily pivot points and their support/resistance levels,
 	/// and enters positions when price bounces off these levels with confirmation.
 	/// </summary>

--- a/API/0080_Pivot_Point_Reversal/pivot_point_strategy.py
+++ b/API/0080_Pivot_Point_Reversal/pivot_point_strategy.py
@@ -18,7 +18,7 @@ from StockSharp.Algo.Strategies import Strategy
 
 class pivot_point_reversal_strategy(Strategy):
     """
-    Strategy #80: Pivot Point Reversal strategy.
+    Pivot Point Reversal strategy.
     The strategy calculates daily pivot points and their support/resistance levels,
     and enters positions when price bounces off these levels with confirmation.
     

--- a/API/0269_CCI_Slope_Breakout/CciSlopeBreakoutStrategy.cs
+++ b/API/0269_CCI_Slope_Breakout/CciSlopeBreakoutStrategy.cs
@@ -9,7 +9,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// CCI Slope Breakout Strategy (Strategy #269)
+	/// CCI Slope Breakout Strategy
 	/// </summary>
 	public class CciSlopeBreakoutStrategy : Strategy
 	{

--- a/API/0269_CCI_Slope_Breakout/cci_slope_breakout_strategy.py
+++ b/API/0269_CCI_Slope_Breakout/cci_slope_breakout_strategy.py
@@ -9,7 +9,7 @@ from StockSharp.Algo.Indicators import CommodityChannelIndex, LinearRegression, 
 from StockSharp.Algo.Strategies import Strategy
 
 class cci_slope_breakout_strategy(Strategy):
-    """CCI Slope Breakout Strategy (Strategy #269)"""
+    """CCI Slope Breakout Strategy"""
 
     def __init__(self):
         super(cci_slope_breakout_strategy, self).__init__()

--- a/API/0270_Williams_R_Slope_Breakout/WilliamsRSlopeBreakoutStrategy.cs
+++ b/API/0270_Williams_R_Slope_Breakout/WilliamsRSlopeBreakoutStrategy.cs
@@ -9,7 +9,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Williams %R Slope Breakout Strategy (Strategy #270)
+	/// Williams %R Slope Breakout Strategy
 	/// </summary>
 	public class WilliamsRSlopeBreakoutStrategy : Strategy
 	{

--- a/API/0270_Williams_R_Slope_Breakout/williams_r_slope_breakout_strategy.py
+++ b/API/0270_Williams_R_Slope_Breakout/williams_r_slope_breakout_strategy.py
@@ -11,7 +11,7 @@ from collections import deque
 
 
 class williams_r_slope_breakout_strategy(Strategy):
-    """Williams %R Slope Breakout Strategy (Strategy #270)"""
+    """Williams %R Slope Breakout Strategy"""
 
     def __init__(self):
         super(williams_r_slope_breakout_strategy, self).__init__()

--- a/API/0271_MACD_Slope_Breakout/MacdSlopeBreakoutStrategy.cs
+++ b/API/0271_MACD_Slope_Breakout/MacdSlopeBreakoutStrategy.cs
@@ -9,7 +9,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// MACD Slope Breakout Strategy (Strategy #271)
+	/// MACD Slope Breakout Strategy
 	/// </summary>
 	public class MacdSlopeBreakoutStrategy : Strategy
 	{

--- a/API/0271_MACD_Slope_Breakout/macd_slope_breakout_strategy.py
+++ b/API/0271_MACD_Slope_Breakout/macd_slope_breakout_strategy.py
@@ -12,7 +12,7 @@ from StockSharp.Algo.Strategies import Strategy
 
 class macd_slope_breakout_strategy(Strategy):
     """
-    MACD Slope Breakout Strategy (Strategy #271)
+    MACD Slope Breakout Strategy
     """
 
     def __init__(self):

--- a/API/0272_ADX_Slope_Breakout/AdxSlopeBreakoutStrategy.cs
+++ b/API/0272_ADX_Slope_Breakout/AdxSlopeBreakoutStrategy.cs
@@ -9,7 +9,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// ADX Slope Breakout Strategy (Strategy #272)
+	/// ADX Slope Breakout Strategy
 	/// </summary>
 	public class AdxSlopeBreakoutStrategy : Strategy
 	{

--- a/API/0272_ADX_Slope_Breakout/adx_slope_breakout_strategy.py
+++ b/API/0272_ADX_Slope_Breakout/adx_slope_breakout_strategy.py
@@ -12,7 +12,7 @@ from StockSharp.Algo.Strategies import Strategy
 
 class adx_slope_breakout_strategy(Strategy):
     """
-    ADX Slope Breakout Strategy (Strategy #272)
+    ADX Slope Breakout Strategy
 
     See more examples: https://github.com/StockSharp/AlgoTrading
     """

--- a/API/0273_ATR_Slope_Breakout/AtrSlopeBreakoutStrategy.cs
+++ b/API/0273_ATR_Slope_Breakout/AtrSlopeBreakoutStrategy.cs
@@ -9,7 +9,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// ATR Slope Breakout Strategy (Strategy #273)
+	/// ATR Slope Breakout Strategy
 	/// </summary>
 	public class AtrSlopeBreakoutStrategy : Strategy
 	{

--- a/API/0273_ATR_Slope_Breakout/atr_slope_breakout_strategy.py
+++ b/API/0273_ATR_Slope_Breakout/atr_slope_breakout_strategy.py
@@ -10,7 +10,7 @@ from StockSharp.Algo.Strategies import Strategy
 
 class atr_slope_breakout_strategy(Strategy):
     """
-    ATR Slope Breakout Strategy (Strategy #273)
+    ATR Slope Breakout Strategy
     """
 
     def __init__(self):

--- a/API/0274_Volume_Slope_Breakout/VolumeSlopeBreakoutStrategy.cs
+++ b/API/0274_Volume_Slope_Breakout/VolumeSlopeBreakoutStrategy.cs
@@ -9,7 +9,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Volume Slope Breakout Strategy (Strategy #274)
+	/// Volume Slope Breakout Strategy
 	/// </summary>
 	public class VolumeSlopeBreakoutStrategy : Strategy
 	{

--- a/API/0274_Volume_Slope_Breakout/volume_slope_breakout_strategy.py
+++ b/API/0274_Volume_Slope_Breakout/volume_slope_breakout_strategy.py
@@ -9,7 +9,7 @@ from StockSharp.Algo.Indicators import VolumeIndicator, SimpleMovingAverage, Exp
 from StockSharp.Algo.Strategies import Strategy
 
 class volume_slope_breakout_strategy(Strategy):
-    """Volume Slope Breakout Strategy (Strategy #274)"""
+    """Volume Slope Breakout Strategy"""
 
     def __init__(self):
         super(volume_slope_breakout_strategy, self).__init__()


### PR DESCRIPTION
## Summary
- remove references to specific strategy numbers in comments for strategy scripts
- restore original tab indentation in C# comments

## Testing
- `pytest -q`
- `dotnet test -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877a25e19f08323acc910705737d5fb