### PR TITLE
Use tf helper for candle types

### DIFF
--- a/API/0001_MA_CrossOver/ma_crossover_strategy.py
+++ b/API/0001_MA_CrossOver/ma_crossover_strategy.py
@@ -10,6 +10,7 @@ from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import SMA
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class ma_crossover_strategy(Strategy):
     """
@@ -34,7 +35,7 @@ class ma_crossover_strategy(Strategy):
         self._stop_loss_percent = self.Param("StopLossPercent", 2.0) \
             .SetDisplay("Stop Loss %", "Stop loss percentage from entry price", "Risk Management")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(1))) \
+        self._candle_type = self.Param("CandleType", tf(1)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
         
         # Initialize state variables

--- a/API/0002_NDay_Breakout/nday_breakout_strategy.py
+++ b/API/0002_NDay_Breakout/nday_breakout_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import Highest, Lowest, SMA
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class nday_breakout_strategy(Strategy):
     """
@@ -33,7 +34,7 @@ class nday_breakout_strategy(Strategy):
         self._stop_loss_percent = self.Param("StopLossPercent", 2.0) \
             .SetDisplay("Stop Loss %", "Stop loss percentage from entry price", "Risk Management")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromDays(1))) \
+        self._candle_type = self.Param("CandleType", tf(1*1440)) \
             .SetDisplay("Candle Type", "Type of candles to use", "Strategy Parameters")
         
         # Initialize indicators (will be created in OnStarted)

--- a/API/0003_ADX_Trend/adx_trend_strategy.py
+++ b/API/0003_ADX_Trend/adx_trend_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import AverageDirectionalIndex, SimpleMovingAverage, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class adx_trend_strategy(Strategy):
     """
@@ -35,7 +36,7 @@ class adx_trend_strategy(Strategy):
         self._adx_exit_threshold = self.Param("AdxExitThreshold", 20) \
             .SetDisplay("ADX Exit Threshold", "ADX level below which to exit position", "Exit parameters")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
         
         # Current trend state

--- a/API/0004_Parabolic_SAR_Trend/parabolic_sar_trend_strategy.py
+++ b/API/0004_Parabolic_SAR_Trend/parabolic_sar_trend_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import ParabolicSar
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class parabolic_sar_trend_strategy(Strategy):
     """
@@ -28,7 +29,7 @@ class parabolic_sar_trend_strategy(Strategy):
         self._max_acceleration_factor = self.Param("MaxAccelerationFactor", 0.2) \
             .SetDisplay("Max Acceleration Factor", "Maximum acceleration factor for SAR calculation", "Indicators")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
         
         # Current state

--- a/API/0005_Donchian_Channel/donchian_channel_strategy.py
+++ b/API/0005_Donchian_Channel/donchian_channel_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import DonchianChannels
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class donchian_channel_strategy(Strategy):
     """
@@ -26,7 +27,7 @@ class donchian_channel_strategy(Strategy):
         self._channel_period = self.Param("ChannelPeriod", 20) \
             .SetDisplay("Channel Period", "Period for Donchian Channel calculation", "Indicators")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
         
         # Current state

--- a/API/0006_Tripple_MA/triple_ma_strategy.py
+++ b/API/0006_Tripple_MA/triple_ma_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class triple_ma_strategy(Strategy):
     """
@@ -35,7 +36,7 @@ class triple_ma_strategy(Strategy):
         self._stop_loss_percent = self.Param("StopLossPercent", 2.0) \
             .SetDisplay("Stop Loss (%)", "Stop loss as a percentage of entry price", "Risk parameters")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
         
         # Current state

--- a/API/0007_Keltner_Channel_Breakout/keltner_channel_breakout_strategy.py
+++ b/API/0007_Keltner_Channel_Breakout/keltner_channel_breakout_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import KeltnerChannels
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class keltner_channel_breakout_strategy(Strategy):
     """
@@ -32,7 +33,7 @@ class keltner_channel_breakout_strategy(Strategy):
         self._atr_multiplier = self.Param("AtrMultiplier", 2.0) \
             .SetDisplay("ATR Multiplier", "Multiplier for ATR to determine channel width", "Indicators")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
         
         # Current state

--- a/API/0008_Hull_MA_Trend/hull_ma_trend_strategy.py
+++ b/API/0008_Hull_MA_Trend/hull_ma_trend_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import HullMovingAverage, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class hull_ma_trend_strategy(Strategy):
     """
@@ -32,7 +33,7 @@ class hull_ma_trend_strategy(Strategy):
         self._atr_multiplier = self.Param("AtrMultiplier", 2.0) \
             .SetDisplay("ATR Multiplier", "Multiplier for ATR to determine stop-loss distance", "Risk parameters")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
         
         # Current state

--- a/API/0009_MACD_Trend/macd_trend_strategy.py
+++ b/API/0009_MACD_Trend/macd_trend_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import MovingAverageConvergenceDivergenceSignal
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class macd_trend_strategy(Strategy):
     """
@@ -35,7 +36,7 @@ class macd_trend_strategy(Strategy):
         self._stop_loss_percent = self.Param("StopLossPercent", 2.0) \
             .SetDisplay("Stop Loss (%)", "Stop loss as a percentage of entry price", "Risk parameters")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
         
         # Current state

--- a/API/0010_Super_Trend/supertrend_strategy.py
+++ b/API/0010_Super_Trend/supertrend_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class supertrend_strategy(Strategy):
     """
@@ -29,7 +30,7 @@ class supertrend_strategy(Strategy):
         self._multiplier = self.Param("Multiplier", 3.0) \
             .SetDisplay("Multiplier", "Multiplier for Supertrend calculation", "Indicators")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
         
         # Current state tracking

--- a/API/0011_Ichimoku_Kumo_Breakout/ichimoku_kumo_breakout_strategy.py
+++ b/API/0011_Ichimoku_Kumo_Breakout/ichimoku_kumo_breakout_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import Ichimoku
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class ichimoku_kumo_breakout_strategy(Strategy):
     """
@@ -32,7 +33,7 @@ class ichimoku_kumo_breakout_strategy(Strategy):
         self._senkou_span_period = self.Param("SenkouSpanPeriod", 52) \
             .SetDisplay("Senkou Span B Period", "Period for Senkou Span B calculation", "Indicators")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candle_type = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
         
         # Current state tracking

--- a/API/0012_Heikin_Ashi_Consecutive/heikin_ashi_consecutive_strategy.py
+++ b/API/0012_Heikin_Ashi_Consecutive/heikin_ashi_consecutive_strategy.py
@@ -8,6 +8,7 @@ from System import Math
 from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class heikin_ashi_consecutive_strategy(Strategy):
     """
@@ -28,7 +29,7 @@ class heikin_ashi_consecutive_strategy(Strategy):
         self._stop_loss_percent = self.Param("StopLossPercent", 2.0) \
             .SetDisplay("Stop Loss (%)", "Stop loss as a percentage of entry price", "Risk parameters")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
         
         # State tracking

--- a/API/0013_DMI_Power_Move/dmi_power_move_strategy.py
+++ b/API/0013_DMI_Power_Move/dmi_power_move_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import AverageDirectionalIndex, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class dmi_power_move_strategy(Strategy):
     """
@@ -38,7 +39,7 @@ class dmi_power_move_strategy(Strategy):
         self._atr_multiplier = self.Param("AtrMultiplier", 2.0) \
             .SetDisplay("ATR Multiplier", "Multiplier for ATR to determine stop-loss distance", "Risk parameters")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candle_type = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
     @property

--- a/API/0014_TradingView_Supertrend_Flip/tradingview_supertrend_flip_strategy.py
+++ b/API/0014_TradingView_Supertrend_Flip/tradingview_supertrend_flip_strategy.py
@@ -10,6 +10,7 @@ from StockSharp.Messages import DataType
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import AverageTrueRange, SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class tradingview_supertrend_flip_strategy(Strategy):
     """
@@ -33,7 +34,7 @@ class tradingview_supertrend_flip_strategy(Strategy):
         self._volume_avg_period = self.Param("VolumeAvgPeriod", 20) \
             .SetDisplay("Volume Avg Period", "Period for volume average calculation", "Indicators")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
         
         # State tracking

--- a/API/0015_Gann_Swing_Breakout/gann_swing_breakout_strategy.py
+++ b/API/0015_Gann_Swing_Breakout/gann_swing_breakout_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class gann_swing_breakout_strategy(Strategy):
     """
@@ -29,7 +30,7 @@ class gann_swing_breakout_strategy(Strategy):
         self._ma_period = self.Param("MaPeriod", 20) \
             .SetDisplay("MA Period", "Period for moving average calculation", "Indicators")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candle_type = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
         
         # State tracking

--- a/API/0016_RSI_Divergence/rsi_divergence_strategy.py
+++ b/API/0016_RSI_Divergence/rsi_divergence_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import RelativeStrengthIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class rsi_divergence_strategy(Strategy):
     """
@@ -29,7 +30,7 @@ class rsi_divergence_strategy(Strategy):
         self._stop_loss_percent = self.Param("StopLossPercent", 2.0) \
             .SetDisplay("Stop Loss %", "Stop loss percentage", "Risk Management")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
         
         # State tracking

--- a/API/0017_Williams_R/williams_percent_r_strategy.py
+++ b/API/0017_Williams_R/williams_percent_r_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import WilliamsR
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class williams_percent_r_strategy(Strategy):
     """
@@ -29,7 +30,7 @@ class williams_percent_r_strategy(Strategy):
         self._stop_loss_percent = self.Param("StopLossPercent", 2.0) \
             .SetDisplay("Stop Loss %", "Stop loss percentage", "Risk Management")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
     @property

--- a/API/0018_ROC_Impulce/roc_impulse_strategy.py
+++ b/API/0018_ROC_Impulce/roc_impulse_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import RateOfChange, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class roc_impulse_strategy(Strategy):
     """
@@ -29,7 +30,7 @@ class roc_impulse_strategy(Strategy):
         self._atr_multiplier = self.Param("AtrMultiplier", 2.0) \
             .SetDisplay("ATR Multiplier", "Multiplier for ATR stop loss", "Risk Management")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
         
         # State tracking

--- a/API/0019_CCI_Breakout/cci_breakout_strategy.py
+++ b/API/0019_CCI_Breakout/cci_breakout_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import CommodityChannelIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class cci_breakout_strategy(Strategy):
     """
@@ -29,7 +30,7 @@ class cci_breakout_strategy(Strategy):
         self._stop_loss_percent = self.Param("StopLossPercent", 2.0) \
             .SetDisplay("Stop Loss %", "Stop loss percentage", "Risk Management")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
     @property

--- a/API/0020_Momentum_Percentage/momentum_percentage_strategy.py
+++ b/API/0020_Momentum_Percentage/momentum_percentage_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import Momentum, SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class momentum_percentage_strategy(Strategy):
     """
@@ -32,7 +33,7 @@ class momentum_percentage_strategy(Strategy):
         self._stop_loss_percent = self.Param("StopLossPercent", 2.0) \
             .SetDisplay("Stop Loss %", "Stop loss percentage", "Risk Management")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
     @property

--- a/API/0021_Bollinger_Squeeze/bollinger_squeeze_strategy.py
+++ b/API/0021_Bollinger_Squeeze/bollinger_squeeze_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import BollingerBands
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class bollinger_squeeze_strategy(Strategy):
     """
@@ -32,7 +33,7 @@ class bollinger_squeeze_strategy(Strategy):
         self._squeeze_threshold = self.Param("SqueezeThreshold", 0.1) \
             .SetDisplay("Squeeze Threshold", "Threshold for Bollinger Bands width to identify squeeze", "Strategy")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
         
         # State tracking

--- a/API/0022_ADX_DI/adx_di_strategy.py
+++ b/API/0022_ADX_DI/adx_di_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import AverageDirectionalIndex, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class adx_di_strategy(Strategy):
     """
@@ -32,7 +33,7 @@ class adx_di_strategy(Strategy):
         self._atr_multiplier = self.Param("AtrMultiplier", 2.0) \
             .SetDisplay("ATR Multiplier", "Multiplier for ATR stop loss", "Risk Management")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
     @property

--- a/API/0023_Elder_Impulse/elder_impulse_strategy.py
+++ b/API/0023_Elder_Impulse/elder_impulse_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import ExponentialMovingAverage, MovingAverageConvergenceDivergenceSignal
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class elder_impulse_strategy(Strategy):
     """
@@ -39,7 +40,7 @@ class elder_impulse_strategy(Strategy):
         self._stop_loss_percent = self.Param("StopLossPercent", 2.0) \
             .SetDisplay("Stop Loss %", "Stop loss percentage", "Risk Management")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
         
         # Cache for EMA direction

--- a/API/0024_RSI_Laguerre/laguerre_rsi_strategy.py
+++ b/API/0024_RSI_Laguerre/laguerre_rsi_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import RelativeStrengthIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class laguerre_rsi_strategy(Strategy):
     """
@@ -29,7 +30,7 @@ class laguerre_rsi_strategy(Strategy):
         self._stop_loss_percent = self.Param("StopLossPercent", 2.0) \
             .SetDisplay("Stop Loss %", "Stop loss percentage", "Risk Management")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
     @property

--- a/API/0025_Stochastic_RSI_Cross/stochastic_rsi_cross_strategy.py
+++ b/API/0025_Stochastic_RSI_Cross/stochastic_rsi_cross_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import RelativeStrengthIndex, StochasticOscillator
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class stochastic_rsi_cross_strategy(Strategy):
     """
@@ -38,7 +39,7 @@ class stochastic_rsi_cross_strategy(Strategy):
         self._stop_loss_percent = self.Param("StopLossPercent", 2.0) \
             .SetDisplay("Stop Loss %", "Stop loss percentage", "Risk Management")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
         
         # Cache for K and D values

--- a/API/0026_RSI_Reversion/rsi_reversion_strategy.py
+++ b/API/0026_RSI_Reversion/rsi_reversion_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import RelativeStrengthIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class rsi_reversion_strategy(Strategy):
     """
@@ -38,7 +39,7 @@ class rsi_reversion_strategy(Strategy):
         self._stop_loss_percent = self.Param("StopLossPercent", 2.0) \
             .SetDisplay("Stop Loss %", "Stop loss percentage", "Risk Management")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
     @property

--- a/API/0027_Bollinger_Reversion/bollinger_reversion_strategy.py
+++ b/API/0027_Bollinger_Reversion/bollinger_reversion_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import BollingerBands, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class bollinger_reversion_strategy(Strategy):
     """
@@ -32,7 +33,7 @@ class bollinger_reversion_strategy(Strategy):
         self._atr_multiplier = self.Param("AtrMultiplier", 2.0) \
             .SetDisplay("ATR Multiplier", "Multiplier for ATR stop loss", "Risk Management")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
     @property

--- a/API/0028_ZScore/z_score_strategy.py
+++ b/API/0028_ZScore/z_score_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class z_score_strategy(Strategy):
     """
@@ -37,7 +38,7 @@ class z_score_strategy(Strategy):
         self._stop_loss_percent = self.Param("StopLossPercent", 2.0) \
             .SetDisplay("Stop Loss %", "Stop loss as percentage from entry price", "Risk Management")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "Data")
         
         # State tracking

--- a/API/0029_MA_Deviation/ma_deviation_strategy.py
+++ b/API/0029_MA_Deviation/ma_deviation_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class ma_deviation_strategy(Strategy):
     """
@@ -35,7 +36,7 @@ class ma_deviation_strategy(Strategy):
         self._atr_multiplier = self.Param("AtrMultiplier", 2.0) \
             .SetDisplay("ATR Multiplier", "ATR multiplier for stop-loss calculation", "Risk Management")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "Data")
 
     @property

--- a/API/0030_VWAP_Reversion/vwap_reversion_strategy.py
+++ b/API/0030_VWAP_Reversion/vwap_reversion_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import VolumeWeightedMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class vwap_reversion_strategy(Strategy):
     """
@@ -29,7 +30,7 @@ class vwap_reversion_strategy(Strategy):
         self._stop_loss_percent = self.Param("StopLossPercent", 2.0) \
             .SetDisplay("Stop Loss %", "Stop loss as percentage from entry price", "Risk Management")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "Data")
 
     @property

--- a/API/0031_Keltner_Reversion/keltner_reversion_strategy.py
+++ b/API/0031_Keltner_Reversion/keltner_reversion_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import ExponentialMovingAverage, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class keltner_reversion_strategy(Strategy):
     """
@@ -35,7 +36,7 @@ class keltner_reversion_strategy(Strategy):
         self._stop_loss_atr_multiplier = self.Param("StopLossAtrMultiplier", 2.0) \
             .SetDisplay("ATR Multiplier (Stop Loss)", "ATR multiplier for stop-loss calculation", "Risk Management")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "Technical Parameters")
 
     @property

--- a/API/0032_ATR_Reversion/atr_reversion_strategy.py
+++ b/API/0032_ATR_Reversion/atr_reversion_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import AverageTrueRange, SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class atr_reversion_strategy(Strategy):
     """
@@ -35,7 +36,7 @@ class atr_reversion_strategy(Strategy):
         self._stop_loss_percent = self.Param("StopLossPercent", 2.0) \
             .SetDisplay("Stop Loss %", "Stop loss as percentage from entry price", "Risk Management")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "Data")
         
         # State tracking

--- a/API/0033_MACD_Zero/macd_zero_strategy.py
+++ b/API/0033_MACD_Zero/macd_zero_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import MovingAverageConvergenceDivergenceSignal
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class macd_zero_strategy(Strategy):
     """
@@ -35,7 +36,7 @@ class macd_zero_strategy(Strategy):
         self._stop_loss_percent = self.Param("StopLossPercent", 2.0) \
             .SetDisplay("Stop Loss %", "Stop loss as percentage from entry price", "Risk Management")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "Data")
         
         # State tracking

--- a/API/0034_Low_Vol_Reversion/low_vol_reversion_strategy.py
+++ b/API/0034_Low_Vol_Reversion/low_vol_reversion_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class low_vol_reversion_strategy(Strategy):
     """
@@ -38,7 +39,7 @@ class low_vol_reversion_strategy(Strategy):
         self._atr_multiplier = self.Param("AtrMultiplier", 2.0) \
             .SetDisplay("ATR Multiplier", "ATR multiplier for stop-loss calculation", "Risk Management")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "Data")
         
         # State tracking

--- a/API/0035_Bollinger_B_Reversion/bollinger_percent_b_strategy.py
+++ b/API/0035_Bollinger_B_Reversion/bollinger_percent_b_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import BollingerBands
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class bollinger_percent_b_strategy(Strategy):
     """
@@ -35,7 +36,7 @@ class bollinger_percent_b_strategy(Strategy):
         self._stop_loss_percent = self.Param("StopLossPercent", 2.0) \
             .SetDisplay("Stop Loss %", "Stop loss as percentage from entry price", "Risk Management")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "Data")
 
     @property

--- a/API/0036_ATR_Expansion/atr_expansion_strategy.py
+++ b/API/0036_ATR_Expansion/atr_expansion_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import AverageTrueRange, SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class atr_expansion_strategy(Strategy):
     """
@@ -32,7 +33,7 @@ class atr_expansion_strategy(Strategy):
         self._atr_multiplier = self.Param("AtrMultiplier", 2.0) \
             .SetDisplay("ATR Multiplier", "ATR multiplier for stop-loss calculation", "Risk Management")
         
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "Data")
         
         # State tracking

--- a/API/0037_VIX_Trigger/vix_trigger_strategy.py
+++ b/API/0037_VIX_Trigger/vix_trigger_strategy.py
@@ -16,6 +16,7 @@ from StockSharp.Messages import Sides
 from StockSharp.Messages import Subscription
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from StockSharp.BusinessEntities import Security
 
 class vix_trigger_strategy(Strategy):
@@ -41,7 +42,7 @@ class vix_trigger_strategy(Strategy):
         self._stopLossPercent = self.Param("StopLossPercent", 2.0) \
             .SetDisplay("Stop Loss %", "Stop loss as percentage from entry price", "Risk Management")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "Data")
 
         self._vixSecurity = self.Param("VixSecurity", None) \

--- a/API/0038_BB_Width/bollinger_band_width_strategy.py
+++ b/API/0038_BB_Width/bollinger_band_width_strategy.py
@@ -16,6 +16,7 @@ from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import BollingerBands
 from StockSharp.Algo.Indicators import AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class bollinger_band_width_strategy(Strategy):
@@ -42,7 +43,7 @@ class bollinger_band_width_strategy(Strategy):
         self._atrMultiplier = self.Param("AtrMultiplier", 2.0) \
             .SetDisplay("ATR Multiplier", "ATR multiplier for stop-loss calculation", "Risk Management")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "Data")
 
     @property

--- a/API/0039_HV_Breakout/hv_breakout_strategy.py
+++ b/API/0039_HV_Breakout/hv_breakout_strategy.py
@@ -16,6 +16,7 @@ from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import StandardDeviation
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class hv_breakout_strategy(Strategy):
     """
@@ -43,7 +44,7 @@ class hv_breakout_strategy(Strategy):
         self._stopLossPercent = self.Param("StopLossPercent", 2.0) \
             .SetDisplay("Stop Loss %", "Stop loss as percentage from entry price", "Risk Management")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "Data")
 
     @property

--- a/API/0040_ATR_Trailing/atr_trailing_strategy.py
+++ b/API/0040_ATR_Trailing/atr_trailing_strategy.py
@@ -16,6 +16,7 @@ from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import AverageTrueRange
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class atr_trailing_strategy(Strategy):
     """
@@ -42,7 +43,7 @@ class atr_trailing_strategy(Strategy):
         self._maPeriod = self.Param("MAPeriod", 20) \
             .SetDisplay("MA Period", "Period for Moving Average calculation for entry", "Entry Parameters")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "Data")
 
     @property

--- a/API/0041_Vol_Adjusted_MA/vol_adjusted_ma_strategy.py
+++ b/API/0041_Vol_Adjusted_MA/vol_adjusted_ma_strategy.py
@@ -16,6 +16,7 @@ from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Indicators import AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class vol_adjusted_ma_strategy(Strategy):
     """
@@ -41,7 +42,7 @@ class vol_adjusted_ma_strategy(Strategy):
         self._atrMultiplier = self.Param("ATRMultiplier", 2.0) \
             .SetDisplay("ATR Multiplier", "Multiplier for ATR to adjust MA bands", "Strategy Parameters")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles for strategy calculation", "Strategy Parameters")
 
     @property

--- a/API/0042_IV_Spike/iv_spike_strategy.py
+++ b/API/0042_IV_Spike/iv_spike_strategy.py
@@ -16,6 +16,7 @@ from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Indicators import StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class iv_spike_strategy(Strategy):
     """
@@ -41,7 +42,7 @@ class iv_spike_strategy(Strategy):
         self._ivSpikeThreshold = self.Param("IVSpikeThreshold", 1.5) \
             .SetDisplay("IV Spike Threshold", "Minimum IV increase multiplier (e.g., 1.5 = 50% increase)", "Strategy Parameters")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles for strategy calculation", "Strategy Parameters")
 
     @property

