### PR TITLE
Remove strategy number references in source files

### DIFF
--- a/API/0151_Ichimoku_Volume/IchimokuVolumeStrategy.cs
+++ b/API/0151_Ichimoku_Volume/IchimokuVolumeStrategy.cs
@@ -11,7 +11,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Implementation of strategy #151 - Ichimoku + Volume.
+	/// Implementation of strategy - Ichimoku + Volume.
 	/// Buy when price is above Kumo cloud, Tenkan-sen is above Kijun-sen, and volume is above average.
 	/// Sell when price is below Kumo cloud, Tenkan-sen is below Kijun-sen, and volume is above average.
 	/// </summary>

--- a/API/0151_Ichimoku_Volume/README.md
+++ b/API/0151_Ichimoku_Volume/README.md
@@ -1,7 +1,7 @@
 # Ichimoku Volume Strategy
 [Русский](README_ru.md) | [中文](README_cn.md)
  
-Implementation of strategy #151 - Ichimoku + Volume. Buy when price is above Kumo cloud, Tenkan-sen is above Kijun-sen, and volume is above average. Sell when price is below Kumo cloud, Tenkan-sen is below Kijun-sen, and volume is above average.
+Implementation of strategy - Ichimoku + Volume. Buy when price is above Kumo cloud, Tenkan-sen is above Kijun-sen, and volume is above average. Sell when price is below Kumo cloud, Tenkan-sen is below Kijun-sen, and volume is above average.
 
 Ichimoku components define the directional bias while surging volume confirms interest. Trades open when price aligns with the cloud and volume picks up.
 

--- a/API/0151_Ichimoku_Volume/ichimoku_volume_strategy.py
+++ b/API/0151_Ichimoku_Volume/ichimoku_volume_strategy.py
@@ -10,7 +10,7 @@ from StockSharp.Algo.Strategies import Strategy
 
 class ichimoku_volume_strategy(Strategy):
     """
-    Implementation of strategy #151 - Ichimoku + Volume.
+    Implementation of strategy - Ichimoku + Volume.
     Buy when price is above Kumo cloud, Tenkan-sen is above Kijun-sen, and volume is above average.
     Sell when price is below Kumo cloud, Tenkan-sen is below Kijun-sen, and volume is above average.
 

--- a/API/0152_Supertrend_RSI/README.md
+++ b/API/0152_Supertrend_RSI/README.md
@@ -1,7 +1,7 @@
 # Supertrend Rsi Strategy
 [Русский](README_ru.md) | [中文](README_cn.md)
  
-Implementation of strategy #152 - Supertrend + RSI. Buy when price is above Supertrend and RSI is below 30 (oversold). Sell when price is below Supertrend and RSI is above 70 (overbought).
+Implementation of strategy - Supertrend + RSI. Buy when price is above Supertrend and RSI is below 30 (oversold). Sell when price is below Supertrend and RSI is above 70 (overbought).
 
 The Supertrend indicator shows the current trend, and RSI spots when price is stretched. Orders follow the Supertrend direction once RSI reaches an extreme.
 

--- a/API/0152_Supertrend_RSI/SupertrendRsiStrategy.cs
+++ b/API/0152_Supertrend_RSI/SupertrendRsiStrategy.cs
@@ -11,7 +11,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Implementation of strategy #152 - Supertrend + RSI.
+	/// Implementation of strategy - Supertrend + RSI.
 	/// Buy when price is above Supertrend and RSI is below 30 (oversold).
 	/// Sell when price is below Supertrend and RSI is above 70 (overbought).
 	/// </summary>

--- a/API/0152_Supertrend_RSI/supertrend_rsi_strategy.py
+++ b/API/0152_Supertrend_RSI/supertrend_rsi_strategy.py
@@ -12,7 +12,7 @@ from StockSharp.Algo.Strategies import Strategy
 
 class supertrend_rsi_strategy(Strategy):
     """
