### PR TITLE
Use process_float for multi-arg indicator calls

### DIFF
--- a/API/0053_Volume_MA_Cross/volume_ma_cross_strategy.py
+++ b/API/0053_Volume_MA_Cross/volume_ma_cross_strategy.py
@@ -132,8 +132,8 @@ class volume_ma_cross_strategy(Strategy):
             return
 
         # Process volume through MAs
-        fastMAValue = to_float(self._fastVolumeMA.Process(candle.TotalVolume, candle.ServerTime, True))
-        slowMAValue = to_float(self._slowVolumeMA.Process(candle.TotalVolume, candle.ServerTime, True))
+        fastMAValue = to_float(process_float(self._fastVolumeMA, candle.TotalVolume, candle.ServerTime, True))
+        slowMAValue = to_float(process_float(self._slowVolumeMA, candle.TotalVolume, candle.ServerTime, True))
 
         # Check if strategy is ready to trade
         if not self.IsFormedAndOnlineAndAllowTrading():

--- a/API/0084_ATR_Exhaustion/atr_exhaustion_strategy.py
+++ b/API/0084_ATR_Exhaustion/atr_exhaustion_strategy.py
@@ -152,7 +152,7 @@ class atr_exhaustion_strategy(Strategy):
             return
 
         # Update ATR average
-        atr_avg_value = to_float(self._atr_avg.Process(atr_value, candle.ServerTime, candle.State == CandleStates.Finished))
+        atr_avg_value = to_float(process_float(self._atr_avg, atr_value, candle.ServerTime, candle.State == CandleStates.Finished))
 
         # Determine candle direction
         is_bullish_candle = candle.ClosePrice > candle.OpenPrice

--- a/API/0115_Volume_Climax_Reversal/volume_climax_reversal_strategy.py
+++ b/API/0115_Volume_Climax_Reversal/volume_climax_reversal_strategy.py
@@ -134,7 +134,7 @@ class volume_climax_reversal_strategy(Strategy):
             return
 
         # Process indicators
-        volumeAverageValue = to_float(self._volumeAverage.Process(candle.TotalVolume, candle.ServerTime, candle.State == CandleStates.Finished))
+        volumeAverageValue = to_float(process_float(self._volumeAverage, candle.TotalVolume, candle.ServerTime, candle.State == CandleStates.Finished))
 
         # Check if strategy is ready to trade
         if not self.IsFormedAndOnlineAndAllowTrading():

--- a/API/0136_Supertrend_Volume/supertrend_volume_strategy.py
+++ b/API/0136_Supertrend_Volume/supertrend_volume_strategy.py
@@ -147,7 +147,7 @@ class supertrend_volume_strategy(Strategy):
         if candle.State != CandleStates.Finished:
             return
 
-        volumeSmaValue = self._volumeSma.Process(candle.TotalVolume, candle.ServerTime, candle.State == CandleStates.Finished)
+        volumeSmaValue = process_float(self._volumeSma, candle.TotalVolume, candle.ServerTime, candle.State == CandleStates.Finished)
 
         if not self.IsFormedAndOnlineAndAllowTrading() or not self._atr.IsFormed or not self._volumeSma.IsFormed:
             return

--- a/API/0188_Parabolic_SAR_Volume/parabolic_sar_volume_strategy.py
+++ b/API/0188_Parabolic_SAR_Volume/parabolic_sar_volume_strategy.py
@@ -142,7 +142,7 @@ class parabolic_sar_volume_strategy(Strategy):
             self.DrawOwnTrades(area)
 
     def ProcessIndicators(self, candle, sarValue, volumeValue):
-        self._currentAvgVolume = to_float(self._volumeAverage.Process(volumeValue, candle.ServerTime, candle.State == CandleStates.Finished))
+        self._currentAvgVolume = to_float(process_float(self._volumeAverage, volumeValue, candle.ServerTime, candle.State == CandleStates.Finished))
 
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0209_Volume_Supertrend/volume_supertrend_strategy.py
+++ b/API/0209_Volume_Supertrend/volume_supertrend_strategy.py
@@ -97,7 +97,7 @@ class volume_supertrend_strategy(Strategy):
         # Bind indicators to handle each candle
         def handle_candle(candle, atr_value):
             # Calculate volume average
-            volume_value = to_float(volume_ma.Process(candle.TotalVolume, candle.ServerTime, candle.State == CandleStates.Finished))
+            volume_value = to_float(process_float(volume_ma, candle.TotalVolume, candle.ServerTime, candle.State == CandleStates.Finished))
 
             # Calculate Supertrend
             if not atr.IsFormed:

--- a/API/0217_Pairs_Trading/pairs_trading_strategy.py
+++ b/API/0217_Pairs_Trading/pairs_trading_strategy.py
@@ -164,8 +164,8 @@ class pairs_trading_strategy(Strategy):
         self._spread = candle.ClosePrice - self._last_second_price
 
         # Process the spread through indicators
-        ma_value = self._spread_ma.Process(self._spread, candle.ServerTime, True)
-        std_dev_value = self._spread_std_dev.Process(self._spread, candle.ServerTime, True)
+        ma_value = process_float(self._spread_ma, self._spread, candle.ServerTime, True)
+        std_dev_value = process_float(self._spread_std_dev, self._spread, candle.ServerTime, True)
 
         # Skip until indicators are formed
         if not self._spread_ma.IsFormed or not self._spread_std_dev.IsFormed:

--- a/API/0219_Statistical_Arbitrage/statistical_arbitrage_strategy.py
+++ b/API/0219_Statistical_Arbitrage/statistical_arbitrage_strategy.py
@@ -221,7 +221,7 @@ class statistical_arbitrage_strategy(Strategy):
         self._last_second_price = candle.ClosePrice
 
         # Process through MA indicator