--- a/API/0043_VCP/vcp_strategy.py
+++ b/API/0043_VCP/vcp_strategy.py
@@ -17,6 +17,7 @@ from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Indicators import Highest
 from StockSharp.Algo.Indicators import Lowest
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class vcp_strategy(Strategy):
     """
@@ -40,7 +41,7 @@ class vcp_strategy(Strategy):
         self._lookbackPeriod = self.Param("LookbackPeriod", 20) \
             .SetDisplay("Lookback Period", "Period for calculating breakout levels", "Strategy Parameters")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles for strategy calculation", "Strategy Parameters")
 
     @property

--- a/API/0044_ATR_Range/atr_range_strategy.py
+++ b/API/0044_ATR_Range/atr_range_strategy.py
@@ -16,6 +16,7 @@ from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Indicators import AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class atr_range_strategy(Strategy):
     """
@@ -42,7 +43,7 @@ class atr_range_strategy(Strategy):
         self._lookbackPeriod = self.Param("LookbackPeriod", 5) \
             .SetDisplay("Lookback Period", "Number of candles to measure price movement", "Strategy Parameters")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles for strategy calculation", "Strategy Parameters")
 
     @property

--- a/API/0045_Choppiness_Index_Breakout/choppiness_index_breakout_strategy.py
+++ b/API/0045_Choppiness_Index_Breakout/choppiness_index_breakout_strategy.py
@@ -16,6 +16,7 @@ from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Indicators import ChoppinessIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class choppiness_index_breakout_strategy(Strategy):
     """
@@ -45,7 +46,7 @@ class choppiness_index_breakout_strategy(Strategy):
         self._highChoppinessThreshold = self.Param("HighChoppinessThreshold", 61.8) \
             .SetDisplay("High Choppiness Threshold", "Threshold above which to exit positions", "Strategy Parameters")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles for strategy calculation", "Strategy Parameters")
 
     @property

--- a/API/0046_Volume_Spike/volume_spike_strategy.py
+++ b/API/0046_Volume_Spike/volume_spike_strategy.py
@@ -15,6 +15,7 @@ from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class volume_spike_strategy(Strategy):
     """
@@ -41,7 +42,7 @@ class volume_spike_strategy(Strategy):
         self._volumeSpikeMultiplier = self.Param("VolumeSpikeMultiplier", 2.0) \
             .SetDisplay("Volume Spike Multiplier", "Minimum volume increase multiplier to generate signal", "Strategy Parameters")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles for strategy calculation", "Strategy Parameters")
 
     @property

--- a/API/0047_OBV_Breakout/obv_breakout_strategy.py
+++ b/API/0047_OBV_Breakout/obv_breakout_strategy.py
@@ -18,6 +18,7 @@ from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Indicators import Highest
 from StockSharp.Algo.Indicators import Lowest
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class obv_breakout_strategy(Strategy):
@@ -44,7 +45,7 @@ class obv_breakout_strategy(Strategy):
         self._obvMAPeriod = self.Param("OBVMAPeriod", 20) \
             .SetDisplay("OBV MA Period", "Period for OBV Moving Average calculation", "Strategy Parameters")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles for strategy calculation", "Strategy Parameters")
 
     @property

--- a/API/0048_VWAP_Breakout/vwap_breakout_strategy.py
+++ b/API/0048_VWAP_Breakout/vwap_breakout_strategy.py
@@ -15,6 +15,7 @@ from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import VolumeWeightedMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class vwap_breakout_strategy(Strategy):
@@ -35,7 +36,7 @@ class vwap_breakout_strategy(Strategy):
         self._isFirstCandle = True
 
         # Initialize strategy parameters
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles for strategy calculation", "Strategy Parameters")
 
     @property

--- a/API/0049_VWMA/vwma_strategy.py
+++ b/API/0049_VWMA/vwma_strategy.py
@@ -15,6 +15,7 @@ from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import VolumeWeightedMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class vwma_strategy(Strategy):
@@ -38,7 +39,7 @@ class vwma_strategy(Strategy):
         self._vwmaPeriod = self.Param("VWMAPeriod", 14) \
             .SetDisplay("VWMA Period", "Period for Volume Weighted Moving Average calculation", "Strategy Parameters")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles for strategy calculation", "Strategy Parameters")
 
     @property

--- a/API/0050_AD/ad_strategy.py
+++ b/API/0050_AD/ad_strategy.py
@@ -16,6 +16,7 @@ from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Indicators import AccumulationDistributionLine
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class ad_strategy(Strategy):
     """
@@ -37,7 +38,7 @@ class ad_strategy(Strategy):
         self._maPeriod = self.Param("MAPeriod", 20) \
             .SetDisplay("MA Period", "Period for Moving Average calculation", "Strategy Parameters")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles for strategy calculation", "Strategy Parameters")
 
     @property

--- a/API/0051_Volume_Weighted_Price_Breakout/volume_weighted_price_breakout_strategy.py
+++ b/API/0051_Volume_Weighted_Price_Breakout/volume_weighted_price_breakout_strategy.py
@@ -16,6 +16,7 @@ from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Indicators import VolumeWeightedMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class volume_weighted_price_breakout_strategy(Strategy):
     """
@@ -36,7 +37,7 @@ class volume_weighted_price_breakout_strategy(Strategy):
         self._vwapPeriod = self.Param("VWAPPeriod", 20) \
             .SetDisplay("VWAP Period", "Period for Volume Weighted Average Price calculation", "Strategy Parameters")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles for strategy calculation", "Strategy Parameters")
 
     @property

--- a/API/0052_Volume_Divergence/volume_divergence_strategy.py
+++ b/API/0052_Volume_Divergence/volume_divergence_strategy.py
@@ -16,6 +16,7 @@ from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Indicators import AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class volume_divergence_strategy(Strategy):
     """
@@ -41,7 +42,7 @@ class volume_divergence_strategy(Strategy):
         self._atrPeriod = self.Param("ATRPeriod", 14) \
             .SetDisplay("ATR Period", "Period for Average True Range calculation", "Strategy Parameters")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles for strategy calculation", "Strategy Parameters")
 
     @property

--- a/API/0053_Volume_MA_Cross/volume_ma_cross_strategy.py
+++ b/API/0053_Volume_MA_Cross/volume_ma_cross_strategy.py
@@ -15,6 +15,7 @@ from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class volume_ma_cross_strategy(Strategy):
@@ -43,7 +44,7 @@ class volume_ma_cross_strategy(Strategy):
         self._slowVolumeMALength = self.Param("SlowVolumeMALength", 50) \
             .SetDisplay("Slow Volume MA Length", "Period for Slow Volume Moving Average", "Strategy Parameters")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles for strategy calculation", "Strategy Parameters")
 
     @property

--- a/API/0054_Cumulative_Delta_Breakout/cumulative_delta_breakout_strategy.py
+++ b/API/0054_Cumulative_Delta_Breakout/cumulative_delta_breakout_strategy.py
@@ -16,6 +16,7 @@ from StockSharp.Messages import ICandleMessage
 from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 import System.Linq
 
 class cumulative_delta_breakout_strategy(Strategy):
@@ -41,7 +42,7 @@ class cumulative_delta_breakout_strategy(Strategy):
         self._lookbackPeriod = self.Param("LookbackPeriod", 20) \
             .SetDisplay("Lookback Period", "Period for calculating highest/lowest delta", "Strategy Parameters")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles for strategy calculation", "Strategy Parameters")
 
     @property

--- a/API/0055_Volume_Surge/volume_surge_strategy.py
+++ b/API/0055_Volume_Surge/volume_surge_strategy.py
@@ -15,6 +15,7 @@ from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class volume_surge_strategy(Strategy):
@@ -42,7 +43,7 @@ class volume_surge_strategy(Strategy):
         self._volumeSurgeMultiplier = self.Param("VolumeSurgeMultiplier", 2.0) \
             .SetDisplay("Volume Surge Multiplier", "Minimum volume increase multiplier to generate signal", "Strategy Parameters")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles for strategy calculation", "Strategy Parameters")
 
     @property

--- a/API/0056_Double_Bottom/double_bottom_strategy.py
+++ b/API/0056_Double_Bottom/double_bottom_strategy.py
@@ -15,6 +15,7 @@ from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import Lowest
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class double_bottom_strategy(Strategy):
@@ -41,7 +42,7 @@ class double_bottom_strategy(Strategy):
         self._similarityPercent = self.Param("SimilarityPercent", 2.0) \
             .SetDisplay("Similarity %", "Maximum percentage difference between two bottoms", "Pattern Parameters")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candleType = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._stopLossPercent = self.Param("StopLossPercent", 1.0) \

--- a/API/0057_Double_Top/double_top_strategy.py
+++ b/API/0057_Double_Top/double_top_strategy.py
@@ -15,6 +15,7 @@ from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import Highest
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class double_top_strategy(Strategy):
@@ -41,7 +42,7 @@ class double_top_strategy(Strategy):
         self._similarityPercent = self.Param("SimilarityPercent", 2.0) \
             .SetDisplay("Similarity %", "Maximum percentage difference between two tops", "Pattern Parameters")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candleType = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._stopLossPercent = self.Param("StopLossPercent", 1.0) \

--- a/API/0058_RSI_Overbought_Oversold/rsi_overbought_oversold_strategy.py
+++ b/API/0058_RSI_Overbought_Oversold/rsi_overbought_oversold_strategy.py
@@ -15,6 +15,7 @@ from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import RelativeStrengthIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class rsi_overbought_oversold_strategy(Strategy):
     """
@@ -38,7 +39,7 @@ class rsi_overbought_oversold_strategy(Strategy):
         self._neutralLevel = self.Param("NeutralLevel", 50) \
             .SetDisplay("Neutral Level", "RSI level for exiting positions", "Signal Parameters")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._stopLossPercent = self.Param("StopLossPercent", 2.0) \

--- a/API/0059_Hammer_Candle/hammer_candle_strategy.py
+++ b/API/0059_Hammer_Candle/hammer_candle_strategy.py
@@ -14,6 +14,7 @@ from StockSharp.Messages import ICandleMessage
 from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class hammer_candle_strategy(Strategy):
     """
@@ -28,7 +29,7 @@ class hammer_candle_strategy(Strategy):
         self._isPositionOpen = False
 
         # Initialize strategy parameters
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use for pattern detection", "General")
 
     @property

--- a/API/0060_Shooting_Star/shooting_star_strategy.py
+++ b/API/0060_Shooting_Star/shooting_star_strategy.py
@@ -15,6 +15,7 @@ from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import Highest
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class shooting_star_strategy(Strategy):
     """
@@ -36,7 +37,7 @@ class shooting_star_strategy(Strategy):
         self._shadowToBodyRatio = self.Param("ShadowToBodyRatio", 2.0) \
             .SetDisplay("Shadow/Body Ratio", "Minimum ratio of upper shadow to body length", "Pattern Parameters")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candleType = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._stopLossPercent = self.Param("StopLossPercent", 1.0) \

--- a/API/0061_MACD_Divergence/macd_divergence_strategy.py
+++ b/API/0061_MACD_Divergence/macd_divergence_strategy.py
@@ -15,6 +15,7 @@ from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import MovingAverageConvergenceDivergenceSignal
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class macd_divergence_strategy(Strategy):
     """
@@ -48,7 +49,7 @@ class macd_divergence_strategy(Strategy):
         self._divergencePeriod = self.Param("DivergencePeriod", 5) \
             .SetDisplay("Divergence Period", "Number of bars to look back for divergence", "Signal Parameters")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candleType = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._stopLossPercent = self.Param("StopLossPercent", 2.0) \

--- a/API/0062_Stochastic_Overbought_Oversold/stochastic_overbought_oversold_strategy.py
+++ b/API/0062_Stochastic_Overbought_Oversold/stochastic_overbought_oversold_strategy.py
@@ -15,6 +15,7 @@ from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import StochasticOscillator
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class stochastic_overbought_oversold_strategy(Strategy):
     """
@@ -35,7 +36,7 @@ class stochastic_overbought_oversold_strategy(Strategy):
         self._dPeriod = self.Param("DPeriod", 3) \
             .SetDisplay("D Period", "Smoothing period for Stochastic %D line", "Indicators")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
     @property

--- a/API/0063_Engulfing_Bullish/engulfing_bullish_strategy.py
+++ b/API/0063_Engulfing_Bullish/engulfing_bullish_strategy.py
@@ -14,6 +14,7 @@ from StockSharp.Messages import ICandleMessage
 from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class engulfing_bullish_strategy(Strategy):
     """
@@ -31,7 +32,7 @@ class engulfing_bullish_strategy(Strategy):
         self._consecutiveDownBars = 0
 
         # Initialize strategy parameters
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candleType = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._stopLossPercent = self.Param("StopLossPercent", 1.0) \

--- a/API/0064_Engulfing_Bearish/engulfing_bearish_strategy.py
+++ b/API/0064_Engulfing_Bearish/engulfing_bearish_strategy.py
@@ -14,6 +14,7 @@ from StockSharp.Messages import ICandleMessage
 from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class engulfing_bearish_strategy(Strategy):
     """
@@ -31,7 +32,7 @@ class engulfing_bearish_strategy(Strategy):
         self._consecutiveUpBars = 0
 
         # Initialize strategy parameters
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candleType = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._stopLossPercent = self.Param("StopLossPercent", 1.0) \

--- a/API/0065_Pinbar_Reversal/pinbar_reversal_strategy.py
+++ b/API/0065_Pinbar_Reversal/pinbar_reversal_strategy.py
@@ -15,6 +15,7 @@ from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class pinbar_reversal_strategy(Strategy):
     """
@@ -37,7 +38,7 @@ class pinbar_reversal_strategy(Strategy):
         self._oppositeTailRatio = self.Param("OppositeTailRatio", 0.5) \
             .SetDisplay("Opposite Tail Ratio", "Maximum ratio of opposite tail to body", "Pattern Parameters")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candleType = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._stopLossPercent = self.Param("StopLossPercent", 1.0) \

--- a/API/0066_Three_Bar_Reversal_Up/three_bar_reversal_up_strategy.py
+++ b/API/0066_Three_Bar_Reversal_Up/three_bar_reversal_up_strategy.py
@@ -17,6 +17,7 @@ from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import Lowest
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class three_bar_reversal_up_strategy(Strategy):
     """
@@ -36,7 +37,7 @@ class three_bar_reversal_up_strategy(Strategy):
         self._lowestIndicator = None
 
         # Initialize strategy parameters
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candleType = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._stopLossPercent = self.Param("StopLossPercent", 1.0) \

--- a/API/0067_Three_Bar_Reversal_Down/three_bar_reversal_down_strategy.py
+++ b/API/0067_Three_Bar_Reversal_Down/three_bar_reversal_down_strategy.py
@@ -17,6 +17,7 @@ from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import Highest
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class three_bar_reversal_down_strategy(Strategy):
     """
@@ -36,7 +37,7 @@ class three_bar_reversal_down_strategy(Strategy):
         self._highestIndicator = None
 
         # Initialize strategy parameters
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candleType = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._stopLossPercent = self.Param("StopLossPercent", 1.0) \

--- a/API/0068_CCI_Divergence/cci_divergence_strategy.py
+++ b/API/0068_CCI_Divergence/cci_divergence_strategy.py
@@ -15,6 +15,7 @@ from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import CommodityChannelIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class cci_divergence_strategy(Strategy):
     """
@@ -42,7 +43,7 @@ class cci_divergence_strategy(Strategy):
         self._divergencePeriod = self.Param("DivergencePeriod", 5) \
             .SetDisplay("Divergence Period", "Number of bars to look back for divergence", "Signal Parameters")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candleType = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._stopLossPercent = self.Param("StopLossPercent", 2.0) \

--- a/API/0069_Bollinger_Band_Reversal/bollinger_band_reversal_strategy.py
+++ b/API/0069_Bollinger_Band_Reversal/bollinger_band_reversal_strategy.py
@@ -16,6 +16,7 @@ from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import BollingerBands
 from StockSharp.Algo.Indicators import AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class bollinger_band_reversal_strategy(Strategy):
     """
@@ -39,7 +40,7 @@ class bollinger_band_reversal_strategy(Strategy):
         self._bollingerDeviation = self.Param("BollingerDeviation", 2.0) \
             .SetDisplay("Bollinger Deviation", "Number of standard deviations for Bollinger Bands", "Indicators")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._atrMultiplier = self.Param("AtrMultiplier", 2.0) \

--- a/API/0070_Morning_Star/morning_star_strategy.py
+++ b/API/0070_Morning_Star/morning_star_strategy.py
@@ -14,6 +14,7 @@ from StockSharp.Messages import ICandleMessage
 from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class morning_star_strategy(Strategy):
     """
@@ -30,7 +31,7 @@ class morning_star_strategy(Strategy):
         self._secondCandle = None
 
         # Initialize strategy parameters
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._stopLossPercent = self.Param("StopLossPercent", 1.0) \

--- a/API/0071_Evening_Star/evening_star_strategy.py
+++ b/API/0071_Evening_Star/evening_star_strategy.py
@@ -14,6 +14,7 @@ from StockSharp.Messages import ICandleMessage
 from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class evening_star_strategy(Strategy):
     """
@@ -30,7 +31,7 @@ class evening_star_strategy(Strategy):
         self._secondCandle = None
 
         # Initialize strategy parameters
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._stopLossPercent = self.Param("StopLossPercent", 1.0) \

--- a/API/0072_Doji_Reversal/doji_reversal_strategy.py
+++ b/API/0072_Doji_Reversal/doji_reversal_strategy.py
@@ -14,6 +14,7 @@ from StockSharp.Messages import ICandleMessage
 from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class doji_reversal_strategy(Strategy):
     """
@@ -30,7 +31,7 @@ class doji_reversal_strategy(Strategy):
         self._previousPreviousCandle = None
 
         # Initialize strategy parameters
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._dojiThreshold = self.Param("DojiThreshold", 0.1) \

--- a/API/0073_Keltner_Channel_Reversal/keltner_channel_reversal_strategy.py
+++ b/API/0073_Keltner_Channel_Reversal/keltner_channel_reversal_strategy.py
@@ -16,6 +16,7 @@ from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import KeltnerChannels
 from StockSharp.Algo.Indicators import AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class keltner_channel_reversal_strategy(Strategy):
     """
@@ -38,7 +39,7 @@ class keltner_channel_reversal_strategy(Strategy):
         self._atrPeriodParam = self.Param("AtrPeriod", 14) \
             .SetDisplay("ATR Period", "Period for ATR calculation", "Indicators")
         
-        self._candleTypeParam = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleTypeParam = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
         
         self._stopLossAtrMultiplierParam = self.Param("StopLossAtrMultiplier", 2.0) \

--- a/API/0074_Williams_R_Divergence/williams_r_strategy.py
+++ b/API/0074_Williams_R_Divergence/williams_r_strategy.py
@@ -15,6 +15,7 @@ from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import WilliamsR
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class williams_percent_r_divergence_strategy(Strategy):
     """
@@ -33,7 +34,7 @@ class williams_percent_r_divergence_strategy(Strategy):
         self._divergencePeriodParam = self.Param("DivergencePeriod", 5) \
             .SetDisplay("Divergence Period", "Number of periods to look back for divergence", "Indicators")
         
-        self._candleTypeParam = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleTypeParam = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
         
         self._stopLossPercentParam = self.Param("StopLossPercent", 2.0) \

--- a/API/0075_OBV_Divergence/obv_strategy.py
+++ b/API/0075_OBV_Divergence/obv_strategy.py
@@ -16,6 +16,7 @@ from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import OnBalanceVolume
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class obv_divergence_strategy(Strategy):
     """
@@ -34,7 +35,7 @@ class obv_divergence_strategy(Strategy):
         self._maPeriodParam = self.Param("MAPeriod", 20) \
             .SetDisplay("MA Period", "Period for moving average calculation (used for exit signal)", "Indicators")
         
-        self._candleTypeParam = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleTypeParam = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
         
         self._stopLossPercentParam = self.Param("StopLossPercent", 2.0) \

--- a/API/0076_Fibonacci_Retracement_Reversal/fibonacci_strategy.py
+++ b/API/0076_Fibonacci_Retracement_Reversal/fibonacci_strategy.py
@@ -14,6 +14,7 @@ from StockSharp.Messages import ICandleMessage
 from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class fibonacci_retracement_reversal_strategy(Strategy):
     """
@@ -35,7 +36,7 @@ class fibonacci_retracement_reversal_strategy(Strategy):
         self._fibLevelBufferParam = self.Param("FibLevelBuffer", 0.5) \
             .SetDisplay("Fib Level Buffer %", "Buffer percentage around Fibonacci levels", "Indicators")
         
-        self._candleTypeParam = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleTypeParam = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
         
         self._stopLossPercentParam = self.Param("StopLossPercent", 2.0) \

--- a/API/0077_Inside_Bar_Breakout/inside_bar_strategy.py
+++ b/API/0077_Inside_Bar_Breakout/inside_bar_strategy.py
@@ -14,6 +14,7 @@ from StockSharp.Messages import ICandleMessage
 from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class inside_bar_breakout_strategy(Strategy):
     """
@@ -27,7 +28,7 @@ class inside_bar_breakout_strategy(Strategy):
         super(inside_bar_breakout_strategy, self).__init__()
         
         # Initialize strategy parameters
-        self._candleTypeParam = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleTypeParam = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
         
         self._stopLossPercentParam = self.Param("StopLossPercent", 1.0) \

--- a/API/0078_Outside_Bar_Reversal/outside_bar_strategy.py
+++ b/API/0078_Outside_Bar_Reversal/outside_bar_strategy.py
@@ -14,6 +14,7 @@ from StockSharp.Messages import ICandleMessage
 from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class outside_bar_reversal_strategy(Strategy):
     """
@@ -27,7 +28,7 @@ class outside_bar_reversal_strategy(Strategy):
         super(outside_bar_reversal_strategy, self).__init__()
         
         # Initialize strategy parameters
-        self._candleTypeParam = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleTypeParam = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
         
         self._stopLossPercentParam = self.Param("StopLossPercent", 1.0) \

--- a/API/0079_Trendline_Bounce/trendline_strategy.py
+++ b/API/0079_Trendline_Bounce/trendline_strategy.py
@@ -18,6 +18,7 @@ from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class trendline_bounce_strategy(Strategy):
     """
@@ -40,7 +41,7 @@ class trendline_bounce_strategy(Strategy):
         self._bounceThresholdPercentParam = self.Param("BounceThresholdPercent", 0.5) \
             .SetDisplay("Bounce Threshold %", "Maximum distance from trendline for bounce detection", "Indicators")
         
-        self._candleTypeParam = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleTypeParam = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
         
         self._stopLossPercentParam = self.Param("StopLossPercent", 2.0) \

--- a/API/0080_Pivot_Point_Reversal/pivot_point_strategy.py
+++ b/API/0080_Pivot_Point_Reversal/pivot_point_strategy.py
@@ -15,6 +15,7 @@ from StockSharp.Messages import ICandleMessage
 from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class pivot_point_reversal_strategy(Strategy):
     """
