### PR TITLE
Fix BindEx usage in Python strategies

### DIFF
--- a/API/0003_ADX_Trend/adx_trend_strategy.py
+++ b/API/0003_ADX_Trend/adx_trend_strategy.py
@@ -123,7 +123,7 @@ class adx_trend_strategy(Strategy):
 
         # Create subscription and bind indicators
         subscription = self.SubscribeCandles(self.candle_type)
-        subscription.Bind(adx, ma, atr, self.ProcessCandle).Start()
+        subscription.BindEx(adx, ma, atr, self.ProcessCandle).Start()
 
         # Setup chart visualization if available
         area = self.CreateChartArea()

--- a/API/0005_Donchian_Channel/donchian_channel_strategy.py
+++ b/API/0005_Donchian_Channel/donchian_channel_strategy.py
@@ -81,7 +81,7 @@ class donchian_channel_strategy(Strategy):
 
         # Create subscription and bind indicators
         subscription = self.SubscribeCandles(self.candle_type)
-        subscription.Bind(donchian, self.ProcessCandle).Start()
+        subscription.BindEx(donchian, self.ProcessCandle).Start()
 
         # Setup chart visualization if available
         area = self.CreateChartArea()

--- a/API/0007_Keltner_Channel_Breakout/keltner_channel_breakout_strategy.py
+++ b/API/0007_Keltner_Channel_Breakout/keltner_channel_breakout_strategy.py
@@ -109,7 +109,7 @@ class keltner_channel_breakout_strategy(Strategy):
 
         # Create subscription and bind indicators
         subscription = self.SubscribeCandles(self.candle_type)
-        subscription.Bind(keltner_channel, self.ProcessCandle).Start()
+        subscription.BindEx(keltner_channel, self.ProcessCandle).Start()
 
         # Setup chart visualization if available
         area = self.CreateChartArea()

--- a/API/0009_MACD_Trend/macd_trend_strategy.py
+++ b/API/0009_MACD_Trend/macd_trend_strategy.py
@@ -114,7 +114,7 @@ class macd_trend_strategy(Strategy):
 
         # Create subscription and bind indicator
         subscription = self.SubscribeCandles(self.candle_type)
-        subscription.Bind(macd, self.ProcessCandle).Start()
+        subscription.BindEx(macd, self.ProcessCandle).Start()
 
         # Setup chart visualization if available
         area = self.CreateChartArea()

--- a/API/0011_Ichimoku_Kumo_Breakout/ichimoku_kumo_breakout_strategy.py
+++ b/API/0011_Ichimoku_Kumo_Breakout/ichimoku_kumo_breakout_strategy.py
@@ -110,7 +110,7 @@ class ichimoku_kumo_breakout_strategy(Strategy):
 
         # Create subscription and bind indicator
         subscription = self.SubscribeCandles(self.candle_type)
-        subscription.Bind(ichimoku, self.ProcessCandle).Start()
+        subscription.BindEx(ichimoku, self.ProcessCandle).Start()
 
         # Setup chart visualization if available
         area = self.CreateChartArea()

--- a/API/0013_DMI_Power_Move/dmi_power_move_strategy.py
+++ b/API/0013_DMI_Power_Move/dmi_power_move_strategy.py
@@ -119,7 +119,7 @@ class dmi_power_move_strategy(Strategy):
 
         # Create subscription and bind indicators
         subscription = self.SubscribeCandles(self.candle_type)
-        subscription.Bind(dmi, atr, self.ProcessCandle).Start()
+        subscription.BindEx(dmi, atr, self.ProcessCandle).Start()
 
         # Setup chart visualization if available
         area = self.CreateChartArea()

--- a/API/0016_RSI_Divergence/rsi_divergence_strategy.py
+++ b/API/0016_RSI_Divergence/rsi_divergence_strategy.py
@@ -93,7 +93,7 @@ class rsi_divergence_strategy(Strategy):
 
         # Subscribe to candles and bind the indicator
         subscription = self.SubscribeCandles(self.candle_type)
-        subscription.Bind(rsi, self.ProcessCandle).Start()
+        subscription.BindEx(rsi, self.ProcessCandle).Start()
 
         # Enable position protection
         self.StartProtection(None, Unit(self.stop_loss_percent, UnitTypes.Percent))