-    Implementation of strategy #152 - Supertrend + RSI.
+    Implementation of strategy - Supertrend + RSI.
     Buy when price is above Supertrend and RSI is below 30 (oversold).
     Sell when price is below Supertrend and RSI is above 70 (overbought).
     """

--- a/API/0157_Keltner_Volume/KeltnerVolumeStrategy.cs
+++ b/API/0157_Keltner_Volume/KeltnerVolumeStrategy.cs
@@ -11,7 +11,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Implementation of strategy #157 - Keltner Channels + Volume.
+	/// Implementation of strategy - Keltner Channels + Volume.
 	/// Buy when price breaks above upper Keltner Channel with above average volume.
 	/// Sell when price breaks below lower Keltner Channel with above average volume.
 	/// </summary>

--- a/API/0157_Keltner_Volume/README.md
+++ b/API/0157_Keltner_Volume/README.md
@@ -1,7 +1,7 @@
 # Keltner Volume Strategy
 [Русский](README_ru.md) | [中文](README_cn.md)
  
-Implementation of strategy #157 - Keltner Channels + Volume. Buy when price breaks above upper Keltner Channel with above average volume. Sell when price breaks below lower Keltner Channel with above average volume.
+Implementation of strategy - Keltner Channels + Volume. Buy when price breaks above upper Keltner Channel with above average volume. Sell when price breaks below lower Keltner Channel with above average volume.
 
 Keltner Channel boundaries define potential reversals, and increased volume signals conviction. The system trades when price touches a band with volume expanding.
 

--- a/API/0157_Keltner_Volume/keltner_volume_strategy.py
+++ b/API/0157_Keltner_Volume/keltner_volume_strategy.py
@@ -15,7 +15,7 @@ from StockSharp.Algo.Strategies import Strategy
 
 class keltner_volume_strategy(Strategy):
     """
-    Implementation of strategy #157 - Keltner Channels + Volume.
+    Implementation of strategy - Keltner Channels + Volume.
     Buy when price breaks above upper Keltner Channel with above average volume.
     Sell when price breaks below lower Keltner Channel with above average volume.
 

--- a/API/0158_Parabolic_SAR_Stochastic/ParabolicSarStochasticStrategy.cs
+++ b/API/0158_Parabolic_SAR_Stochastic/ParabolicSarStochasticStrategy.cs
@@ -11,7 +11,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Implementation of strategy #158 - Parabolic SAR + Stochastic.
+	/// Implementation of strategy - Parabolic SAR + Stochastic.
 	/// Buy when price is above SAR and Stochastic %K is below 20 (oversold).
 	/// Sell when price is below SAR and Stochastic %K is above 80 (overbought).
 	/// </summary>

--- a/API/0158_Parabolic_SAR_Stochastic/README.md
+++ b/API/0158_Parabolic_SAR_Stochastic/README.md
@@ -1,7 +1,7 @@
 # Parabolic Sar Stochastic Strategy
 [Русский](README_ru.md) | [中文](README_cn.md)
  
-Implementation of strategy #158 - Parabolic SAR + Stochastic. Buy when price is above SAR and Stochastic %K is below 20 (oversold). Sell when price is below SAR and Stochastic %K is above 80 (overbought).
+Implementation of strategy - Parabolic SAR + Stochastic. Buy when price is above SAR and Stochastic %K is below 20 (oversold). Sell when price is below SAR and Stochastic %K is above 80 (overbought).
 
 Parabolic SAR supplies the trend and Stochastic refines entry on pullbacks. Signals flip when SAR changes side.
 