-        self._second_ma.Process(candle.ClosePrice, candle.ServerTime, candle.State == CandleStates.Finished)
+        process_float(self._second_ma, candle.ClosePrice, candle.ServerTime, candle.State == CandleStates.Finished)
 
     def CreateClone(self):
         """

--- a/API/0230_Delta_Neutral_Arbitrage/delta_neutral_arbitrage_strategy.py
+++ b/API/0230_Delta_Neutral_Arbitrage/delta_neutral_arbitrage_strategy.py
@@ -201,8 +201,8 @@ class delta_neutral_arbitrage_strategy(Strategy):
         self._current_spread = self._last_asset1_price - self._last_asset2_price
 
         # Process the spread with our indicators
-        spread_value = self._spread_sma.Process(self._current_spread, candle.ServerTime, candle.State == CandleStates.Finished)
-        std_dev_value = self._spread_std_dev.Process(self._current_spread, candle.ServerTime, candle.State == CandleStates.Finished)
+        spread_value = process_float(self._spread_sma, self._current_spread, candle.ServerTime, candle.State == CandleStates.Finished)
+        std_dev_value = process_float(self._spread_std_dev, self._current_spread, candle.ServerTime, candle.State == CandleStates.Finished)
 
         # Check if indicators are formed
         if not self._spread_sma.IsFormed or not self._spread_std_dev.IsFormed:

--- a/API/0231_Volatility_Skew_Arbitrage/volatility_skew_arbitrage_strategy.py
+++ b/API/0231_Volatility_Skew_Arbitrage/volatility_skew_arbitrage_strategy.py
@@ -137,7 +137,7 @@ class volatility_skew_arbitrage_strategy(Strategy):
             return
 
         # Process volatility skew through the indicator
-        std_dev_value = self._vol_skew_std_dev.Process(vol_skew, time, is_final)
+        std_dev_value = process_float(self._vol_skew_std_dev, vol_skew, time, is_final)
 
         # Update running average for the first LookbackPeriod bars
         if self._bar_count < self.lookback_period:

--- a/API/0232_Correlation_Breakout/correlation_breakout_strategy.py
+++ b/API/0232_Correlation_Breakout/correlation_breakout_strategy.py
@@ -188,7 +188,7 @@ class correlation_breakout_strategy(Strategy):
         self._last_correlation = self._calculate_pearson_correlation(self._asset1_prices, self._asset2_prices)
 
         # Process correlation through the indicator
-        std_dev_value = self._corr_std_dev.Process(self._last_correlation, candle.ServerTime, candle.State == CandleStates.Finished)
+        std_dev_value = process_float(self._corr_std_dev, self._last_correlation, candle.ServerTime, candle.State == CandleStates.Finished)
 
         # Move to next bar after first LookbackPeriod bars filled
         if not self._corr_std_dev.IsFormed:

--- a/API/0236_RSI_Mean_Reversion/rsi_mean_reversion_strategy.py
+++ b/API/0236_RSI_Mean_Reversion/rsi_mean_reversion_strategy.py
@@ -120,8 +120,8 @@ class rsi_mean_reversion_strategy(Strategy):
             return
 
         # Process RSI through average and standard deviation indicators
-        rsi_avg_value = to_float(self._rsi_average.Process(rsi_value, candle.ServerTime, candle.State == CandleStates.Finished))
-        rsi_std_dev_value = to_float(self._rsi_std_dev.Process(rsi_value, candle.ServerTime, candle.State == CandleStates.Finished))
+        rsi_avg_value = to_float(process_float(self._rsi_average, rsi_value, candle.ServerTime, candle.State == CandleStates.Finished))
+        rsi_std_dev_value = to_float(process_float(self._rsi_std_dev, rsi_value, candle.ServerTime, candle.State == CandleStates.Finished))
 
         # Store previous RSI value for changes detection
         current_rsi_value = rsi_value

--- a/API/0237_Stochastic_Mean_Reversion/stochastic_mean_reversion_strategy.py
+++ b/API/0237_Stochastic_Mean_Reversion/stochastic_mean_reversion_strategy.py
@@ -151,8 +151,8 @@ class stochastic_mean_reversion_strategy(Strategy):
             return
 
         # Process Stochastic %K through average and standard deviation indicators
-        stoch_avg_value = to_float(self._stoch_average.Process(k_value, candle.ServerTime, candle.State == CandleStates.Finished))
-        stoch_stddev_value = to_float(self._stoch_stddev.Process(k_value, candle.ServerTime, candle.State == CandleStates.Finished))
+        stoch_avg_value = to_float(process_float(self._stoch_average, k_value, candle.ServerTime, candle.State == CandleStates.Finished))
+        stoch_stddev_value = to_float(process_float(self._stoch_stddev, k_value, candle.ServerTime, candle.State == CandleStates.Finished))
 
         # Store previous Stochastic %K value for changes detection
         current_stoch_k_value = k_value

--- a/API/0245_Momentum_Breakout/momentum_breakout_strategy.py
+++ b/API/0245_Momentum_Breakout/momentum_breakout_strategy.py
@@ -130,8 +130,8 @@ class momentum_breakout_strategy(Strategy):
         self._current_momentum = momentum_value
 
         # Process momentum through average and standard deviation indicators
-        avg_val = self._momentum_average.Process(momentum_value, candle.ServerTime, candle.State == CandleStates.Finished)
-        std_val = self._momentum_stddev.Process(momentum_value, candle.ServerTime, candle.State == CandleStates.Finished)
+        avg_val = process_float(self._momentum_average, momentum_value, candle.ServerTime, candle.State == CandleStates.Finished)
+        std_val = process_float(self._momentum_stddev, momentum_value, candle.ServerTime, candle.State == CandleStates.Finished)
 
         self._momentum_avg_value = to_float(avg_val)
         self._momentum_stddev_value = to_float(std_val)

--- a/API/0247_RSI_Breakout/rsi_breakout_strategy.py
+++ b/API/0247_RSI_Breakout/rsi_breakout_strategy.py
@@ -148,8 +148,8 @@ class rsi_breakout_strategy(Strategy):
         self._currentRsiValue = rsi_value
 
         # Process RSI through average and standard deviation indicators
-        avg_value = self._rsiAverage.Process(rsi_value, candle.ServerTime, candle.State == CandleStates.Finished)
-        std_dev_value = self._rsiStdDev.Process(rsi_value, candle.ServerTime, candle.State == CandleStates.Finished)
+        avg_value = process_float(self._rsiAverage, rsi_value, candle.ServerTime, candle.State == CandleStates.Finished)
+        std_dev_value = process_float(self._rsiStdDev, rsi_value, candle.ServerTime, candle.State == CandleStates.Finished)
 
         self._currentRsiAvg = to_float(avg_value)
         self._currentRsiStdDev = to_float(std_dev_value)

--- a/API/0248_Stochastic_Breakout/stochastic_breakout_strategy.py
+++ b/API/0248_Stochastic_Breakout/stochastic_breakout_strategy.py
@@ -164,8 +164,8 @@ class stochastic_breakout_strategy(Strategy):
         stochK = stochTyped.K
 
         # Calculate average and standard deviation of stochastic
-        stochAvgValue = to_float(self._stochAverage.Process(stochK, candle.ServerTime, candle.State == CandleStates.Finished))
-        tempStdDevValue = to_float(self._stochStdDev.Process(stochK, candle.ServerTime, candle.State == CandleStates.Finished))
+        stochAvgValue = to_float(process_float(self._stochAverage, stochK, candle.ServerTime, candle.State == CandleStates.Finished))
+        tempStdDevValue = to_float(process_float(self._stochStdDev, stochK, candle.ServerTime, candle.State == CandleStates.Finished))
 
         # First values initialization - skip trading decision
         if self._prevStochValue == 0:

--- a/API/0250_Williams_R_Breakout/williams_r_breakout_strategy.py
+++ b/API/0250_Williams_R_Breakout/williams_r_breakout_strategy.py
@@ -144,7 +144,7 @@ class williams_r_breakout_strategy(Strategy):
         currentWilliamsR = to_float(williamsRValue)
 
         # Process Williams %R through average indicator
-        williamsRAvgValue = self._williamsRAverage.Process(currentWilliamsR, candle.ServerTime, candle.State == CandleStates.Finished)
+        williamsRAvgValue = process_float(self._williamsRAverage, currentWilliamsR, candle.ServerTime, candle.State == CandleStates.Finished)
         currentWilliamsRAvg = to_float(williamsRAvgValue)
 
         # For first values, just save and skip

--- a/API/0251_MACD_Breakout/macd_breakout_strategy.py
+++ b/API/0251_MACD_Breakout/macd_breakout_strategy.py
@@ -184,8 +184,8 @@ class macd_breakout_strategy(Strategy):
         macd = float(macd_typed.Macd)
 
         # Process indicators for MACD histogram
-        macd_hist_sma_value = float(to_float(self._macd_hist_sma.Process(macd, candle.ServerTime, candle.State == CandleStates.Finished)))
-        macd_hist_stddev_value = float(to_float(self._macd_hist_stddev.Process(macd, candle.ServerTime, candle.State == CandleStates.Finished)))
+        macd_hist_sma_value = float(to_float(process_float(self._macd_hist_sma, macd, candle.ServerTime, candle.State == CandleStates.Finished)))
+        macd_hist_stddev_value = float(to_float(process_float(self._macd_hist_stddev, macd, candle.ServerTime, candle.State == CandleStates.Finished)))
 
         # Store previous values on first call
         if self._prev_macd_hist_value == 0 and self._prev_macd_hist_sma_value == 0:

--- a/API/0252_ADX_Breakout/adx_breakout_strategy.py
+++ b/API/0252_ADX_Breakout/adx_breakout_strategy.py
@@ -146,7 +146,7 @@ class adx_breakout_strategy(Strategy):
             return
 
         # Process ADX through average indicator
-        adxAvgValue = self._adx_average.Process(currentAdx, candle.ServerTime, candle.State == CandleStates.Finished)
+        adxAvgValue = process_float(self._adx_average, currentAdx, candle.ServerTime, candle.State == CandleStates.Finished)
         currentAdxAvg = float(to_float(adxAvgValue))
 
         # For first values, just save and skip

--- a/API/0254_Volume_Breakout/volume_breakout_strategy.py
+++ b/API/0254_Volume_Breakout/volume_breakout_strategy.py
@@ -122,12 +122,12 @@ class volume_breakout_strategy(Strategy):
         volume = candle.TotalVolume
 
         # Calculate volume average
-        avg_value = self._volume_average.Process(volume, candle.ServerTime, candle.State == CandleStates.Finished)
+        avg_value = process_float(self._volume_average, volume, candle.ServerTime, candle.State == CandleStates.Finished)
         avg_volume = float(avg_value)
 
         # Calculate standard deviation approximation
         deviation = Math.Abs(volume - avg_volume)
-        std_dev_value = self._volume_std_dev.Process(deviation, candle.ServerTime, candle.State == CandleStates.Finished)
+        std_dev_value = process_float(self._volume_std_dev, deviation, candle.ServerTime, candle.State == CandleStates.Finished)
         std_dev = float(std_dev_value)
 
         # Skip the first N candles until we have enough data

--- a/API/0256_Bollinger_Band_Width_Breakout/bollinger_band_width_breakout_strategy.py
+++ b/API/0256_Bollinger_Band_Width_Breakout/bollinger_band_width_breakout_strategy.py
@@ -158,7 +158,7 @@ class bollinger_band_width_breakout_strategy(Strategy):
         last_width = upper_band - lower_band
 
         # Process width through average
-        width_avg_value = self._width_average.Process(last_width, candle.ServerTime, candle.State == CandleStates.Finished)
+        width_avg_value = process_float(self._width_average, last_width, candle.ServerTime, candle.State == CandleStates.Finished)
         avg_width = to_float(width_avg_value)
 
         # Calculate width standard deviation (simplified approach)

--- a/API/0257_Keltner_Channel_Width_Breakout/keltner_width_breakout_strategy.py
+++ b/API/0257_Keltner_Channel_Width_Breakout/keltner_width_breakout_strategy.py
@@ -184,7 +184,7 @@ class keltner_width_breakout_strategy(Strategy):
         width = upperBand - lowerBand
 
         # Process width through average
-        widthAvgValue = self._widthAverage.Process(width, candle.ServerTime, candle.State == CandleStates.Finished)
+        widthAvgValue = process_float(self._widthAverage, width, candle.ServerTime, candle.State == CandleStates.Finished)
         avgWidth = float(widthAvgValue)
 
         # For first values, just save and skip

--- a/API/0258_Donchian_Channel_Width_Breakout/donchian_width_breakout_strategy.py
+++ b/API/0258_Donchian_Channel_Width_Breakout/donchian_width_breakout_strategy.py
@@ -153,7 +153,7 @@ class donchian_width_breakout_strategy(Strategy):
         width = highest_value - lowest_value
 
         # Process width through average
-        width_avg_value = self._width_average.Process(width, candle.ServerTime, candle.State == CandleStates.Finished)
+        width_avg_value = process_float(self._width_average, width, candle.ServerTime, candle.State == CandleStates.Finished)
         avg_width = to_float(width_avg_value)
 
         # For first values, just save and skip

--- a/API/0259_Ichimoku_Cloud_Width_Breakout/ichimoku_width_breakout_strategy.py
+++ b/API/0259_Ichimoku_Cloud_Width_Breakout/ichimoku_width_breakout_strategy.py
@@ -189,7 +189,7 @@ class ichimoku_width_breakout_strategy(Strategy):
         width = Math.Abs(senkou_span_a - senkou_span_b)
 
         # Process width through average
-        width_avg_value = self._width_average.Process(width, candle.ServerTime, candle.State == CandleStates.Finished)
+        width_avg_value = process_float(self._width_average, width, candle.ServerTime, candle.State == CandleStates.Finished)
         avg_width = to_float(width_avg_value)
 
         # For first values, just save and skip

--- a/API/0269_CCI_Slope_Breakout/cci_slope_breakout_strategy.py
+++ b/API/0269_CCI_Slope_Breakout/cci_slope_breakout_strategy.py
@@ -134,7 +134,7 @@ class cci_slope_breakout_strategy(Strategy):
             return
 
         # Calculate CCI slope
-        currentSlopeTyped = self._cciSlope.Process(cciValue, candle.ServerTime, candle.State == CandleStates.Finished)
+        currentSlopeTyped = process_float(self._cciSlope, cciValue, candle.ServerTime, candle.State == CandleStates.Finished)
 
         if not hasattr(currentSlopeTyped, 'LinearReg') or currentSlopeTyped.LinearReg is None:
             return

--- a/API/0270_Williams_R_Slope_Breakout/williams_r_slope_breakout_strategy.py
+++ b/API/0270_Williams_R_Slope_Breakout/williams_r_slope_breakout_strategy.py
@@ -137,7 +137,7 @@ class williams_r_slope_breakout_strategy(Strategy):
             return
 
         # Calculate Williams %R slope
-        current_slope_typed = self._williams_r_slope.Process(williams_r_value, candle.ServerTime, candle.State == CandleStates.Finished)
+        current_slope_typed = process_float(self._williams_r_slope, williams_r_value, candle.ServerTime, candle.State == CandleStates.Finished)
         if not hasattr(current_slope_typed, 'LinearReg'):
             return  # Skip if slope is not available
         current_slope_value = current_slope_typed.LinearReg

--- a/API/0271_MACD_Slope_Breakout/macd_slope_breakout_strategy.py
+++ b/API/0271_MACD_Slope_Breakout/macd_slope_breakout_strategy.py
@@ -173,7 +173,7 @@ class macd_slope_breakout_strategy(Strategy):
         macd_hist = macd_typed.Macd - macd_typed.Signal
 
         # Calculate MACD histogram slope
-        current_slope_typed = self._macd_hist_slope.Process(macd_hist, candle.ServerTime, candle.State == CandleStates.Finished)
+        current_slope_typed = process_float(self._macd_hist_slope, macd_hist, candle.ServerTime, candle.State == CandleStates.Finished)
         current_slope_value = current_slope_typed.LinearReg
         if current_slope_value is None:
             return

--- a/API/0272_ADX_Slope_Breakout/adx_slope_breakout_strategy.py
+++ b/API/0272_ADX_Slope_Breakout/adx_slope_breakout_strategy.py
@@ -155,7 +155,7 @@ class adx_slope_breakout_strategy(Strategy):
             return
 
         # Calculate ADX slope
-        currentSlopeTyped = self._adxSlope.Process(adx, candle.ServerTime, candle.State == CandleStates.Finished)
+        currentSlopeTyped = process_float(self._adxSlope, adx, candle.ServerTime, candle.State == CandleStates.Finished)
         currentSlopeValue = currentSlopeTyped.LinearReg
         if currentSlopeValue is None:
             return

--- a/API/0273_ATR_Slope_Breakout/atr_slope_breakout_strategy.py
+++ b/API/0273_ATR_Slope_Breakout/atr_slope_breakout_strategy.py
@@ -155,7 +155,7 @@ class atr_slope_breakout_strategy(Strategy):
         price_above_ema = candle.ClosePrice > ema_value
 
         # Calculate ATR slope
-        current_slope_typed = self._atr_slope.Process(atr, candle.ServerTime, candle.State == CandleStates.Finished)
+        current_slope_typed = process_float(self._atr_slope, atr, candle.ServerTime, candle.State == CandleStates.Finished)
         if not hasattr(current_slope_typed, 'LinearReg') or current_slope_typed.LinearReg is None:
             return  # Skip if we can't get the slope value
         current_slope_value = float(current_slope_typed.LinearReg)

--- a/API/0274_Volume_Slope_Breakout/volume_slope_breakout_strategy.py
+++ b/API/0274_Volume_Slope_Breakout/volume_slope_breakout_strategy.py
@@ -148,7 +148,7 @@ class volume_slope_breakout_strategy(Strategy):
             return
 
         # Process volume SMA
-        volumeSma = to_float(self._volumeSma.Process(volumeValue, candle.ServerTime, candle.State == CandleStates.Finished))
+        volumeSma = to_float(process_float(self._volumeSma, volumeValue, candle.ServerTime, candle.State == CandleStates.Finished))
 
         # Process price EMA for trend direction
         priceEma = to_float(self._priceEma.Process(candle))
@@ -158,7 +158,7 @@ class volume_slope_breakout_strategy(Strategy):
         volumeRatio = volumeValue / volumeSma
 
         # We use LinearRegression to calculate slope of this ratio
-        currentSlopeTyped = self._volumeSlope.Process(volumeRatio, candle.ServerTime, candle.State == CandleStates.Finished)
+        currentSlopeTyped = process_float(self._volumeSlope, volumeRatio, candle.ServerTime, candle.State == CandleStates.Finished)
 
         if not isinstance(currentSlopeTyped, LinearRegressionValue) or currentSlopeTyped.LinearReg is None:
             return  # Skip if slope is not available

--- a/API/0275_OBV_Slope_Breakout/obv_slope_breakout_strategy.py
+++ b/API/0275_OBV_Slope_Breakout/obv_slope_breakout_strategy.py
@@ -139,7 +139,7 @@ class obv_slope_breakout_strategy(Strategy):
             return
 
         # Calculate OBV slope
-        slopeTyped = self._obvSlope.Process(obvValue, candle.ServerTime, candle.State == CandleStates.Finished)
+        slopeTyped = process_float(self._obvSlope, obvValue, candle.ServerTime, candle.State == CandleStates.Finished)
         if hasattr(slopeTyped, 'IsFinal') and not slopeTyped.IsFinal:
             return
 
@@ -150,8 +150,8 @@ class obv_slope_breakout_strategy(Strategy):
         self._lastObvSlope = slopeValue
 
         # Calculate slope average and standard deviation
-        avgValue = self._obvSlopeAvg.Process(slopeValue, candle.ServerTime, candle.State == CandleStates.Finished)
-        stdDevValue = self._obvSlopeStdDev.Process(slopeValue, candle.ServerTime, candle.State == CandleStates.Finished)
+        avgValue = process_float(self._obvSlopeAvg, slopeValue, candle.ServerTime, candle.State == CandleStates.Finished)
+        stdDevValue = process_float(self._obvSlopeStdDev, slopeValue, candle.ServerTime, candle.State == CandleStates.Finished)
 
         # Store values for decision making
         self._lastObvValue = obvValue

--- a/API/0276_Bollinger_Width_Mean_Reversion/bollinger_width_mean_reversion_strategy.py
+++ b/API/0276_Bollinger_Width_Mean_Reversion/bollinger_width_mean_reversion_strategy.py
@@ -179,8 +179,8 @@ class bollinger_width_mean_reversion_strategy(Strategy):
         lastWidth = float(bollingerTyped.UpBand) - float(bollingerTyped.LowBand)
 
         # Calculate width's average and standard deviation
-        widthAvg = self._widthAvg.Process(lastWidth, candle.ServerTime, candle.State == CandleStates.Finished)
-        widthStdDev = self._widthStdDev.Process(lastWidth, candle.ServerTime, candle.State == CandleStates.Finished)
+        widthAvg = process_float(self._widthAvg, lastWidth, candle.ServerTime, candle.State == CandleStates.Finished)
+        widthStdDev = process_float(self._widthStdDev, lastWidth, candle.ServerTime, candle.State == CandleStates.Finished)
 
         if widthAvg.IsFinal and widthStdDev.IsFinal:
             self._lastWidthAvg = float(widthAvg)

--- a/API/0277_Keltner_Width_Mean_Reversion/keltner_width_mean_reversion_strategy.py
+++ b/API/0277_Keltner_Width_Mean_Reversion/keltner_width_mean_reversion_strategy.py
@@ -199,8 +199,8 @@ class keltner_width_mean_reversion_strategy(Strategy):
             self._lastChannelWidth = channelWidth
 
             # Process width's average and standard deviation
-            widthAvgValue = self._widthAvg.Process(channelWidth, candle.ServerTime, candle.State == CandleStates.Finished)
-            widthStdDevValue = self._widthStdDev.Process(channelWidth, candle.ServerTime, candle.State == CandleStates.Finished)
+            widthAvgValue = process_float(self._widthAvg, channelWidth, candle.ServerTime, candle.State == CandleStates.Finished)
+            widthStdDevValue = process_float(self._widthStdDev, channelWidth, candle.ServerTime, candle.State == CandleStates.Finished)
 
             if widthAvgValue.IsFinal and widthStdDevValue.IsFinal:
                 self._lastWidthAvg = to_float(widthAvgValue)

--- a/API/0278_Donchian_Width_Mean_Reversion/donchian_width_mean_reversion_strategy.py
+++ b/API/0278_Donchian_Width_Mean_Reversion/donchian_width_mean_reversion_strategy.py
@@ -158,8 +158,8 @@ class donchian_width_mean_reversion_strategy(Strategy):
         self._current_width = upper_band - lower_band
 
         # Calculate the average and standard deviation of the width
-        width_average = to_float(self._width_average.Process(self._current_width, candle.ServerTime, True))
-        width_std_dev = to_float(self._width_std_dev.Process(self._current_width, candle.ServerTime, True))
+        width_average = to_float(process_float(self._width_average, self._current_width, candle.ServerTime, True))
+        width_std_dev = to_float(process_float(self._width_std_dev, self._current_width, candle.ServerTime, True))
 
         # Skip the first value
         if self._prev_width == 0:

--- a/API/0279_Ichimoku_Cloud_Width_Mean_Reversion/ichimoku_cloud_width_mean_reversion_strategy.py
+++ b/API/0279_Ichimoku_Cloud_Width_Mean_Reversion/ichimoku_cloud_width_mean_reversion_strategy.py
@@ -182,8 +182,8 @@ class ichimoku_cloud_width_mean_reversion_strategy(Strategy):
         self._currentCloudWidth = Math.Abs(senkouA - senkouB)
 
         # Calculate average and standard deviation of cloud width
-        cloudWidthAverage = to_float(self._cloudWidthAverage.Process(self._currentCloudWidth, candle.ServerTime, candle.State == CandleStates.Finished))
-        cloudWidthStdDev = to_float(self._cloudWidthStdDev.Process(self._currentCloudWidth, candle.ServerTime, candle.State == CandleStates.Finished))
+        cloudWidthAverage = to_float(process_float(self._cloudWidthAverage, self._currentCloudWidth, candle.ServerTime, candle.State == CandleStates.Finished))
+        cloudWidthStdDev = to_float(process_float(self._cloudWidthStdDev, self._currentCloudWidth, candle.ServerTime, candle.State == CandleStates.Finished))
 
         # Skip the first value
         if self._prevCloudWidth == 0:

--- a/API/0280_Supertrend_Distance_Mean_Reversion/supertrend_distance_mean_reversion_strategy.py
+++ b/API/0280_Supertrend_Distance_Mean_Reversion/supertrend_distance_mean_reversion_strategy.py
@@ -167,11 +167,11 @@ class supertrend_distance_mean_reversion_strategy(Strategy):
         self._current_distance_short = self._supertrend_value - candle.ClosePrice
 
         # Calculate averages and standard deviations for both distances
-        long_distance_avg = float(self._distance_average.Process(self._current_distance_long, candle.ServerTime, candle.State == CandleStates.Finished))
-        long_distance_std_dev = float(self._distance_std_dev.Process(self._current_distance_long, candle.ServerTime, candle.State == CandleStates.Finished))
+        long_distance_avg = float(process_float(self._distance_average, self._current_distance_long, candle.ServerTime, candle.State == CandleStates.Finished))
+        long_distance_std_dev = float(process_float(self._distance_std_dev, self._current_distance_long, candle.ServerTime, candle.State == CandleStates.Finished))
 
-        short_distance_avg = float(self._distance_average.Process(self._current_distance_short, candle.ServerTime, candle.State == CandleStates.Finished))
-        short_distance_std_dev = float(self._distance_std_dev.Process(self._current_distance_short, candle.ServerTime, candle.State == CandleStates.Finished))
+        short_distance_avg = float(process_float(self._distance_average, self._current_distance_short, candle.ServerTime, candle.State == CandleStates.Finished))
+        short_distance_std_dev = float(process_float(self._distance_std_dev, self._current_distance_short, candle.ServerTime, candle.State == CandleStates.Finished))
 
         # Skip the first value
         if self._prev_distance_long == 0 or self._prev_distance_short == 0:

--- a/API/0281_Parabolic_SAR_Distance_Mean_Reversion/parabolic_sar_distance_mean_reversion_strategy.py
+++ b/API/0281_Parabolic_SAR_Distance_Mean_Reversion/parabolic_sar_distance_mean_reversion_strategy.py
@@ -175,11 +175,11 @@ class parabolic_sar_distance_mean_reversion_strategy(Strategy):
         self._current_distance_short = self._sar_value - candle.ClosePrice
 
         # Calculate averages and standard deviations for both distances
-        long_distance_avg = to_float(self._distance_average.Process(self._current_distance_long, candle.ServerTime, True))
-        long_distance_std = to_float(self._distance_std_dev.Process(self._current_distance_long, candle.ServerTime, True))
+        long_distance_avg = to_float(process_float(self._distance_average, self._current_distance_long, candle.ServerTime, True))
+        long_distance_std = to_float(process_float(self._distance_std_dev, self._current_distance_long, candle.ServerTime, True))
 
-        short_distance_avg = to_float(self._distance_average.Process(self._current_distance_short, candle.ServerTime, True))
-        short_distance_std = to_float(self._distance_std_dev.Process(self._current_distance_short, candle.ServerTime, True))
+        short_distance_avg = to_float(process_float(self._distance_average, self._current_distance_short, candle.ServerTime, True))
+        short_distance_std = to_float(process_float(self._distance_std_dev, self._current_distance_short, candle.ServerTime, True))
 
         # Skip the first value
         if self._prev_distance_long == 0 or self._prev_distance_short == 0:

--- a/API/0282_Hull_MA_Slope_Mean_Reversion/hull_ma_slope_mean_reversion_strategy.py
+++ b/API/0282_Hull_MA_Slope_Mean_Reversion/hull_ma_slope_mean_reversion_strategy.py
@@ -172,8 +172,8 @@ class hull_ma_slope_mean_reversion_strategy(Strategy):
         self._currentSlope = (self._currentHullMa - self._prevHullMa) / self._prevHullMa * 100  # As percentage
 
         # Calculate average and standard deviation of slope
-        slopeAverage = to_float(self._slopeAverage.Process(self._currentSlope, candle.ServerTime, candle.State == CandleStates.Finished))
-        slopeStdDev = to_float(self._slopeStdDev.Process(self._currentSlope, candle.ServerTime, candle.State == CandleStates.Finished))
+        slopeAverage = to_float(process_float(self._slopeAverage, self._currentSlope, candle.ServerTime, candle.State == CandleStates.Finished))
+        slopeStdDev = to_float(process_float(self._slopeStdDev, self._currentSlope, candle.ServerTime, candle.State == CandleStates.Finished))
 
         # Skip until we have enough slope data
         if self._prevSlope == 0:

--- a/API/0294_OBV_Slope_Mean_Reversion/obv_slope_mean_reversion_strategy.py
+++ b/API/0294_OBV_Slope_Mean_Reversion/obv_slope_mean_reversion_strategy.py
@@ -166,7 +166,7 @@ class obv_slope_mean_reversion_strategy(Strategy):
         obv_value = to_float(self._obv.Process(candle))
 
         # Process OBV through SMA
-        obv_sma_value = to_float(self._obv_sma.Process(obv_value, candle.ServerTime, candle.State == CandleStates.Finished))
+        obv_sma_value = to_float(process_float(self._obv_sma, obv_value, candle.ServerTime, candle.State == CandleStates.Finished))
 
         # Skip if OBV SMA is not formed yet
         if not self._obv_sma.IsFormed:

--- a/API/0295_Pairs_Trading_Volatility_Filter/pairs_trading_volatility_filter_strategy.py
+++ b/API/0295_Pairs_Trading_Volatility_Filter/pairs_trading_volatility_filter_strategy.py
@@ -215,7 +215,7 @@ class pairs_trading_volatility_filter_strategy(Strategy):
 
         # Store ATR value for volatility filter
         self._current_atr = atr_value
-        atr_sma_value = to_float(self._atr_sma.Process(atr_value, candle.ServerTime, candle.State == CandleStates.Finished))
+        atr_sma_value = to_float(process_float(self._atr_sma, atr_value, candle.ServerTime, candle.State == CandleStates.Finished))
         self._average_atr = atr_sma_value
 
         # Check if we have all necessary data to make a trading decision
@@ -233,8 +233,8 @@ class pairs_trading_volatility_filter_strategy(Strategy):
         self._current_spread = price1 - (price2 * self._volume_ratio)
 
         # Calculate spread statistics
-        spread_sma_value = to_float(self._spread_sma.Process(self._current_spread, candle.ServerTime, candle.State == CandleStates.Finished))
-        std_dev_value = to_float(self._std_dev.Process(self._current_spread, candle.ServerTime, candle.State == CandleStates.Finished))
+        spread_sma_value = to_float(process_float(self._spread_sma, self._current_spread, candle.ServerTime, candle.State == CandleStates.Finished))
+        std_dev_value = to_float(process_float(self._std_dev, self._current_spread, candle.ServerTime, candle.State == CandleStates.Finished))
 
         self._average_spread = spread_sma_value
         self._standard_deviation = std_dev_value

--- a/API/0298_Correlation_Mean_Reversion/correlation_mean_reversion_strategy.py
+++ b/API/0298_Correlation_Mean_Reversion/correlation_mean_reversion_strategy.py
@@ -235,8 +235,8 @@ class correlation_mean_reversion_strategy(Strategy):
         self._current_correlation = self.CalculateCorrelationCoefficient(series1, series2)
 
         # Process indicators
-        self._average_correlation = to_float(self._correlation_sma.Process(self._current_correlation, time, is_final))
-        self._correlation_std_deviation = to_float(self._correlation_std_dev.Process(self._current_correlation, time, is_final))
+        self._average_correlation = to_float(process_float(self._correlation_sma, self._current_correlation, time, is_final))
+        self._correlation_std_deviation = to_float(process_float(self._correlation_std_dev, self._current_correlation, time, is_final))
 
         if self._correlation_std_deviation == 0:
             return

--- a/API/0302_Volatility_Cluster_Breakout/volatility_cluster_breakout_strategy.py
+++ b/API/0302_Volatility_Cluster_Breakout/volatility_cluster_breakout_strategy.py
@@ -142,7 +142,7 @@ class volatility_cluster_breakout_strategy(Strategy):
         if candle.State != CandleStates.Finished:
             return
 
-        atr_avg_val = self._atr_avg.Process(atr_value, candle.ServerTime, candle.State == CandleStates.Finished)
+        atr_avg_val = process_float(self._atr_avg, atr_value, candle.ServerTime, candle.State == CandleStates.Finished)
 
         # Check if strategy is ready to trade
         if not self.IsFormedAndOnlineAndAllowTrading():

--- a/API/0305_RSI_Dynamic_Overbought_Oversold/rsi_dynamic_overbought_oversold_strategy.py
+++ b/API/0305_RSI_Dynamic_Overbought_Oversold/rsi_dynamic_overbought_oversold_strategy.py
@@ -142,8 +142,8 @@ class rsi_dynamic_overbought_oversold_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        smaValue = self._rsiSma.Process(rsiValue, candle.ServerTime, candle.State == CandleStates.Finished)
-        stdDevValue = self._rsiStdDev.Process(rsiValue, candle.ServerTime, candle.State == CandleStates.Finished)
+        smaValue = process_float(self._rsiSma, rsiValue, candle.ServerTime, candle.State == CandleStates.Finished)
+        stdDevValue = process_float(self._rsiStdDev, rsiValue, candle.ServerTime, candle.State == CandleStates.Finished)
 
         # Get values from indicators
         rsiSmaValue = to_float(smaValue)

--- a/API/0306_Bollinger_Volatility_Breakout/bollinger_volatility_breakout_strategy.py
+++ b/API/0306_Bollinger_Volatility_Breakout/bollinger_volatility_breakout_strategy.py
@@ -161,8 +161,8 @@ class bollinger_volatility_breakout_strategy(Strategy):
         atr_dec = to_float(atr_value)
 
         # Get values from indicators
-        atr_sma_value = to_float(self._atr_sma.Process(atr_dec, candle.ServerTime, True))  # Default to current ATR if SMA not available
-        atr_std_dev_value = to_float(self._atr_std_dev.Process(atr_dec, candle.ServerTime, True)) * 0.2  # Default to 20% of ATR if StdDev not available
+        atr_sma_value = to_float(process_float(self._atr_sma, atr_dec, candle.ServerTime, True))  # Default to current ATR if SMA not available
+        atr_std_dev_value = to_float(process_float(self._atr_std_dev, atr_dec, candle.ServerTime, True)) * 0.2  # Default to 20% of ATR if StdDev not available
 
         # Calculate volatility threshold for breakout confirmation
         volatility_threshold = atr_sma_value + self.AtrDeviationMultiplier * atr_std_dev_value

--- a/API/0308_Ichimoku_Volume_Cluster/ichimoku_volume_cluster_strategy.py
+++ b/API/0308_Ichimoku_Volume_Cluster/ichimoku_volume_cluster_strategy.py
@@ -160,8 +160,8 @@ class ichimoku_volume_cluster_strategy(Strategy):
 
         volume = candle.TotalVolume
 
-        volume_avg_value = to_float(self._volume_avg.Process(volume, candle.ServerTime, candle.State == CandleStates.Finished))
-        volume_std_dev_value = to_float(self._volume_std_dev.Process(volume, candle.ServerTime, candle.State == CandleStates.Finished))
+        volume_avg_value = to_float(process_float(self._volume_avg, volume, candle.ServerTime, candle.State == CandleStates.Finished))
+        volume_std_dev_value = to_float(process_float(self._volume_std_dev, volume, candle.ServerTime, candle.State == CandleStates.Finished))
 
         # Check if strategy is ready to trade
         if not self.IsFormedAndOnlineAndAllowTrading():

--- a/API/0312_Hull_MA_Volume_Spike/hull_ma_volume_spike_strategy.py
+++ b/API/0312_Hull_MA_Volume_Spike/hull_ma_volume_spike_strategy.py
@@ -109,8 +109,8 @@ class hull_ma_volume_spike_strategy(Strategy):
 
         def process(candle, hma_value):
             # Process volume indicators
-            volume_sma_value = volume_sma.Process(candle.TotalVolume, candle.ServerTime, candle.State == CandleStates.Finished)
-            volume_std_dev_value = volume_std_dev.Process(candle.TotalVolume, candle.ServerTime, candle.State == CandleStates.Finished)
+            volume_sma_value = process_float(volume_sma, candle.TotalVolume, candle.ServerTime, candle.State == CandleStates.Finished)
+            volume_std_dev_value = process_float(volume_std_dev, candle.TotalVolume, candle.ServerTime, candle.State == CandleStates.Finished)
 
             # Process the strategy logic
             self.ProcessStrategy(

--- a/API/0314_Parabolic_SAR_Volatility_Expansion/parabolic_sar_volatility_expansion_strategy.py
+++ b/API/0314_Parabolic_SAR_Volatility_Expansion/parabolic_sar_volatility_expansion_strategy.py
@@ -128,8 +128,8 @@ class parabolic_sar_volatility_expansion_strategy(Strategy):
 
     def _on_candle(self, candle, sar_value, atr_value):
         # Calculate ATR average and standard deviation
-        atr_avg = float(self._atr_sma.Process(atr_value, candle.ServerTime, candle.State == CandleStates.Finished))
-        atr_std = float(self._atr_std_dev.Process(atr_value, candle.ServerTime, candle.State == CandleStates.Finished))
+        atr_avg = float(process_float(self._atr_sma, atr_value, candle.ServerTime, candle.State == CandleStates.Finished))
+        atr_std = float(process_float(self._atr_std_dev, atr_value, candle.ServerTime, candle.State == CandleStates.Finished))
 
         # Process the strategy logic
         self.ProcessStrategy(candle, sar_value, atr_value, atr_avg, atr_std)

--- a/API/0315_Stochastic_Dynamic_Zones/stochastic_with_dynamic_zones_strategy.py
+++ b/API/0315_Stochastic_Dynamic_Zones/stochastic_with_dynamic_zones_strategy.py
@@ -156,8 +156,8 @@ class stochastic_with_dynamic_zones_strategy(Strategy):
 
         # Calculate dynamic zones
         stoch_k = float(stoch_typed.K)
-        stoch_k_avg = to_float(self._stoch_sma.Process(stoch_k, candle.ServerTime, candle.State == CandleStates.Finished))
-        stoch_k_std_dev = to_float(self._stoch_std_dev.Process(stoch_k, candle.ServerTime, candle.State == CandleStates.Finished))
+        stoch_k_avg = to_float(process_float(self._stoch_sma, stoch_k, candle.ServerTime, candle.State == CandleStates.Finished))
+        stoch_k_std_dev = to_float(process_float(self._stoch_std_dev, stoch_k, candle.ServerTime, candle.State == CandleStates.Finished))
 
         dynamic_oversold = stoch_k_avg - (self.StandardDeviationFactor * stoch_k_std_dev)
         dynamic_overbought = stoch_k_avg + (self.StandardDeviationFactor * stoch_k_std_dev)

--- a/API/0316_ADX_Volume_Breakout/adx_with_volume_breakout_strategy.py
+++ b/API/0316_ADX_Volume_Breakout/adx_with_volume_breakout_strategy.py
@@ -114,8 +114,8 @@ class adx_with_volume_breakout_strategy(Strategy):
             minus_di = dx.Minus
 
             # Process volume indicators
-            sma_val = to_float(volume_sma.Process(candle.TotalVolume, candle.ServerTime, candle.State == CandleStates.Finished))
-            std_dev_val = to_float(volume_std_dev.Process(candle.TotalVolume, candle.ServerTime, candle.State == CandleStates.Finished))
+            sma_val = to_float(process_float(volume_sma, candle.TotalVolume, candle.ServerTime, candle.State == CandleStates.Finished))
+            std_dev_val = to_float(process_float(volume_std_dev, candle.TotalVolume, candle.ServerTime, candle.State == CandleStates.Finished))
 
             # Process the strategy logic
             self.ProcessStrategy(

--- a/API/0318_Williams_R_Momentum/williams_percent_r_with_momentum_strategy.py
+++ b/API/0318_Williams_R_Momentum/williams_percent_r_with_momentum_strategy.py
@@ -114,7 +114,7 @@ class williams_percent_r_with_momentum_strategy(Strategy):
 
         def on_process(candle, williamsRValue, momentumValue):
             # Calculate momentum average
-            momentumAvg = to_float(momentumSma.Process(momentumValue, candle.ServerTime, candle.State == CandleStates.Finished))
+            momentumAvg = to_float(process_float(momentumSma, momentumValue, candle.ServerTime, candle.State == CandleStates.Finished))
 
             # Process the strategy logic
             self.ProcessStrategy(candle, williamsRValue, momentumValue, momentumAvg)

--- a/API/0347_RSI_Option_Open_Interest/rsi_with_option_open_interest_strategy.py
+++ b/API/0347_RSI_Option_Open_Interest/rsi_with_option_open_interest_strategy.py
@@ -171,11 +171,11 @@ class rsi_with_option_open_interest_strategy(Strategy):
         self.SimulateOptionOI(candle)
 
         # Process option OI with indicators
-        call_oi_value_sma = self._call_oi_sma.Process(self._current_call_oi, candle.ServerTime, candle.State == CandleStates.Finished)
-        put_oi_value_sma = self._put_oi_sma.Process(self._current_put_oi, candle.ServerTime, candle.State == CandleStates.Finished)
+        call_oi_value_sma = process_float(self._call_oi_sma, self._current_call_oi, candle.ServerTime, candle.State == CandleStates.Finished)
+        put_oi_value_sma = process_float(self._put_oi_sma, self._current_put_oi, candle.ServerTime, candle.State == CandleStates.Finished)
 
-        call_oi_value_stddev = self._call_oi_stddev.Process(self._current_call_oi, candle.ServerTime, candle.State == CandleStates.Finished)
-        put_oi_value_stddev = self._put_oi_stddev.Process(self._current_put_oi, candle.ServerTime, candle.State == CandleStates.Finished)
+        call_oi_value_stddev = process_float(self._call_oi_stddev, self._current_call_oi, candle.ServerTime, candle.State == CandleStates.Finished)
+        put_oi_value_stddev = process_float(self._put_oi_stddev, self._current_put_oi, candle.ServerTime, candle.State == CandleStates.Finished)
 
         # Update state variables
         self._avg_call_oi = to_float(call_oi_value_sma)

--- a/API/0348_Stochastic_Implied_Volatility_Skew/stochastic_implied_volatility_skew_strategy.py
+++ b/API/0348_Stochastic_Implied_Volatility_Skew/stochastic_implied_volatility_skew_strategy.py
@@ -156,7 +156,7 @@ class stochastic_implied_volatility_skew_strategy(Strategy):
         self.SimulateIvSkew(candle)
 
         # Process IV Skew with SMA
-        iv_skew_sma_value = self._iv_skew_sma.Process(self._current_iv_skew, candle.ServerTime, candle.State == CandleStates.Finished)
+        iv_skew_sma_value = process_float(self._iv_skew_sma, self._current_iv_skew, candle.ServerTime, candle.State == CandleStates.Finished)
         self._avg_iv_skew = to_float(iv_skew_sma_value)
 
         # Check if strategy is ready to trade

--- a/API/indicator_extensions.py
+++ b/API/indicator_extensions.py
@@ -1,0 +1,23 @@
+import clr
+clr.AddReference("System")
+clr.AddReference("StockSharp.Algo")
+
+from System import Decimal
+
+
+def to_float(value):
+    """Convert .NET Decimal or indicator value to Python float."""
+    try:
+        if hasattr(value, "ToDecimal"):
+            return float(value.ToDecimal())
+        return float(value)
+    except Exception:
+        try:
+            return float(str(value))
+        except Exception:
+            return value
+
+
+def process_float(indicator, value, time, is_final):
+    """Wrapper for indicator.Process accepting Python float."""
+    return indicator.Process(float(value), time, is_final)


### PR DESCRIPTION
## Summary
- add `indicator_extensions.py` with `process_float` helper
- update all python strategies to use `process_float` when passing three arguments to indicators

## Testing
- `dotnet test` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6877dfe497d08323905565e58610473e