@@ -28,7 +29,7 @@ class pivot_point_reversal_strategy(Strategy):
         super(pivot_point_reversal_strategy, self).__init__()
         
         # Initialize strategy parameters
-        self._candleTypeParam = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleTypeParam = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
         
         self._stopLossPercentParam = self.Param("StopLossPercent", 2.0) \
@@ -86,7 +87,7 @@ class pivot_point_reversal_strategy(Strategy):
         subscription = self.SubscribeCandles(self.CandleType)
         
         # Subscribe to the previous day's candles to get OHLC data
-        dailySubscription = self.SubscribeCandles(DataType.TimeFrame(TimeSpan.FromDays(1)))
+        dailySubscription = self.SubscribeCandles(tf(1*1440))
         
         # Process daily candles to get previous day's data
         dailySubscription.Bind(self.ProcessDailyCandle).Start()

--- a/API/0081_VWAP_Bounce/vwap_bounce_strategy.py
+++ b/API/0081_VWAP_Bounce/vwap_bounce_strategy.py
@@ -14,6 +14,7 @@ from StockSharp.Messages import ICandleMessage
 from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class vwap_bounce_strategy(Strategy):
     """
@@ -27,7 +28,7 @@ class vwap_bounce_strategy(Strategy):
         super(vwap_bounce_strategy, self).__init__()
         
         # Initialize strategy parameters
-        self._candleTypeParam = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleTypeParam = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
         
         self._stopLossParam = self.Param("StopLoss", Unit(2, UnitTypes.Percent)) \

--- a/API/0082_Volume_Exhaustion/volume_exhaustion_strategy.py
+++ b/API/0082_Volume_Exhaustion/volume_exhaustion_strategy.py
@@ -16,6 +16,7 @@ from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Indicators import AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class volume_exhaustion_strategy(Strategy):
     """
@@ -40,7 +41,7 @@ class volume_exhaustion_strategy(Strategy):
         self._atrMultiplierParam = self.Param("AtrMultiplier", Unit(2, UnitTypes.Absolute)) \
             .SetDisplay("ATR Multiplier", "Multiplier for ATR stop-loss", "Risk Management")
         
-        self._candleTypeParam = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleTypeParam = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
         
         self._stopLossPercentParam = self.Param("StopLossPercent", 1.0) \

--- a/API/0083_ADX_Weakening/adx_weakening_strategy.py
+++ b/API/0083_ADX_Weakening/adx_weakening_strategy.py
@@ -14,6 +14,7 @@ from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Indicators import AverageDirectionalIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class adx_weakening_strategy(Strategy):
@@ -44,7 +45,7 @@ class adx_weakening_strategy(Strategy):
             .SetRange(1.0, 3.0) \
             .SetCanOptimize(True)
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candleType = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Internal state

--- a/API/0084_ATR_Exhaustion/atr_exhaustion_strategy.py
+++ b/API/0084_ATR_Exhaustion/atr_exhaustion_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class atr_exhaustion_strategy(Strategy):
@@ -48,7 +49,7 @@ class atr_exhaustion_strategy(Strategy):
             .SetRange(1.0, 3.0) \
             .SetCanOptimize(True)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._atr_avg = None

--- a/API/0085_Ichimoku_Tenkan/ichimoku_tenkan_kijun_strategy.py
+++ b/API/0085_Ichimoku_Tenkan/ichimoku_tenkan_kijun_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import Ichimoku
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class ichimoku_tenkan_kijun_strategy(Strategy):
     """Ichimoku Tenkan/Kijun Cross Strategy.
@@ -33,7 +34,7 @@ class ichimoku_tenkan_kijun_strategy(Strategy):
             .SetRange(40, 60) \
             .SetCanOptimize(True)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(30))) \
+        self._candle_type = self.Param("CandleType", tf(30)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._stop_loss_percent = self.Param("StopLossPercent", 1.0) \

--- a/API/0086_Heikin_Ashi_Reversal/heikin_ashi_reversal_strategy.py
+++ b/API/0086_Heikin_Ashi_Reversal/heikin_ashi_reversal_strategy.py
@@ -7,6 +7,7 @@ clr.AddReference("StockSharp.Algo")
 from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class heikin_ashi_reversal_strategy(Strategy):
     """
@@ -21,7 +22,7 @@ class heikin_ashi_reversal_strategy(Strategy):
         super(heikin_ashi_reversal_strategy, self).__init__()
 
         # Initialize strategy parameters
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candleType = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._stopLoss = self.Param("StopLoss", Unit(2, UnitTypes.Percent)) \

--- a/API/0087_Parabolic_SAR_Reversal/parabolic_sar_reversal_strategy.py
+++ b/API/0087_Parabolic_SAR_Reversal/parabolic_sar_reversal_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates
 from StockSharp.Algo.Indicators import ParabolicSar
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class parabolic_sar_reversal_strategy(Strategy):
@@ -30,7 +31,7 @@ class parabolic_sar_reversal_strategy(Strategy):
             .SetRange(0.1, 0.3) \
             .SetCanOptimize(True)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candle_type = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._prev_is_sar_above_price = None

--- a/API/0088_Supertrend_Reversal/supertrend_reversal_strategy.py
+++ b/API/0088_Supertrend_Reversal/supertrend_reversal_strategy.py
@@ -8,6 +8,7 @@ from System import Math
 from StockSharp.Messages import DataType, CandleStates
 from StockSharp.Algo.Indicators import AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class supertrend_reversal_strategy(Strategy):
@@ -32,7 +33,7 @@ class supertrend_reversal_strategy(Strategy):
             .SetRange(2.0, 4.0) \
             .SetCanOptimize(True)
 
-        self._candle_type = self.Param("CandleType", TimeSpan.FromMinutes(15).TimeFrame()) \
+        self._candle_type = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Previous state variables

--- a/API/0089_Hull_MA_Reversal/hull_ma_reversal_strategy.py
+++ b/API/0089_Hull_MA_Reversal/hull_ma_reversal_strategy.py
@@ -8,6 +8,7 @@ from System import Math
 from StockSharp.Messages import UnitTypes, Unit, DataType, ICandleMessage, CandleStates
 from StockSharp.Algo.Indicators import HullMovingAverage, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class hull_ma_reversal_strategy(Strategy):
     """
@@ -24,7 +25,7 @@ class hull_ma_reversal_strategy(Strategy):
             .SetDisplay("HMA Period", "Period for Hull Moving Average", "Indicator Settings")
         self._atr_multiplier = self.Param("AtrMultiplier", Unit(2, UnitTypes.Absolute)) \
             .SetDisplay("ATR Multiplier", "Multiplier for ATR stop-loss", "Risk Management")
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candle_type = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
         self._stop_loss_percent = self.Param("StopLossPercent", 1.0) \
             .SetDisplay("Stop Loss %", "Stop loss percentage from entry price", "Risk Management")

--- a/API/0090_Donchian_Reversal/donchian_reversal_strategy.py
+++ b/API/0090_Donchian_Reversal/donchian_reversal_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import DonchianChannels
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class donchian_reversal_strategy(Strategy):
     """
@@ -31,7 +32,7 @@ class donchian_reversal_strategy(Strategy):
             .SetOptimize(1.0, 3.0, 0.5) \
             .SetCanOptimize(True)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candle_type = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Internal state

--- a/API/0091_MACD_Histogram_Reversal/macd_histogram_reversal_strategy.py
+++ b/API/0091_MACD_Histogram_Reversal/macd_histogram_reversal_strategy.py
@@ -8,6 +8,7 @@ from System import Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import MovingAverageConvergenceDivergenceHistogram
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class macd_histogram_reversal_strategy(Strategy):
     """
@@ -42,7 +43,7 @@ class macd_histogram_reversal_strategy(Strategy):
             .SetRange(1.0, 3.0) \
             .SetCanOptimize(True)
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candleType = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Previous MACD histogram value

--- a/API/0092_RSI_Hook_Reversal/rsi_hook_reversal_strategy.py
+++ b/API/0092_RSI_Hook_Reversal/rsi_hook_reversal_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import RelativeStrengthIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class rsi_hook_reversal_strategy(Strategy):
     """
@@ -31,7 +32,7 @@ class rsi_hook_reversal_strategy(Strategy):
             .SetDisplay("Exit Level", "Exit level for RSI (neutral zone)", "RSI Settings")
         self._stop_loss = self.Param("StopLoss", Unit(2, UnitTypes.Percent)) \
             .SetDisplay("Stop Loss", "Stop loss as percentage from entry price", "Risk Management")
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candle_type = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Previous RSI value

--- a/API/0093_Stochastic_Hook_Reversal/stochastic_hook_reversal_strategy.py
+++ b/API/0093_Stochastic_Hook_Reversal/stochastic_hook_reversal_strategy.py
@@ -8,6 +8,7 @@ from System import Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import StochasticOscillator, StochasticOscillatorValue
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class stochastic_hook_reversal_strategy(Strategy):
@@ -44,7 +45,7 @@ class stochastic_hook_reversal_strategy(Strategy):
         self._stop_loss = self.Param("StopLoss", Unit(2, UnitTypes.Percent)) \
             .SetDisplay("Stop Loss", "Stop loss as percentage from entry price", "Risk Management")
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candle_type = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Previous %K value

--- a/API/0094_CCI_Hook_Reversal/cci_hook_reversal_strategy.py
+++ b/API/0094_CCI_Hook_Reversal/cci_hook_reversal_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import CommodityChannelIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class cci_hook_reversal_strategy(Strategy):
     """
@@ -35,7 +36,7 @@ class cci_hook_reversal_strategy(Strategy):
         self._stop_loss_percent = self.Param("StopLoss", 2.0) \
             .SetDisplay("Stop Loss", "Stop loss as percentage from entry price", "Risk Management")
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candle_type = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Previous CCI value

--- a/API/0095_Williams_R_Hook_Reversal/williams_r_hook_reversal_strategy.py
+++ b/API/0095_Williams_R_Hook_Reversal/williams_r_hook_reversal_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import WilliamsR
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class williams_r_hook_reversal_strategy(Strategy):
@@ -45,7 +46,7 @@ class williams_r_hook_reversal_strategy(Strategy):
             .SetRange(1.0, 3.0) \
             .SetCanOptimize(True)
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candleType = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Internal state

--- a/API/0096_Three_White_Soldiers/three_white_soldiers_strategy.py
+++ b/API/0096_Three_White_Soldiers/three_white_soldiers_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class three_white_soldiers_strategy(Strategy):
     """
@@ -26,7 +27,7 @@ class three_white_soldiers_strategy(Strategy):
         self._currentCandle = None
 
         # Initialize strategy parameters
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles for strategy calculation", "General")
 
         self._stopLossPercent = self.Param("StopLossPercent", 1.0) \

--- a/API/0097_Three_Black_Crows/three_black_crows_strategy.py
+++ b/API/0097_Three_Black_Crows/three_black_crows_strategy.py
@@ -13,6 +13,7 @@ from StockSharp.Messages import ICandleMessage
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import SMA
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class three_black_crows_strategy(Strategy):
     """
@@ -35,7 +36,7 @@ class three_black_crows_strategy(Strategy):
         self._current_candle = None
 
         # Initialize strategy parameters
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles for strategy calculation", "General")
 
         self._stop_loss_percent = self.Param("StopLossPercent", 1.0) \

--- a/API/0098_Gap_Fill_Reversal/gap_fill_reversal_strategy.py
+++ b/API/0098_Gap_Fill_Reversal/gap_fill_reversal_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan
 from System import Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class gap_fill_reversal_strategy(Strategy):
     """
@@ -18,7 +19,7 @@ class gap_fill_reversal_strategy(Strategy):
         super(gap_fill_reversal_strategy, self).__init__()
 
         # Initialize strategy parameters
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles for strategy calculation", "General")
 
         self._stop_loss_percent = self.Param("StopLossPercent", 2.0) \

--- a/API/0099_Tweezer_Bottom/tweezer_bottom_strategy.py
+++ b/API/0099_Tweezer_Bottom/tweezer_bottom_strategy.py
@@ -6,6 +6,7 @@ clr.AddReference("StockSharp.Algo")
 from System import TimeSpan, Math
 from StockSharp.Messages import DataType, ICandleMessage, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class tweezer_bottom_strategy(Strategy):
     """
@@ -17,7 +18,7 @@ class tweezer_bottom_strategy(Strategy):
     def __init__(self):
         super(tweezer_bottom_strategy, self).__init__()
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles for strategy calculation", "General")
 
         self._stop_loss_percent = self.Param("StopLossPercent", 1.0) \

--- a/API/0100_Tweezer_Top/tweezer_top_strategy.py
+++ b/API/0100_Tweezer_Top/tweezer_top_strategy.py
@@ -6,6 +6,7 @@ clr.AddReference("StockSharp.Algo")
 from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class tweezer_top_strategy(Strategy):
@@ -21,7 +22,7 @@ class tweezer_top_strategy(Strategy):
         super(tweezer_top_strategy, self).__init__()
 
         # Initialize strategy parameters
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles for strategy calculation", "General")
 
         self._stopLossPercent = self.Param("StopLossPercent", 1.0) \

--- a/API/0101_Harami_Bullish/harami_bullish_strategy.py
+++ b/API/0101_Harami_Bullish/harami_bullish_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan
 from System import Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class harami_bullish_strategy(Strategy):
@@ -21,7 +22,7 @@ class harami_bullish_strategy(Strategy):
         super(harami_bullish_strategy, self).__init__()
 
         # Initialize strategy parameters
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use for pattern detection", "General")
 
         self._stopLossPercent = self.Param("StopLossPercent", 1.0) \

--- a/API/0102_Harami_Bearish/harami_bearish_strategy.py
+++ b/API/0102_Harami_Bearish/harami_bearish_strategy.py
@@ -6,6 +6,7 @@ clr.AddReference("StockSharp.Algo")
 from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, ICandleMessage, CandleStates
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class harami_bearish_strategy(Strategy):
@@ -24,7 +25,7 @@ class harami_bearish_strategy(Strategy):
         self._pattern_detected = False
 
         # Strategy parameters
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use for pattern detection", "General")
 
         self._stop_loss_percent = self.Param("StopLossPercent", 1.0) \

--- a/API/0103_Dark_Pool_Prints/dark_pool_prints_strategy.py
+++ b/API/0103_Dark_Pool_Prints/dark_pool_prints_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage, AverageDirectionalIndex, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class dark_pool_prints_strategy(Strategy):
     """
@@ -21,7 +22,7 @@ class dark_pool_prints_strategy(Strategy):
         super(dark_pool_prints_strategy, self).__init__()
 
         # Candle type and timeframe for the strategy.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use for analysis", "General")
 
         # Period for volume average calculation.

--- a/API/0104_Rejection_Candle/rejection_candle_strategy.py
+++ b/API/0104_Rejection_Candle/rejection_candle_strategy.py
@@ -11,6 +11,7 @@ from StockSharp.Messages import Sides
 from StockSharp.Messages import Unit
 from StockSharp.Messages import UnitTypes
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class rejection_candle_strategy(Strategy):
     """
@@ -23,7 +24,7 @@ class rejection_candle_strategy(Strategy):
         super(rejection_candle_strategy, self).__init__()
 
         # Initialize strategy parameters
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use for pattern detection", "General")
 
         self._stop_loss_percent = self.Param("StopLossPercent", 1.0) \

--- a/API/0105_False_Breakout_Trap/false_breakout_trap_strategy.py
+++ b/API/0105_False_Breakout_Trap/false_breakout_trap_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes, Sides
 from StockSharp.Algo.Indicators import SimpleMovingAverage, Highest, Lowest
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class false_breakout_trap_strategy(Strategy):
     """
@@ -19,7 +20,7 @@ class false_breakout_trap_strategy(Strategy):
         super(false_breakout_trap_strategy, self).__init__()
 
         # Candle type and timeframe for the strategy.
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use for analysis", "General")
 
         # Period for high/low range detection.

--- a/API/0106_Spring_Reversal/spring_reversal_strategy.py
+++ b/API/0106_Spring_Reversal/spring_reversal_strategy.py
@@ -9,6 +9,7 @@ from System import Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates, ICandleMessage
 from StockSharp.Algo.Indicators import SimpleMovingAverage, Lowest
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class spring_reversal_strategy(Strategy):
     """
@@ -20,7 +21,7 @@ class spring_reversal_strategy(Strategy):
         super(spring_reversal_strategy, self).__init__()
 
         # Strategy parameters
-        self._candle_type_param = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type_param = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use for analysis", "General")
         self._lookback_period_param = self.Param("LookbackPeriod", 20) \
             .SetDisplay("Lookback Period", "Period for support level detection", "Range") \

--- a/API/0107_Upthrust_Reversal/upthrust_reversal_strategy.py
+++ b/API/0107_Upthrust_Reversal/upthrust_reversal_strategy.py
@@ -11,6 +11,7 @@ from StockSharp.Messages import Unit
 from StockSharp.Messages import UnitTypes
 from StockSharp.Algo.Indicators import SimpleMovingAverage, Highest
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class upthrust_reversal_strategy(Strategy):
@@ -25,7 +26,7 @@ class upthrust_reversal_strategy(Strategy):
         super(upthrust_reversal_strategy, self).__init__()
 
         # Initialize strategy parameters
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use for analysis", "General")
 
         self._lookbackPeriod = self.Param("LookbackPeriod", 20) \

--- a/API/0108_Wyckoff_Accumulation/wyckoff_accumulation_strategy.py
+++ b/API/0108_Wyckoff_Accumulation/wyckoff_accumulation_strategy.py
@@ -8,6 +8,7 @@ from System import Math
 from StockSharp.Messages import DataType, UnitTypes, Unit, CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage, Highest, Lowest
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class WyckoffPhase:
@@ -27,7 +28,7 @@ class wyckoff_accumulation_strategy(Strategy):
         super(wyckoff_accumulation_strategy, self).__init__()
 
         # Initialize strategy parameters
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candleType = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use for analysis", "General")
 
         self._maPeriod = self.Param("MaPeriod", 20) \

--- a/API/0109_Wyckoff_Distribution/wyckoff_distribution_strategy.py
+++ b/API/0109_Wyckoff_Distribution/wyckoff_distribution_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, UnitTypes, Unit
 from StockSharp.Algo.Indicators import SimpleMovingAverage, Highest, Lowest
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class wyckoff_distribution_strategy(Strategy):
     """
@@ -27,7 +28,7 @@ class wyckoff_distribution_strategy(Strategy):
         super(wyckoff_distribution_strategy, self).__init__()
 
         # Initialize strategy parameters
-        self._candle_type = self.Param("CandleType", TimeSpan.FromMinutes(15).TimeFrame()) \
+        self._candle_type = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use for analysis", "General")
 
         self._ma_period = self.Param("MaPeriod", 20) \

--- a/API/0110_RSI_Failure_Swing/rsi_failure_swing_strategy.py
+++ b/API/0110_RSI_Failure_Swing/rsi_failure_swing_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates, Sides
 from StockSharp.Algo.Indicators import RelativeStrengthIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class rsi_failure_swing_strategy(Strategy):
     """
@@ -21,7 +22,7 @@ class rsi_failure_swing_strategy(Strategy):
         super(rsi_failure_swing_strategy, self).__init__()
 
         # Initialize strategy parameters
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use for analysis", "General")
 
         self._rsiPeriod = self.Param("RsiPeriod", 14) \

--- a/API/0111_Stochastic_Failure_Swing/stochastic_failure_swing_strategy.py
+++ b/API/0111_Stochastic_Failure_Swing/stochastic_failure_swing_strategy.py
@@ -8,6 +8,7 @@ from System import Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates, Sides
 from StockSharp.Algo.Indicators import StochasticOscillator
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class stochastic_failure_swing_strategy(Strategy):
     """
@@ -19,7 +20,7 @@ class stochastic_failure_swing_strategy(Strategy):
         super(stochastic_failure_swing_strategy, self).__init__()
 
         # Candle type and timeframe for the strategy.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use for analysis", "General")
 
         # K period for Stochastic calculation.

--- a/API/0112_CCI_Failure_Swing/cci_failure_swing_strategy.py
+++ b/API/0112_CCI_Failure_Swing/cci_failure_swing_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates, Sides
 from StockSharp.Algo.Indicators import CommodityChannelIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class cci_failure_swing_strategy(Strategy):
     """
@@ -20,7 +21,7 @@ class cci_failure_swing_strategy(Strategy):
         super(cci_failure_swing_strategy, self).__init__()
 
         # Initialize strategy parameters
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use for analysis", "General")
 
         self._cci_period = self.Param("CciPeriod", 20) \

--- a/API/0113_Bullish_Abandoned_Baby/bullish_abandoned_baby_strategy.py
+++ b/API/0113_Bullish_Abandoned_Baby/bullish_abandoned_baby_strategy.py
@@ -14,6 +14,7 @@ from StockSharp.Messages import ICandleMessage
 from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class bullish_abandoned_baby_strategy(Strategy):
     """
@@ -23,7 +24,7 @@ class bullish_abandoned_baby_strategy(Strategy):
         super(bullish_abandoned_baby_strategy, self).__init__()
 
         # Candle type and timeframe.
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candleType = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use for analysis", "Candles")
 
         # Stop-loss percent from entry price.

--- a/API/0114_Bearish_Abandoned_Baby/bearish_abandoned_baby_strategy.py
+++ b/API/0114_Bearish_Abandoned_Baby/bearish_abandoned_baby_strategy.py
@@ -6,6 +6,7 @@ clr.AddReference("StockSharp.Algo")
 from System import TimeSpan
 from StockSharp.Messages import DataType, UnitTypes, Unit, CandleStates
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class bearish_abandoned_baby_strategy(Strategy):
     """Strategy based on Bearish Abandoned Baby candlestick pattern."""
@@ -14,7 +15,7 @@ class bearish_abandoned_baby_strategy(Strategy):
         super(bearish_abandoned_baby_strategy, self).__init__()
 
         # Initialize strategy parameters
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candle_type = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use for analysis", "Candles")
 
         self._stop_loss_percent = self.Param("StopLossPercent", 1.0) \

--- a/API/0115_Volume_Climax_Reversal/volume_climax_reversal_strategy.py
+++ b/API/0115_Volume_Climax_Reversal/volume_climax_reversal_strategy.py
@@ -10,6 +10,7 @@ from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Indicators import AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 
@@ -25,7 +26,7 @@ class volume_climax_reversal_strategy(Strategy):
         # Initializes a new instance of the <see cref="VolumeClimaxReversalStrategy"/>.
 
         # Initialize strategy parameters
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candleType = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "Candles")
 
         self._volumePeriod = self.Param("VolumePeriod", 20) \

--- a/API/0116_Day_of_Week/day_of_week_strategy.py
+++ b/API/0116_Day_of_Week/day_of_week_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math, DayOfWeek
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class day_of_week_strategy(Strategy):
     """
@@ -24,7 +25,7 @@ class day_of_week_strategy(Strategy):
         self._ma_period = self.Param("MaPeriod", 20) \
             .SetDisplay("MA Period", "Moving average period for trend confirmation", "Strategy")
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candle_type = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles for strategy", "Strategy")
 
     @property

--- a/API/0117_Month_of_Year/month_of_year_strategy.py
+++ b/API/0117_Month_of_Year/month_of_year_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class month_of_year_strategy(Strategy):
     """
