### PR TITLE
Update python strategies to use to_float helper

### DIFF
--- a/API/0038_BB_Width/bollinger_band_width_strategy.py
+++ b/API/0038_BB_Width/bollinger_band_width_strategy.py
@@ -16,6 +16,7 @@ from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import BollingerBands
 from StockSharp.Algo.Indicators import AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class bollinger_band_width_strategy(Strategy):
     """
@@ -152,7 +153,7 @@ class bollinger_band_width_strategy(Strategy):
         isPriceAboveMiddleBand = candle.ClosePrice > bollingerValue.MovingAverage
         
         # Calculate stop-loss amount based on ATR
-        stopLossAmount = atrValue.ToDecimal() * self.AtrMultiplier
+        stopLossAmount = to_float(atrValue) * self.AtrMultiplier
 
         if self.Position == 0:
             # No position - check for entry signals

--- a/API/0047_OBV_Breakout/obv_breakout_strategy.py
+++ b/API/0047_OBV_Breakout/obv_breakout_strategy.py
@@ -18,6 +18,7 @@ from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Indicators import Highest
 from StockSharp.Algo.Indicators import Lowest
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class obv_breakout_strategy(Strategy):
     """
@@ -141,18 +142,18 @@ class obv_breakout_strategy(Strategy):
             return
         
         # Process the OBV value through other indicators
-        obvMAValue = self._obvMA.Process(obvValue).ToDecimal()
-        obvVal = obvValue.ToDecimal()
+        obvMAValue = to_float(self._obvMA.Process(obvValue))
+        obvVal = to_float(obvValue)
         
         if not self._isFirstCandle:
             # Calculate highest and lowest OBV values
             if self._highest.IsFormed and self._highestOBV is not None:
-                highestValue = self._highest.Process(obvValue).ToDecimal()
+                highestValue = to_float(self._highest.Process(obvValue))
             else:
                 highestValue = Math.Max(self._highestOBV or obvVal, obvVal) if self._highestOBV is not None else obvVal
             
             if self._lowest.IsFormed and self._lowestOBV is not None:
-                lowestValue = self._lowest.Process(obvValue).ToDecimal()
+                lowestValue = to_float(self._lowest.Process(obvValue))
             else:
                 lowestValue = Math.Min(self._lowestOBV or obvVal, obvVal) if self._lowestOBV is not None else obvVal
             

--- a/API/0048_VWAP_Breakout/vwap_breakout_strategy.py
+++ b/API/0048_VWAP_Breakout/vwap_breakout_strategy.py
@@ -15,6 +15,7 @@ from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import VolumeWeightedMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class vwap_breakout_strategy(Strategy):
     """
@@ -102,7 +103,7 @@ class vwap_breakout_strategy(Strategy):
             return
 
         # Extract VWAP value from indicator result
-        vwapPrice = vwapValue.ToDecimal()
+        vwapPrice = to_float(vwapValue)
         
         # Skip the first candle, just initialize values
         if self._isFirstCandle:

--- a/API/0049_VWMA/vwma_strategy.py
+++ b/API/0049_VWMA/vwma_strategy.py
@@ -15,6 +15,7 @@ from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import VolumeWeightedMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class vwma_strategy(Strategy):
     """
@@ -114,7 +115,7 @@ class vwma_strategy(Strategy):
             return
 
         # Extract VWMA value from indicator result
-        vwmaPrice = vwmaValue.ToDecimal()
+        vwmaPrice = to_float(vwmaValue)
         
         # Skip the first candle, just initialize values
         if self._isFirstCandle:

--- a/API/0053_Volume_MA_Cross/volume_ma_cross_strategy.py
+++ b/API/0053_Volume_MA_Cross/volume_ma_cross_strategy.py
@@ -15,6 +15,7 @@ from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class volume_ma_cross_strategy(Strategy):
     """
@@ -130,8 +131,8 @@ class volume_ma_cross_strategy(Strategy):
             return
 
         # Process volume through MAs
-        fastMAValue = self._fastVolumeMA.Process(candle.TotalVolume, candle.ServerTime, True).ToDecimal()
-        slowMAValue = self._slowVolumeMA.Process(candle.TotalVolume, candle.ServerTime, True).ToDecimal()
+        fastMAValue = to_float(self._fastVolumeMA.Process(candle.TotalVolume, candle.ServerTime, True))
+        slowMAValue = to_float(self._slowVolumeMA.Process(candle.TotalVolume, candle.ServerTime, True))
 
         # Check if strategy is ready to trade
         if not self.IsFormedAndOnlineAndAllowTrading():

--- a/API/0055_Volume_Surge/volume_surge_strategy.py
+++ b/API/0055_Volume_Surge/volume_surge_strategy.py
@@ -15,6 +15,7 @@ from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class volume_surge_strategy(Strategy):
     """
@@ -117,8 +118,8 @@ class volume_surge_strategy(Strategy):
         :param candle: The candle message.
         :param maValue: The Moving Average value.
         """
-        volumeMAValue = self._volumeMA.Process(candle.TotalVolume, candle.ServerTime, 
-                                              candle.State == CandleStates.Finished).ToDecimal()
+        volumeMAValue = to_float(self._volumeMA.Process(candle.TotalVolume, candle.ServerTime, 
+                                              candle.State == CandleStates.Finished))
 
         # Check if strategy is ready to trade
         if not self.IsFormedAndOnlineAndAllowTrading():

--- a/API/0056_Double_Bottom/double_bottom_strategy.py
+++ b/API/0056_Double_Bottom/double_bottom_strategy.py
@@ -15,6 +15,7 @@ from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import Lowest
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class double_bottom_strategy(Strategy):
     """
@@ -135,7 +136,7 @@ class double_bottom_strategy(Strategy):
             return
 
         # Process the candle with the Lowest indicator
-        lowestValue = self._lowestIndicator.Process(candle).ToDecimal()
+        lowestValue = to_float(self._lowestIndicator.Process(candle))
 
         # If strategy is not ready yet, return
         if not self.IsFormedAndOnlineAndAllowTrading():

--- a/API/0057_Double_Top/double_top_strategy.py
+++ b/API/0057_Double_Top/double_top_strategy.py
@@ -15,6 +15,7 @@ from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import Highest
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class double_top_strategy(Strategy):
     """
@@ -135,7 +136,7 @@ class double_top_strategy(Strategy):
             return
 
         # Process the candle with the Highest indicator
-        highestValue = self._highestIndicator.Process(candle).ToDecimal()
+        highestValue = to_float(self._highestIndicator.Process(candle))
 
         # If strategy is not ready yet, return
         if not self.IsFormedAndOnlineAndAllowTrading():

--- a/API/0083_ADX_Weakening/adx_weakening_strategy.py
+++ b/API/0083_ADX_Weakening/adx_weakening_strategy.py
@@ -14,6 +14,7 @@ from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Indicators import AverageDirectionalIndex
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class adx_weakening_strategy(Strategy):
     """
@@ -137,7 +138,7 @@ class adx_weakening_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        ma = maValue.ToDecimal()
+        ma = to_float(maValue)
 
         adxTyped = adxValue
         if not hasattr(adxTyped, 'MovingAverage') or adxTyped.MovingAverage is None:

--- a/API/0084_ATR_Exhaustion/atr_exhaustion_strategy.py
+++ b/API/0084_ATR_Exhaustion/atr_exhaustion_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class atr_exhaustion_strategy(Strategy):
     """
@@ -150,7 +151,7 @@ class atr_exhaustion_strategy(Strategy):
             return
 
         # Update ATR average
-        atr_avg_value = self._atr_avg.Process(atr_value, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal()
+        atr_avg_value = to_float(self._atr_avg.Process(atr_value, candle.ServerTime, candle.State == CandleStates.Finished))
 
         # Determine candle direction
         is_bullish_candle = candle.ClosePrice > candle.OpenPrice

--- a/API/0115_Volume_Climax_Reversal/volume_climax_reversal_strategy.py
+++ b/API/0115_Volume_Climax_Reversal/volume_climax_reversal_strategy.py
@@ -10,6 +10,7 @@ from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Indicators import AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 
 class volume_climax_reversal_strategy(Strategy):
@@ -132,7 +133,7 @@ class volume_climax_reversal_strategy(Strategy):
             return
 
         # Process indicators
-        volumeAverageValue = self._volumeAverage.Process(candle.TotalVolume, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal()
+        volumeAverageValue = to_float(self._volumeAverage.Process(candle.TotalVolume, candle.ServerTime, candle.State == CandleStates.Finished))
 
         # Check if strategy is ready to trade
         if not self.IsFormedAndOnlineAndAllowTrading():

--- a/API/0131_MACD_RSI/macd_rsi_strategy.py
+++ b/API/0131_MACD_RSI/macd_rsi_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import MovingAverageConvergenceDivergenceSignal, RelativeStrengthIndex
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 
 class macd_rsi_strategy(Strategy):
@@ -189,7 +190,7 @@ class macd_rsi_strategy(Strategy):
 
         macd_dec = macd_value.Macd
         signal_value = macd_value.Signal
-        rsi_dec = rsi_value.ToDecimal()
+        rsi_dec = to_float(rsi_value)
 
         # Trading logic: Combine MACD trend with RSI extreme values
 

--- a/API/0132_Bollinger_Stochastic/bollinger_stochastic_strategy.py
+++ b/API/0132_Bollinger_Stochastic/bollinger_stochastic_strategy.py
@@ -8,6 +8,7 @@ from System import Math
 from StockSharp.Messages import DataType, CandleStates, Sides
 from StockSharp.Algo.Indicators import BollingerBands, StochasticOscillator, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class bollinger_stochastic_strategy(Strategy):
     """