--- a/API/0017_Williams_R/williams_percent_r_strategy.py
+++ b/API/0017_Williams_R/williams_percent_r_strategy.py
@@ -80,7 +80,7 @@ class williams_percent_r_strategy(Strategy):
 
         # Subscribe to candles and bind the indicator
         subscription = self.SubscribeCandles(self.candle_type)
-        subscription.Bind(williams_r, self.ProcessCandle).Start()
+        subscription.BindEx(williams_r, self.ProcessCandle).Start()
             
         # Enable position protection
         self.StartProtection(None, Unit(self.stop_loss_percent, UnitTypes.Percent))

--- a/API/0019_CCI_Breakout/cci_breakout_strategy.py
+++ b/API/0019_CCI_Breakout/cci_breakout_strategy.py
@@ -80,7 +80,7 @@ class cci_breakout_strategy(Strategy):
 
         # Subscribe to candles and bind the indicator
         subscription = self.SubscribeCandles(self.candle_type)
-        subscription.Bind(cci, self.ProcessCandle).Start()
+        subscription.BindEx(cci, self.ProcessCandle).Start()
 
         # Enable stop loss protection
         self.StartProtection(None, Unit(self.stop_loss_percent, UnitTypes.Percent))

--- a/API/0021_Bollinger_Squeeze/bollinger_squeeze_strategy.py
+++ b/API/0021_Bollinger_Squeeze/bollinger_squeeze_strategy.py
@@ -106,7 +106,7 @@ class bollinger_squeeze_strategy(Strategy):
 
         # Subscribe to candles and bind the indicator
         subscription = self.SubscribeCandles(self.candle_type)
-        subscription.Bind(bollinger_bands, self.ProcessCandle).Start()
+        subscription.BindEx(bollinger_bands, self.ProcessCandle).Start()
 
         # Setup chart visualization
         area = self.CreateChartArea()

--- a/API/0022_ADX_DI/adx_di_strategy.py
+++ b/API/0022_ADX_DI/adx_di_strategy.py
@@ -97,7 +97,7 @@ class adx_di_strategy(Strategy):
         subscription = self.SubscribeCandles(self.candle_type)
         
         # Bind indicators and process candles
-        subscription.Bind(adx, atr, self.ProcessCandle).Start()
+        subscription.BindEx(adx, atr, self.ProcessCandle).Start()
 
         # Enable position protection
         self.StartProtection(None, Unit(self.atr_multiplier, UnitTypes.Absolute))

--- a/API/0023_Elder_Impulse/elder_impulse_strategy.py
+++ b/API/0023_Elder_Impulse/elder_impulse_strategy.py
@@ -134,7 +134,7 @@ class elder_impulse_strategy(Strategy):
         subscription = self.SubscribeCandles(self.candle_type)
         
         # Process candles with both indicators
-        subscription.Bind(ema, macd, self.ProcessCandle).Start()
+        subscription.BindEx(ema, macd, self.ProcessCandle).Start()
 
         # Enable position protection
         self.StartProtection(None, Unit(self.stop_loss_percent, UnitTypes.Percent))

--- a/API/0024_RSI_Laguerre/laguerre_rsi_strategy.py
+++ b/API/0024_RSI_Laguerre/laguerre_rsi_strategy.py
@@ -82,7 +82,7 @@ class laguerre_rsi_strategy(Strategy):
 
         # Subscribe to candles
         subscription = self.SubscribeCandles(self.candle_type)
-        subscription.Bind(rsi, self.ProcessCandle).Start()
+        subscription.BindEx(rsi, self.ProcessCandle).Start()
 
         # Enable position protection
         self.StartProtection(None, Unit(self.stop_loss_percent, UnitTypes.Percent))

--- a/API/0025_Stochastic_RSI_Cross/stochastic_rsi_cross_strategy.py
+++ b/API/0025_Stochastic_RSI_Cross/stochastic_rsi_cross_strategy.py
@@ -135,7 +135,7 @@ class stochastic_rsi_cross_strategy(Strategy):
         subscription = self.SubscribeCandles(self.candle_type)
         
         # Create a custom binding to simulate Stochastic RSI since it's not built-in