@@ -28,7 +29,7 @@ class month_of_year_strategy(Strategy):
             .SetGreaterThanZero() \
             .SetDisplay("MA Period", "Moving average period for trend confirmation", "Strategy")
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromDays(1))) \
+        self._candle_type = self.Param("CandleType", tf(1*1440)) \
             .SetDisplay("Candle Type", "Type of candles for strategy", "Strategy")
 
     @property

--- a/API/0118_Turnaround_Tuesday/turnaround_tuesday_strategy.py
+++ b/API/0118_Turnaround_Tuesday/turnaround_tuesday_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math, DayOfWeek
 from StockSharp.Messages import DataType, UnitTypes, Unit, CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class turnaround_tuesday_strategy(Strategy):
     """
@@ -26,7 +27,7 @@ class turnaround_tuesday_strategy(Strategy):
         self._ma_period = self.Param("MaPeriod", 20) \
             .SetDisplay("MA Period", "Moving average period for trend confirmation", "Strategy")
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromDays(1))) \
+        self._candle_type = self.Param("CandleType", tf(1*1440)) \
             .SetDisplay("Candle Type", "Type of candles for strategy", "Strategy")
 
         # Internal state

--- a/API/0119_End_of_Month_Strength/end_of_month_strength_strategy.py
+++ b/API/0119_End_of_Month_Strength/end_of_month_strength_strategy.py
@@ -12,6 +12,7 @@ from StockSharp.Messages import ICandleMessage
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class end_of_month_strength_strategy(Strategy):
     """
@@ -33,7 +34,7 @@ class end_of_month_strength_strategy(Strategy):
             .SetGreaterThanZero() \
             .SetDisplay("MA Period", "Moving average period for trend confirmation", "Strategy")
 
-        self._candleType = self.Param("CandleType", TimeSpan.FromDays(1).TimeFrame()) \
+        self._candleType = self.Param("CandleType", tf(1*1440)) \
             .SetDisplay("Candle Type", "Type of candles for strategy", "Strategy")
 
     @property

--- a/API/0120_First_Day_of_Month/first_day_of_month_strategy.py
+++ b/API/0120_First_Day_of_Month/first_day_of_month_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, UnitTypes, Unit, CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class first_day_of_month_strategy(Strategy):
@@ -27,7 +28,7 @@ class first_day_of_month_strategy(Strategy):
         self._ma_period = self.Param("MaPeriod", 20) \
             .SetDisplay("MA Period", "Moving average period for trend confirmation", "Strategy")
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromDays(1))) \
+        self._candle_type = self.Param("CandleType", tf(1*1440)) \
             .SetDisplay("Candle Type", "Type of candles for strategy", "Strategy")
 
         self._sma = None

--- a/API/0121_Santa_Claus_Rally/santa_claus_rally_strategy.py
+++ b/API/0121_Santa_Claus_Rally/santa_claus_rally_strategy.py
@@ -8,6 +8,7 @@ from StockSharp.Messages import UnitTypes, Unit, DataType, CandleStates
 from StockSharp.Messages import ICandleMessage
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class santa_claus_rally_strategy(Strategy):
     """
@@ -28,7 +29,7 @@ class santa_claus_rally_strategy(Strategy):
         self._ma_period = self.Param("MaPeriod", 20) \
             .SetDisplay("MA Period", "Moving average period for trend confirmation", "Strategy")
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromDays(1))) \
+        self._candle_type = self.Param("CandleType", tf(1*1440)) \
             .SetDisplay("Candle Type", "Type of candles for strategy", "Strategy")
 
     @property

--- a/API/0122_January_Effect/january_effect_strategy.py
+++ b/API/0122_January_Effect/january_effect_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class january_effect_strategy(Strategy):
     """
@@ -28,7 +29,7 @@ class january_effect_strategy(Strategy):
         self._ma_period = self.Param("MaPeriod", 20) \
             .SetDisplay("MA Period", "Moving average period for trend confirmation", "Strategy")
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromDays(1))) \
+        self._candle_type = self.Param("CandleType", tf(1*1440)) \
             .SetDisplay("Candle Type", "Type of candles for strategy", "Strategy")
 
     @property

--- a/API/0123_Monday_Weakness/monday_weakness_strategy.py
+++ b/API/0123_Monday_Weakness/monday_weakness_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math, DayOfWeek
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class monday_weakness_strategy(Strategy):
     """
@@ -25,7 +26,7 @@ class monday_weakness_strategy(Strategy):
         self._ma_period = self.Param("MaPeriod", 20) \
             .SetDisplay("MA Period", "Moving average period for trend confirmation", "Strategy")
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromDays(1))) \
+        self._candle_type = self.Param("CandleType", tf(1*1440)) \
             .SetDisplay("Candle Type", "Type of candles for strategy", "Strategy")
 
     @property

--- a/API/0124_Pre-Holiday_Strength/pre_holiday_strength_strategy.py
+++ b/API/0124_Pre-Holiday_Strength/pre_holiday_strength_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, ICandleMessage, CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class pre_holiday_strength_strategy(Strategy):
     """
@@ -42,7 +43,7 @@ class pre_holiday_strength_strategy(Strategy):
             .SetGreaterThanZero() \
             .SetDisplay("MA Period", "Moving average period for trend confirmation", "Strategy")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromDays(1))) \
+        self._candleType = self.Param("CandleType", tf(1*1440)) \
             .SetDisplay("Candle Type", "Type of candles for strategy", "Strategy")
 
     @property

--- a/API/0125_Post-Holiday_Weakness/post_holiday_weakness_strategy.py
+++ b/API/0125_Post-Holiday_Weakness/post_holiday_weakness_strategy.py
@@ -8,6 +8,7 @@ from System import Math
 from StockSharp.Messages import DataType, CandleStates, UnitTypes, Unit
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class post_holiday_weakness_strategy(Strategy):
@@ -27,7 +28,7 @@ class post_holiday_weakness_strategy(Strategy):
             .SetGreaterThanZero() \
             .SetDisplay("MA Period", "Moving average period for trend confirmation", "Strategy")
 
-        self._candle_type = self.Param("CandleType", TimeSpan.FromDays(1).TimeFrame()) \
+        self._candle_type = self.Param("CandleType", tf(1*1440)) \
             .SetDisplay("Candle Type", "Type of candles for strategy", "Strategy")
 
         # Dictionary of common holidays (month, day)

--- a/API/0126_Quarterly_Expiry/quarterly_expiry_strategy.py
+++ b/API/0126_Quarterly_Expiry/quarterly_expiry_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math, DayOfWeek, DateTimeOffset
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class quarterly_expiry_strategy(Strategy):
     """
@@ -26,7 +27,7 @@ class quarterly_expiry_strategy(Strategy):
         self._ma_period = self.Param("MaPeriod", 20) \
             .SetDisplay("MA Period", "Moving average period for trend confirmation", "Strategy")
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromDays(1))) \
+        self._candle_type = self.Param("CandleType", tf(1*1440)) \
             .SetDisplay("Candle Type", "Type of candles for strategy", "Strategy")
 
     @property

--- a/API/0127_Open_Drive/open_drive_strategy.py
+++ b/API/0127_Open_Drive/open_drive_strategy.py
@@ -8,6 +8,7 @@ from System import Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class open_drive_strategy(Strategy):
     """Implementation of Open Drive trading strategy.
@@ -29,7 +30,7 @@ class open_drive_strategy(Strategy):
             .SetDisplay("MA Period", "Moving average period for trend confirmation", "Strategy")
 
         # Candle type for strategy.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candle_type = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles for strategy", "Strategy")
 
         # Internal state

--- a/API/0128_Midday_Reversal/midday_reversal_strategy.py
+++ b/API/0128_Midday_Reversal/midday_reversal_strategy.py
@@ -6,6 +6,7 @@ clr.AddReference("StockSharp.Algo")
 from System import TimeSpan, Math
 from StockSharp.Messages import DataType, UnitTypes, Unit, CandleStates
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class midday_reversal_strategy(Strategy):
     """
@@ -23,7 +24,7 @@ class midday_reversal_strategy(Strategy):
             .SetNotNegative() \
             .SetDisplay("Stop Loss %", "Stop loss percentage from entry price", "Protection")
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(30))) \
+        self._candle_type = self.Param("CandleType", tf(30)) \
             .SetDisplay("Candle Type", "Type of candles for strategy", "Strategy")
 
         # Previous candle closing prices

--- a/API/0129_Overnight_Gap/overnight_gap_strategy.py
+++ b/API/0129_Overnight_Gap/overnight_gap_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class overnight_gap_strategy(Strategy):
     """
@@ -26,7 +27,7 @@ class overnight_gap_strategy(Strategy):
         self._ma_period = self.Param("MaPeriod", 20) \
             .SetDisplay("MA Period", "Moving average period for trend confirmation", "Strategy")
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromDays(1))) \
+        self._candle_type = self.Param("CandleType", tf(1*1440)) \
             .SetDisplay("Candle Type", "Type of candles for strategy", "Strategy")
 
         # Internal state

--- a/API/0130_Lunch_Break_Fade/lunch_break_fade_strategy.py
+++ b/API/0130_Lunch_Break_Fade/lunch_break_fade_strategy.py
@@ -6,6 +6,7 @@ clr.AddReference("StockSharp.Algo")
 from System import TimeSpan, Math
 from StockSharp.Messages import DataType, UnitTypes, Unit, CandleStates
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class lunch_break_fade_strategy(Strategy):
     """
@@ -18,7 +19,7 @@ class lunch_break_fade_strategy(Strategy):
         super(lunch_break_fade_strategy, self).__init__()
 
         # Data type for candles.
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Hour when lunch break typically starts (default is 13:00).

--- a/API/0131_MACD_RSI/macd_rsi_strategy.py
+++ b/API/0131_MACD_RSI/macd_rsi_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import MovingAverageConvergenceDivergenceSignal, RelativeStrengthIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 
@@ -22,7 +23,7 @@ class macd_rsi_strategy(Strategy):
         super(macd_rsi_strategy, self).__init__()
 
         # Initialize strategy parameters
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candle_type = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._macd_fast = self.Param("MacdFast", 12) \

--- a/API/0132_Bollinger_Stochastic/bollinger_stochastic_strategy.py
+++ b/API/0132_Bollinger_Stochastic/bollinger_stochastic_strategy.py
@@ -8,6 +8,7 @@ from System import Math
 from StockSharp.Messages import DataType, CandleStates, Sides
 from StockSharp.Algo.Indicators import BollingerBands, StochasticOscillator, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class bollinger_stochastic_strategy(Strategy):
@@ -22,7 +23,7 @@ class bollinger_stochastic_strategy(Strategy):
         super(bollinger_stochastic_strategy, self).__init__()
 
         # Initialize strategy parameters
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candle_type = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._bollinger_period = self.Param("BollingerPeriod", 20) \

--- a/API/0133_MA_Volume/ma_volume_strategy.py
+++ b/API/0133_MA_Volume/ma_volume_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 
@@ -19,7 +20,7 @@ class ma_volume_strategy(Strategy):
         super(ma_volume_strategy, self).__init__()
 
         # Initialize strategy parameters
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candle_type = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._ma_period = self.Param("MaPeriod", 20) \

--- a/API/0134_ADX_MACD/adx_macd_strategy.py
+++ b/API/0134_ADX_MACD/adx_macd_strategy.py
@@ -15,6 +15,7 @@ from StockSharp.Algo.Indicators import AverageDirectionalIndex
 from StockSharp.Algo.Indicators import MovingAverageConvergenceDivergenceSignal
 from StockSharp.Algo.Indicators import AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class adx_macd_strategy(Strategy):
@@ -29,7 +30,7 @@ class adx_macd_strategy(Strategy):
         super(adx_macd_strategy, self).__init__()
 
         # Initialize strategy parameters
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candleType = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._adxPeriod = self.Param("AdxPeriod", 14) \

--- a/API/0135_Ichimoku_RSI/ichimoku_rsi_strategy.py
+++ b/API/0135_Ichimoku_RSI/ichimoku_rsi_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import Ichimoku, RelativeStrengthIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class ichimoku_rsi_strategy(Strategy):
     """
@@ -18,7 +19,7 @@ class ichimoku_rsi_strategy(Strategy):
         super(ichimoku_rsi_strategy, self).__init__()
 
         # Data type for candles.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(30))) \
+        self._candle_type = self.Param("CandleType", tf(30)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Tenkan-sen (Conversion Line) period.

--- a/API/0136_Supertrend_Volume/supertrend_volume_strategy.py
+++ b/API/0136_Supertrend_Volume/supertrend_volume_strategy.py
@@ -8,6 +8,7 @@ from System import Math
 from StockSharp.Messages import DataType, CandleStates
 from StockSharp.Algo.Indicators import AverageTrueRange, SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class supertrend_volume_strategy(Strategy):
     """
@@ -21,7 +22,7 @@ class supertrend_volume_strategy(Strategy):
         super(supertrend_volume_strategy, self).__init__()
 
         # Initialize strategy parameters
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candleType = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._supertrendPeriod = self.Param("SupertrendPeriod", 10) \

--- a/API/0137_Bollinger_RSI/bollinger_rsi_strategy.py
+++ b/API/0137_Bollinger_RSI/bollinger_rsi_strategy.py
@@ -8,6 +8,7 @@ from System import Math
 from StockSharp.Messages import DataType, UnitTypes, Unit, ICandleMessage, CandleStates
 from StockSharp.Algo.Indicators import BollingerBands, RelativeStrengthIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class bollinger_rsi_strategy(Strategy):
@@ -50,7 +51,7 @@ class bollinger_rsi_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(60, 80, 5)
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._stopLossAtr = self.Param("StopLossAtr", 2.0) \

--- a/API/0138_MA_Stochastic/ma_stochastic_strategy.py
+++ b/API/0138_MA_Stochastic/ma_stochastic_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage, StochasticOscillator
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class ma_stochastic_strategy(Strategy):
     """
@@ -61,7 +62,7 @@ class ma_stochastic_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 5.0, 1.0)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
     @property

--- a/API/0139_ATR_MACD/atr_macd_strategy.py
+++ b/API/0139_ATR_MACD/atr_macd_strategy.py
@@ -8,6 +8,7 @@ from System import Math
 from StockSharp.Messages import DataType, UnitTypes, Unit, CandleStates
 from StockSharp.Algo.Indicators import AverageTrueRange, SimpleMovingAverage, MovingAverageConvergenceDivergenceSignal
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class atr_macd_strategy(Strategy):
@@ -63,7 +64,7 @@ class atr_macd_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._atr_delta_percent = self.Param("AtrDeltaPercent", 10.0) \

--- a/API/0140_VWAP_RSI/vwap_rsi_strategy.py
+++ b/API/0140_VWAP_RSI/vwap_rsi_strategy.py
@@ -8,6 +8,7 @@ from StockSharp.Messages import DataType, Unit, UnitTypes
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import RelativeStrengthIndex, VolumeWeightedMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class vwap_rsi_strategy(Strategy):
     """
@@ -35,7 +36,7 @@ class vwap_rsi_strategy(Strategy):
         self._stop_loss_percent = self.Param("StopLossPercent", 2.0) \
             .SetDisplay("Stop Loss %", "Stop loss as percentage of entry price", "Risk Management")
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
     @property

--- a/API/0141_Donchian_Volume/donchian_volume_strategy.py
+++ b/API/0141_Donchian_Volume/donchian_volume_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import Highest, Lowest, SimpleMovingAverage, DonchianChannels
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class donchian_volume_strategy(Strategy):
     """
@@ -45,7 +46,7 @@ class donchian_volume_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._average_volume = 0.0

--- a/API/0142_Keltner_Stochastic/keltner_stochastic_strategy.py
+++ b/API/0142_Keltner_Stochastic/keltner_stochastic_strategy.py
@@ -12,6 +12,7 @@ from StockSharp.Messages import UnitTypes
 from StockSharp.Algo.Indicators import KeltnerChannels
 from StockSharp.Algo.Indicators import StochasticOscillator
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class keltner_stochastic_strategy(Strategy):
     """
@@ -78,7 +79,7 @@ class keltner_stochastic_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", TimeSpan.FromMinutes(5).TimeFrame()) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
     @property

--- a/API/0143_Parabolic_SAR_RSI/parabolic_sar_rsi_strategy.py
+++ b/API/0143_Parabolic_SAR_RSI/parabolic_sar_rsi_strategy.py
@@ -11,6 +11,7 @@ from StockSharp.Messages import Unit
 from StockSharp.Messages import UnitTypes
 from StockSharp.Algo.Indicators import ParabolicSar, RelativeStrengthIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class parabolic_sar_rsi_strategy(Strategy):
@@ -53,7 +54,7 @@ class parabolic_sar_rsi_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(60.0, 80.0, 5.0)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
     @property

--- a/API/0144_Hull_MA_Volume/hull_ma_volume_strategy.py
+++ b/API/0144_Hull_MA_Volume/hull_ma_volume_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import Unit, UnitTypes, DataType, CandleStates
 from StockSharp.Algo.Indicators import HullMovingAverage, SimpleMovingAverage, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class hull_ma_volume_strategy(Strategy):
     """
@@ -50,7 +51,7 @@ class hull_ma_volume_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(7, 21, 7)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Internal state

--- a/API/0145_ADX_Stochastic/adx_stochastic_strategy.py
+++ b/API/0145_ADX_Stochastic/adx_stochastic_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import AverageDirectionalIndex, StochasticOscillator
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class adx_stochastic_strategy(Strategy):
     """
@@ -70,7 +71,7 @@ class adx_stochastic_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
     @property

--- a/API/0146_MACD_Volume/macd_volume_strategy.py
+++ b/API/0146_MACD_Volume/macd_volume_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, UnitTypes, Unit
 from StockSharp.Algo.Indicators import MovingAverageConvergenceDivergenceSignal, SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class macd_volume_strategy(Strategy):
     """
@@ -50,7 +51,7 @@ class macd_volume_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # State variables

--- a/API/0147_Bollinger_Volume/bollinger_volume_strategy.py
+++ b/API/0147_Bollinger_Volume/bollinger_volume_strategy.py
@@ -17,6 +17,7 @@ from StockSharp.Algo.Indicators import BollingerBands
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Indicators import AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class bollinger_volume_strategy(Strategy):
@@ -47,7 +48,7 @@ class bollinger_volume_strategy(Strategy):
         self._atrPeriod = self.Param("AtrPeriod", 14) \
             .SetDisplay("ATR Period", "Period of the ATR for stop loss calculation", "Risk Management")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Internal state

--- a/API/0148_RSI_Stochastic/rsi_stochastic_strategy.py
+++ b/API/0148_RSI_Stochastic/rsi_stochastic_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, UnitTypes, Unit, CandleStates
 from StockSharp.Algo.Indicators import RelativeStrengthIndex, StochasticOscillator
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class rsi_stochastic_strategy(Strategy):
@@ -75,7 +76,7 @@ class rsi_stochastic_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
     @property

--- a/API/0149_MA_ADX/ma_adx_strategy.py
+++ b/API/0149_MA_ADX/ma_adx_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage, AverageDirectionalIndex, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class ma_adx_strategy(Strategy):
     """
@@ -32,7 +33,7 @@ class ma_adx_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(7, 28, 7)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._stop_loss_percent = self.Param("StopLossPercent", 2.0) \

--- a/API/0150_VWAP_Stochastic/vwap_stochastic_strategy.py
+++ b/API/0150_VWAP_Stochastic/vwap_stochastic_strategy.py
@@ -9,6 +9,7 @@ from System import Math
 from StockSharp.Messages import UnitTypes, Unit, DataType, CandleStates
 from StockSharp.Algo.Indicators import VolumeWeightedMovingAverage, StochasticOscillator
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class vwap_stochastic_strategy(Strategy):
@@ -60,7 +61,7 @@ class vwap_stochastic_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 5.0, 0.5)
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
     @property

--- a/API/0151_Ichimoku_Volume/ichimoku_volume_strategy.py
+++ b/API/0151_Ichimoku_Volume/ichimoku_volume_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import Ichimoku
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class ichimoku_volume_strategy(Strategy):
     """
@@ -40,7 +41,7 @@ class ichimoku_volume_strategy(Strategy):
         self._stop_loss = self.Param("StopLoss", Unit(2, UnitTypes.Percent)) \
             .SetDisplay("Stop Loss", "Stop loss percent or value", "Risk Management")
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Candle type for strategy", "General")
 
         self._average_volume = 0.0

--- a/API/0152_Supertrend_RSI/supertrend_rsi_strategy.py
+++ b/API/0152_Supertrend_RSI/supertrend_rsi_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import SuperTrend, RelativeStrengthIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class supertrend_rsi_strategy(Strategy):
     """
@@ -41,7 +42,7 @@ class supertrend_rsi_strategy(Strategy):
             .SetRange(1, 100) \
             .SetDisplay("RSI Overbought", "RSI level to consider market overbought", "RSI Parameters")
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Candle type for strategy", "General")
 
         # Indicators

--- a/API/0153_Bollinger_ADX/bollinger_adx_strategy.py
+++ b/API/0153_Bollinger_ADX/bollinger_adx_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, UnitTypes, Unit, CandleStates
 from StockSharp.Algo.Indicators import BollingerBands, ADX, ATR
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class bollinger_adx_strategy(Strategy):
     """
@@ -50,7 +51,7 @@ class bollinger_adx_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
     @property

--- a/API/0154_MA_CCI/ma_cci_strategy.py
+++ b/API/0154_MA_CCI/ma_cci_strategy.py
@@ -8,6 +8,7 @@ from System import Math
 from StockSharp.Messages import DataType, UnitTypes, Unit, CandleStates
 from StockSharp.Algo.Indicators import SMA, CCI
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class ma_cci_strategy(Strategy):
     """
@@ -50,7 +51,7 @@ class ma_cci_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 5.0, 1.0)
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
     @property

--- a/API/0155_VWAP_Volume/vwap_volume_strategy.py
+++ b/API/0155_VWAP_Volume/vwap_volume_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, UnitTypes, Unit, CandleStates
 from StockSharp.Algo.Indicators import VolumeWeightedMovingAverage, SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class vwap_volume_strategy(Strategy):
@@ -39,7 +40,7 @@ class vwap_volume_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Indicator for volume

--- a/API/0156_Donchian_RSI/donchian_rsi_strategy.py
+++ b/API/0156_Donchian_RSI/donchian_rsi_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import DonchianChannels, RSI
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 
@@ -35,7 +36,7 @@ class donchian_rsi_strategy(Strategy):
         self._stop_loss_percent = self.Param("StopLossPercent", 2.0) \
             .SetDisplay("Stop Loss %", "Stop loss percentage from entry price", "Risk Management")
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Variables to store previous high and low values for breakout detection

--- a/API/0157_Keltner_Volume/keltner_volume_strategy.py
+++ b/API/0157_Keltner_Volume/keltner_volume_strategy.py
@@ -12,6 +12,7 @@ from StockSharp.Messages import UnitTypes
 from StockSharp.Algo.Indicators import ExponentialMovingAverage
 from StockSharp.Algo.Indicators import AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class keltner_volume_strategy(Strategy):
     """