@@ -190,7 +191,7 @@ class bollinger_stochastic_strategy(Strategy):
         k = stochastic_typed.K
         d = stochastic_typed.D
 
-        atr_val = atr_value.ToDecimal()
+        atr_val = to_float(atr_value)
 
         # Calculate stop loss distance based on ATR
         stop_loss_distance = atr_val * self.atr_multiplier

--- a/API/0133_MA_Volume/ma_volume_strategy.py
+++ b/API/0133_MA_Volume/ma_volume_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 
 class ma_volume_strategy(Strategy):
@@ -136,14 +137,14 @@ class ma_volume_strategy(Strategy):
             return
 
         # Process indicators
-        sma_value = self._price_sma.Process(candle).ToDecimal()
+        sma_value = to_float(self._price_sma.Process(candle))
 
         # Handle volume
-        volume_sma_value = self._volume_sma.Process(
+        volume_sma_value = to_float(self._volume_sma.Process(
             candle.TotalVolume,
             candle.ServerTime,
             candle.State == CandleStates.Finished
-        ).ToDecimal()
+        ))
 
         if not self.IsFormedAndOnlineAndAllowTrading() or not self._price_sma.IsFormed or not self._volume_sma.IsFormed:
             return

--- a/API/0134_ADX_MACD/adx_macd_strategy.py
+++ b/API/0134_ADX_MACD/adx_macd_strategy.py
@@ -15,6 +15,7 @@ from StockSharp.Algo.Indicators import AverageDirectionalIndex
 from StockSharp.Algo.Indicators import MovingAverageConvergenceDivergenceSignal
 from StockSharp.Algo.Indicators import AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class adx_macd_strategy(Strategy):
     """
@@ -184,7 +185,7 @@ class adx_macd_strategy(Strategy):
         except AttributeError:
             return
 
-        atrIndicatorValue = atrValue.ToDecimal()
+        atrIndicatorValue = to_float(atrValue)
 
         # ADX trend strength check
         strongTrend = adxIndicatorValue > self.AdxThreshold

--- a/API/0137_Bollinger_RSI/bollinger_rsi_strategy.py
+++ b/API/0137_Bollinger_RSI/bollinger_rsi_strategy.py
@@ -8,6 +8,7 @@ from System import Math
 from StockSharp.Messages import DataType, UnitTypes, Unit, ICandleMessage, CandleStates
 from StockSharp.Algo.Indicators import BollingerBands, RelativeStrengthIndex
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class bollinger_rsi_strategy(Strategy):
     """
@@ -169,7 +170,7 @@ class bollinger_rsi_strategy(Strategy):
         upperBand = bollingerTyped.UpBand
         lowerBand = bollingerTyped.LowBand
         middleBand = bollingerTyped.MovingAverage
-        rsiTyped = rsiValue.ToDecimal()
+        rsiTyped = to_float(rsiValue)
 
         # Long entry: price below lower Bollinger Band and RSI oversold
         if candle.ClosePrice < lowerBand and rsiTyped < self.RsiOversold and self.Position <= 0:

--- a/API/0139_ATR_MACD/atr_macd_strategy.py
+++ b/API/0139_ATR_MACD/atr_macd_strategy.py
@@ -8,6 +8,7 @@ from System import Math
 from StockSharp.Messages import DataType, UnitTypes, Unit, CandleStates
 from StockSharp.Algo.Indicators import AverageTrueRange, SimpleMovingAverage, MovingAverageConvergenceDivergenceSignal
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class atr_macd_strategy(Strategy):
     """
@@ -203,13 +204,13 @@ class atr_macd_strategy(Strategy):
             return
 
         # Process ATR through averaging indicator
-        current_atr = atr_value.ToDecimal()
+        current_atr = to_float(atr_value)
         avg_value = self._atr_avg.Process(atr_value)
         if not avg_value.IsFinal:
             return
 
         # Store current ATR average value
-        current_atr_avg = avg_value.ToDecimal()
+        current_atr_avg = to_float(avg_value)
         self._prev_atr_avg = current_atr_avg
 
         # Skip unfinished candles

--- a/API/0147_Bollinger_Volume/bollinger_volume_strategy.py
+++ b/API/0147_Bollinger_Volume/bollinger_volume_strategy.py
@@ -17,6 +17,7 @@ from StockSharp.Algo.Indicators import BollingerBands
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Indicators import AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class bollinger_volume_strategy(Strategy):
     """\
@@ -154,7 +155,7 @@ class bollinger_volume_strategy(Strategy):
     def ProcessIndicators(self, candle, volumeAvgValue, bollingerValue, atrValue):
         """Process Bollinger Bands and ATR indicator values."""
         if volumeAvgValue.IsFinal:
-            self._avgVolume = volumeAvgValue.ToDecimal()
+            self._avgVolume = to_float(volumeAvgValue)
 
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:
@@ -169,7 +170,7 @@ class bollinger_volume_strategy(Strategy):
         upperBand = bb.UpBand
         lowerBand = bb.LowBand
 
-        atr = atrValue.ToDecimal()
+        atr = to_float(atrValue)
 
         # Check volume confirmation
         isVolumeHighEnough = candle.TotalVolume > self._avgVolume * self.VolumeMultiplier

--- a/API/0150_VWAP_Stochastic/vwap_stochastic_strategy.py
+++ b/API/0150_VWAP_Stochastic/vwap_stochastic_strategy.py
@@ -9,6 +9,7 @@ from System import Math
 from StockSharp.Messages import UnitTypes, Unit, DataType, CandleStates
 from StockSharp.Algo.Indicators import VolumeWeightedMovingAverage, StochasticOscillator
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class vwap_stochastic_strategy(Strategy):
     """
@@ -175,7 +176,7 @@ class vwap_stochastic_strategy(Strategy):
         stochTyped = stochValue
         kValue = stochTyped.K
 
-        vwapDec = vwapValue.ToDecimal()
+        vwapDec = to_float(vwapValue)
 
         # Trading logic
         if candle.ClosePrice < vwapDec and kValue < self.OversoldLevel and self.Position <= 0:

--- a/API/0155_VWAP_Volume/vwap_volume_strategy.py
+++ b/API/0155_VWAP_Volume/vwap_volume_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, UnitTypes, Unit, CandleStates
 from StockSharp.Algo.Indicators import VolumeWeightedMovingAverage, SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class vwap_volume_strategy(Strategy):
     """
@@ -121,11 +122,11 @@ class vwap_volume_strategy(Strategy):
 
     def ProcessCandle(self, candle):
         # Process volume with indicator
-        volume_ma = self._volumeMA.Process(
+        volume_ma = to_float(self._volumeMA.Process(
             candle.TotalVolume,
             candle.ServerTime,
             candle.State == CandleStates.Finished
-        ).ToDecimal()
+        ))
 
         # Calculate VWAP manually for the current candle
         vwap = 0

--- a/API/0156_Donchian_RSI/donchian_rsi_strategy.py
+++ b/API/0156_Donchian_RSI/donchian_rsi_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import DonchianChannels, RSI
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 
 class donchian_rsi_strategy(Strategy):
@@ -179,7 +180,7 @@ class donchian_rsi_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        rsi_dec = rsi_value.ToDecimal() if hasattr(rsi_value, 'ToDecimal') else float(rsi_value)
+        rsi_dec = to_float(rsi_value) if hasattr(rsi_value, 'ToDecimal') else float(rsi_value)
 
         # Detect breakouts by comparing current price to previous Donchian bands
         upper_breakout = candle.ClosePrice > self._prev_upper_band

--- a/API/0158_Parabolic_SAR_Stochastic/parabolic_sar_stochastic_strategy.py
+++ b/API/0158_Parabolic_SAR_Stochastic/parabolic_sar_stochastic_strategy.py
@@ -10,6 +10,7 @@ from System.Drawing import Color
 from StockSharp.Messages import UnitTypes, Unit, DataType, ICandleMessage, CandleStates, Sides
 from StockSharp.Algo.Indicators import ParabolicSar, StochasticOscillator
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class parabolic_sar_stochastic_strategy(Strategy):
     """
@@ -180,7 +181,7 @@ class parabolic_sar_stochastic_strategy(Strategy):
         else:
             return
 
-        sarDec = sarValue.ToDecimal()
+        sarDec = to_float(sarValue)
 
         currentPrice = candle.ClosePrice
         priceAboveSar = currentPrice > sarDec

--- a/API/0161_MACD_CCI/macd_cci_strategy.py
+++ b/API/0161_MACD_CCI/macd_cci_strategy.py
@@ -12,6 +12,7 @@ from StockSharp.Messages import UnitTypes
 from StockSharp.Algo.Indicators import MovingAverageConvergenceDivergenceSignal
 from StockSharp.Algo.Indicators import CommodityChannelIndex
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class macd_cci_strategy(Strategy):
     """