-        subscription.Bind(stoch, rsi, self.ProcessCandle).Start()
+        subscription.BindEx(stoch, rsi, self.ProcessCandle).Start()
 
         # Enable position protection
         self.StartProtection(None, Unit(self.stop_loss_percent, UnitTypes.Percent))

--- a/API/0026_RSI_Reversion/rsi_reversion_strategy.py
+++ b/API/0026_RSI_Reversion/rsi_reversion_strategy.py
@@ -116,7 +116,7 @@ class rsi_reversion_strategy(Strategy):
 
         # Subscribe to candles
         subscription = self.SubscribeCandles(self.candle_type)
-        subscription.Bind(rsi, self.ProcessCandle).Start()
+        subscription.BindEx(rsi, self.ProcessCandle).Start()
 
         # Enable position protection
         self.StartProtection(None, Unit(self.stop_loss_percent, UnitTypes.Percent))

--- a/API/0027_Bollinger_Reversion/bollinger_reversion_strategy.py
+++ b/API/0027_Bollinger_Reversion/bollinger_reversion_strategy.py
@@ -96,7 +96,7 @@ class bollinger_reversion_strategy(Strategy):
 
         # Subscribe to candles
         subscription = self.SubscribeCandles(self.candle_type)
-        subscription.Bind(bollinger_bands, atr, self.ProcessCandle).Start()
+        subscription.BindEx(bollinger_bands, atr, self.ProcessCandle).Start()
 
         # Enable position protection with ATR-based stop loss
         self.StartProtection(None, Unit(self.atr_multiplier, UnitTypes.Absolute))

--- a/API/0033_MACD_Zero/macd_zero_strategy.py
+++ b/API/0033_MACD_Zero/macd_zero_strategy.py
@@ -113,7 +113,7 @@ class macd_zero_strategy(Strategy):
 
         # Create subscription and bind MACD indicator
         subscription = self.SubscribeCandles(self.candle_type)
-        subscription.Bind(macd, self.ProcessCandle).Start()
+        subscription.BindEx(macd, self.ProcessCandle).Start()
 
         # Configure chart
         area = self.CreateChartArea()

--- a/API/0035_Bollinger_B_Reversion/bollinger_percent_b_strategy.py
+++ b/API/0035_Bollinger_B_Reversion/bollinger_percent_b_strategy.py
@@ -105,7 +105,7 @@ class bollinger_percent_b_strategy(Strategy):
 
         # Create subscription and bind indicators
         subscription = self.SubscribeCandles(self.candle_type)
-        subscription.Bind(bollinger, self.ProcessCandle).Start()
+        subscription.BindEx(bollinger, self.ProcessCandle).Start()
 
         # Configure chart
         area = self.CreateChartArea()

--- a/API/0090_Donchian_Reversal/donchian_reversal_strategy.py
+++ b/API/0090_Donchian_Reversal/donchian_reversal_strategy.py
@@ -100,7 +100,7 @@ class donchian_reversal_strategy(Strategy):
         subscription = self.SubscribeCandles(self.CandleType)
 
         # Bind indicator and process candles
-        subscription.Bind(donchian, self.ProcessCandle).Start()
+        subscription.BindEx(donchian, self.ProcessCandle).Start()
 
         # Setup chart visualization
         area = self.CreateChartArea()

--- a/API/0103_Dark_Pool_Prints/dark_pool_prints_strategy.py
+++ b/API/0103_Dark_Pool_Prints/dark_pool_prints_strategy.py
@@ -108,7 +108,7 @@ class dark_pool_prints_strategy(Strategy):
         subscription = self.SubscribeCandles(self.CandleType)
 
         # Bind indicators and processor
-        subscription.Bind(self._ma, self._volume_average, self._adx, self._atr, self.ProcessCandle).Start()
+        subscription.BindEx(self._ma, self._volume_average, self._adx, self._atr, self.ProcessCandle).Start()
 
         # Enable stop-loss protection
         self.StartProtection(Unit(0), Unit(self.AtrMultiplier, UnitTypes.Absolute))