@@ -51,7 +52,7 @@ class keltner_volume_strategy(Strategy):
         self._stopLoss = self.Param("StopLoss", Unit(2, UnitTypes.Absolute)) \
             .SetDisplay("Stop Loss", "Stop loss in ATR or value", "Risk Management")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Candle type for strategy", "General")
 
     @property

--- a/API/0158_Parabolic_SAR_Stochastic/parabolic_sar_stochastic_strategy.py
+++ b/API/0158_Parabolic_SAR_Stochastic/parabolic_sar_stochastic_strategy.py
@@ -10,6 +10,7 @@ from System.Drawing import Color
 from StockSharp.Messages import UnitTypes, Unit, DataType, ICandleMessage, CandleStates, Sides
 from StockSharp.Algo.Indicators import ParabolicSar, StochasticOscillator
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class parabolic_sar_stochastic_strategy(Strategy):
@@ -52,7 +53,7 @@ class parabolic_sar_stochastic_strategy(Strategy):
             .SetRange(1, 100) \
             .SetDisplay("Overbought Level", "Level above which market is considered overbought", "Stochastic Parameters")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Candle type for strategy", "General")
 
         self._lastStochK = 50  # Initialize to a neutral value

--- a/API/0159_Hull_MA_RSI/hull_ma_rsi_strategy.py
+++ b/API/0159_Hull_MA_RSI/hull_ma_rsi_strategy.py
@@ -12,6 +12,7 @@ from StockSharp.Messages import UnitTypes
 from StockSharp.Algo.Indicators import HullMovingAverage
 from StockSharp.Algo.Indicators import RelativeStrengthIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class hull_ma_rsi_strategy(Strategy):
     """
@@ -45,7 +46,7 @@ class hull_ma_rsi_strategy(Strategy):
         self._stop_loss = self.Param("StopLoss", Unit(2, UnitTypes.Absolute)) \
             .SetDisplay("Stop Loss", "Stop loss in ATR or value", "Risk Management")
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Candle type for strategy", "General")
 
         # Previous HMA value

--- a/API/0160_ADX_Volume/adx_volume_strategy.py
+++ b/API/0160_ADX_Volume/adx_volume_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import AverageDirectionalIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class adx_volume_strategy(Strategy):
     """
@@ -34,7 +35,7 @@ class adx_volume_strategy(Strategy):
         self._stop_loss = self.Param("StopLoss", Unit(2, UnitTypes.Absolute)) \
             .SetDisplay("Stop Loss", "Stop loss in ATR or value", "Risk Management")
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Candle type for strategy", "General")
 
         # For volume tracking

--- a/API/0161_MACD_CCI/macd_cci_strategy.py
+++ b/API/0161_MACD_CCI/macd_cci_strategy.py
@@ -12,6 +12,7 @@ from StockSharp.Messages import UnitTypes
 from StockSharp.Algo.Indicators import MovingAverageConvergenceDivergenceSignal
 from StockSharp.Algo.Indicators import CommodityChannelIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class macd_cci_strategy(Strategy):
@@ -48,7 +49,7 @@ class macd_cci_strategy(Strategy):
         self._stopLoss = self.Param("StopLoss", Unit(2, UnitTypes.Percent)) \
             .SetDisplay("Stop Loss", "Stop loss percent or value", "Risk Management")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Candle type for strategy", "General")
 
     @property

--- a/API/0162_Bollinger_CCI/bollinger_cci_strategy.py
+++ b/API/0162_Bollinger_CCI/bollinger_cci_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import BollingerBands, CommodityChannelIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class bollinger_cci_strategy(Strategy):
     """
@@ -40,7 +41,7 @@ class bollinger_cci_strategy(Strategy):
         self._stop_loss = self.Param("StopLoss", Unit(2, UnitTypes.Absolute)) \
             .SetDisplay("Stop Loss", "Stop loss in ATR or value", "Risk Management")
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Candle type for strategy", "General")
 
     @property

--- a/API/0163_RSI_Williams_R/rsi_williams_r_strategy.py
+++ b/API/0163_RSI_Williams_R/rsi_williams_r_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import RelativeStrengthIndex, WilliamsR
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class rsi_williams_r_strategy(Strategy):
@@ -49,7 +50,7 @@ class rsi_williams_r_strategy(Strategy):
         self._stop_loss = self.Param("StopLoss", Unit(2, UnitTypes.Percent)) \
             .SetDisplay("Stop Loss", "Stop loss percent or value", "Risk Management")
 
-        self._candle_type = self.Param("CandleType", TimeSpan.FromMinutes(5).TimeFrame()) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Candle type for strategy", "General")
 
     @property

--- a/API/0164_MA_Williams_R/ma_williams_r_strategy.py
+++ b/API/0164_MA_Williams_R/ma_williams_r_strategy.py
@@ -9,6 +9,7 @@ from System.Drawing import Color
 from StockSharp.Messages import UnitTypes, Unit, DataType, ICandleMessage, CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage, ExponentialMovingAverage, WeightedMovingAverage, SmoothedMovingAverage, HullMovingAverage, WilliamsR
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from enum import Enum
 
 class MovingAverageTypeEnum(Enum):
@@ -51,7 +52,7 @@ class ma_williams_r_strategy(Strategy):
         self._stopLoss = self.Param("StopLoss", Unit(2, UnitTypes.Percent)) \
             .SetDisplay("Stop Loss", "Stop loss percent or value", "Risk Management")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Candle type for strategy", "General")
 
     @property

--- a/API/0165_VWAP_CCI/vwap_cci_strategy.py
+++ b/API/0165_VWAP_CCI/vwap_cci_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import VolumeWeightedMovingAverage, CommodityChannelIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class vwap_cci_strategy(Strategy):
     """
@@ -32,7 +33,7 @@ class vwap_cci_strategy(Strategy):
         self._stop_loss = self.Param("StopLoss", Unit(2, UnitTypes.Percent)) \
             .SetDisplay("Stop Loss", "Stop loss percent or value", "Risk Management")
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Candle type for strategy", "General")
 
     @property

--- a/API/0166_Donchian_Stochastic/donchian_stochastic_strategy.py
+++ b/API/0166_Donchian_Stochastic/donchian_stochastic_strategy.py
@@ -12,6 +12,7 @@ from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import DonchianChannels
 from StockSharp.Algo.Indicators import StochasticOscillator
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class donchian_stochastic_strategy(Strategy):
     """
@@ -37,7 +38,7 @@ class donchian_stochastic_strategy(Strategy):
         self._stochD = self.Param("StochD", 3) \
             .SetDisplay("Stochastic %D", "Stochastic %D period", "Indicators")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._stopLossPercent = self.Param("StopLossPercent", 2.0) \

--- a/API/0167_Keltner_RSI/keltner_rsi_strategy.py
+++ b/API/0167_Keltner_RSI/keltner_rsi_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import ExponentialMovingAverage, ATR, RSI
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class keltner_rsi_strategy(Strategy):
     """
@@ -44,7 +45,7 @@ class keltner_rsi_strategy(Strategy):
         self._stopLossPercent = self.Param("StopLossPercent", 2.0) \
             .SetDisplay("Stop Loss %", "Stop loss percentage from entry price", "Risk Management")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Fields for indicators

--- a/API/0169_Hull_MA_Stochastic/hull_ma_stochastic_strategy.py
+++ b/API/0169_Hull_MA_Stochastic/hull_ma_stochastic_strategy.py
@@ -8,6 +8,7 @@ from System import Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import HullMovingAverage, StochasticOscillator, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class hull_ma_stochastic_strategy(Strategy):
     """
@@ -45,7 +46,7 @@ class hull_ma_stochastic_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1, 10, 1)
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._stopLossPercent = self.Param("StopLossPercent", 1.0) \

--- a/API/0170_ADX_CCI/adx_cci_strategy.py
+++ b/API/0170_ADX_CCI/adx_cci_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import AverageDirectionalIndex, CommodityChannelIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class adx_cci_strategy(Strategy):
     """
@@ -32,7 +33,7 @@ class adx_cci_strategy(Strategy):
             .SetDisplay("Stop Loss %", "Stop loss as percentage of entry price", "Risk Management")
 
         # Candle type for strategy calculation
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Timeframe for strategy", "General")
 
         # Internal state

--- a/API/0171_MACD_Williams_R/macd_williams_r_strategy.py
+++ b/API/0171_MACD_Williams_R/macd_williams_r_strategy.py
@@ -8,6 +8,7 @@ from System import Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import MovingAverageConvergenceDivergenceSignal, WilliamsR
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class macd_williams_r_strategy(Strategy):
     """
@@ -47,7 +48,7 @@ class macd_williams_r_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Timeframe for strategy", "General")
 
     @property

--- a/API/0172_Bollinger_Williams_R/bollinger_williams_r_strategy.py
+++ b/API/0172_Bollinger_Williams_R/bollinger_williams_r_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Sides
 from StockSharp.Algo.Indicators import BollingerBands, WilliamsR, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class bollinger_williams_r_strategy(Strategy):
@@ -40,7 +41,7 @@ class bollinger_williams_r_strategy(Strategy):
             .SetDisplay("ATR Multiplier", "Multiplier for ATR-based stop-loss", "Risk Management")
 
         # Candle type for strategy calculation
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Timeframe for strategy", "General")
 
     @property

--- a/API/0174_MACD_VWAP/macd_vwap_strategy.py
+++ b/API/0174_MACD_VWAP/macd_vwap_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, Unit, UnitTypes
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import MovingAverageConvergenceDivergenceSignal, VolumeWeightedMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class macd_vwap_strategy(Strategy):
@@ -38,7 +39,7 @@ class macd_vwap_strategy(Strategy):
             .SetDisplay("Stop Loss %", "Stop loss as percentage of entry price", "Risk Management")
 
         # Candle type for strategy calculation
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Timeframe for strategy", "General")
 
     @property

--- a/API/0175_RSI_Supertrend/rsi_supertrend_strategy.py
+++ b/API/0175_RSI_Supertrend/rsi_supertrend_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates
 from StockSharp.Algo.Indicators import RelativeStrengthIndex, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class rsi_supertrend_strategy(Strategy):
     """
@@ -39,7 +40,7 @@ class rsi_supertrend_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(2.0, 4.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Timeframe for strategy", "General")
 
         # Custom Supertrend indicator

--- a/API/0176_ADX_Bollinger/adx_bollinger_strategy.py
+++ b/API/0176_ADX_Bollinger/adx_bollinger_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Sides
 from StockSharp.Algo.Indicators import AverageDirectionalIndex, BollingerBands, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class adx_bollinger_strategy(Strategy):
     """
@@ -36,7 +37,7 @@ class adx_bollinger_strategy(Strategy):
         self._atr_multiplier = self.Param("AtrMultiplier", 2.0) \
             .SetDisplay("ATR Multiplier", "Multiplier for ATR-based stop-loss", "Risk Management")
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Timeframe for strategy", "General")
 
     @property

--- a/API/0177_Ichimoku_Stochastic/ichimoku_stochastic_strategy.py
+++ b/API/0177_Ichimoku_Stochastic/ichimoku_stochastic_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Sides
 from StockSharp.Algo.Indicators import Ichimoku, StochasticOscillator
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class ichimoku_stochastic_strategy(Strategy):
     """
@@ -57,7 +58,7 @@ class ichimoku_stochastic_strategy(Strategy):
             .SetOptimize(1, 5, 1)
 
         # Candle type for strategy calculation
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(30))) \
+        self._candle_type = self.Param("CandleType", tf(30)) \
             .SetDisplay("Candle Type", "Timeframe for strategy", "General")
 
     @property

--- a/API/0185_Supertrend_Stochastic/supertrend_stochastic_strategy.py
+++ b/API/0185_Supertrend_Stochastic/supertrend_stochastic_strategy.py
@@ -8,6 +8,7 @@ from System import Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import SuperTrend, StochasticOscillator
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class supertrend_stochastic_strategy(Strategy):
     """
@@ -46,7 +47,7 @@ class supertrend_stochastic_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1, 10, 1)
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._stopLossPercent = self.Param("StopLossPercent", 1.0) \

--- a/API/0187_Donchian_MACD/donchian_macd_strategy.py
+++ b/API/0187_Donchian_MACD/donchian_macd_strategy.py
@@ -16,6 +16,7 @@ from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import DonchianChannels
 from StockSharp.Algo.Indicators import MovingAverageConvergenceDivergenceSignal
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class donchian_macd_strategy(Strategy):
     """
@@ -47,7 +48,7 @@ class donchian_macd_strategy(Strategy):
         self._stopLossPercent = self.Param("StopLossPercent", 2.0) \
             .SetDisplay("Stop-Loss %", "Stop-loss percentage from entry price", "Risk Management")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
     @property

--- a/API/0188_Parabolic_SAR_Volume/parabolic_sar_volume_strategy.py
+++ b/API/0188_Parabolic_SAR_Volume/parabolic_sar_volume_strategy.py
@@ -15,6 +15,7 @@ from StockSharp.Messages import CandleStates
 from StockSharp.Messages import Sides
 from StockSharp.Algo.Indicators import ParabolicSar, VolumeIndicator, SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class parabolic_sar_volume_strategy(Strategy):
@@ -43,7 +44,7 @@ class parabolic_sar_volume_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetDisplay("Volume Period", "Period for volume moving average", "Indicators")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Indicators will be initialized in OnStarted

--- a/API/0190_VWAP_ADX/vwap_adx_strategy.py
+++ b/API/0190_VWAP_ADX/vwap_adx_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import AverageDirectionalIndex, VolumeWeightedMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class vwap_adx_strategy(Strategy):
@@ -33,7 +34,7 @@ class vwap_adx_strategy(Strategy):
             .SetOptimize(10, 20, 1)
 
         # Candle type for strategy.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Timeframe of data for strategy", "General")
 
         self._adx = None

--- a/API/0193_Supertrend_ADX/supertrend_adx_strategy.py
+++ b/API/0193_Supertrend_ADX/supertrend_adx_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates
 from StockSharp.Algo.Indicators import AverageTrueRange, SuperTrend, AverageDirectionalIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class supertrend_adx_strategy(Strategy):
     """
@@ -49,7 +50,7 @@ class supertrend_adx_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(20.0, 30.0, 5.0)
 
-        self._candle_type = self.Param("CandleType", TimeSpan.FromMinutes(15).TimeFrame()) \
+        self._candle_type = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._last_supertrend = 0

--- a/API/0194_Keltner_MACD/keltner_macd_strategy.py
+++ b/API/0194_Keltner_MACD/keltner_macd_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import ExponentialMovingAverage, AverageTrueRange, MovingAverageConvergenceDivergenceSignal
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class keltner_macd_strategy(Strategy):
     """
@@ -50,7 +51,7 @@ class keltner_macd_strategy(Strategy):
         self._atrMultiplier = self.Param("AtrMultiplier", 2.0) \
             .SetDisplay("Stop Loss ATR Multiplier", "ATR multiplier for stop loss calculation", "Risk Management")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candleType = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Timeframe of data for strategy", "General")
 
         self._stopLossPercent = self.Param("StopLossPercent", 1.0) \

--- a/API/0197_Hull_MA_ADX/hull_ma_adx_strategy.py
+++ b/API/0197_Hull_MA_ADX/hull_ma_adx_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import HullMovingAverage, AverageDirectionalIndex, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class hull_ma_adx_strategy(Strategy):
     """
@@ -35,7 +36,7 @@ class hull_ma_adx_strategy(Strategy):
         self._atr_multiplier = self.Param("AtrMultiplier", 2.0) \
             .SetDisplay("ATR Multiplier", "ATR multiplier for stop loss calculation", "Risk Management")
 
-        self._candle_type = self.Param("CandleType", TimeSpan.FromMinutes(15).TimeFrame()) \
+        self._candle_type = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Timeframe of data for strategy", "General")
 
         self._stop_loss_percent = self.Param("StopLossPercent", 1.0) \

--- a/API/0198_VWAP_MACD/vwap_macd_strategy.py
+++ b/API/0198_VWAP_MACD/vwap_macd_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import MovingAverageConvergenceDivergenceSignal, VolumeWeightedMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class vwap_macd_strategy(Strategy):
@@ -40,7 +41,7 @@ class vwap_macd_strategy(Strategy):
             .SetDisplay("Stop Loss (%)", "Stop loss percentage from entry price", "Risk Management")
 
         # Candle type for strategy.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Timeframe of data for strategy", "General")
 
         self._macd = None

--- a/API/0200_Ichimoku_ADX/ichimoku_adx_strategy.py
+++ b/API/0200_Ichimoku_ADX/ichimoku_adx_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates
 from StockSharp.Algo.Indicators import Ichimoku, AverageDirectionalIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class ichimoku_adx_strategy(Strategy):
     """
@@ -62,7 +63,7 @@ class ichimoku_adx_strategy(Strategy):
             .SetOptimize(20.0, 30.0, 5.0)
 
         # Type of candles to use.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candle_type = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Previous state tracking

--- a/API/0201_VWAP_Williams_R/vwap_williams_r_strategy.py
+++ b/API/0201_VWAP_Williams_R/vwap_williams_r_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import VolumeWeightedMovingAverage, WilliamsR
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class vwap_williams_r_strategy(Strategy):
@@ -31,7 +32,7 @@ class vwap_williams_r_strategy(Strategy):
             .SetDisplay("Stop-Loss %", "Stop-loss percentage from entry price", "Risk Management") \
             .SetCanOptimize(True)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
     @property