@@ -183,7 +184,7 @@ class macd_cci_strategy(Strategy):
         # Determine if MACD is above or below signal line
         isMacdAboveSignal = macdLine > signalLine
 
-        cciDec = cciValue.ToDecimal()
+        cciDec = to_float(cciValue)
 
         self.LogInfo(
             "Candle: {0}, Close: {1}, MACD: {2}, Signal: {3}, MACD > Signal: {4}, CCI: {5}".format(

--- a/API/0172_Bollinger_Williams_R/bollinger_williams_r_strategy.py
+++ b/API/0172_Bollinger_Williams_R/bollinger_williams_r_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Sides
 from StockSharp.Algo.Indicators import BollingerBands, WilliamsR, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class bollinger_williams_r_strategy(Strategy):
     """
@@ -141,9 +142,9 @@ class bollinger_williams_r_strategy(Strategy):
         price = candle.ClosePrice
 
         # Stop-loss size based on ATR
-        stop_size = atr_value.ToDecimal() * self.AtrMultiplier
+        stop_size = to_float(atr_value) * self.AtrMultiplier
 
-        williams_value_dec = williams_r_value.ToDecimal()
+        williams_value_dec = to_float(williams_r_value)
 
         # Trading logic
         if price <= lower_band and williams_value_dec < -80 and self.Position <= 0:

--- a/API/0174_MACD_VWAP/macd_vwap_strategy.py
+++ b/API/0174_MACD_VWAP/macd_vwap_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, Unit, UnitTypes
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import MovingAverageConvergenceDivergenceSignal, VolumeWeightedMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class macd_vwap_strategy(Strategy):
     """
@@ -118,7 +119,7 @@ class macd_vwap_strategy(Strategy):
         macd_typed = macd_value
         macd_line = macd_typed.Macd
         signal_line = macd_typed.Signal
-        vwap = vwap_value.ToDecimal()
+        vwap = to_float(vwap_value)
 
         # Current price (close of the candle)
         price = candle.ClosePrice

--- a/API/0188_Parabolic_SAR_Volume/parabolic_sar_volume_strategy.py
+++ b/API/0188_Parabolic_SAR_Volume/parabolic_sar_volume_strategy.py
@@ -15,6 +15,7 @@ from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import ParabolicSar, VolumeIndicator, SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class parabolic_sar_volume_strategy(Strategy):
     """
@@ -140,7 +141,7 @@ class parabolic_sar_volume_strategy(Strategy):
             self.DrawOwnTrades(area)
 
     def ProcessIndicators(self, candle, sarValue, volumeValue):
-        self._currentAvgVolume = self._volumeAverage.Process(volumeValue, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal()
+        self._currentAvgVolume = to_float(self._volumeAverage.Process(volumeValue, candle.ServerTime, candle.State == CandleStates.Finished))
 
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0190_VWAP_ADX/vwap_adx_strategy.py
+++ b/API/0190_VWAP_ADX/vwap_adx_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import AverageDirectionalIndex, VolumeWeightedMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class vwap_adx_strategy(Strategy):
     """
@@ -101,7 +102,7 @@ class vwap_adx_strategy(Strategy):
         if candle.State != CandleStates.Finished:
             return
 
-        vwap = self._vwap.Process(candle).ToDecimal()
+        vwap = to_float(self._vwap.Process(candle))
 
         # Get current ADX value
         typed_adx = adx_value

--- a/API/0198_VWAP_MACD/vwap_macd_strategy.py
+++ b/API/0198_VWAP_MACD/vwap_macd_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import MovingAverageConvergenceDivergenceSignal, VolumeWeightedMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class vwap_macd_strategy(Strategy):
     """
@@ -129,7 +130,7 @@ class vwap_macd_strategy(Strategy):
             return
 
         # Get VWAP value (calculated per day)
-        vwap = self._vwap.Process(candle).ToDecimal()
+        vwap = to_float(self._vwap.Process(candle))
 
         macd_typed = macd_value
 

--- a/API/0209_Volume_Supertrend/volume_supertrend_strategy.py
+++ b/API/0209_Volume_Supertrend/volume_supertrend_strategy.py
@@ -8,6 +8,7 @@ from StockSharp.Messages import DataType, CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage, AverageTrueRange
 from StockSharp.Algo.Indicators import VolumeIndicator
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class volume_supertrend_strategy(Strategy):
     """Strategy based on Volume and Supertrend indicators (#209)"""
@@ -95,7 +96,7 @@ class volume_supertrend_strategy(Strategy):
         # Bind indicators to handle each candle
         def handle_candle(candle, atr_value):
             # Calculate volume average
-            volume_value = volume_ma.Process(candle.TotalVolume, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal()
+            volume_value = to_float(volume_ma.Process(candle.TotalVolume, candle.ServerTime, candle.State == CandleStates.Finished))
 
             # Calculate Supertrend
             if not atr.IsFormed:

--- a/API/0214_Bollinger_Supertrend/bollinger_supertrend_strategy.py
+++ b/API/0214_Bollinger_Supertrend/bollinger_supertrend_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates
 from StockSharp.Algo.Indicators import BollingerBands, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class bollinger_supertrend_strategy(Strategy):
     """
@@ -153,7 +154,7 @@ class bollinger_supertrend_strategy(Strategy):
         lower_band = bb.LowBand
 
         # Calculate Supertrend (simplified)
-        atr_val = atr_value.ToDecimal() * self.SupertrendMultiplier
+        atr_val = to_float(atr_value) * self.SupertrendMultiplier
         upper_band2 = (candle.HighPrice + candle.LowPrice) / 2 + atr_val
         lower_band2 = (candle.HighPrice + candle.LowPrice) / 2 - atr_val
 

--- a/API/0231_Volatility_Skew_Arbitrage/volatility_skew_arbitrage_strategy.py
+++ b/API/0231_Volatility_Skew_Arbitrage/volatility_skew_arbitrage_strategy.py
@@ -7,6 +7,7 @@ from System import Math
 from StockSharp.Messages import Level1Fields, Unit, UnitTypes
 from StockSharp.Algo.Indicators import StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 
 class volatility_skew_arbitrage_strategy(Strategy):
@@ -154,7 +155,7 @@ class volatility_skew_arbitrage_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        std_dev = std_dev_value.ToDecimal()
+        std_dev = to_float(std_dev_value)
 
         # Trading logic for volatility skew arbitrage
         if vol_skew > self._avg_vol_skew + self.threshold * std_dev and self.Position <= 0:

--- a/API/0232_Correlation_Breakout/correlation_breakout_strategy.py
+++ b/API/0232_Correlation_Breakout/correlation_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 from StockSharp.BusinessEntities import Security
 
 class correlation_breakout_strategy(Strategy):
@@ -206,7 +207,7 @@ class correlation_breakout_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        std_dev = float(std_dev_value.ToDecimal()) if hasattr(std_dev_value, 'ToDecimal') else float(std_dev_value)
+        std_dev = float(to_float(std_dev_value)) if hasattr(std_dev_value, 'ToDecimal') else float(std_dev_value)
 
         # Trading logic for correlation breakout
         if self._last_correlation < self._avg_correlation - self.Threshold * std_dev and self._get_position_value(self.Asset1) <= 0 and self._get_position_value(self.Asset2) >= 0:

--- a/API/0236_RSI_Mean_Reversion/rsi_mean_reversion_strategy.py
+++ b/API/0236_RSI_Mean_Reversion/rsi_mean_reversion_strategy.py
@@ -8,6 +8,7 @@ from System import Math
 from StockSharp.Messages import DataType, UnitTypes, Unit, CandleStates
 from StockSharp.Algo.Indicators import RelativeStrengthIndex, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class rsi_mean_reversion_strategy(Strategy):
     """
@@ -118,8 +119,8 @@ class rsi_mean_reversion_strategy(Strategy):
             return
 
         # Process RSI through average and standard deviation indicators
-        rsi_avg_value = self._rsi_average.Process(rsi_value, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal()
-        rsi_std_dev_value = self._rsi_std_dev.Process(rsi_value, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal()
+        rsi_avg_value = to_float(self._rsi_average.Process(rsi_value, candle.ServerTime, candle.State == CandleStates.Finished))
+        rsi_std_dev_value = to_float(self._rsi_std_dev.Process(rsi_value, candle.ServerTime, candle.State == CandleStates.Finished))
 
         # Store previous RSI value for changes detection
         current_rsi_value = rsi_value

--- a/API/0237_Stochastic_Mean_Reversion/stochastic_mean_reversion_strategy.py
+++ b/API/0237_Stochastic_Mean_Reversion/stochastic_mean_reversion_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import StochasticOscillator, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 
 class stochastic_mean_reversion_strategy(Strategy):
@@ -149,8 +150,8 @@ class stochastic_mean_reversion_strategy(Strategy):
             return
 
         # Process Stochastic %K through average and standard deviation indicators
-        stoch_avg_value = self._stoch_average.Process(k_value, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal()
-        stoch_stddev_value = self._stoch_stddev.Process(k_value, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal()
+        stoch_avg_value = to_float(self._stoch_average.Process(k_value, candle.ServerTime, candle.State == CandleStates.Finished))
+        stoch_stddev_value = to_float(self._stoch_stddev.Process(k_value, candle.ServerTime, candle.State == CandleStates.Finished))
 
         # Store previous Stochastic %K value for changes detection
         current_stoch_k_value = k_value

--- a/API/0238_CCI_Mean_Reversion/cci_mean_reversion_strategy.py
+++ b/API/0238_CCI_Mean_Reversion/cci_mean_reversion_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import CommodityChannelIndex
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class cci_mean_reversion_strategy(Strategy):
     """
@@ -146,7 +147,7 @@ class cci_mean_reversion_strategy(Strategy):
             return
 
         # Extract CCI value
-        current_cci = cci_value.ToDecimal()
+        current_cci = to_float(cci_value)
 
         # Update CCI statistics
         self.UpdateCciStatistics(current_cci)

--- a/API/0239_Williams_R_Mean_Reversion/williams_r_mean_reversion_strategy.py
+++ b/API/0239_Williams_R_Mean_Reversion/williams_r_mean_reversion_strategy.py
@@ -8,6 +8,7 @@ from System.Collections.Generic import Queue
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import WilliamsR
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class williams_r_mean_reversion_strategy(Strategy):
     """
@@ -142,7 +143,7 @@ class williams_r_mean_reversion_strategy(Strategy):
             return
 
         # Extract Williams %R value
-        current_williams_r = williams_r_value.ToDecimal()
+        current_williams_r = to_float(williams_r_value)
 
         # Update Williams %R statistics
         self.UpdateWilliamsRStatistics(current_williams_r)

--- a/API/0245_Momentum_Breakout/momentum_breakout_strategy.py
+++ b/API/0245_Momentum_Breakout/momentum_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import Momentum, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class momentum_breakout_strategy(Strategy):
     """
@@ -131,8 +132,8 @@ class momentum_breakout_strategy(Strategy):
         avg_val = self._momentum_average.Process(momentum_value, candle.ServerTime, candle.State == CandleStates.Finished)
         std_val = self._momentum_stddev.Process(momentum_value, candle.ServerTime, candle.State == CandleStates.Finished)
 
-        self._momentum_avg_value = avg_val.ToDecimal()
-        self._momentum_stddev_value = std_val.ToDecimal()
+        self._momentum_avg_value = to_float(avg_val)
+        self._momentum_stddev_value = to_float(std_val)
 
         # Check if strategy is ready for trading
         if not self.IsFormedAndOnlineAndAllowTrading() or not self._momentum_average.IsFormed or not self._momentum_stddev.IsFormed:

--- a/API/0247_RSI_Breakout/rsi_breakout_strategy.py
+++ b/API/0247_RSI_Breakout/rsi_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import RelativeStrengthIndex, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 
 class rsi_breakout_strategy(Strategy):
@@ -149,8 +150,8 @@ class rsi_breakout_strategy(Strategy):
         avg_value = self._rsiAverage.Process(rsi_value, candle.ServerTime, candle.State == CandleStates.Finished)
         std_dev_value = self._rsiStdDev.Process(rsi_value, candle.ServerTime, candle.State == CandleStates.Finished)
 
-        self._currentRsiAvg = avg_value.ToDecimal()
-        self._currentRsiStdDev = std_dev_value.ToDecimal()
+        self._currentRsiAvg = to_float(avg_value)
+        self._currentRsiStdDev = to_float(std_dev_value)
 
         # Check if strategy is ready for trading
         if not self.IsFormedAndOnlineAndAllowTrading() or not self._rsiAverage.IsFormed or not self._rsiStdDev.IsFormed:

--- a/API/0248_Stochastic_Breakout/stochastic_breakout_strategy.py
+++ b/API/0248_Stochastic_Breakout/stochastic_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import StochasticOscillator, SimpleMovingAverage, StandardDeviation, StochasticOscillatorValue
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class stochastic_breakout_strategy(Strategy):
     """
@@ -162,8 +163,8 @@ class stochastic_breakout_strategy(Strategy):
         stochK = stochTyped.K
 
         # Calculate average and standard deviation of stochastic
-        stochAvgValue = self._stochAverage.Process(stochK, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal()
-        tempStdDevValue = self._stochStdDev.Process(stochK, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal()
+        stochAvgValue = to_float(self._stochAverage.Process(stochK, candle.ServerTime, candle.State == CandleStates.Finished))
+        tempStdDevValue = to_float(self._stochStdDev.Process(stochK, candle.ServerTime, candle.State == CandleStates.Finished))
 
         # First values initialization - skip trading decision
         if self._prevStochValue == 0:

--- a/API/0250_Williams_R_Breakout/williams_r_breakout_strategy.py
+++ b/API/0250_Williams_R_Breakout/williams_r_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import WilliamsR, SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 
 class williams_r_breakout_strategy(Strategy):
@@ -139,11 +140,11 @@ class williams_r_breakout_strategy(Strategy):
             return
 
         # Get current Williams %R value
-        currentWilliamsR = williamsRValue.ToDecimal()
+        currentWilliamsR = to_float(williamsRValue)
 
         # Process Williams %R through average indicator
         williamsRAvgValue = self._williamsRAverage.Process(currentWilliamsR, candle.ServerTime, candle.State == CandleStates.Finished)
-        currentWilliamsRAvg = williamsRAvgValue.ToDecimal()
+        currentWilliamsRAvg = to_float(williamsRAvgValue)
 
         # For first values, just save and skip
         if self._prevWilliamsRValue == 0:

--- a/API/0251_MACD_Breakout/macd_breakout_strategy.py
+++ b/API/0251_MACD_Breakout/macd_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import MovingAverageConvergenceDivergenceSignal, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class macd_breakout_strategy(Strategy):
     """
@@ -182,8 +183,8 @@ class macd_breakout_strategy(Strategy):
         macd = float(macd_typed.Macd)
 
         # Process indicators for MACD histogram
-        macd_hist_sma_value = float(self._macd_hist_sma.Process(macd, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal())
-        macd_hist_stddev_value = float(self._macd_hist_stddev.Process(macd, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal())
+        macd_hist_sma_value = float(to_float(self._macd_hist_sma.Process(macd, candle.ServerTime, candle.State == CandleStates.Finished)))
+        macd_hist_stddev_value = float(to_float(self._macd_hist_stddev.Process(macd, candle.ServerTime, candle.State == CandleStates.Finished)))
 
         # Store previous values on first call
         if self._prev_macd_hist_value == 0 and self._prev_macd_hist_sma_value == 0:

--- a/API/0252_ADX_Breakout/adx_breakout_strategy.py
+++ b/API/0252_ADX_Breakout/adx_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import AverageDirectionalIndex, SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class adx_breakout_strategy(Strategy):
     """
@@ -145,7 +146,7 @@ class adx_breakout_strategy(Strategy):
 
         # Process ADX through average indicator
         adxAvgValue = self._adx_average.Process(currentAdx, candle.ServerTime, candle.State == CandleStates.Finished)
-        currentAdxAvg = float(adxAvgValue.ToDecimal())
+        currentAdxAvg = float(to_float(adxAvgValue))
 
         # For first values, just save and skip
         if self._prev_adx_value == 0:

--- a/API/0256_Bollinger_Band_Width_Breakout/bollinger_band_width_breakout_strategy.py
+++ b/API/0256_Bollinger_Band_Width_Breakout/bollinger_band_width_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates
 from StockSharp.Algo.Indicators import BollingerBands, SimpleMovingAverage, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 
 class bollinger_band_width_breakout_strategy(Strategy):
@@ -142,7 +143,7 @@ class bollinger_band_width_breakout_strategy(Strategy):
             return
 
         # Process candle through ATR
-        current_atr = atr_value.ToDecimal()
+        current_atr = to_float(atr_value)
 
         # Calculate Bollinger Band width
         bollinger_typed = bollinger_value
@@ -157,7 +158,7 @@ class bollinger_band_width_breakout_strategy(Strategy):
 
         # Process width through average
         width_avg_value = self._width_average.Process(last_width, candle.ServerTime, candle.State == CandleStates.Finished)
-        avg_width = width_avg_value.ToDecimal()
+        avg_width = to_float(width_avg_value)
 
         # Calculate width standard deviation (simplified approach)
         std_dev = Math.Abs(last_width - avg_width) * 1.5

--- a/API/0258_Donchian_Channel_Width_Breakout/donchian_width_breakout_strategy.py
+++ b/API/0258_Donchian_Channel_Width_Breakout/donchian_width_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import Highest, Lowest, SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class donchian_width_breakout_strategy(Strategy):
     """
@@ -144,15 +145,15 @@ class donchian_width_breakout_strategy(Strategy):
             return
 
         # Process candle through Highest and Lowest indicators
-        highest_value = self._highest.Process(candle).ToDecimal()
-        lowest_value = self._lowest.Process(candle).ToDecimal()
+        highest_value = to_float(self._highest.Process(candle))
+        lowest_value = to_float(self._lowest.Process(candle))
 
         # Calculate Donchian Channel width
         width = highest_value - lowest_value
 
         # Process width through average
         width_avg_value = self._width_average.Process(width, candle.ServerTime, candle.State == CandleStates.Finished)
-        avg_width = width_avg_value.ToDecimal()
+        avg_width = to_float(width_avg_value)
 
         # For first values, just save and skip
         if self._last_width == 0:

--- a/API/0259_Ichimoku_Cloud_Width_Breakout/ichimoku_width_breakout_strategy.py
+++ b/API/0259_Ichimoku_Cloud_Width_Breakout/ichimoku_width_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import Ichimoku, SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 
 class ichimoku_width_breakout_strategy(Strategy):
@@ -188,7 +189,7 @@ class ichimoku_width_breakout_strategy(Strategy):
 
         # Process width through average
         width_avg_value = self._width_average.Process(width, candle.ServerTime, candle.State == CandleStates.Finished)
-        avg_width = width_avg_value.ToDecimal()
+        avg_width = to_float(width_avg_value)
 
         # For first values, just save and skip
         if self._last_width == 0:

--- a/API/0273_ATR_Slope_Breakout/atr_slope_breakout_strategy.py
+++ b/API/0273_ATR_Slope_Breakout/atr_slope_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates
 from StockSharp.Algo.Indicators import AverageTrueRange, ExponentialMovingAverage, LinearRegression
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class atr_slope_breakout_strategy(Strategy):
     """
@@ -145,11 +146,11 @@ class atr_slope_breakout_strategy(Strategy):
             return
 
         # Get ATR value and track it for stop loss calculations
-        atr = atr_value.ToDecimal()
+        atr = to_float(atr_value)
         self._last_atr = atr
 
         # Process price for trend direction
-        ema_value = self._price_ema.Process(candle).ToDecimal()
+        ema_value = to_float(self._price_ema.Process(candle))
         price_above_ema = candle.ClosePrice > ema_value
 
         # Calculate ATR slope

--- a/API/0274_Volume_Slope_Breakout/volume_slope_breakout_strategy.py
+++ b/API/0274_Volume_Slope_Breakout/volume_slope_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import VolumeIndicator, SimpleMovingAverage, ExponentialMovingAverage, LinearRegression, LinearRegressionValue
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class volume_slope_breakout_strategy(Strategy):
     """Volume Slope Breakout Strategy"""
@@ -146,10 +147,10 @@ class volume_slope_breakout_strategy(Strategy):
             return
 
         # Process volume SMA
-        volumeSma = self._volumeSma.Process(volumeValue, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal()
+        volumeSma = to_float(self._volumeSma.Process(volumeValue, candle.ServerTime, candle.State == CandleStates.Finished))
 
         # Process price EMA for trend direction
-        priceEma = self._priceEma.Process(candle).ToDecimal()
+        priceEma = to_float(self._priceEma.Process(candle))
         priceAboveEma = candle.ClosePrice > priceEma
 
         # Calculate volume slope (current volume relative to SMA)

--- a/API/0275_OBV_Slope_Breakout/obv_slope_breakout_strategy.py
+++ b/API/0275_OBV_Slope_Breakout/obv_slope_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import OnBalanceVolume, LinearRegression, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class obv_slope_breakout_strategy(Strategy):
     """
@@ -155,8 +156,8 @@ class obv_slope_breakout_strategy(Strategy):
         self._lastObvValue = obvValue
 
         if getattr(avgValue, 'IsFinal', True) and getattr(stdDevValue, 'IsFinal', True):
-            self._lastSlopeAvg = avgValue.ToDecimal()
-            self._lastSlopeStdDev = stdDevValue.ToDecimal()
+            self._lastSlopeAvg = to_float(avgValue)
+            self._lastSlopeStdDev = to_float(stdDevValue)
 
             # Check if strategy is ready to trade
             if not self.IsFormedAndOnlineAndAllowTrading():

--- a/API/0277_Keltner_Width_Mean_Reversion/keltner_width_mean_reversion_strategy.py
+++ b/API/0277_Keltner_Width_Mean_Reversion/keltner_width_mean_reversion_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates
 from StockSharp.Algo.Indicators import ExponentialMovingAverage, AverageTrueRange, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 
 class keltner_width_mean_reversion_strategy(Strategy):
@@ -179,12 +180,12 @@ class keltner_width_mean_reversion_strategy(Strategy):
         # Process EMA
         emaValue = self._ema.Process(candle)
         if emaValue.IsFinal:
-            self._lastEma = emaValue.ToDecimal()
+            self._lastEma = to_float(emaValue)
 
         # Process ATR
         atrValue = self._atr.Process(candle)
         if atrValue.IsFinal:
-            self._lastAtr = atrValue.ToDecimal()
+            self._lastAtr = to_float(atrValue)
 
         # Calculate Keltner Channel
         if self._lastEma > 0 and self._lastAtr > 0:
@@ -201,8 +202,8 @@ class keltner_width_mean_reversion_strategy(Strategy):
             widthStdDevValue = self._widthStdDev.Process(channelWidth, candle.ServerTime, candle.State == CandleStates.Finished)
 
             if widthAvgValue.IsFinal and widthStdDevValue.IsFinal:
-                self._lastWidthAvg = widthAvgValue.ToDecimal()
-                self._lastWidthStdDev = widthStdDevValue.ToDecimal()
+                self._lastWidthAvg = to_float(widthAvgValue)
+                self._lastWidthStdDev = to_float(widthStdDevValue)
 
                 # Check if strategy is ready to trade
                 if not self.IsFormedAndOnlineAndAllowTrading():

--- a/API/0278_Donchian_Width_Mean_Reversion/donchian_width_mean_reversion_strategy.py
+++ b/API/0278_Donchian_Width_Mean_Reversion/donchian_width_mean_reversion_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import DonchianChannels, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class donchian_width_mean_reversion_strategy(Strategy):
     """
@@ -156,8 +157,8 @@ class donchian_width_mean_reversion_strategy(Strategy):
         self._current_width = upper_band - lower_band
 
         # Calculate the average and standard deviation of the width
-        width_average = self._width_average.Process(self._current_width, candle.ServerTime, True).ToDecimal()
-        width_std_dev = self._width_std_dev.Process(self._current_width, candle.ServerTime, True).ToDecimal()
+        width_average = to_float(self._width_average.Process(self._current_width, candle.ServerTime, True))
+        width_std_dev = to_float(self._width_std_dev.Process(self._current_width, candle.ServerTime, True))
 
         # Skip the first value
         if self._prev_width == 0:

--- a/API/0279_Ichimoku_Cloud_Width_Mean_Reversion/ichimoku_cloud_width_mean_reversion_strategy.py
+++ b/API/0279_Ichimoku_Cloud_Width_Mean_Reversion/ichimoku_cloud_width_mean_reversion_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates
 from StockSharp.Algo.Indicators import Ichimoku, SimpleMovingAverage, StandardDeviation, IchimokuValue
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 
 class ichimoku_cloud_width_mean_reversion_strategy(Strategy):
@@ -180,8 +181,8 @@ class ichimoku_cloud_width_mean_reversion_strategy(Strategy):
         self._currentCloudWidth = Math.Abs(senkouA - senkouB)
 
         # Calculate average and standard deviation of cloud width
-        cloudWidthAverage = self._cloudWidthAverage.Process(self._currentCloudWidth, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal()
-        cloudWidthStdDev = self._cloudWidthStdDev.Process(self._currentCloudWidth, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal()
+        cloudWidthAverage = to_float(self._cloudWidthAverage.Process(self._currentCloudWidth, candle.ServerTime, candle.State == CandleStates.Finished))
+        cloudWidthStdDev = to_float(self._cloudWidthStdDev.Process(self._currentCloudWidth, candle.ServerTime, candle.State == CandleStates.Finished))
 
         # Skip the first value
         if self._prevCloudWidth == 0:

--- a/API/0281_Parabolic_SAR_Distance_Mean_Reversion/parabolic_sar_distance_mean_reversion_strategy.py
+++ b/API/0281_Parabolic_SAR_Distance_Mean_Reversion/parabolic_sar_distance_mean_reversion_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import ParabolicSar, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class parabolic_sar_distance_mean_reversion_strategy(Strategy):
     """
@@ -173,11 +174,11 @@ class parabolic_sar_distance_mean_reversion_strategy(Strategy):
         self._current_distance_short = self._sar_value - candle.ClosePrice
 
         # Calculate averages and standard deviations for both distances
-        long_distance_avg = self._distance_average.Process(self._current_distance_long, candle.ServerTime, True).ToDecimal()
-        long_distance_std = self._distance_std_dev.Process(self._current_distance_long, candle.ServerTime, True).ToDecimal()
+        long_distance_avg = to_float(self._distance_average.Process(self._current_distance_long, candle.ServerTime, True))
+        long_distance_std = to_float(self._distance_std_dev.Process(self._current_distance_long, candle.ServerTime, True))
 
-        short_distance_avg = self._distance_average.Process(self._current_distance_short, candle.ServerTime, True).ToDecimal()
-        short_distance_std = self._distance_std_dev.Process(self._current_distance_short, candle.ServerTime, True).ToDecimal()
+        short_distance_avg = to_float(self._distance_average.Process(self._current_distance_short, candle.ServerTime, True))
+        short_distance_std = to_float(self._distance_std_dev.Process(self._current_distance_short, candle.ServerTime, True))
 
         # Skip the first value
         if self._prev_distance_long == 0 or self._prev_distance_short == 0:

--- a/API/0282_Hull_MA_Slope_Mean_Reversion/hull_ma_slope_mean_reversion_strategy.py
+++ b/API/0282_Hull_MA_Slope_Mean_Reversion/hull_ma_slope_mean_reversion_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, ICandleMessage, CandleStates
 from StockSharp.Algo.Indicators import HullMovingAverage, AverageTrueRange, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class hull_ma_slope_mean_reversion_strategy(Strategy):
     """
@@ -156,10 +157,10 @@ class hull_ma_slope_mean_reversion_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        self._currentAtr = atrValue.ToDecimal()
+        self._currentAtr = to_float(atrValue)
 
         # Get the Hull MA value
-        self._currentHullMa = hullValue.ToDecimal()
+        self._currentHullMa = to_float(hullValue)
 
         # First value handling
         if self._prevHullMa == 0:
@@ -170,8 +171,8 @@ class hull_ma_slope_mean_reversion_strategy(Strategy):
         self._currentSlope = (self._currentHullMa - self._prevHullMa) / self._prevHullMa * 100  # As percentage
 
         # Calculate average and standard deviation of slope
-        slopeAverage = self._slopeAverage.Process(self._currentSlope, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal()
-        slopeStdDev = self._slopeStdDev.Process(self._currentSlope, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal()
+        slopeAverage = to_float(self._slopeAverage.Process(self._currentSlope, candle.ServerTime, candle.State == CandleStates.Finished))
+        slopeStdDev = to_float(self._slopeStdDev.Process(self._currentSlope, candle.ServerTime, candle.State == CandleStates.Finished))
 
         # Skip until we have enough slope data
         if self._prevSlope == 0:

--- a/API/0293_Volume_Slope_Mean_Reversion/volume_slope_mean_reversion_strategy.py
+++ b/API/0293_Volume_Slope_Mean_Reversion/volume_slope_mean_reversion_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 
 class volume_slope_mean_reversion_strategy(Strategy):
@@ -160,7 +161,7 @@ class volume_slope_mean_reversion_strategy(Strategy):
             return
 
         # Calculate volume ratio (current volume / average volume)
-        volume_ratio = candle.TotalVolume / volume_indicator_value.ToDecimal()
+        volume_ratio = candle.TotalVolume / to_float(volume_indicator_value)
 
         # Calculate volume ratio slope
         if self._is_first_calculation:

--- a/API/0294_OBV_Slope_Mean_Reversion/obv_slope_mean_reversion_strategy.py
+++ b/API/0294_OBV_Slope_Mean_Reversion/obv_slope_mean_reversion_strategy.py
@@ -15,6 +15,7 @@ from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import OnBalanceVolume
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class obv_slope_mean_reversion_strategy(Strategy):
     """
@@ -161,10 +162,10 @@ class obv_slope_mean_reversion_strategy(Strategy):
             return
 
         # Process the candle with OBV indicator
-        obv_value = self._obv.Process(candle).ToDecimal()
+        obv_value = to_float(self._obv.Process(candle))
 
         # Process OBV through SMA
-        obv_sma_value = self._obv_sma.Process(obv_value, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal()
+        obv_sma_value = to_float(self._obv_sma.Process(obv_value, candle.ServerTime, candle.State == CandleStates.Finished))
 
         # Skip if OBV SMA is not formed yet
         if not self._obv_sma.IsFormed:

--- a/API/0295_Pairs_Trading_Volatility_Filter/pairs_trading_volatility_filter_strategy.py
+++ b/API/0295_Pairs_Trading_Volatility_Filter/pairs_trading_volatility_filter_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import AverageTrueRange, StandardDeviation, SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 from StockSharp.BusinessEntities import Security
 
 
@@ -213,7 +214,7 @@ class pairs_trading_volatility_filter_strategy(Strategy):
 
         # Store ATR value for volatility filter
         self._current_atr = atr_value
-        atr_sma_value = self._atr_sma.Process(atr_value, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal()
+        atr_sma_value = to_float(self._atr_sma.Process(atr_value, candle.ServerTime, candle.State == CandleStates.Finished))
         self._average_atr = atr_sma_value
 
         # Check if we have all necessary data to make a trading decision
@@ -231,8 +232,8 @@ class pairs_trading_volatility_filter_strategy(Strategy):
         self._current_spread = price1 - (price2 * self._volume_ratio)
 
         # Calculate spread statistics
-        spread_sma_value = self._spread_sma.Process(self._current_spread, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal()
-        std_dev_value = self._std_dev.Process(self._current_spread, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal()
+        spread_sma_value = to_float(self._spread_sma.Process(self._current_spread, candle.ServerTime, candle.State == CandleStates.Finished))
+        std_dev_value = to_float(self._std_dev.Process(self._current_spread, candle.ServerTime, candle.State == CandleStates.Finished))
 
         self._average_spread = spread_sma_value
         self._standard_deviation = std_dev_value

--- a/API/0298_Correlation_Mean_Reversion/correlation_mean_reversion_strategy.py
+++ b/API/0298_Correlation_Mean_Reversion/correlation_mean_reversion_strategy.py
@@ -11,6 +11,7 @@ from System.Collections.Generic import Queue
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes, ICandleMessage
 from StockSharp.Algo.Indicators import SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 from StockSharp.BusinessEntities import Security
 
 
@@ -233,8 +234,8 @@ class correlation_mean_reversion_strategy(Strategy):
         self._current_correlation = self.CalculateCorrelationCoefficient(series1, series2)
 
         # Process indicators
-        self._average_correlation = self._correlation_sma.Process(self._current_correlation, time, is_final).ToDecimal()
-        self._correlation_std_deviation = self._correlation_std_dev.Process(self._current_correlation, time, is_final).ToDecimal()
+        self._average_correlation = to_float(self._correlation_sma.Process(self._current_correlation, time, is_final))
+        self._correlation_std_deviation = to_float(self._correlation_std_dev.Process(self._current_correlation, time, is_final))
 
         if self._correlation_std_deviation == 0:
             return

--- a/API/0305_RSI_Dynamic_Overbought_Oversold/rsi_dynamic_overbought_oversold_strategy.py
+++ b/API/0305_RSI_Dynamic_Overbought_Oversold/rsi_dynamic_overbought_oversold_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import RelativeStrengthIndex, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 
 class rsi_dynamic_overbought_oversold_strategy(Strategy):
@@ -144,8 +145,8 @@ class rsi_dynamic_overbought_oversold_strategy(Strategy):
         stdDevValue = self._rsiStdDev.Process(rsiValue, candle.ServerTime, candle.State == CandleStates.Finished)
 
         # Get values from indicators
-        rsiSmaValue = smaValue.ToDecimal()
-        rsiStdDevValue = stdDevValue.ToDecimal()
+        rsiSmaValue = to_float(smaValue)
+        rsiStdDevValue = to_float(stdDevValue)
 
         # Get the indicator containers using container names
 

--- a/API/0306_Bollinger_Volatility_Breakout/bollinger_volatility_breakout_strategy.py
+++ b/API/0306_Bollinger_Volatility_Breakout/bollinger_volatility_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit
 from StockSharp.Algo.Indicators import BollingerBands, AverageTrueRange, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 
 class bollinger_volatility_breakout_strategy(Strategy):
@@ -156,11 +157,11 @@ class bollinger_volatility_breakout_strategy(Strategy):
         bb_lower = bb.LowBand
         bb_middle = bb.MovingAverage
 
-        atr_dec = atr_value.ToDecimal()
+        atr_dec = to_float(atr_value)
 
         # Get values from indicators
-        atr_sma_value = self._atr_sma.Process(atr_dec, candle.ServerTime, True).ToDecimal()  # Default to current ATR if SMA not available
-        atr_std_dev_value = self._atr_std_dev.Process(atr_dec, candle.ServerTime, True).ToDecimal() * 0.2  # Default to 20% of ATR if StdDev not available
+        atr_sma_value = to_float(self._atr_sma.Process(atr_dec, candle.ServerTime, True))  # Default to current ATR if SMA not available
+        atr_std_dev_value = to_float(self._atr_std_dev.Process(atr_dec, candle.ServerTime, True)) * 0.2  # Default to 20% of ATR if StdDev not available
 
         # Calculate volatility threshold for breakout confirmation
         volatility_threshold = atr_sma_value + self.AtrDeviationMultiplier * atr_std_dev_value

--- a/API/0307_MACD_Adaptive_Histogram/macd_adaptive_histogram_strategy.py
+++ b/API/0307_MACD_Adaptive_Histogram/macd_adaptive_histogram_strategy.py
@@ -11,6 +11,7 @@ from StockSharp.Algo.Indicators import (
     StandardDeviation,
 )
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 
 class macd_adaptive_histogram_strategy(Strategy):
@@ -200,12 +201,12 @@ class macd_adaptive_histogram_strategy(Strategy):
         histogram = macd - signal
 
         # Process the histogram through the statistics indicators
-        hist_avg_value = self._hist_avg.Process(
+        hist_avg_value = to_float(self._hist_avg.Process(
             histogram, macd_value.Time, macd_value.IsFinal
-        ).ToDecimal()
-        hist_std_dev_value = self._hist_std_dev.Process(
+        ))
+        hist_std_dev_value = to_float(self._hist_std_dev.Process(
             histogram, macd_value.Time, macd_value.IsFinal
-        ).ToDecimal()
+        ))
 
         # Check if strategy is ready to trade
         if not self.IsFormedAndOnlineAndAllowTrading():

--- a/API/0308_Ichimoku_Volume_Cluster/ichimoku_volume_cluster_strategy.py
+++ b/API/0308_Ichimoku_Volume_Cluster/ichimoku_volume_cluster_strategy.py
@@ -8,6 +8,7 @@ from System import Math
 from StockSharp.Messages import DataType, CandleStates, Unit
 from StockSharp.Algo.Indicators import Ichimoku, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class ichimoku_volume_cluster_strategy(Strategy):
     """
@@ -158,8 +159,8 @@ class ichimoku_volume_cluster_strategy(Strategy):
 
         volume = candle.TotalVolume
 
-        volume_avg_value = self._volume_avg.Process(volume, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal()
-        volume_std_dev_value = self._volume_std_dev.Process(volume, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal()
+        volume_avg_value = to_float(self._volume_avg.Process(volume, candle.ServerTime, candle.State == CandleStates.Finished))
+        volume_std_dev_value = to_float(self._volume_std_dev.Process(volume, candle.ServerTime, candle.State == CandleStates.Finished))
 
         # Check if strategy is ready to trade
         if not self.IsFormedAndOnlineAndAllowTrading():

--- a/API/0310_Donchian_Volatility_Contraction/donchian_volatility_contraction_strategy.py
+++ b/API/0310_Donchian_Volatility_Contraction/donchian_volatility_contraction_strategy.py
@@ -13,6 +13,7 @@ from StockSharp.Algo.Indicators import (
     StandardDeviation,
 )
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 
 class donchian_volatility_contraction_strategy(Strategy):
@@ -126,11 +127,11 @@ class donchian_volatility_contraction_strategy(Strategy):
         subscription = self.SubscribeCandles(self.CandleType)
 
         def handler(candle, high_value):
-            high_price = high_value.ToDecimal()
+            high_price = to_float(high_value)
 
             # Process Donchian Low separately
             low_value = donchian_low.Process(candle)
-            low_price = low_value.ToDecimal()
+            low_price = to_float(low_value)
 
             # Process ATR
             atr_value = atr.Process(candle)
@@ -150,11 +151,11 @@ class donchian_volatility_contraction_strategy(Strategy):
                 candle.State == CandleStates.Finished,
             )
 
-            self._avg_dc_width = sma_value.ToDecimal()
-            self._std_dev_dc_width = std_dev_value.ToDecimal()
+            self._avg_dc_width = to_float(sma_value)
+            self._std_dev_dc_width = to_float(std_dev_value)
 
             # Process the strategy logic
-            self.ProcessStrategy(candle, high_price, low_price, atr_value.ToDecimal())
+            self.ProcessStrategy(candle, high_price, low_price, to_float(atr_value))
 
         subscription.BindEx(donchian_high, handler).Start()
 

--- a/API/0312_Hull_MA_Volume_Spike/hull_ma_volume_spike_strategy.py
+++ b/API/0312_Hull_MA_Volume_Spike/hull_ma_volume_spike_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import HullMovingAverage, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 
 class hull_ma_volume_spike_strategy(Strategy):
@@ -115,8 +116,8 @@ class hull_ma_volume_spike_strategy(Strategy):
                 candle,
                 float(hma_value),
                 float(candle.TotalVolume),
-                float(volume_sma_value.ToDecimal()),
-                float(volume_std_dev_value.ToDecimal())
+                float(to_float(volume_sma_value)),
+                float(to_float(volume_std_dev_value))
             )
 
         subscription.BindEx(hma, process).Start()

--- a/API/0315_Stochastic_Dynamic_Zones/stochastic_with_dynamic_zones_strategy.py
+++ b/API/0315_Stochastic_Dynamic_Zones/stochastic_with_dynamic_zones_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import StochasticOscillator, StochasticOscillatorValue, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 
 class stochastic_with_dynamic_zones_strategy(Strategy):
@@ -154,8 +155,8 @@ class stochastic_with_dynamic_zones_strategy(Strategy):
 
         # Calculate dynamic zones
         stoch_k = float(stoch_typed.K)
-        stoch_k_avg = self._stoch_sma.Process(stoch_k, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal()
-        stoch_k_std_dev = self._stoch_std_dev.Process(stoch_k, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal()
+        stoch_k_avg = to_float(self._stoch_sma.Process(stoch_k, candle.ServerTime, candle.State == CandleStates.Finished))
+        stoch_k_std_dev = to_float(self._stoch_std_dev.Process(stoch_k, candle.ServerTime, candle.State == CandleStates.Finished))
 
         dynamic_oversold = stoch_k_avg - (self.StandardDeviationFactor * stoch_k_std_dev)
         dynamic_overbought = stoch_k_avg + (self.StandardDeviationFactor * stoch_k_std_dev)

--- a/API/0316_ADX_Volume_Breakout/adx_with_volume_breakout_strategy.py
+++ b/API/0316_ADX_Volume_Breakout/adx_with_volume_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import AverageDirectionalIndex, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class adx_with_volume_breakout_strategy(Strategy):
     """Strategy based on ADX with Volume Breakout."""
@@ -112,8 +113,8 @@ class adx_with_volume_breakout_strategy(Strategy):
             minus_di = dx.Minus
 
             # Process volume indicators
-            sma_val = volume_sma.Process(candle.TotalVolume, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal()
-            std_dev_val = volume_std_dev.Process(candle.TotalVolume, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal()
+            sma_val = to_float(volume_sma.Process(candle.TotalVolume, candle.ServerTime, candle.State == CandleStates.Finished))
+            std_dev_val = to_float(volume_std_dev.Process(candle.TotalVolume, candle.ServerTime, candle.State == CandleStates.Finished))
 
             # Process the strategy logic
             self.ProcessStrategy(

--- a/API/0317_CCI_Volatility_Filter/cci_with_volatility_filter_strategy.py
+++ b/API/0317_CCI_Volatility_Filter/cci_with_volatility_filter_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, UnitTypes, Unit, CandleStates
 from StockSharp.Algo.Indicators import CommodityChannelIndex, AverageTrueRange, SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class cci_with_volatility_filter_strategy(Strategy):
     """
@@ -124,11 +125,11 @@ class cci_with_volatility_filter_strategy(Strategy):
 
     def _on_candle(self, candle, cci_value, atr_value):
         # Calculate ATR average
-        atr_avg = self._atrSma.Process(
+        atr_avg = to_float(self._atrSma.Process(
             atr_value,
             candle.ServerTime,
             candle.State == CandleStates.Finished
-        ).ToDecimal()
+        ))
 
         # Process the strategy logic
         self.ProcessStrategy(candle, cci_value, atr_value, atr_avg)

--- a/API/0318_Williams_R_Momentum/williams_percent_r_with_momentum_strategy.py
+++ b/API/0318_Williams_R_Momentum/williams_percent_r_with_momentum_strategy.py
@@ -6,6 +6,7 @@ clr.AddReference("StockSharp.Algo")
 from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 from StockSharp.Algo.Indicators import WilliamsR, Momentum, SimpleMovingAverage
 
 class williams_percent_r_with_momentum_strategy(Strategy):
@@ -112,7 +113,7 @@ class williams_percent_r_with_momentum_strategy(Strategy):
 
         def on_process(candle, williamsRValue, momentumValue):
             # Calculate momentum average
-            momentumAvg = momentumSma.Process(momentumValue, candle.ServerTime, candle.State == CandleStates.Finished).ToDecimal()
+            momentumAvg = to_float(momentumSma.Process(momentumValue, candle.ServerTime, candle.State == CandleStates.Finished))
 
             # Process the strategy logic
             self.ProcessStrategy(candle, williamsRValue, momentumValue, momentumAvg)

--- a/API/0326_VWAP_Stochastic_Divergence/vwap_adx_trend_strategy.py
+++ b/API/0326_VWAP_Stochastic_Divergence/vwap_adx_trend_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import VolumeWeightedMovingAverage, AverageDirectionalIndex, DirectionalIndex
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 
 class vwap_adx_trend_strategy(Strategy):
@@ -136,7 +137,7 @@ class vwap_adx_trend_strategy(Strategy):
         minus_di = dx.Minus
 
         # Extract values from indicators
-        self._vwap_value = vwap_value.ToDecimal()
+        self._vwap_value = to_float(vwap_value)
         self._adx_value = adx
         self._plus_di_value = plus_di  # +DI
         self._minus_di_value = minus_di  # -DI

--- a/API/0327_Parabolic_SAR_Hurst_Filter/parabolic_sar_hurst_strategy.py
+++ b/API/0327_Parabolic_SAR_Hurst_Filter/parabolic_sar_hurst_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import ParabolicSar, HurstExponent
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 
 class parabolic_sar_hurst_strategy(Strategy):
@@ -129,8 +130,8 @@ class parabolic_sar_hurst_strategy(Strategy):
             return
 
         # Get SAR and Hurst values
-        sar_price = sar_value.ToDecimal()
-        self._hurst_value = hurst_value.ToDecimal()
+        sar_price = to_float(sar_value)
+        self._hurst_value = to_float(hurst_value)
 
         # Store previous SAR for comparison
         current_sar_value = sar_price

--- a/API/0328_Bollinger_Kalman_Filter/bollinger_kalman_filter_strategy.py
+++ b/API/0328_Bollinger_Kalman_Filter/bollinger_kalman_filter_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import BollingerBands, KalmanFilter
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 
 class bollinger_kalman_filter_strategy(Strategy):
@@ -146,7 +147,7 @@ class bollinger_kalman_filter_strategy(Strategy):
         if mid_band is None:
             return
 
-        kalman_filter_value = kalman_value.ToDecimal()
+        kalman_filter_value = to_float(kalman_value)
 
         # Log the values
         self.LogInfo(

--- a/API/0330_Ichimoku_Volatility_Contraction/ichimoku_volatility_contraction_strategy.py
+++ b/API/0330_Ichimoku_Volatility_Contraction/ichimoku_volatility_contraction_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import Ichimoku, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class ichimoku_volatility_contraction_strategy(Strategy):
     """
@@ -158,7 +159,7 @@ class ichimoku_volatility_contraction_strategy(Strategy):
             return
 
         # Get ATR value and calculate statistics
-        current_atr = atr_value.ToDecimal()
+        current_atr = to_float(atr_value)
         self._processed_candles += 1
 
         # Using exponential moving average approach for ATR statistics

--- a/API/0332_Donchian_Hurst_Exponent/donchian_hurst_strategy.py
+++ b/API/0332_Donchian_Hurst_Exponent/donchian_hurst_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import DonchianChannels, FractalDimension
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class donchian_hurst_strategy(Strategy):
     """
@@ -132,7 +133,7 @@ class donchian_hurst_strategy(Strategy):
             return
 
         # --- FractalDimension logic (was ProcessFractalDimension) ---
-        fractalDimension = fractalDimensionValue.ToDecimal()
+        fractalDimension = to_float(fractalDimensionValue)
         self._hurstValue = 2 - fractalDimension
 
         # Log Hurst Exponent value periodically

--- a/API/0337_Adaptive_RSI_Volume_Filter/adaptive_rsi_volume_strategy.py
+++ b/API/0337_Adaptive_RSI_Volume_Filter/adaptive_rsi_volume_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import RelativeStrengthIndex, AverageTrueRange, SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 
 class adaptive_rsi_volume_strategy(Strategy):
@@ -147,7 +148,7 @@ class adaptive_rsi_volume_strategy(Strategy):
 
         # Calculate adaptive RSI period based on ATR
         if atr_value.IsFinal:
-            atr = atr_value.ToDecimal()
+            atr = to_float(atr_value)
 
             # Normalize ATR to a value between 0 and 1 using historical range
             # This is a simplified approach - in a real implementation you would
@@ -173,7 +174,7 @@ class adaptive_rsi_volume_strategy(Strategy):
 
         # Store RSI value
         if rsi_value.IsFinal:
-            self._adaptiveRsiValue = rsi_value.ToDecimal()
+            self._adaptiveRsiValue = to_float(rsi_value)
 
             # Trading logic based on RSI with volume confirmation
             if self._avgVolume > 0:  # Make sure we have volume data
@@ -205,7 +206,7 @@ class adaptive_rsi_volume_strategy(Strategy):
                                              candle.State == CandleStates.Finished)
 
         if volumeValue.IsFinal:
-            self._avgVolume = volumeValue.ToDecimal()
+            self._avgVolume = to_float(volumeValue)
 
     def CreateClone(self):
         """!! REQUIRED!! Creates a new instance of the strategy."""

--- a/API/0346_Parabolic_SAR_Sentiment_Divergence/parabolic_sar_sentiment_divergence_strategy.py
+++ b/API/0346_Parabolic_SAR_Sentiment_Divergence/parabolic_sar_sentiment_divergence_strategy.py
@@ -8,6 +8,7 @@ from System import TimeSpan
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import ParabolicSar
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 from Ecng.Common import RandomGen
 
 class parabolic_sar_sentiment_divergence_strategy(Strategy):
@@ -103,7 +104,7 @@ class parabolic_sar_sentiment_divergence_strategy(Strategy):
             return
 
         # Get SAR value
-        sar_price = sar_value.ToDecimal()
+        sar_price = to_float(sar_value)
 
         # Get current price and sentiment
         price = candle.ClosePrice

--- a/API/0347_RSI_Option_Open_Interest/rsi_with_option_open_interest_strategy.py
+++ b/API/0347_RSI_Option_Open_Interest/rsi_with_option_open_interest_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math, Random
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import RelativeStrengthIndex, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 
 class rsi_with_option_open_interest_strategy(Strategy):
@@ -163,7 +164,7 @@ class rsi_with_option_open_interest_strategy(Strategy):
             return
 
         # Get current RSI value
-        rsi = rsi_value.ToDecimal()
+        rsi = to_float(rsi_value)
 
         # Simulate option open interest data (in real implementation, this would come from a data provider)
         self.SimulateOptionOI(candle)
@@ -176,10 +177,10 @@ class rsi_with_option_open_interest_strategy(Strategy):
         put_oi_value_stddev = self._put_oi_stddev.Process(self._current_put_oi, candle.ServerTime, candle.State == CandleStates.Finished)
 
         # Update state variables
-        self._avg_call_oi = call_oi_value_sma.ToDecimal()
-        self._avg_put_oi = put_oi_value_sma.ToDecimal()
-        self._stddev_call_oi = call_oi_value_stddev.ToDecimal()
-        self._stddev_put_oi = put_oi_value_stddev.ToDecimal()
+        self._avg_call_oi = to_float(call_oi_value_sma)
+        self._avg_put_oi = to_float(put_oi_value_sma)
+        self._stddev_call_oi = to_float(call_oi_value_stddev)
+        self._stddev_put_oi = to_float(put_oi_value_stddev)
 
         # Check if strategy is ready to trade
         if not self.IsFormedAndOnlineAndAllowTrading():

--- a/API/0348_Stochastic_Implied_Volatility_Skew/stochastic_implied_volatility_skew_strategy.py
+++ b/API/0348_Stochastic_Implied_Volatility_Skew/stochastic_implied_volatility_skew_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math, Random
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes, ICandleMessage
 from StockSharp.Algo.Indicators import StochasticOscillator, SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from indicator_extensions import *
 
 class stochastic_implied_volatility_skew_strategy(Strategy):
     """Stochastic strategy with Implied Volatility Skew."""
@@ -155,7 +156,7 @@ class stochastic_implied_volatility_skew_strategy(Strategy):
 
         # Process IV Skew with SMA
         iv_skew_sma_value = self._iv_skew_sma.Process(self._current_iv_skew, candle.ServerTime, candle.State == CandleStates.Finished)
-        self._avg_iv_skew = iv_skew_sma_value.ToDecimal()
+        self._avg_iv_skew = to_float(iv_skew_sma_value)
 
         # Check if strategy is ready to trade
         if not self.IsFormedAndOnlineAndAllowTrading():


### PR DESCRIPTION
## Summary
- replace `.to_float()` method calls with `to_float()` helper function in python strategies
- keep `indicator_extensions` import

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877ba4b8dec832384d4b531f875d9b1