--- a/API/0131_MACD_RSI/macd_rsi_strategy.py
+++ b/API/0131_MACD_RSI/macd_rsi_strategy.py
@@ -158,7 +158,7 @@ class macd_rsi_strategy(Strategy):
         subscription = self.SubscribeCandles(self.candle_type)
 
         # When both indicators are ready, process the candle
-        subscription.Bind(macd, rsi, self.ProcessCandle).Start()
+        subscription.BindEx(macd, rsi, self.ProcessCandle).Start()
 
         # Set up chart if available
         area = self.CreateChartArea()

--- a/API/0149_MA_ADX/ma_adx_strategy.py
+++ b/API/0149_MA_ADX/ma_adx_strategy.py
@@ -129,7 +129,7 @@ class ma_adx_strategy(Strategy):
         subscription = self.SubscribeCandles(self.candle_type)
 
         # Bind indicators to candles
-        subscription.Bind(ma, adx, atr, self.ProcessCandle).Start()
+        subscription.BindEx(ma, adx, atr, self.ProcessCandle).Start()
 
         # Enable stop-loss and take-profit
         self.StartProtection(

--- a/API/0151_Ichimoku_Volume/ichimoku_volume_strategy.py
+++ b/API/0151_Ichimoku_Volume/ichimoku_volume_strategy.py
@@ -125,7 +125,7 @@ class ichimoku_volume_strategy(Strategy):
         subscription = self.SubscribeCandles(self.candle_type)
 
         # Bind Ichimoku indicator to candles
-        subscription.Bind(ichimoku, self.ProcessCandle).Start()
+        subscription.BindEx(ichimoku, self.ProcessCandle).Start()
 
         # Setup chart visualization if available
         area = self.CreateChartArea()

--- a/API/0156_Donchian_RSI/donchian_rsi_strategy.py
+++ b/API/0156_Donchian_RSI/donchian_rsi_strategy.py
@@ -129,7 +129,7 @@ class donchian_rsi_strategy(Strategy):
         subscription = self.SubscribeCandles(self.candle_type)
 
         # Bind indicators to candles
-        subscription.Bind(donchian, rsi, self.ProcessCandle).Start()
+        subscription.BindEx(donchian, rsi, self.ProcessCandle).Start()
 
         # Enable stop-loss
         self.StartProtection(

--- a/API/0170_ADX_CCI/adx_cci_strategy.py
+++ b/API/0170_ADX_CCI/adx_cci_strategy.py
@@ -93,7 +93,7 @@ class adx_cci_strategy(Strategy):
 
         # Subscribe to candles and bind indicators
         subscription = self.SubscribeCandles(self.CandleType)
-        subscription.Bind(adx, cci, self.ProcessCandle).Start()
+        subscription.BindEx(adx, cci, self.ProcessCandle).Start()
 
         # Setup chart visualization if available
         area = self.CreateChartArea()

--- a/API/0202_Donchian_CCI/donchian_cci_strategy.py
+++ b/API/0202_Donchian_CCI/donchian_cci_strategy.py
@@ -91,7 +91,7 @@ class donchian_cci_strategy(Strategy):
 
         # Create subscription and bind indicators
         subscription = self.SubscribeCandles(self.CandleType)
-        subscription.Bind(donchian, cci, self.ProcessIndicators).Start()
+        subscription.BindEx(donchian, cci, self.ProcessIndicators).Start()
 
         # Enable stop-loss protection
         self.StartProtection(takeProfit=None, stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent))

--- a/API/0210_ADX_Donchian/adx_donchian_strategy.py
+++ b/API/0210_ADX_Donchian/adx_donchian_strategy.py
@@ -116,7 +116,7 @@ class adx_donchian_strategy(Strategy):
 
         # Create subscription and bind indicators
         subscription = self.SubscribeCandles(self.candle_type)
-        subscription.Bind(donchian, adx, self.ProcessCandle).Start()
+        subscription.BindEx(donchian, adx, self.ProcessCandle).Start()
 
         # Enable percentage-based stop-loss protection
         self.StartProtection(Unit(self.stop_loss_percent, UnitTypes.Percent), None)

--- a/API/0221_Bollinger_Band_Squeeze/bollinger_band_squeeze_strategy.py
+++ b/API/0221_Bollinger_Band_Squeeze/bollinger_band_squeeze_strategy.py
@@ -111,7 +111,7 @@ class bollinger_band_squeeze_strategy(Strategy):
 
         # Create subscription and bind indicator
         subscription = self.SubscribeCandles(self.CandleType)
-        subscription.Bind(self._bollinger, self._atr, self.ProcessCandle).Start()
+        subscription.BindEx(self._bollinger, self._atr, self.ProcessCandle).Start()
 
         # Setup chart visualization if available
         area = self.CreateChartArea()

--- a/API/0238_CCI_Mean_Reversion/cci_mean_reversion_strategy.py
+++ b/API/0238_CCI_Mean_Reversion/cci_mean_reversion_strategy.py
@@ -121,7 +121,7 @@ class cci_mean_reversion_strategy(Strategy):
 
         # Create subscription and bind indicator
         subscription = self.SubscribeCandles(self.CandleType)
-        subscription.Bind(cci, self.ProcessCandle).Start()
+        subscription.BindEx(cci, self.ProcessCandle).Start()
 
         # Setup chart visualization
         area = self.CreateChartArea()

--- a/API/0239_Williams_R_Mean_Reversion/williams_r_mean_reversion_strategy.py
+++ b/API/0239_Williams_R_Mean_Reversion/williams_r_mean_reversion_strategy.py
@@ -119,7 +119,7 @@ class williams_r_mean_reversion_strategy(Strategy):
 
         # Create subscription and bind indicator
         subscription = self.SubscribeCandles(self.CandleType)
-        subscription.Bind(williams_r, self.ProcessCandle).Start()
+        subscription.BindEx(williams_r, self.ProcessCandle).Start()
 
         # Setup chart visualization
         area = self.CreateChartArea()

--- a/API/0256_Bollinger_Band_Width_Breakout/bollinger_band_width_breakout_strategy.py
+++ b/API/0256_Bollinger_Band_Width_Breakout/bollinger_band_width_breakout_strategy.py
@@ -130,7 +130,7 @@ class bollinger_band_width_breakout_strategy(Strategy):
         # Bind Bollinger Bands
         subscription.BindEx(self._bollinger, self._atr, self.ProcessBollinger).Start()
 
-        self.SubscribeOrderBook().Bind(self._update_best_prices).Start()
+        self.SubscribeOrderBook().BindEx(self._update_best_prices).Start()
 
         # Create chart area for visualization
         area = self.CreateChartArea()

--- a/API/0279_Ichimoku_Cloud_Width_Mean_Reversion/ichimoku_cloud_width_mean_reversion_strategy.py
+++ b/API/0279_Ichimoku_Cloud_Width_Mean_Reversion/ichimoku_cloud_width_mean_reversion_strategy.py
@@ -138,7 +138,7 @@ class ichimoku_cloud_width_mean_reversion_strategy(Strategy):
 
         # Create subscription and bind indicators
         subscription = self.SubscribeCandles(self.CandleType)
-        subscription.Bind(self._ichimoku, self.ProcessIchimoku).Start()
+        subscription.BindEx(self._ichimoku, self.ProcessIchimoku).Start()
 
         # Setup chart visualization if available
         area = self.CreateChartArea()

--- a/API/0321_Ichimoku_Hurst_Exponent/ichimoku_hurst_exponent_strategy.py
+++ b/API/0321_Ichimoku_Hurst_Exponent/ichimoku_hurst_exponent_strategy.py
@@ -123,7 +123,7 @@ class ichimoku_hurst_exponent_strategy(Strategy):
 
         # Create subscription and bind indicator
         subscription = self.SubscribeCandles(self.CandleType)
-        subscription.Bind(self._ichimoku, self.ProcessCandle).Start()
+        subscription.BindEx(self._ichimoku, self.ProcessCandle).Start()
 
         # Setup chart visualization if available
         area = self.CreateChartArea()


### PR DESCRIPTION
## Summary
- align Python strategies with C# counterparts by using `BindEx` instead of `Bind`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877ca39454483239e7f3aa41f194588