--- a/API/0158_Parabolic_SAR_Stochastic/parabolic_sar_stochastic_strategy.py
+++ b/API/0158_Parabolic_SAR_Stochastic/parabolic_sar_stochastic_strategy.py
@@ -13,7 +13,7 @@ from StockSharp.Algo.Strategies import Strategy
 
 class parabolic_sar_stochastic_strategy(Strategy):
     """
-    Implementation of strategy #158 - Parabolic SAR + Stochastic.
+    Implementation of strategy - Parabolic SAR + Stochastic.
     Buy when price is above SAR and Stochastic %K is below 20 (oversold).
     Sell when price is below SAR and Stochastic %K is above 80 (overbought).
 

--- a/API/0159_Hull_MA_RSI/HullMaRsiStrategy.cs
+++ b/API/0159_Hull_MA_RSI/HullMaRsiStrategy.cs
@@ -11,7 +11,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Implementation of strategy #159 - Hull Moving Average + RSI.
+	/// Implementation of strategy - Hull Moving Average + RSI.
 	/// Buy when HMA is rising and RSI is below 30 (oversold).
 	/// Sell when HMA is falling and RSI is above 70 (overbought).
 	/// </summary>

--- a/API/0159_Hull_MA_RSI/README.md
+++ b/API/0159_Hull_MA_RSI/README.md
@@ -1,7 +1,7 @@
 # Hull Ma Rsi Strategy
 [Русский](README_ru.md) | [中文](README_cn.md)
  
-Implementation of strategy #159 - Hull Moving Average + RSI. Buy when HMA is rising and RSI is below 30 (oversold). Sell when HMA is falling and RSI is above 70 (overbought).
+Implementation of strategy - Hull Moving Average + RSI. Buy when HMA is rising and RSI is below 30 (oversold). Sell when HMA is falling and RSI is above 70 (overbought).
 
 Hull MA provides a smoothed trend line and RSI highlights momentum divergences. Trades occur when RSI turns at extremes while price follows the Hull direction.
 

--- a/API/0159_Hull_MA_RSI/hull_ma_rsi_strategy.py
+++ b/API/0159_Hull_MA_RSI/hull_ma_rsi_strategy.py
@@ -15,7 +15,7 @@ from StockSharp.Algo.Strategies import Strategy
 
 class hull_ma_rsi_strategy(Strategy):
     """
-    Implementation of strategy #159 - Hull Moving Average + RSI.
+    Implementation of strategy - Hull Moving Average + RSI.
     Buy when HMA is rising and RSI is below 30 (oversold).
     Sell when HMA is falling and RSI is above 70 (overbought).
 

--- a/API/0160_ADX_Volume/AdxVolumeStrategy.cs
+++ b/API/0160_ADX_Volume/AdxVolumeStrategy.cs
@@ -11,7 +11,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Implementation of strategy #160 - ADX + Volume.
+	/// Implementation of strategy - ADX + Volume.
 	/// Enter trades when ADX is above threshold with above average volume.
 	/// Direction determined by DI+ and DI- comparison.
 	/// </summary>

--- a/API/0160_ADX_Volume/README.md
+++ b/API/0160_ADX_Volume/README.md
@@ -1,7 +1,7 @@
 # Adx Volume Strategy
 [Русский](README_ru.md) | [中文](README_cn.md)
  
-Implementation of strategy #160 - ADX + Volume. Enter trades when ADX is above threshold with above average volume. Direction determined by DI+ and DI- comparison.
+Implementation of strategy - ADX + Volume. Enter trades when ADX is above threshold with above average volume. Direction determined by DI+ and DI- comparison.
 
 High ADX denotes a strong trend and volume spikes confirm commitment. Entries are made when both indicators show strength together.
 

--- a/API/0160_ADX_Volume/adx_volume_strategy.py
+++ b/API/0160_ADX_Volume/adx_volume_strategy.py
@@ -10,7 +10,7 @@ from StockSharp.Algo.Strategies import Strategy
 
 class adx_volume_strategy(Strategy):
     """
-    Implementation of strategy #160 - ADX + Volume.
+    Implementation of strategy - ADX + Volume.
     Enter trades when ADX is above threshold with above average volume.
     Direction determined by DI+ and DI- comparison.
     """

--- a/API/0161_MACD_CCI/MacdCciStrategy.cs
+++ b/API/0161_MACD_CCI/MacdCciStrategy.cs
@@ -11,7 +11,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Implementation of strategy #161 - MACD + CCI.
+	/// Implementation of strategy - MACD + CCI.
 	/// Buy when MACD is above Signal line and CCI is below -100 (oversold).
 	/// Sell when MACD is below Signal line and CCI is above 100 (overbought).
 	/// </summary>

--- a/API/0161_MACD_CCI/README.md
+++ b/API/0161_MACD_CCI/README.md
@@ -1,7 +1,7 @@
 # Macd Cci Strategy
 [Русский](README_ru.md) | [中文](README_cn.md)
  
-Implementation of strategy #161 - MACD + CCI. Buy when MACD is above Signal line and CCI is below -100 (oversold). Sell when MACD is below Signal line and CCI is above 100 (overbought).
+Implementation of strategy - MACD + CCI. Buy when MACD is above Signal line and CCI is below -100 (oversold). Sell when MACD is below Signal line and CCI is above 100 (overbought).
 
 MACD swings highlight momentum shifts; CCI helps time pullback entries in that direction. Both long and short trades are possible.
 