--- a/API/0202_Donchian_CCI/donchian_cci_strategy.py
+++ b/API/0202_Donchian_CCI/donchian_cci_strategy.py
@@ -8,6 +8,7 @@ from System import Math
 from StockSharp.Messages import DataType, CandleStates, UnitTypes, Unit
 from StockSharp.Algo.Indicators import DonchianChannels, CommodityChannelIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class donchian_cci_strategy(Strategy):
     """
@@ -33,7 +34,7 @@ class donchian_cci_strategy(Strategy):
             .SetDisplay("Stop-Loss %", "Stop-loss percentage from entry price", "Risk Management") \
             .SetCanOptimize(True)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
     @property

--- a/API/0203_Keltner_Williams_R/keltner_williams_r_strategy.py
+++ b/API/0203_Keltner_Williams_R/keltner_williams_r_strategy.py
@@ -8,6 +8,7 @@ from System import Math
 from StockSharp.Messages import DataType, CandleStates, UnitTypes, Unit
 from StockSharp.Algo.Indicators import KeltnerChannels, WilliamsR
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class keltner_williams_r_strategy(Strategy):
     """Strategy based on Keltner Channels and Williams %R indicators (#203)"""
@@ -36,7 +37,7 @@ class keltner_williams_r_strategy(Strategy):
             .SetDisplay("Williams %R Period", "Period for Williams %R indicator", "Indicators") \
             .SetCanOptimize(True)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
     @property

--- a/API/0204_Parabolic_SAR_CCI/parabolic_sar_cci_strategy.py
+++ b/API/0204_Parabolic_SAR_CCI/parabolic_sar_cci_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates
 from StockSharp.Algo.Indicators import ParabolicSar, CommodityChannelIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class parabolic_sar_cci_strategy(Strategy):
@@ -31,7 +32,7 @@ class parabolic_sar_cci_strategy(Strategy):
             .SetDisplay("CCI Period", "Period for CCI indicator", "Indicators") \
             .SetCanOptimize(True)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
     @property

--- a/API/0205_Hull_MA_CCI/hull_ma_cci_strategy.py
+++ b/API/0205_Hull_MA_CCI/hull_ma_cci_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import HullMovingAverage, CommodityChannelIndex, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class hull_ma_cci_strategy(Strategy):
@@ -41,7 +42,7 @@ class hull_ma_cci_strategy(Strategy):
             .SetCanOptimize(True)
 
         # Candle type for strategy
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._previous_hull_value = 0.0

--- a/API/0206_MACD_Bollinger/macd_bollinger_strategy.py
+++ b/API/0206_MACD_Bollinger/macd_bollinger_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import MovingAverageConvergenceDivergenceSignal, BollingerBands, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class macd_bollinger_strategy(Strategy):
     """
@@ -59,7 +60,7 @@ class macd_bollinger_strategy(Strategy):
             .SetCanOptimize(True)
 
         # Candle type for strategy
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
     @property

--- a/API/0207_RSI_Hull_MA/rsi_hull_ma_strategy.py
+++ b/API/0207_RSI_Hull_MA/rsi_hull_ma_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import RelativeStrengthIndex, HullMovingAverage, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class rsi_hull_ma_strategy(Strategy):
@@ -42,7 +43,7 @@ class rsi_hull_ma_strategy(Strategy):
             .SetCanOptimize(True)
 
         # Candle type for strategy
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._previous_hull_value = 0

--- a/API/0208_Stochastic_Keltner/stochastic_keltner_strategy.py
+++ b/API/0208_Stochastic_Keltner/stochastic_keltner_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import StochasticOscillator, KeltnerChannels, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class stochastic_keltner_strategy(Strategy):
     """
@@ -52,7 +53,7 @@ class stochastic_keltner_strategy(Strategy):
             .SetDisplay("ATR Multiplier", "Multiplier for ATR-based stop-loss", "Risk Management") \
             .SetCanOptimize(True)
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
     @property

--- a/API/0209_Volume_Supertrend/volume_supertrend_strategy.py
+++ b/API/0209_Volume_Supertrend/volume_supertrend_strategy.py
@@ -8,6 +8,7 @@ from StockSharp.Messages import DataType, CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage, AverageTrueRange
 from StockSharp.Algo.Indicators import VolumeIndicator
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class volume_supertrend_strategy(Strategy):
@@ -36,7 +37,7 @@ class volume_supertrend_strategy(Strategy):
             .SetCanOptimize(True)
 
         # Candle type for strategy
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
     @property

--- a/API/0210_ADX_Donchian/adx_donchian_strategy.py
+++ b/API/0210_ADX_Donchian/adx_donchian_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import AverageDirectionalIndex, DonchianChannels
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class adx_donchian_strategy(Strategy):
     """
@@ -34,7 +35,7 @@ class adx_donchian_strategy(Strategy):
             .SetDisplay("Stop-Loss %", "Stop-loss percentage from entry price", "Risk Management") \
             .SetCanOptimize(True)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._adx_threshold = self.Param("AdxThreshold", 10) \

--- a/API/0211_CCI_VWAP/cci_vwap_strategy.py
+++ b/API/0211_CCI_VWAP/cci_vwap_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes, Level1Fields, Subscription
 from StockSharp.Algo.Indicators import CommodityChannelIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class cci_vwap_strategy(Strategy):
     """
@@ -33,7 +34,7 @@ class cci_vwap_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle type", "Type of candles to use", "General")
 
         self._cci = None

--- a/API/0212_Williams_R_Ichimoku/williams_ichimoku_strategy.py
+++ b/API/0212_Williams_R_Ichimoku/williams_ichimoku_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import WilliamsR, Ichimoku
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class williams_ichimoku_strategy(Strategy):
@@ -48,7 +49,7 @@ class williams_ichimoku_strategy(Strategy):
             .SetOptimize(40, 60, 4)
 
         # Candle type parameter.
-        self._candle_type = self.Param("CandleType", TimeSpan.FromMinutes(15).TimeFrame()) \
+        self._candle_type = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Internal indicator instances

--- a/API/0213_MA_Parabolic_SAR/ma_parabolic_sar_strategy.py
+++ b/API/0213_MA_Parabolic_SAR/ma_parabolic_sar_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import SimpleMovingAverage, ParabolicSar
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class ma_parabolic_sar_strategy(Strategy):
@@ -39,7 +40,7 @@ class ma_parabolic_sar_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(0.1, 0.3, 0.05)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._take_value = self.Param("TakeValue", Unit(0, UnitTypes.Absolute)) \

--- a/API/0214_Bollinger_Supertrend/bollinger_supertrend_strategy.py
+++ b/API/0214_Bollinger_Supertrend/bollinger_supertrend_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates
 from StockSharp.Algo.Indicators import BollingerBands, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class bollinger_supertrend_strategy(Strategy):
@@ -49,7 +50,7 @@ class bollinger_supertrend_strategy(Strategy):
             .SetOptimize(2.0, 4.0, 0.5)
 
         # Candle type parameter.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candle_type = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Internal state

--- a/API/0215_RSI_Donchian/rsi_donchian_strategy.py
+++ b/API/0215_RSI_Donchian/rsi_donchian_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import RelativeStrengthIndex, Highest, Lowest
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class rsi_donchian_strategy(Strategy):
@@ -41,7 +42,7 @@ class rsi_donchian_strategy(Strategy):
             .SetCanOptimize(True)
 
         # Candle type parameter.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candle_type = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._rsi = None

--- a/API/0216_Mean_Reversion/mean_reversion_strategy.py
+++ b/API/0216_Mean_Reversion/mean_reversion_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class mean_reversion_strategy(Strategy):
@@ -39,7 +40,7 @@ class mean_reversion_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._ma = None

--- a/API/0217_Pairs_Trading/pairs_trading_strategy.py
+++ b/API/0217_Pairs_Trading/pairs_trading_strategy.py
@@ -8,6 +8,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, UnitTypes, Unit, CandleStates, Subscription
 from StockSharp.Algo.Indicators import SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from StockSharp.BusinessEntities import Security
 
 class pairs_trading_strategy(Strategy):
@@ -39,7 +40,7 @@ class pairs_trading_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._second_security = self.Param("SecondSecurity", None) \

--- a/API/0218_ZScore_Reversal/z_score_reversal_strategy.py
+++ b/API/0218_ZScore_Reversal/z_score_reversal_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, UnitTypes, Unit, CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class z_score_reversal_strategy(Strategy):
     """
@@ -40,7 +41,7 @@ class z_score_reversal_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(10))) \
+        self._candle_type = self.Param("CandleType", tf(10)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._ma = None

--- a/API/0219_Statistical_Arbitrage/statistical_arbitrage_strategy.py
+++ b/API/0219_Statistical_Arbitrage/statistical_arbitrage_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes, ICandleMessage
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from StockSharp.BusinessEntities import Security
 
 class statistical_arbitrage_strategy(Strategy):
@@ -31,7 +32,7 @@ class statistical_arbitrage_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candle_type = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._second_security = self.Param("SecondSecurity", None) \

--- a/API/0220_Volatility_Breakout/volatility_breakout_strategy.py
+++ b/API/0220_Volatility_Breakout/volatility_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, UnitTypes, Unit, ICandleMessage, CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class volatility_breakout_strategy(Strategy):
     """
@@ -31,7 +32,7 @@ class volatility_breakout_strategy(Strategy):
             .SetOptimize(1.0, 3.0, 0.5)
 
         # Candle type for strategy.
-        self._candle_type_param = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type_param = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Candle type for strategy", "Common")
 
         # Indicators and state variables

--- a/API/0221_Bollinger_Band_Squeeze/bollinger_band_squeeze_strategy.py
+++ b/API/0221_Bollinger_Band_Squeeze/bollinger_band_squeeze_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import BollingerBands, AverageTrueRange, BollingerBandsValue
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class bollinger_band_squeeze_strategy(Strategy):
     """
@@ -41,7 +42,7 @@ class bollinger_band_squeeze_strategy(Strategy):
             .SetOptimize(10, 30, 5)
 
         # Candle type for strategy.
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Candle type for strategy", "Common")
 
         # Internal state fields

--- a/API/0222_Cointegration_Pairs/cointegration_pairs_strategy.py
+++ b/API/0222_Cointegration_Pairs/cointegration_pairs_strategy.py
@@ -8,6 +8,7 @@ from System import TimeSpan, Math
 from System.Collections.Generic import Queue
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates, Sides, Subscription
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from StockSharp.BusinessEntities import Order
 
 class cointegration_pairs_strategy(Strategy):
@@ -52,7 +53,7 @@ class cointegration_pairs_strategy(Strategy):
             .SetOptimize(1.0, 5.0, 1.0)
 
         # Candle type for strategy.
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Candle type for strategy", "Common")
 
         # Internal state

--- a/API/0223_Momentum_Divergence/momentum_divergence_strategy.py
+++ b/API/0223_Momentum_Divergence/momentum_divergence_strategy.py
@@ -12,6 +12,7 @@ from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import Momentum
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class momentum_divergence_strategy(Strategy):
     """
@@ -37,7 +38,7 @@ class momentum_divergence_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(10, 50, 10)
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Candle type for strategy", "Common")
 
         # Initialize internal state

--- a/API/0224_ATR_Mean_Reversion/atr_mean_reversion_strategy.py
+++ b/API/0224_ATR_Mean_Reversion/atr_mean_reversion_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import SimpleMovingAverage, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class atr_mean_reversion_strategy(Strategy):
     """
@@ -34,7 +35,7 @@ class atr_mean_reversion_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Candle type for strategy", "Common")
 
         # Indicators

--- a/API/0225_Kalman_Filter_Trend/kalman_filter_trend_strategy.py
+++ b/API/0225_Kalman_Filter_Trend/kalman_filter_trend_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import KalmanFilter, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class kalman_filter_trend_strategy(Strategy):
     """
@@ -32,7 +33,7 @@ class kalman_filter_trend_strategy(Strategy):
             .SetOptimize(0.01, 1.0, 0.1)
 
         # Candle type for strategy.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Candle type for strategy", "Common")
 
     @property

--- a/API/0226_Volatility_Adjusted_Mean_Reversion/volatility_adjusted_mean_reversion_strategy.py
+++ b/API/0226_Volatility_Adjusted_Mean_Reversion/volatility_adjusted_mean_reversion_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage, AverageTrueRange, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class volatility_adjusted_mean_reversion_strategy(Strategy):
     """
@@ -34,7 +35,7 @@ class volatility_adjusted_mean_reversion_strategy(Strategy):
             .SetOptimize(1.0, 3.0, 0.5)
 
         # Candle type for strategy.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Candle type for strategy", "Common")
 
     @property

--- a/API/0227_Hurst_Exponent_Trend/hurst_exponent_trend_strategy.py
+++ b/API/0227_Hurst_Exponent_Trend/hurst_exponent_trend_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import HurstExponent, SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class hurst_exponent_trend_strategy(Strategy):
     """
@@ -39,7 +40,7 @@ class hurst_exponent_trend_strategy(Strategy):
             .SetOptimize(0.5, 0.6, 0.05)
 
         # Candle type for strategy.
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Candle type for strategy", "Common")
 
         # Internal indicators

--- a/API/0228_Hurst_Exponent_Reversion/hurst_exponent_reversion_strategy.py
+++ b/API/0228_Hurst_Exponent_Reversion/hurst_exponent_reversion_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math, Random
 from StockSharp.Messages import DataType, UnitTypes, Unit, CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class hurst_exponent_reversion_strategy(Strategy):
     """
@@ -34,7 +35,7 @@ class hurst_exponent_reversion_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle type", "Type of candles to use", "General")
 
         self._sma = None

--- a/API/0229_Autocorrelation_Reversal/autocorrelation_reversion_strategy.py
+++ b/API/0229_Autocorrelation_Reversal/autocorrelation_reversion_strategy.py
@@ -8,6 +8,7 @@ from System import Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from StockSharp.BusinessEntities import Security
 
 
@@ -39,7 +40,7 @@ class autocorrelation_reversion_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle type", "Type of candles to use", "General")
 
         self._sma = None

--- a/API/0230_Delta_Neutral_Arbitrage/delta_neutral_arbitrage_strategy.py
+++ b/API/0230_Delta_Neutral_Arbitrage/delta_neutral_arbitrage_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Sides
 from StockSharp.Algo.Indicators import SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class delta_neutral_arbitrage_strategy(Strategy):
     """
@@ -44,7 +45,7 @@ class delta_neutral_arbitrage_strategy(Strategy):
             .SetOptimize(1.0, 3.0, 0.5)
 
         # Type of candles to use.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle type", "Type of candles to use", "General")
 
         self._spread_sma = None

--- a/API/0231_Volatility_Skew_Arbitrage/volatility_skew_arbitrage_strategy.py
+++ b/API/0231_Volatility_Skew_Arbitrage/volatility_skew_arbitrage_strategy.py
@@ -7,6 +7,7 @@ from System import Math
 from StockSharp.Messages import Level1Fields, Unit, UnitTypes
 from StockSharp.Algo.Indicators import StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 

--- a/API/0232_Correlation_Breakout/correlation_breakout_strategy.py
+++ b/API/0232_Correlation_Breakout/correlation_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 from StockSharp.BusinessEntities import Security
 
@@ -27,7 +28,7 @@ class correlation_breakout_strategy(Strategy):
             .SetDisplay("Asset 2", "Second asset for correlation", "Instruments")
 
         # Candle type for data
-        self._candle_type_param = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type_param = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Period for calculating correlations

--- a/API/0233_Beta_Neutral_Arbitrage/beta_neutral_arbitrage_strategy.py
+++ b/API/0233_Beta_Neutral_Arbitrage/beta_neutral_arbitrage_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class beta_neutral_arbitrage_strategy(Strategy):
@@ -29,7 +30,7 @@ class beta_neutral_arbitrage_strategy(Strategy):
         self._market_index_param = self.Param("MarketIndex") \
             .SetDisplay("Market Index", "Market index for beta calculation", "Instruments")
 
-        self._candle_type_param = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type_param = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._lookback_period_param = self.Param("LookbackPeriod", 20) \

--- a/API/0235_VWAP_Mean_Reversion/vwap_mean_reversion_strategy.py
+++ b/API/0235_VWAP_Mean_Reversion/vwap_mean_reversion_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import AverageTrueRange, VolumeWeightedMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class vwap_mean_reversion_strategy(Strategy):
     """
@@ -25,7 +26,7 @@ class vwap_mean_reversion_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 4.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "Strategy Parameters")
 
         self._atr_period = self.Param("AtrPeriod", 14) \

--- a/API/0236_RSI_Mean_Reversion/rsi_mean_reversion_strategy.py
+++ b/API/0236_RSI_Mean_Reversion/rsi_mean_reversion_strategy.py
@@ -8,6 +8,7 @@ from System import Math
 from StockSharp.Messages import DataType, UnitTypes, Unit, CandleStates
 from StockSharp.Algo.Indicators import RelativeStrengthIndex, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class rsi_mean_reversion_strategy(Strategy):
@@ -36,7 +37,7 @@ class rsi_mean_reversion_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "Strategy Parameters")
 
         # Internal indicators

--- a/API/0237_Stochastic_Mean_Reversion/stochastic_mean_reversion_strategy.py
+++ b/API/0237_Stochastic_Mean_Reversion/stochastic_mean_reversion_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import StochasticOscillator, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 
@@ -40,7 +41,7 @@ class stochastic_mean_reversion_strategy(Strategy):
         self._multiplier = self.Param("Multiplier", 2.0) \
             .SetDisplay("StdDev Multiplier", "Standard deviation multiplier for entry", "Strategy Parameters")
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "Strategy Parameters")
 
         # Internal state

--- a/API/0238_CCI_Mean_Reversion/cci_mean_reversion_strategy.py
+++ b/API/0238_CCI_Mean_Reversion/cci_mean_reversion_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import CommodityChannelIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class cci_mean_reversion_strategy(Strategy):
@@ -40,7 +41,7 @@ class cci_mean_reversion_strategy(Strategy):
             .SetDisplay("Deviation Multiplier", "Multiplier for standard deviation", "Settings")
 
         # Candle type.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Stop-loss percentage.

--- a/API/0239_Williams_R_Mean_Reversion/williams_r_mean_reversion_strategy.py
+++ b/API/0239_Williams_R_Mean_Reversion/williams_r_mean_reversion_strategy.py
@@ -8,6 +8,7 @@ from System.Collections.Generic import Queue
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import WilliamsR
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class williams_r_mean_reversion_strategy(Strategy):
@@ -41,7 +42,7 @@ class williams_r_mean_reversion_strategy(Strategy):
             .SetDisplay("Deviation Multiplier", "Multiplier for standard deviation", "Settings")
 
         # Candle type.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Stop-loss percentage.

--- a/API/0240_MACD_Mean_Reversion/macd_mean_reversion_strategy.py
+++ b/API/0240_MACD_Mean_Reversion/macd_mean_reversion_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import MovingAverageConvergenceDivergenceHistogram, MovingAverageConvergenceDivergenceHistogramValue
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class macd_mean_reversion_strategy(Strategy):
     """
@@ -48,7 +49,7 @@ class macd_mean_reversion_strategy(Strategy):
             .SetOptimize(1.5, 3.0, 0.5) \
             .SetDisplay("Deviation Multiplier", "Multiplier for standard deviation", "Settings")
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._stop_loss_percent = self.Param("StopLossPercent", 2.0) \

--- a/API/0241_ADX_Mean_Reversion/adx_mean_reversion_strategy.py
+++ b/API/0241_ADX_Mean_Reversion/adx_mean_reversion_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes, Sides
 from StockSharp.Algo.Indicators import AverageDirectionalIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class adx_mean_reversion_strategy(Strategy):
@@ -39,7 +40,7 @@ class adx_mean_reversion_strategy(Strategy):
             .SetOptimize(1.5, 3.0, 0.5) \
             .SetDisplay("Deviation Multiplier", "Multiplier for standard deviation", "Settings")
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._stop_loss_percent = self.Param("StopLossPercent", 2.0) \

--- a/API/0242_Volatility_Mean_Reversion/volatility_mean_reversion_strategy.py
+++ b/API/0242_Volatility_Mean_Reversion/volatility_mean_reversion_strategy.py
@@ -9,6 +9,7 @@ from System.Collections.Generic import Queue
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class volatility_mean_reversion_strategy(Strategy):
     """
@@ -38,7 +39,7 @@ class volatility_mean_reversion_strategy(Strategy):
             .SetOptimize(1.5, 3.0, 0.5) \
             .SetDisplay("Deviation Multiplier", "Multiplier for standard deviation", "Settings")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._stopLossPercent = self.Param("StopLossPercent", 1.0) \

--- a/API/0243_Volume_Mean_Reversion/volume_mean_reversion_strategy.py
+++ b/API/0243_Volume_Mean_Reversion/volume_mean_reversion_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, ICandleMessage, CandleStates, Sides
 from StockSharp.Algo.Indicators import VolumeIndicator
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class volume_mean_reversion_strategy(Strategy):
     """
@@ -34,7 +35,7 @@ class volume_mean_reversion_strategy(Strategy):
             .SetDisplay("Deviation Multiplier", "Multiplier for standard deviation", "Settings")
 
         # Candle type.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Stop-loss percentage.

--- a/API/0244_OBV_Mean_Reversion/obv_mean_reversion_strategy.py
+++ b/API/0244_OBV_Mean_Reversion/obv_mean_reversion_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, UnitTypes, Unit
 from StockSharp.Algo.Indicators import OnBalanceVolume, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class obv_mean_reversion_strategy(Strategy):
     """
@@ -33,7 +34,7 @@ class obv_mean_reversion_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "Strategy Parameters")
 
         # Internal fields

--- a/API/0245_Momentum_Breakout/momentum_breakout_strategy.py
+++ b/API/0245_Momentum_Breakout/momentum_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import Momentum, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class momentum_breakout_strategy(Strategy):
@@ -38,7 +39,7 @@ class momentum_breakout_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "Strategy Parameters")
 
         # Indicators

--- a/API/0247_RSI_Breakout/rsi_breakout_strategy.py
+++ b/API/0247_RSI_Breakout/rsi_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import RelativeStrengthIndex, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 
@@ -39,7 +40,7 @@ class rsi_breakout_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "Strategy Parameters")
 
         # Internal indicators

--- a/API/0248_Stochastic_Breakout/stochastic_breakout_strategy.py
+++ b/API/0248_Stochastic_Breakout/stochastic_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import StochasticOscillator, SimpleMovingAverage, StandardDeviation, StochasticOscillatorValue
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class stochastic_breakout_strategy(Strategy):
@@ -36,7 +37,7 @@ class stochastic_breakout_strategy(Strategy):
         self._deviationMultiplier = self.Param("DeviationMultiplier", 2.0) \
             .SetDisplay("Deviation Multiplier", "Deviation multiplier for breakout detection", "Breakout")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Candle type for strategy", "General")
 
         # Internal indicators and state

--- a/API/0250_Williams_R_Breakout/williams_r_breakout_strategy.py
+++ b/API/0250_Williams_R_Breakout/williams_r_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import WilliamsR, SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 
@@ -39,7 +40,7 @@ class williams_r_breakout_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._stopLoss = self.Param("StopLoss", 2.0) \

--- a/API/0251_MACD_Breakout/macd_breakout_strategy.py
+++ b/API/0251_MACD_Breakout/macd_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import MovingAverageConvergenceDivergenceSignal, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class macd_breakout_strategy(Strategy):
@@ -54,7 +55,7 @@ class macd_breakout_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 4.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", TimeSpan.FromMinutes(5).TimeFrame()) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Indicators

--- a/API/0252_ADX_Breakout/adx_breakout_strategy.py
+++ b/API/0252_ADX_Breakout/adx_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import AverageDirectionalIndex, SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class adx_breakout_strategy(Strategy):
@@ -39,7 +40,7 @@ class adx_breakout_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(0.0, 1.0, 0.1)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._stop_loss = self.Param("StopLoss", 2.0) \

--- a/API/0254_Volume_Breakout/volume_breakout_strategy.py
+++ b/API/0254_Volume_Breakout/volume_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, UnitTypes, Unit, CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class volume_breakout_strategy(Strategy):
     """
@@ -30,7 +31,7 @@ class volume_breakout_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._stop_loss = self.Param("StopLoss", 2.0) \

--- a/API/0256_Bollinger_Band_Width_Breakout/bollinger_band_width_breakout_strategy.py
+++ b/API/0256_Bollinger_Band_Width_Breakout/bollinger_band_width_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates
 from StockSharp.Algo.Indicators import BollingerBands, SimpleMovingAverage, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 
@@ -37,7 +38,7 @@ class bollinger_band_width_breakout_strategy(Strategy):
             .SetDisplay("Multiplier", "Standard deviation multiplier for breakout detection", "Indicators")
 
         # Candle type for strategy.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Stop-loss ATR multiplier.

--- a/API/0257_Keltner_Channel_Width_Breakout/keltner_width_breakout_strategy.py
+++ b/API/0257_Keltner_Channel_Width_Breakout/keltner_width_breakout_strategy.py
@@ -8,6 +8,7 @@ from System import Math
 from StockSharp.Messages import DataType, CandleStates, Sides
 from StockSharp.Algo.Indicators import ExponentialMovingAverage, AverageTrueRange, SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class keltner_width_breakout_strategy(Strategy):
     """
@@ -37,7 +38,7 @@ class keltner_width_breakout_strategy(Strategy):
         self._multiplier = self.Param("Multiplier", 2.0) \
             .SetDisplay("Multiplier", "Standard deviation multiplier for breakout detection", "Indicators")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._stopMultiplier = self.Param("StopMultiplier", 2) \

--- a/API/0258_Donchian_Channel_Width_Breakout/donchian_width_breakout_strategy.py
+++ b/API/0258_Donchian_Channel_Width_Breakout/donchian_width_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import Highest, Lowest, SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class donchian_width_breakout_strategy(Strategy):
@@ -41,7 +42,7 @@ class donchian_width_breakout_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._stop_loss = self.Param("StopLoss", 2.0) \

--- a/API/0259_Ichimoku_Cloud_Width_Breakout/ichimoku_width_breakout_strategy.py
+++ b/API/0259_Ichimoku_Cloud_Width_Breakout/ichimoku_width_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import Ichimoku, SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 
@@ -42,7 +43,7 @@ class ichimoku_width_breakout_strategy(Strategy):
             .SetGreaterThanZero() \
             .SetDisplay("Multiplier", "Standard deviation multiplier for breakout detection", "Indicators")
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._stop_loss = self.Param("StopLoss", 2.0) \

--- a/API/0260_Supertrend_Distance_Breakout/supertrend_distance_breakout_strategy.py
+++ b/API/0260_Supertrend_Distance_Breakout/supertrend_distance_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import SuperTrend, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class supertrend_distance_breakout_strategy(Strategy):
@@ -43,7 +44,7 @@ class supertrend_distance_breakout_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._supertrend = None

--- a/API/0261_Parabolic_SAR_Distance_Breakout/parabolic_sar_distance_breakout_strategy.py
+++ b/API/0261_Parabolic_SAR_Distance_Breakout/parabolic_sar_distance_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates
 from StockSharp.Algo.Indicators import ParabolicSar
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class parabolic_sar_distance_breakout_strategy(Strategy):
@@ -45,7 +46,7 @@ class parabolic_sar_distance_breakout_strategy(Strategy):
             .SetOptimize(1.0, 3.0, 0.5)
 
         # Candle type
-        self._candle_type = self.Param("CandleType", TimeSpan.FromMinutes(5).TimeFrame()) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._parabolic_sar = None

--- a/API/0262_Hull_MA_Slope_Breakout/hull_ma_slope_breakout_strategy.py
+++ b/API/0262_Hull_MA_Slope_Breakout/hull_ma_slope_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, ICandleMessage, CandleStates
 from StockSharp.Algo.Indicators import HullMovingAverage, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class hull_ma_slope_breakout_strategy(Strategy):
@@ -39,7 +40,7 @@ class hull_ma_slope_breakout_strategy(Strategy):
         self._stop_loss = self.Param("StopLoss", Unit(2, UnitTypes.Absolute)) \
             .SetDisplay("Stop Loss", "Stop loss value in ATRs", "Risk Management")
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._hull_ma = None

--- a/API/0263_MA_Slope_Breakout/ma_slope_breakout_strategy.py
+++ b/API/0263_MA_Slope_Breakout/ma_slope_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class ma_slope_breakout_strategy(Strategy):
     """
@@ -44,7 +45,7 @@ class ma_slope_breakout_strategy(Strategy):
             .SetDisplay("Stop Loss %", "Stop loss percentage", "Risk Management")
 
         # Candle type
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Internal state

--- a/API/0264_EMA_Slope_Breakout/ema_slope_breakout_strategy.py
+++ b/API/0264_EMA_Slope_Breakout/ema_slope_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import ExponentialMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class ema_slope_breakout_strategy(Strategy):
     """
@@ -40,7 +41,7 @@ class ema_slope_breakout_strategy(Strategy):
             .SetGreaterThanZero() \
             .SetDisplay("Stop Loss %", "Stop loss percentage", "Risk Management")
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Internal state variables

--- a/API/0265_Volatility_Adjusted_Momentum/volatility_adjusted_momentum_strategy.py
+++ b/API/0265_Volatility_Adjusted_Momentum/volatility_adjusted_momentum_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import Momentum, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class volatility_adjusted_momentum_strategy(Strategy):
     """
@@ -51,7 +52,7 @@ class volatility_adjusted_momentum_strategy(Strategy):
             .SetDisplay("Stop Loss", "Stop loss value in ATRs", "Risk Management")
 
         # Candle type
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Internal variables

--- a/API/0266_VWAP_Slope_Breakout/vwap_slope_breakout_strategy.py
+++ b/API/0266_VWAP_Slope_Breakout/vwap_slope_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import VolumeWeightedMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class vwap_slope_breakout_strategy(Strategy):
@@ -35,7 +36,7 @@ class vwap_slope_breakout_strategy(Strategy):
             .SetGreaterThanZero() \
             .SetDisplay("Stop Loss %", "Stop loss percentage", "Risk Management")
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Internal state

--- a/API/0267_RSI_Slope_Breakout/rsi_slope_breakout_strategy.py
+++ b/API/0267_RSI_Slope_Breakout/rsi_slope_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import RelativeStrengthIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class rsi_slope_breakout_strategy(Strategy):
     """
@@ -40,7 +41,7 @@ class rsi_slope_breakout_strategy(Strategy):
             .SetGreaterThanZero() \
             .SetDisplay("Stop Loss %", "Stop loss percentage", "Risk Management")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Indicators and state variables

--- a/API/0268_Stochastic_Slope_Breakout/stochastic_slope_breakout_strategy.py
+++ b/API/0268_Stochastic_Slope_Breakout/stochastic_slope_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import StochasticOscillator
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class stochastic_slope_breakout_strategy(Strategy):
     """ 
@@ -58,7 +59,7 @@ class stochastic_slope_breakout_strategy(Strategy):
             .SetDisplay("Stop Loss %", "Stop loss percentage", "Risk Management")
 
         # Candle type
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Internal variables

--- a/API/0269_CCI_Slope_Breakout/cci_slope_breakout_strategy.py
+++ b/API/0269_CCI_Slope_Breakout/cci_slope_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import CommodityChannelIndex, LinearRegression, LinearRegressionValue
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class cci_slope_breakout_strategy(Strategy):
     """CCI Slope Breakout Strategy"""
@@ -38,7 +39,7 @@ class cci_slope_breakout_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._cci = None

--- a/API/0270_Williams_R_Slope_Breakout/williams_r_slope_breakout_strategy.py
+++ b/API/0270_Williams_R_Slope_Breakout/williams_r_slope_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import WilliamsR, LinearRegression
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from collections import deque
 
 
@@ -40,7 +41,7 @@ class williams_r_slope_breakout_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._williams_r = None

--- a/API/0271_MACD_Slope_Breakout/macd_slope_breakout_strategy.py
+++ b/API/0271_MACD_Slope_Breakout/macd_slope_breakout_strategy.py
@@ -9,6 +9,7 @@ from System.Collections.Generic import Queue
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import MovingAverageConvergenceDivergenceSignal, LinearRegression
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class macd_slope_breakout_strategy(Strategy):
     """
@@ -55,7 +56,7 @@ class macd_slope_breakout_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._macd = None

--- a/API/0272_ADX_Slope_Breakout/adx_slope_breakout_strategy.py
+++ b/API/0272_ADX_Slope_Breakout/adx_slope_breakout_strategy.py
@@ -9,6 +9,7 @@ from System.Collections.Generic import Queue
 from StockSharp.Messages import UnitTypes, Unit, DataType, CandleStates
 from StockSharp.Algo.Indicators import AverageDirectionalIndex, LinearRegression
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class adx_slope_breakout_strategy(Strategy):
     """
@@ -55,7 +56,7 @@ class adx_slope_breakout_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candleType = self.Param("CandleType", TimeSpan.FromMinutes(5).TimeFrame()) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
     @property

--- a/API/0273_ATR_Slope_Breakout/atr_slope_breakout_strategy.py
+++ b/API/0273_ATR_Slope_Breakout/atr_slope_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates
 from StockSharp.Algo.Indicators import AverageTrueRange, ExponentialMovingAverage, LinearRegression
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class atr_slope_breakout_strategy(Strategy):
@@ -42,7 +43,7 @@ class atr_slope_breakout_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Internal state

--- a/API/0274_Volume_Slope_Breakout/volume_slope_breakout_strategy.py
+++ b/API/0274_Volume_Slope_Breakout/volume_slope_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import VolumeIndicator, SimpleMovingAverage, ExponentialMovingAverage, LinearRegression, LinearRegressionValue
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class volume_slope_breakout_strategy(Strategy):
@@ -39,7 +40,7 @@ class volume_slope_breakout_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Internal state

--- a/API/0275_OBV_Slope_Breakout/obv_slope_breakout_strategy.py
+++ b/API/0275_OBV_Slope_Breakout/obv_slope_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import OnBalanceVolume, LinearRegression, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class obv_slope_breakout_strategy(Strategy):
@@ -47,7 +48,7 @@ class obv_slope_breakout_strategy(Strategy):
             .SetOptimize(1.0, 5.0, 0.5)
 
         # Type of candles to use in the strategy.
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use in the strategy", "General")
 
         self._obv = None

--- a/API/0276_Bollinger_Width_Mean_Reversion/bollinger_width_mean_reversion_strategy.py
+++ b/API/0276_Bollinger_Width_Mean_Reversion/bollinger_width_mean_reversion_strategy.py
@@ -8,6 +8,7 @@ from System import Math
 from StockSharp.Messages import DataType, CandleStates, Sides
 from StockSharp.Algo.Indicators import BollingerBands, SimpleMovingAverage, StandardDeviation, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class bollinger_width_mean_reversion_strategy(Strategy):
     """
@@ -57,7 +58,7 @@ class bollinger_width_mean_reversion_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use in the strategy", "General")
 
         # Internal variables

--- a/API/0277_Keltner_Width_Mean_Reversion/keltner_width_mean_reversion_strategy.py
+++ b/API/0277_Keltner_Width_Mean_Reversion/keltner_width_mean_reversion_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates
 from StockSharp.Algo.Indicators import ExponentialMovingAverage, AverageTrueRange, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 
@@ -58,7 +59,7 @@ class keltner_width_mean_reversion_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use in the strategy", "General")
 
         # Internal state

--- a/API/0278_Donchian_Width_Mean_Reversion/donchian_width_mean_reversion_strategy.py
+++ b/API/0278_Donchian_Width_Mean_Reversion/donchian_width_mean_reversion_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import DonchianChannels, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class donchian_width_mean_reversion_strategy(Strategy):
@@ -41,7 +42,7 @@ class donchian_width_mean_reversion_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 5.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Candle type for strategy", "General")
 
         # Indicators

--- a/API/0279_Ichimoku_Cloud_Width_Mean_Reversion/ichimoku_cloud_width_mean_reversion_strategy.py
+++ b/API/0279_Ichimoku_Cloud_Width_Mean_Reversion/ichimoku_cloud_width_mean_reversion_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates
 from StockSharp.Algo.Indicators import Ichimoku, SimpleMovingAverage, StandardDeviation, IchimokuValue
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 
@@ -45,7 +46,7 @@ class ichimoku_cloud_width_mean_reversion_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Candle type for strategy", "General")
 
         self._ichimoku = None

--- a/API/0280_Supertrend_Distance_Mean_Reversion/supertrend_distance_mean_reversion_strategy.py
+++ b/API/0280_Supertrend_Distance_Mean_Reversion/supertrend_distance_mean_reversion_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates
 from StockSharp.Algo.Indicators import AverageTrueRange, SuperTrend, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class supertrend_distance_mean_reversion_strategy(Strategy):
@@ -40,7 +41,7 @@ class supertrend_distance_mean_reversion_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Candle type for strategy", "General")
 
         # Indicators

--- a/API/0281_Parabolic_SAR_Distance_Mean_Reversion/parabolic_sar_distance_mean_reversion_strategy.py
+++ b/API/0281_Parabolic_SAR_Distance_Mean_Reversion/parabolic_sar_distance_mean_reversion_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType
 from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import ParabolicSar, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class parabolic_sar_distance_mean_reversion_strategy(Strategy):
@@ -41,7 +42,7 @@ class parabolic_sar_distance_mean_reversion_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Candle type for strategy", "General")
 
         # Indicators

--- a/API/0282_Hull_MA_Slope_Mean_Reversion/hull_ma_slope_mean_reversion_strategy.py
+++ b/API/0282_Hull_MA_Slope_Mean_Reversion/hull_ma_slope_mean_reversion_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, ICandleMessage, CandleStates
 from StockSharp.Algo.Indicators import HullMovingAverage, AverageTrueRange, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class hull_ma_slope_mean_reversion_strategy(Strategy):
@@ -43,7 +44,7 @@ class hull_ma_slope_mean_reversion_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Candle type for strategy", "General")
 
         self._hullMa = None

--- a/API/0283_MA_Slope_Mean_Reversion/ma_slope_mean_reversion_strategy.py
+++ b/API/0283_MA_Slope_Mean_Reversion/ma_slope_mean_reversion_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class ma_slope_mean_reversion_strategy(Strategy):
     """MA Slope Mean Reversion Strategy - strategy based on mean reversion of moving average slope."""
@@ -34,7 +35,7 @@ class ma_slope_mean_reversion_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._previous_ma_value = 0.0

--- a/API/0284_EMA_Slope_Mean_Reversion/ema_slope_mean_reversion_strategy.py
+++ b/API/0284_EMA_Slope_Mean_Reversion/ema_slope_mean_reversion_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import ExponentialMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class ema_slope_mean_reversion_strategy(Strategy):
     """
@@ -39,7 +40,7 @@ class ema_slope_mean_reversion_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Internal state variables

--- a/API/0285_VWAP_Slope_Mean_Reversion/vwap_slope_mean_reversion_strategy.py
+++ b/API/0285_VWAP_Slope_Mean_Reversion/vwap_slope_mean_reversion_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import VolumeWeightedMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class vwap_slope_mean_reversion_strategy(Strategy):
@@ -31,7 +32,7 @@ class vwap_slope_mean_reversion_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Internal state variables

--- a/API/0286_RSI_Slope_Mean_Reversion/rsi_slope_mean_reversion_strategy.py
+++ b/API/0286_RSI_Slope_Mean_Reversion/rsi_slope_mean_reversion_strategy.py
@@ -8,6 +8,7 @@ from System import Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import RelativeStrengthIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class rsi_slope_mean_reversion_strategy(Strategy):
     """
@@ -44,7 +45,7 @@ class rsi_slope_mean_reversion_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Internal state

--- a/API/0287_Stochastic_Slope_Mean_Reversion/stochastic_slope_mean_reversion_strategy.py
+++ b/API/0287_Stochastic_Slope_Mean_Reversion/stochastic_slope_mean_reversion_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import StochasticOscillator, StochasticOscillatorValue
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class stochastic_slope_mean_reversion_strategy(Strategy):
@@ -48,7 +49,7 @@ class stochastic_slope_mean_reversion_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Internal variables

--- a/API/0288_CCI_Slope_Mean_Reversion/cci_slope_mean_reversion_strategy.py
+++ b/API/0288_CCI_Slope_Mean_Reversion/cci_slope_mean_reversion_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, UnitTypes, Unit
 from StockSharp.Algo.Indicators import CommodityChannelIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class cci_slope_mean_reversion_strategy(Strategy):
@@ -39,7 +40,7 @@ class cci_slope_mean_reversion_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Internal state variables

--- a/API/0289_Williams_R_Slope_Mean_Reversion/williams_r_slope_mean_reversion_strategy.py
+++ b/API/0289_Williams_R_Slope_Mean_Reversion/williams_r_slope_mean_reversion_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import WilliamsR
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class williams_r_slope_mean_reversion_strategy(Strategy):
@@ -47,7 +48,7 @@ class williams_r_slope_mean_reversion_strategy(Strategy):
             .SetOptimize(1.0, 5.0, 0.5)
 
         # Candle type for strategy.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Internal state variables

--- a/API/0290_MACD_Slope_Mean_Reversion/macd_slope_mean_reversion_strategy.py
+++ b/API/0290_MACD_Slope_Mean_Reversion/macd_slope_mean_reversion_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import MovingAverageConvergenceDivergenceSignal
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class macd_slope_mean_reversion_strategy(Strategy):
     """
@@ -42,7 +43,7 @@ class macd_slope_mean_reversion_strategy(Strategy):
             .SetDisplay("Stop Loss %", "Stop loss percentage from entry price", "Risk Management") \
             .SetCanOptimize(True).SetOptimize(1.0, 5.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # State variables

--- a/API/0291_ADX_Slope_Mean_Reversion/adx_slope_mean_reversion_strategy.py
+++ b/API/0291_ADX_Slope_Mean_Reversion/adx_slope_mean_reversion_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import AverageDirectionalIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class adx_slope_mean_reversion_strategy(Strategy):
     """
@@ -44,7 +45,7 @@ class adx_slope_mean_reversion_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 5.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Internal state

--- a/API/0292_ATR_Slope_Mean_Reversion/atr_slope_mean_reversion_strategy.py
+++ b/API/0292_ATR_Slope_Mean_Reversion/atr_slope_mean_reversion_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes, ICandleMessage
 from StockSharp.Algo.Indicators import AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class atr_slope_mean_reversion_strategy(Strategy):
     """ATR Slope Mean Reversion Strategy.
@@ -41,7 +42,7 @@ class atr_slope_mean_reversion_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1, 5, 1)
 
-        self._candleType = self.Param("CandleType", TimeSpan.FromMinutes(5).TimeFrame()) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._stopLossPercent = self.Param("StopLossPercent", 1.0) \

--- a/API/0293_Volume_Slope_Mean_Reversion/volume_slope_mean_reversion_strategy.py
+++ b/API/0293_Volume_Slope_Mean_Reversion/volume_slope_mean_reversion_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 
@@ -48,7 +49,7 @@ class volume_slope_mean_reversion_strategy(Strategy):
             .SetOptimize(1.0, 5.0, 0.5)
 
         # Candle type for strategy.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._volume_ma = None

--- a/API/0294_OBV_Slope_Mean_Reversion/obv_slope_mean_reversion_strategy.py
+++ b/API/0294_OBV_Slope_Mean_Reversion/obv_slope_mean_reversion_strategy.py
@@ -15,6 +15,7 @@ from StockSharp.Messages import CandleStates
 from StockSharp.Algo.Indicators import OnBalanceVolume
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class obv_slope_mean_reversion_strategy(Strategy):
@@ -55,7 +56,7 @@ class obv_slope_mean_reversion_strategy(Strategy):
             .SetOptimize(1.0, 5.0, 0.5)
 
         # Candle type for strategy.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._obv = None

--- a/API/0295_Pairs_Trading_Volatility_Filter/pairs_trading_volatility_filter_strategy.py
+++ b/API/0295_Pairs_Trading_Volatility_Filter/pairs_trading_volatility_filter_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import AverageTrueRange, StandardDeviation, SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 from StockSharp.BusinessEntities import Security
 
@@ -118,7 +119,7 @@ class pairs_trading_volatility_filter_strategy(Strategy):
     # endregion
 
     def GetWorkingSecurities(self):
-        dt = DataType.TimeFrame(TimeSpan.FromMinutes(5))
+        dt = tf(5)
         result = []
         if self.Security1 is not None:
             result.append((self.Security1, dt))

--- a/API/0296_Z-Score_Volume_Filter/zscore_volume_filter_strategy.py
+++ b/API/0296_Z-Score_Volume_Filter/zscore_volume_filter_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class zscore_volume_filter_strategy(Strategy):
     """
@@ -33,7 +34,7 @@ class zscore_volume_filter_strategy(Strategy):
             .SetDisplay("Stop Loss", "Stop loss percentage from entry price", "Parameters") \
             .SetCanOptimize(True)
 
-        self._candle_type = self.Param("CandleType", TimeSpan.FromMinutes(5).TimeFrame()) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Timeframe for candles", "Parameters")
 
         # Technical indicators

--- a/API/0298_Correlation_Mean_Reversion/correlation_mean_reversion_strategy.py
+++ b/API/0298_Correlation_Mean_Reversion/correlation_mean_reversion_strategy.py
@@ -11,6 +11,7 @@ from System.Collections.Generic import Queue
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes, ICandleMessage
 from StockSharp.Algo.Indicators import SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 from StockSharp.BusinessEntities import Security
 
@@ -64,7 +65,7 @@ class correlation_mean_reversion_strategy(Strategy):
             .SetDisplay("Stop Loss", "Stop loss percentage from entry price", "Parameters") \
             .SetCanOptimize(True)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Timeframe for candles", "Parameters")
 
     # First security for correlation calculation.

--- a/API/0299_Beta_Adjusted_Pairs_Trading/beta_adjusted_pairs_strategy.py
+++ b/API/0299_Beta_Adjusted_Pairs_Trading/beta_adjusted_pairs_strategy.py
@@ -8,6 +8,7 @@ from System import Math
 from StockSharp.Messages import DataType, Level1Fields, Level1ChangeMessage, Subscription
 from StockSharp.Messages import Sides, OrderTypes, Order
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from StockSharp.BusinessEntities import Security, Portfolio
 
 class beta_adjusted_pairs_strategy(Strategy):

--- a/API/0300_Hurst_Exponent_Volatility_Filter/hurst_volatility_filter_strategy.py
+++ b/API/0300_Hurst_Exponent_Volatility_Filter/hurst_volatility_filter_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates, ICandleMessage
 from StockSharp.Algo.Indicators import SimpleMovingAverage, AverageTrueRange, HurstExponent
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class hurst_volatility_filter_strategy(Strategy):
     """
@@ -42,7 +43,7 @@ class hurst_volatility_filter_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candle_type_param = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type_param = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Indicators

--- a/API/0301_Adaptive_EMA_Breakout/adaptive_ema_breakout_strategy.py
+++ b/API/0301_Adaptive_EMA_Breakout/adaptive_ema_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import KaufmanAdaptiveMovingAverage, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class adaptive_ema_breakout_strategy(Strategy):
     """
@@ -45,7 +46,7 @@ class adaptive_ema_breakout_strategy(Strategy):
             .SetOptimize(1.0, 3.0, 0.5)
 
         # Candle type parameter.
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle type", "Type of candles for strategy", "General")
 
         # Internal state variables

--- a/API/0302_Volatility_Cluster_Breakout/volatility_cluster_breakout_strategy.py
+++ b/API/0302_Volatility_Cluster_Breakout/volatility_cluster_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit
 from StockSharp.Algo.Indicators import SimpleMovingAverage, StandardDeviation, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class volatility_cluster_breakout_strategy(Strategy):
@@ -47,7 +48,7 @@ class volatility_cluster_breakout_strategy(Strategy):
             .SetOptimize(1.0, 3.0, 0.5)
 
         # Candle type parameter.
-        self._candle_type = self.Param("CandleType", TimeSpan.FromMinutes(5).TimeFrame()) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles for strategy", "General")
 
         self._atr_avg = None

--- a/API/0303_Seasonality_Adjusted_Momentum/seasonality_adjusted_momentum_strategy.py
+++ b/API/0303_Seasonality_Adjusted_Momentum/seasonality_adjusted_momentum_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import Momentum, SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class seasonality_adjusted_momentum_strategy(Strategy):
     """
@@ -39,7 +40,7 @@ class seasonality_adjusted_momentum_strategy(Strategy):
             .SetOptimize(1.0, 3.0, 0.5)
 
         # Candle type parameter.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromDays(1))) \
+        self._candle_type = self.Param("CandleType", tf(1*1440)) \
             .SetDisplay("Candle Type", "Type of candles for strategy", "General")
 
         # Dictionary to store seasonality strength values for each month

--- a/API/0305_RSI_Dynamic_Overbought_Oversold/rsi_dynamic_overbought_oversold_strategy.py
+++ b/API/0305_RSI_Dynamic_Overbought_Oversold/rsi_dynamic_overbought_oversold_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import RelativeStrengthIndex, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 
@@ -45,7 +46,7 @@ class rsi_dynamic_overbought_oversold_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles for strategy", "General")
 
         self._rsiSma = None

--- a/API/0306_Bollinger_Volatility_Breakout/bollinger_volatility_breakout_strategy.py
+++ b/API/0306_Bollinger_Volatility_Breakout/bollinger_volatility_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit
 from StockSharp.Algo.Indicators import BollingerBands, AverageTrueRange, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 
@@ -42,7 +43,7 @@ class bollinger_volatility_breakout_strategy(Strategy):
             .SetDisplay("Stop Loss Multiplier", "ATR multiplier for stop-loss", "Strategy Settings") \
             .SetCanOptimize(True)
 
-        self._candle_type = self.Param("CandleType", TimeSpan.FromMinutes(5).TimeFrame()) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles for strategy", "General")
 
         # Internal indicators

--- a/API/0307_MACD_Adaptive_Histogram/macd_adaptive_histogram_strategy.py
+++ b/API/0307_MACD_Adaptive_Histogram/macd_adaptive_histogram_strategy.py
@@ -11,6 +11,7 @@ from StockSharp.Algo.Indicators import (
     StandardDeviation,
 )
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 
@@ -78,7 +79,7 @@ class macd_adaptive_histogram_strategy(Strategy):
         )
 
         self._candle_type = (
-            self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            self.Param("CandleType", tf(15))
             .SetDisplay("Candle Type", "Type of candles for strategy", "General")
         )
 

