### PR TITLE
Add indicator_extensions import for process_float strategies

### DIFF
--- a/API/0136_Supertrend_Volume/supertrend_volume_strategy.py
+++ b/API/0136_Supertrend_Volume/supertrend_volume_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, CandleStates
 from StockSharp.Algo.Indicators import AverageTrueRange, SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
 from datatype_extensions import *
+from indicator_extensions import *
 
 class supertrend_volume_strategy(Strategy):
     """

--- a/API/0217_Pairs_Trading/pairs_trading_strategy.py
+++ b/API/0217_Pairs_Trading/pairs_trading_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit, CandleStates, Subscri
 from StockSharp.Algo.Indicators import SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
 from datatype_extensions import *
+from indicator_extensions import *
 from StockSharp.BusinessEntities import Security
 
 class pairs_trading_strategy(Strategy):

--- a/API/0219_Statistical_Arbitrage/statistical_arbitrage_strategy.py
+++ b/API/0219_Statistical_Arbitrage/statistical_arbitrage_strategy.py
@@ -8,6 +8,7 @@ from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes, ICandle
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
 from datatype_extensions import *
+from indicator_extensions import *
 from StockSharp.BusinessEntities import Security
 
 class statistical_arbitrage_strategy(Strategy):

--- a/API/0230_Delta_Neutral_Arbitrage/delta_neutral_arbitrage_strategy.py
+++ b/API/0230_Delta_Neutral_Arbitrage/delta_neutral_arbitrage_strategy.py
@@ -8,6 +8,7 @@ from StockSharp.Messages import DataType, CandleStates, Sides
 from StockSharp.Algo.Indicators import SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
 from datatype_extensions import *
+from indicator_extensions import *
 
 class delta_neutral_arbitrage_strategy(Strategy):
     """

--- a/API/0254_Volume_Breakout/volume_breakout_strategy.py
+++ b/API/0254_Volume_Breakout/volume_breakout_strategy.py
@@ -8,6 +8,7 @@ from StockSharp.Messages import DataType, UnitTypes, Unit, CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
 from datatype_extensions import *
+from indicator_extensions import *
 
 class volume_breakout_strategy(Strategy):
     """

--- a/API/0257_Keltner_Channel_Width_Breakout/keltner_width_breakout_strategy.py
+++ b/API/0257_Keltner_Channel_Width_Breakout/keltner_width_breakout_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, CandleStates, Sides
 from StockSharp.Algo.Indicators import ExponentialMovingAverage, AverageTrueRange, SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
 from datatype_extensions import *
+from indicator_extensions import *
 
 class keltner_width_breakout_strategy(Strategy):
     """

--- a/API/0269_CCI_Slope_Breakout/cci_slope_breakout_strategy.py
+++ b/API/0269_CCI_Slope_Breakout/cci_slope_breakout_strategy.py
@@ -8,6 +8,7 @@ from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import CommodityChannelIndex, LinearRegression, LinearRegressionValue
 from StockSharp.Algo.Strategies import Strategy
 from datatype_extensions import *
+from indicator_extensions import *
 
 class cci_slope_breakout_strategy(Strategy):
     """CCI Slope Breakout Strategy"""

--- a/API/0270_Williams_R_Slope_Breakout/williams_r_slope_breakout_strategy.py
+++ b/API/0270_Williams_R_Slope_Breakout/williams_r_slope_breakout_strategy.py
@@ -8,6 +8,7 @@ from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import WilliamsR, LinearRegression
 from StockSharp.Algo.Strategies import Strategy
 from datatype_extensions import *
+from indicator_extensions import *
 from collections import deque
 
 

--- a/API/0271_MACD_Slope_Breakout/macd_slope_breakout_strategy.py
+++ b/API/0271_MACD_Slope_Breakout/macd_slope_breakout_strategy.py
@@ -10,6 +10,7 @@ from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes
 from StockSharp.Algo.Indicators import MovingAverageConvergenceDivergenceSignal, LinearRegression
 from StockSharp.Algo.Strategies import Strategy
 from datatype_extensions import *
+from indicator_extensions import *
 
 class macd_slope_breakout_strategy(Strategy):
     """

--- a/API/0272_ADX_Slope_Breakout/adx_slope_breakout_strategy.py
+++ b/API/0272_ADX_Slope_Breakout/adx_slope_breakout_strategy.py
@@ -10,6 +10,7 @@ from StockSharp.Messages import UnitTypes, Unit, DataType, CandleStates
 from StockSharp.Algo.Indicators import AverageDirectionalIndex, LinearRegression
 from StockSharp.Algo.Strategies import Strategy
 from datatype_extensions import *
+from indicator_extensions import *
 
 class adx_slope_breakout_strategy(Strategy):
     """

--- a/API/0276_Bollinger_Width_Mean_Reversion/bollinger_width_mean_reversion_strategy.py
+++ b/API/0276_Bollinger_Width_Mean_Reversion/bollinger_width_mean_reversion_strategy.py
@@ -9,6 +9,7 @@ from StockSharp.Messages import DataType, CandleStates, Sides
 from StockSharp.Algo.Indicators import BollingerBands, SimpleMovingAverage, StandardDeviation, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
 from datatype_extensions import *
+from indicator_extensions import *
 
 class bollinger_width_mean_reversion_strategy(Strategy):
     """

--- a/API/0280_Supertrend_Distance_Mean_Reversion/supertrend_distance_mean_reversion_strategy.py
+++ b/API/0280_Supertrend_Distance_Mean_Reversion/supertrend_distance_mean_reversion_strategy.py
@@ -8,6 +8,7 @@ from StockSharp.Messages import DataType, CandleStates
 from StockSharp.Algo.Indicators import AverageTrueRange, SuperTrend, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
 from datatype_extensions import *
+from indicator_extensions import *
 
 
 class supertrend_distance_mean_reversion_strategy(Strategy):

--- a/API/0302_Volatility_Cluster_Breakout/volatility_cluster_breakout_strategy.py
+++ b/API/0302_Volatility_Cluster_Breakout/volatility_cluster_breakout_strategy.py
@@ -8,6 +8,7 @@ from StockSharp.Messages import DataType, CandleStates, Unit
 from StockSharp.Algo.Indicators import SimpleMovingAverage, StandardDeviation, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
 from datatype_extensions import *
+from indicator_extensions import *
 
 
 class volatility_cluster_breakout_strategy(Strategy):

--- a/API/0314_Parabolic_SAR_Volatility_Expansion/parabolic_sar_volatility_expansion_strategy.py
+++ b/API/0314_Parabolic_SAR_Volatility_Expansion/parabolic_sar_volatility_expansion_strategy.py
@@ -8,6 +8,7 @@ from StockSharp.Messages import DataType, CandleStates
 from StockSharp.Algo.Indicators import ParabolicSar, AverageTrueRange, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
 from datatype_extensions import *
+from indicator_extensions import *
 
 
 class parabolic_sar_volatility_expansion_strategy(Strategy):


### PR DESCRIPTION
## Summary
- add `from indicator_extensions import *` to strategies that call `process_float`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877ed34b3708323bb39e6fa29312b45