--- a/API/0161_MACD_CCI/macd_cci_strategy.py
+++ b/API/0161_MACD_CCI/macd_cci_strategy.py
@@ -15,7 +15,7 @@ from StockSharp.Algo.Strategies import Strategy
 
 class macd_cci_strategy(Strategy):
     """
-    Implementation of strategy #161 - MACD + CCI.
+    Implementation of strategy - MACD + CCI.
     Buy when MACD is above Signal line and CCI is below -100 (oversold).
     Sell when MACD is below Signal line and CCI is above 100 (overbought).
 

--- a/API/0162_Bollinger_CCI/BollingerCciStrategy.cs
+++ b/API/0162_Bollinger_CCI/BollingerCciStrategy.cs
@@ -11,7 +11,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Implementation of strategy #162 - Bollinger Bands + CCI.
+	/// Implementation of strategy - Bollinger Bands + CCI.
 	/// Buy when price is below lower Bollinger Band and CCI is below -100 (oversold).
 	/// Sell when price is above upper Bollinger Band and CCI is above 100 (overbought).
 	/// </summary>

--- a/API/0162_Bollinger_CCI/README.md
+++ b/API/0162_Bollinger_CCI/README.md
@@ -1,7 +1,7 @@
 # Bollinger Cci Strategy
 [Русский](README_ru.md) | [中文](README_cn.md)
  
-Implementation of strategy #162 - Bollinger Bands + CCI. Buy when price is below lower Bollinger Band and CCI is below -100 (oversold). Sell when price is above upper Bollinger Band and CCI is above 100 (overbought).
+Implementation of strategy - Bollinger Bands + CCI. Buy when price is below lower Bollinger Band and CCI is below -100 (oversold). Sell when price is above upper Bollinger Band and CCI is above 100 (overbought).
 
 Bollinger bands map volatility limits, and CCI measures the distance from the mean. Breaks beyond a band with CCI confirmation trigger trades.
 

--- a/API/0162_Bollinger_CCI/bollinger_cci_strategy.py
+++ b/API/0162_Bollinger_CCI/bollinger_cci_strategy.py
@@ -10,7 +10,7 @@ from StockSharp.Algo.Strategies import Strategy
 
 class bollinger_cci_strategy(Strategy):
     """
-    Implementation of strategy #162 - Bollinger Bands + CCI.
+    Implementation of strategy - Bollinger Bands + CCI.
     Buy when price is below lower Bollinger Band and CCI is below -100 (oversold).
     Sell when price is above upper Bollinger Band and CCI is above 100 (overbought).
     """

--- a/API/0163_RSI_Williams_R/README.md
+++ b/API/0163_RSI_Williams_R/README.md
@@ -1,7 +1,7 @@
 # Rsi Williams R Strategy
 [Русский](README_ru.md) | [中文](README_cn.md)
  
-Implementation of strategy #163 - RSI + Williams %R. Buy when RSI is below 30 and Williams %R is below -80 (double oversold condition). Sell when RSI is above 70 and Williams %R is above -20 (double overbought condition).
+Implementation of strategy - RSI + Williams %R. Buy when RSI is below 30 and Williams %R is below -80 (double oversold condition). Sell when RSI is above 70 and Williams %R is above -20 (double overbought condition).
 
 RSI outlines the overall momentum, while Williams %R gives a quicker signal of reversal. Trades act on agreement between the two oscillators.
 

--- a/API/0163_RSI_Williams_R/RsiWilliamsRStrategy.cs
+++ b/API/0163_RSI_Williams_R/RsiWilliamsRStrategy.cs
@@ -11,7 +11,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Implementation of strategy #163 - RSI + Williams %R.
+	/// Implementation of strategy - RSI + Williams %R.
 	/// Buy when RSI is below 30 and Williams %R is below -80 (double oversold condition).
 	/// Sell when RSI is above 70 and Williams %R is above -20 (double overbought condition).
 	/// </summary>

--- a/API/0163_RSI_Williams_R/rsi_williams_r_strategy.py
+++ b/API/0163_RSI_Williams_R/rsi_williams_r_strategy.py
@@ -11,7 +11,7 @@ from StockSharp.Algo.Strategies import Strategy
 
 class rsi_williams_r_strategy(Strategy):
     """