--- a/API/0308_Ichimoku_Volume_Cluster/ichimoku_volume_cluster_strategy.py
+++ b/API/0308_Ichimoku_Volume_Cluster/ichimoku_volume_cluster_strategy.py
@@ -8,6 +8,7 @@ from System import Math
 from StockSharp.Messages import DataType, CandleStates, Unit
 from StockSharp.Algo.Indicators import Ichimoku, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class ichimoku_volume_cluster_strategy(Strategy):
@@ -49,7 +50,7 @@ class ichimoku_volume_cluster_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromHours(1))) \
+        self._candle_type = self.Param("CandleType", tf(1*60)) \
             .SetDisplay("Candle Type", "Type of candles for strategy", "General")
 
         # Internal indicators

--- a/API/0309_Supertrend_Momentum_Filter/supertrend_momentum_filter_strategy.py
+++ b/API/0309_Supertrend_Momentum_Filter/supertrend_momentum_filter_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import SuperTrend, Momentum
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class supertrend_momentum_filter_strategy(Strategy):
     """
@@ -38,7 +39,7 @@ class supertrend_momentum_filter_strategy(Strategy):
             .SetOptimize(5, 30, 5)
 
         # Candle type parameter.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Store previous values to detect changes

--- a/API/0310_Donchian_Volatility_Contraction/donchian_volatility_contraction_strategy.py
+++ b/API/0310_Donchian_Volatility_Contraction/donchian_volatility_contraction_strategy.py
@@ -13,6 +13,7 @@ from StockSharp.Algo.Indicators import (
     StandardDeviation,
 )
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 
@@ -55,7 +56,7 @@ class donchian_volatility_contraction_strategy(Strategy):
 
         # Candle type parameter.
         self._candle_type = (
-            self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5)))
+            self.Param("CandleType", tf(5))
             .SetDisplay("Candle Type", "Type of candles to use", "General")
         )
 

--- a/API/0311_Keltner_RSI_Divergence/keltner_rsi_divergence_strategy.py
+++ b/API/0311_Keltner_RSI_Divergence/keltner_rsi_divergence_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import ExponentialMovingAverage, AverageTrueRange, RelativeStrengthIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class keltner_rsi_divergence_strategy(Strategy):
     """
@@ -45,7 +46,7 @@ class keltner_rsi_divergence_strategy(Strategy):
             .SetOptimize(7, 28, 7)
 
         # Candle type parameter.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Store previous values to detect divergence

--- a/API/0312_Hull_MA_Volume_Spike/hull_ma_volume_spike_strategy.py
+++ b/API/0312_Hull_MA_Volume_Spike/hull_ma_volume_spike_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import HullMovingAverage, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 
@@ -38,7 +39,7 @@ class hull_ma_volume_spike_strategy(Strategy):
             .SetOptimize(1.5, 3.0, 0.5)
 
         # Candle type parameter.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Store previous HMA value to detect direction changes

--- a/API/0313_VWAP_ADX_Trend_Strength/vwap_adx_trend_strength_strategy.py
+++ b/API/0313_VWAP_ADX_Trend_Strength/vwap_adx_trend_strength_strategy.py
@@ -5,6 +5,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import AverageDirectionalIndex, VolumeWeightedMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class vwap_adx_trend_strength_strategy(Strategy):
@@ -30,7 +31,7 @@ class vwap_adx_trend_strength_strategy(Strategy):
             .SetOptimize(15, 35, 5)
 
         # Candle type parameter.
-        self._candle_type = self.Param("CandleType", TimeSpan.FromMinutes(5).TimeFrame()) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
     @property

--- a/API/0314_Parabolic_SAR_Volatility_Expansion/parabolic_sar_volatility_expansion_strategy.py
+++ b/API/0314_Parabolic_SAR_Volatility_Expansion/parabolic_sar_volatility_expansion_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates
 from StockSharp.Algo.Indicators import ParabolicSar, AverageTrueRange, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class parabolic_sar_volatility_expansion_strategy(Strategy):
@@ -47,7 +48,7 @@ class parabolic_sar_volatility_expansion_strategy(Strategy):
             .SetOptimize(1.5, 3.0, 0.5)
 
         # Candle type parameter.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Indicators

--- a/API/0315_Stochastic_Dynamic_Zones/stochastic_with_dynamic_zones_strategy.py
+++ b/API/0315_Stochastic_Dynamic_Zones/stochastic_with_dynamic_zones_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import StochasticOscillator, StochasticOscillatorValue, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 
@@ -51,7 +52,7 @@ class stochastic_with_dynamic_zones_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Internal fields

--- a/API/0316_ADX_Volume_Breakout/adx_with_volume_breakout_strategy.py
+++ b/API/0316_ADX_Volume_Breakout/adx_with_volume_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import AverageDirectionalIndex, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class adx_with_volume_breakout_strategy(Strategy):
@@ -44,7 +45,7 @@ class adx_with_volume_breakout_strategy(Strategy):
             .SetOptimize(1.5, 3.0, 0.5)
 
         # Candle type parameter.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
     @property

--- a/API/0317_CCI_Volatility_Filter/cci_with_volatility_filter_strategy.py
+++ b/API/0317_CCI_Volatility_Filter/cci_with_volatility_filter_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, UnitTypes, Unit, CandleStates
 from StockSharp.Algo.Indicators import CommodityChannelIndex, AverageTrueRange, SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class cci_with_volatility_filter_strategy(Strategy):
@@ -44,7 +45,7 @@ class cci_with_volatility_filter_strategy(Strategy):
             .SetOptimize(50, 150, 25)
 
         # Candle type parameter.
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Internal indicators

--- a/API/0318_Williams_R_Momentum/williams_percent_r_with_momentum_strategy.py
+++ b/API/0318_Williams_R_Momentum/williams_percent_r_with_momentum_strategy.py
@@ -6,6 +6,7 @@ clr.AddReference("StockSharp.Algo")
 from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 from StockSharp.Algo.Indicators import WilliamsR, Momentum, SimpleMovingAverage
 
@@ -44,7 +45,7 @@ class williams_percent_r_with_momentum_strategy(Strategy):
             .SetOptimize(-30, -10, 5)
 
         # Candle type parameter.
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
     @property

--- a/API/0319_Bollinger_K-Means_Cluster/bollinger_kmeans_strategy.py
+++ b/API/0319_Bollinger_K-Means_Cluster/bollinger_kmeans_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import BollingerBands, RelativeStrengthIndex, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from enum import Enum
 
 
@@ -38,7 +39,7 @@ class bollinger_kmeans_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._kmeans_history_length = self.Param("KMeansHistoryLength", 50) \

--- a/API/0320_MACD_Hidden_Markov_Model/macd_hidden_markov_model_strategy.py
+++ b/API/0320_MACD_Hidden_Markov_Model/macd_hidden_markov_model_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import MovingAverageConvergenceDivergenceSignal
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class macd_hidden_markov_model_strategy(Strategy):
     """
@@ -38,7 +39,7 @@ class macd_hidden_markov_model_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(7, 15, 1)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._hmm_history_length = self.Param("HmmHistoryLength", 100) \

--- a/API/0321_Ichimoku_Hurst_Exponent/ichimoku_hurst_exponent_strategy.py
+++ b/API/0321_Ichimoku_Hurst_Exponent/ichimoku_hurst_exponent_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates
 from StockSharp.Algo.Indicators import Ichimoku
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class ichimoku_hurst_exponent_strategy(Strategy):
     """
@@ -48,7 +49,7 @@ class ichimoku_hurst_exponent_strategy(Strategy):
             .SetOptimize(0.45, 0.6, 0.05)
 
         # Candle type to use for the strategy.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candle_type = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Data for Hurst exponent calculations

--- a/API/0322_Supertrend_RSI_Divergence/supertrend_rsi_divergence_strategy.py
+++ b/API/0322_Supertrend_RSI_Divergence/supertrend_rsi_divergence_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates
 from StockSharp.Algo.Indicators import SuperTrend, RelativeStrengthIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class supertrend_rsi_divergence_strategy(Strategy):
     """
@@ -32,7 +33,7 @@ class supertrend_rsi_divergence_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(8, 20, 2)
 
-        self._candle_type = self.Param("CandleType", TimeSpan.FromMinutes(15).TimeFrame()) \
+        self._candle_type = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Indicator instances

--- a/API/0323_Donchian_Seasonal_Filter/donchian_seasonal_filter_strategy.py
+++ b/API/0323_Donchian_Seasonal_Filter/donchian_seasonal_filter_strategy.py
@@ -8,6 +8,7 @@ from System import Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import DonchianChannels
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class donchian_seasonal_filter_strategy(Strategy):
     """
@@ -42,7 +43,7 @@ class donchian_seasonal_filter_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(0.2, 1.0, 0.1)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candle_type = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._donchian = None

--- a/API/0324_Keltner_Kalman_Filter/keltner_kalman_strategy.py
+++ b/API/0324_Keltner_Kalman_Filter/keltner_kalman_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import ExponentialMovingAverage, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class keltner_kalman_strategy(Strategy):
@@ -61,7 +62,7 @@ class keltner_kalman_strategy(Strategy):
             .SetOptimize(0.01, 1.0, 0.05)
 
         # Candle type to use for the strategy.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candle_type = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._ema = None

--- a/API/0325_Hull_MA_Volatility_Contraction/hull_ma_volatility_contraction_strategy.py
+++ b/API/0325_Hull_MA_Volatility_Contraction/hull_ma_volatility_contraction_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import HullMovingAverage, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class hull_ma_volatility_contraction_strategy(Strategy):
     """
@@ -32,7 +33,7 @@ class hull_ma_volatility_contraction_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candle_type = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Indicators

--- a/API/0326_VWAP_Stochastic_Divergence/vwap_adx_trend_strategy.py
+++ b/API/0326_VWAP_Stochastic_Divergence/vwap_adx_trend_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import VolumeWeightedMovingAverage, AverageDirectionalIndex, DirectionalIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 
@@ -33,7 +34,7 @@ class vwap_adx_trend_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(10.0, 25.0, 5.0)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._vwap = None

--- a/API/0327_Parabolic_SAR_Hurst_Filter/parabolic_sar_hurst_strategy.py
+++ b/API/0327_Parabolic_SAR_Hurst_Filter/parabolic_sar_hurst_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import ParabolicSar, HurstExponent
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 
@@ -40,7 +41,7 @@ class parabolic_sar_hurst_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(50, 150, 25)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._prev_sar_value = 0

--- a/API/0328_Bollinger_Kalman_Filter/bollinger_kalman_filter_strategy.py
+++ b/API/0328_Bollinger_Kalman_Filter/bollinger_kalman_filter_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import BollingerBands, KalmanFilter
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 
@@ -44,7 +45,7 @@ class bollinger_kalman_filter_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(0.01, 1.0, 0.1)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
     @property

--- a/API/0329_MACD_Volume_Cluster/macd_volume_cluster_strategy.py
+++ b/API/0329_MACD_Volume_Cluster/macd_volume_cluster_strategy.py
@@ -11,6 +11,7 @@ from StockSharp.Algo.Indicators import (
     StandardDeviation,
 )
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class macd_volume_cluster_strategy(Strategy):
@@ -55,7 +56,7 @@ class macd_volume_cluster_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.5, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Internal state variables

--- a/API/0330_Ichimoku_Volatility_Contraction/ichimoku_volatility_contraction_strategy.py
+++ b/API/0330_Ichimoku_Volatility_Contraction/ichimoku_volatility_contraction_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import Ichimoku, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class ichimoku_volatility_contraction_strategy(Strategy):
@@ -49,7 +50,7 @@ class ichimoku_volatility_contraction_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.5, 3.0, 0.5)
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Internal state variables for ATR statistics

--- a/API/0332_Donchian_Hurst_Exponent/donchian_hurst_strategy.py
+++ b/API/0332_Donchian_Hurst_Exponent/donchian_hurst_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import DonchianChannels, FractalDimension
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class donchian_hurst_strategy(Strategy):
@@ -37,7 +38,7 @@ class donchian_hurst_strategy(Strategy):
             .SetGreaterThanZero() \
             .SetDisplay("Stop Loss %", "Stop Loss percentage from entry price", "Risk Management")
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Internal state

--- a/API/0333_Keltner_Seasonal_Filter/keltner_seasonal_strategy.py
+++ b/API/0333_Keltner_Seasonal_Filter/keltner_seasonal_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import ExponentialMovingAverage, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class keltner_seasonal_strategy(Strategy):
@@ -38,7 +39,7 @@ class keltner_seasonal_strategy(Strategy):
             .SetDisplay("Seasonal Threshold", "Minimum seasonal strength to consider for trading", "Seasonal Settings")
 
         # Strategy parameter: Candle type.
-        self._candleType = self.Param("CandleType", TimeSpan.FromMinutes(5).TimeFrame()) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Initialize seasonal data dictionary

--- a/API/0334_Hull_MA_K-Means_Cluster/hull_kmeans_cluster_strategy.py
+++ b/API/0334_Hull_MA_K-Means_Cluster/hull_kmeans_cluster_strategy.py
@@ -8,6 +8,7 @@ from System.Collections.Generic import Queue
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import HullMovingAverage, RelativeStrengthIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class hull_kmeans_cluster_strategy(Strategy):
     """Strategy that trades based on Hull Moving Average direction with K-Means clustering for market state detection."""
@@ -31,7 +32,7 @@ class hull_kmeans_cluster_strategy(Strategy):
             .SetDisplay("RSI Period", "Period for RSI calculation as a clustering feature", "Indicator Settings")
 
         # Strategy parameter: Candle type.
-        self._candle_type = self.Param("CandleType", TimeSpan.FromMinutes(5).TimeFrame()) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Enum representing market state

--- a/API/0335_VWAP_Hidden_Markov_Model/vwap_hidden_markov_model_strategy.py
+++ b/API/0335_VWAP_Hidden_Markov_Model/vwap_hidden_markov_model_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import VolumeWeightedMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from collections import deque
 from enum import Enum
 
@@ -35,7 +36,7 @@ class vwap_hidden_markov_model_strategy(Strategy):
             .SetDisplay("Stop Loss %", "Stop Loss percentage from entry price", "Risk Management")
 
         # Strategy parameter: Candle type.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # HMM state and data

--- a/API/0336_Parabolic_SAR_RSI_Divergence/parabolic_sar_rsi_divergence_strategy.py
+++ b/API/0336_Parabolic_SAR_RSI_Divergence/parabolic_sar_rsi_divergence_strategy.py
@@ -8,6 +8,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates
 from StockSharp.Algo.Indicators import ParabolicSar, RelativeStrengthIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class parabolic_sar_rsi_divergence_strategy(Strategy):
@@ -32,7 +33,7 @@ class parabolic_sar_rsi_divergence_strategy(Strategy):
             .SetDisplay("RSI Period", "Period for RSI calculation", "Indicator Settings")
 
         # Strategy parameter: Candle type.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._prev_rsi = 0

--- a/API/0337_Adaptive_RSI_Volume_Filter/adaptive_rsi_volume_strategy.py
+++ b/API/0337_Adaptive_RSI_Volume_Filter/adaptive_rsi_volume_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import RelativeStrengthIndex, AverageTrueRange, SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 
@@ -40,7 +41,7 @@ class adaptive_rsi_volume_strategy(Strategy):
             .SetDisplay("Volume Lookback", "Number of periods to calculate volume average", "Volume Settings")
 
         # Strategy parameter: Candle type.
-        self._candleType = self.Param("CandleType", TimeSpan.FromMinutes(5).TimeFrame()) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Internal state

--- a/API/0338_Adaptive_Bollinger_Breakout/adaptive_bollinger_breakout_strategy.py
+++ b/API/0338_Adaptive_Bollinger_Breakout/adaptive_bollinger_breakout_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import BollingerBands, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class adaptive_bollinger_breakout_strategy(Strategy):
@@ -42,7 +43,7 @@ class adaptive_bollinger_breakout_strategy(Strategy):
             .SetDisplay("ATR Period", "Period for ATR volatility calculation", "Indicator Settings")
 
         # Strategy parameter: Candle type.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Internal fields

--- a/API/0339_MACD_Sentiment_Filter/macd_with_sentiment_filter_strategy.py
+++ b/API/0339_MACD_Sentiment_Filter/macd_with_sentiment_filter_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import MovingAverageConvergenceDivergenceSignal
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 import random
 
 class macd_with_sentiment_filter_strategy(Strategy):
@@ -70,7 +71,7 @@ class macd_with_sentiment_filter_strategy(Strategy):
 
         # Type of candles to use.
         self._candle_type = (
-            self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15)))
+            self.Param("CandleType", tf(15))
             .SetDisplay("Candle Type", "Type of candles to use", "General")
         )
 

--- a/API/0340_Ichimoku_Implied_Volatility/ichimoku_implied_volatility_strategy.py
+++ b/API/0340_Ichimoku_Implied_Volatility/ichimoku_implied_volatility_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit
 from StockSharp.Algo.Indicators import Ichimoku
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 import random
 
@@ -54,7 +55,7 @@ class ichimoku_implied_volatility_strategy(Strategy):
             .SetOptimize(10, 30, 5)
 
         # Type of candles to use.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candle_type = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Internal state

--- a/API/0341_Supertrend_Put_Call_Ratio/supertrend_put_call_ratio_strategy.py
+++ b/API/0341_Supertrend_Put_Call_Ratio/supertrend_put_call_ratio_strategy.py
@@ -9,6 +9,7 @@ from Ecng.Common import RandomGen
 from StockSharp.Messages import DataType, CandleStates
 from StockSharp.Algo.Indicators import SuperTrend
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class supertrend_put_call_ratio_strategy(Strategy):
     """
@@ -48,7 +49,7 @@ class supertrend_put_call_ratio_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candleType = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._pcrHistory = []

--- a/API/0343_Keltner_Reinforcement_Learning_Signal/keltner_with_rl_signal_strategy.py
+++ b/API/0343_Keltner_Reinforcement_Learning_Signal/keltner_with_rl_signal_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Sides
 from StockSharp.Algo.Indicators import KeltnerChannels
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class keltner_with_rl_signal_strategy(Strategy):
@@ -52,7 +53,7 @@ class keltner_with_rl_signal_strategy(Strategy):
             .SetOptimize(1.0, 3.0, 0.5)
 
         # Type of candles to use.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candle_type = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         class RLSignal:

--- a/API/0344_Hull_MA_Implied_Volatility_Breakout/hull_ma_implied_volatility_breakout_strategy.py
+++ b/API/0344_Hull_MA_Implied_Volatility_Breakout/hull_ma_implied_volatility_breakout_strategy.py
@@ -9,6 +9,7 @@ from Ecng.Common import RandomGen
 from StockSharp.Messages import DataType, CandleStates
 from StockSharp.Algo.Indicators import HullMovingAverage, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class hull_ma_implied_volatility_breakout_strategy(Strategy):
@@ -50,7 +51,7 @@ class hull_ma_implied_volatility_breakout_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(15))) \
+        self._candleType = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Track trade direction

--- a/API/0345_VWAP_Behavioral_Bias_Filter/vwap_with_behavioral_bias_filter_strategy.py
+++ b/API/0345_VWAP_Behavioral_Bias_Filter/vwap_with_behavioral_bias_filter_strategy.py
@@ -11,6 +11,7 @@ from StockSharp.Messages import Unit
 from StockSharp.Messages import UnitTypes
 from StockSharp.Algo.Indicators import VolumeWeightedMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 class vwap_with_behavioral_bias_filter_strategy(Strategy):
     """
@@ -47,7 +48,7 @@ class vwap_with_behavioral_bias_filter_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetOptimize(1.0, 3.0, 0.5)
 
-        self._candleType = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candleType = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Indicators and state variables

--- a/API/0346_Parabolic_SAR_Sentiment_Divergence/parabolic_sar_sentiment_divergence_strategy.py
+++ b/API/0346_Parabolic_SAR_Sentiment_Divergence/parabolic_sar_sentiment_divergence_strategy.py
@@ -8,6 +8,7 @@ from System import TimeSpan
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import ParabolicSar
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 from Ecng.Common import RandomGen
 
@@ -30,7 +31,7 @@ class parabolic_sar_sentiment_divergence_strategy(Strategy):
             .SetDisplay("Maximum AF", "Maximum acceleration factor for Parabolic SAR", "SAR Parameters")
 
         # Candle type for strategy calculation.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._parabolic_sar = None

--- a/API/0347_RSI_Option_Open_Interest/rsi_with_option_open_interest_strategy.py
+++ b/API/0347_RSI_Option_Open_Interest/rsi_with_option_open_interest_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math, Random
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import RelativeStrengthIndex, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 
@@ -25,7 +26,7 @@ class rsi_with_option_open_interest_strategy(Strategy):
             .SetDisplay("RSI Period", "Period for RSI calculation", "Indicators")
 
         # Candle type for strategy calculation.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Open Interest averaging period.

--- a/API/0348_Stochastic_Implied_Volatility_Skew/stochastic_implied_volatility_skew_strategy.py
+++ b/API/0348_Stochastic_Implied_Volatility_Skew/stochastic_implied_volatility_skew_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math, Random
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes, ICandleMessage
 from StockSharp.Algo.Indicators import StochasticOscillator, SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 from indicator_extensions import *
 
 class stochastic_implied_volatility_skew_strategy(Strategy):
@@ -46,7 +47,7 @@ class stochastic_implied_volatility_skew_strategy(Strategy):
             .SetDisplay("Stop Loss %", "Stop Loss percentage", "Risk Management")
 
         # Candle type for strategy calculation.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Internal fields

--- a/API/0349_ADX_Sentiment_Momentum/adx_sentiment_momentum_strategy.py
+++ b/API/0349_ADX_Sentiment_Momentum/adx_sentiment_momentum_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import AverageDirectionalIndex
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 import random
 
@@ -42,7 +43,7 @@ class adx_sentiment_momentum_strategy(Strategy):
             .SetDisplay("Stop Loss %", "Stop Loss percentage", "Risk Management")
 
         # Candle type for strategy calculation.
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._adx = None

--- a/API/0350_CCI_Put_Call_Ratio_Divergence/cci_put_call_ratio_divergence_strategy.py
+++ b/API/0350_CCI_Put_Call_Ratio_Divergence/cci_put_call_ratio_divergence_strategy.py
@@ -7,6 +7,7 @@ from System import TimeSpan, Math, Random
 from StockSharp.Messages import DataType, CandleStates
 from StockSharp.Algo.Indicators import CommodityChannelIndex, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
+from datatype_extensions import *
 
 
 class cci_put_call_ratio_divergence_strategy(Strategy):
@@ -26,7 +27,7 @@ class cci_put_call_ratio_divergence_strategy(Strategy):
             .SetCanOptimize(True) \
             .SetDisplay("ATR Multiplier", "Multiplier for ATR-based stop loss", "Risk Management")
 
-        self._candle_type = self.Param("CandleType", DataType.TimeFrame(TimeSpan.FromMinutes(5))) \
+        self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         # Indicators will be created in OnStarted

--- a/API/datatype_extensions.py
+++ b/API/datatype_extensions.py
@@ -1,0 +1,9 @@
+import clr
+clr.AddReference("StockSharp.Messages")
+clr.AddReference("StockSharp.Algo")
+from System import TimeSpan
+from StockSharp.Messages import DataType
+
+def tf(minutes):
+    """Return TimeFrame candle type for the given number of minutes."""
+    return DataType.TimeFrame(TimeSpan.FromMinutes(minutes))


### PR DESCRIPTION
## Summary
- add `datatype_extensions.py` to centralize `tf()` helper for `DataType.TimeFrame`
- use `tf()` for candle type parameters across all Python strategies

## Testing
- `dotnet test` *(fails: `command not found: dotnet`)*

------
https://chatgpt.com/codex/tasks/task_e_6877c5894d988323be96af421442ffed