-    Implementation of strategy #163 - RSI + Williams %R.
+    Implementation of strategy - RSI + Williams %R.
     Buy when RSI is below 30 and Williams %R is below -80 (double oversold condition).
     Sell when RSI is above 70 and Williams %R is above -20 (double overbought condition).
 

--- a/API/0164_MA_Williams_R/MaWilliamsRStrategy.cs
+++ b/API/0164_MA_Williams_R/MaWilliamsRStrategy.cs
@@ -11,7 +11,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Implementation of strategy #164 - MA + Williams %R.
+	/// Implementation of strategy - MA + Williams %R.
 	/// Buy when price is above MA and Williams %R is below -80 (oversold).
 	/// Sell when price is below MA and Williams %R is above -20 (overbought).
 	/// </summary>

--- a/API/0164_MA_Williams_R/README.md
+++ b/API/0164_MA_Williams_R/README.md
@@ -1,7 +1,7 @@
 # Ma Williams R Strategy
 [Русский](README_ru.md) | [中文](README_cn.md)
  
-Implementation of strategy #164 - MA + Williams %R. Buy when price is above MA and Williams %R is below -80 (oversold). Sell when price is below MA and Williams %R is above -20 (overbought).
+Implementation of strategy - MA + Williams %R. Buy when price is above MA and Williams %R is below -80 (oversold). Sell when price is below MA and Williams %R is above -20 (overbought).
 
 The moving average shows the prevailing trend direction. Williams %R looks for overbought or oversold points relative to that trend.
 

--- a/API/0164_MA_Williams_R/ma_williams_r_strategy.py
+++ b/API/0164_MA_Williams_R/ma_williams_r_strategy.py
@@ -21,7 +21,7 @@ class MovingAverageTypeEnum(Enum):
 
 class ma_williams_r_strategy(Strategy):
     """
-    Implementation of strategy #164 - MA + Williams %R.
+    Implementation of strategy - MA + Williams %R.
     Buy when price is above MA and Williams %R is below -80 (oversold).
     Sell when price is below MA and Williams %R is above -20 (overbought).
     """

--- a/API/0165_VWAP_CCI/README.md
+++ b/API/0165_VWAP_CCI/README.md
@@ -1,7 +1,7 @@
 # Vwap Cci Strategy
 [Русский](README_ru.md) | [中文](README_cn.md)
  
-Implementation of strategy #165 - VWAP + CCI. Buy when price is below VWAP and CCI is below -100 (oversold). Sell when price is above VWAP and CCI is above 100 (overbought).
+Implementation of strategy - VWAP + CCI. Buy when price is below VWAP and CCI is below -100 (oversold). Sell when price is above VWAP and CCI is above 100 (overbought).
 
 VWAP acts as a value benchmark, and CCI highlights momentum moves away from it. Entries favor strong CCI readings relative to VWAP.
 

--- a/API/0165_VWAP_CCI/VwapCciStrategy.cs
+++ b/API/0165_VWAP_CCI/VwapCciStrategy.cs
@@ -11,7 +11,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Implementation of strategy #165 - VWAP + CCI.
+	/// Implementation of strategy - VWAP + CCI.
 	/// Buy when price is below VWAP and CCI is below -100 (oversold).
 	/// Sell when price is above VWAP and CCI is above 100 (overbought).
 	/// </summary>

--- a/API/0165_VWAP_CCI/vwap_cci_strategy.py
+++ b/API/0165_VWAP_CCI/vwap_cci_strategy.py
@@ -10,7 +10,7 @@ from StockSharp.Algo.Strategies import Strategy
 
 class vwap_cci_strategy(Strategy):
     """
-    Implementation of strategy #165 - VWAP + CCI.
+    Implementation of strategy - VWAP + CCI.
     Buy when price is below VWAP and CCI is below -100 (oversold).
     Sell when price is above VWAP and CCI is above 100 (overbought).
     """


### PR DESCRIPTION
## Summary
- scrub strategy numbers from CS and PY strategy implementations

## Testing
- `dotnet test --no-build` *(fails: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877ad2c50988323a538a4abdb5b0b68