### PR TITLE
Fix StartProtection argument usage

### DIFF
--- a/API/0003_ADX_Trend/adx_trend_strategy.py
+++ b/API/0003_ADX_Trend/adx_trend_strategy.py
@@ -134,8 +134,10 @@ class adx_trend_strategy(Strategy):
             self.DrawOwnTrades(area)
 
         # Start protection for positions
-        self.StartProtection(None, Unit(self.atr_multiplier, UnitTypes.Absolute))
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=Unit(self.atr_multiplier, UnitTypes.Absolute)
+        )
     def ProcessCandle(self, candle, adx_value, ma_value, atr_value):
         """
         Processes each finished candle and executes ADX-based trading logic.

--- a/API/0006_Tripple_MA/triple_ma_strategy.py
+++ b/API/0006_Tripple_MA/triple_ma_strategy.py
@@ -129,8 +129,10 @@ class triple_ma_strategy(Strategy):
             self.DrawOwnTrades(area)
 
         # Start protection with stop loss
-        self.StartProtection(None, Unit(self.stop_loss_percent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
+        )
     def ProcessCandle(self, candle, short_ma_value, middle_ma_value, long_ma_value):
         """
         Processes each finished candle and executes Triple MA trading logic.

--- a/API/0008_Hull_MA_Trend/hull_ma_trend_strategy.py
+++ b/API/0008_Hull_MA_Trend/hull_ma_trend_strategy.py
@@ -112,8 +112,10 @@ class hull_ma_trend_strategy(Strategy):
             self.DrawOwnTrades(area)
 
         # Setup protection using ATR
-        self.StartProtection(None, Unit(self.atr_multiplier, UnitTypes.Absolute))
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=Unit(self.atr_multiplier, UnitTypes.Absolute)
+        )
     def ProcessCandle(self, candle, hma_value, atr_value):
         """
         Processes each finished candle and executes Hull MA trend-based trading logic.

--- a/API/0009_MACD_Trend/macd_trend_strategy.py
+++ b/API/0009_MACD_Trend/macd_trend_strategy.py
@@ -124,8 +124,10 @@ class macd_trend_strategy(Strategy):
             self.DrawOwnTrades(area)
 
         # Start protection with stop loss
-        self.StartProtection(None, Unit(self.stop_loss_percent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
+        )
     def ProcessCandle(self, candle, macd_value):
         """
         Processes each finished candle and executes MACD-based trading logic.

--- a/API/0012_Heikin_Ashi_Consecutive/heikin_ashi_consecutive_strategy.py
+++ b/API/0012_Heikin_Ashi_Consecutive/heikin_ashi_consecutive_strategy.py
@@ -108,8 +108,10 @@ class heikin_ashi_consecutive_strategy(Strategy):
             self.DrawOwnTrades(area)
 
         # Start protection with stop loss
-        self.StartProtection(None, Unit(self.stop_loss_percent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
+        )
     def ProcessCandle(self, candle):
         """
         Processes each finished candle and executes Heikin-Ashi consecutive logic.

--- a/API/0013_DMI_Power_Move/dmi_power_move_strategy.py
+++ b/API/0013_DMI_Power_Move/dmi_power_move_strategy.py
@@ -129,8 +129,10 @@ class dmi_power_move_strategy(Strategy):
             self.DrawOwnTrades(area)
 
         # Start protection with ATR-based stop loss
-        self.StartProtection(None, Unit(self.atr_multiplier, UnitTypes.Absolute))
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=Unit(self.atr_multiplier, UnitTypes.Absolute)
+        )
     def ProcessCandle(self, candle, adx_value, atr_value):
         """
         Processes each finished candle and executes DMI-based trading logic.

--- a/API/0016_RSI_Divergence/rsi_divergence_strategy.py
+++ b/API/0016_RSI_Divergence/rsi_divergence_strategy.py
@@ -96,8 +96,10 @@ class rsi_divergence_strategy(Strategy):
         subscription.BindEx(rsi, self.ProcessCandle).Start()
 
         # Enable position protection
-        self.StartProtection(None, Unit(self.stop_loss_percent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
+        )
         # Setup chart visualization
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0017_Williams_R/williams_percent_r_strategy.py
+++ b/API/0017_Williams_R/williams_percent_r_strategy.py
@@ -83,8 +83,10 @@ class williams_percent_r_strategy(Strategy):
         subscription.BindEx(williams_r, self.ProcessCandle).Start()
             
         # Enable position protection
-        self.StartProtection(None, Unit(self.stop_loss_percent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
+        )
         # Setup chart visualization
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0018_ROC_Impulce/roc_impulse_strategy.py
+++ b/API/0018_ROC_Impulce/roc_impulse_strategy.py
@@ -96,8 +96,10 @@ class roc_impulse_strategy(Strategy):
         subscription.Bind(roc, atr, self.ProcessCandle).Start()
 
         # Enable position protection with ATR-based stop loss
-        self.StartProtection(None, Unit(self.atr_multiplier, UnitTypes.Absolute))
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=Unit(self.atr_multiplier, UnitTypes.Absolute)
+        )
         # Setup chart visualization
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0019_CCI_Breakout/cci_breakout_strategy.py
+++ b/API/0019_CCI_Breakout/cci_breakout_strategy.py
@@ -83,8 +83,10 @@ class cci_breakout_strategy(Strategy):
         subscription.BindEx(cci, self.ProcessCandle).Start()
 
         # Enable stop loss protection
-        self.StartProtection(None, Unit(self.stop_loss_percent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
+        )
         # Setup chart visualization
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0020_Momentum_Percentage/momentum_percentage_strategy.py
+++ b/API/0020_Momentum_Percentage/momentum_percentage_strategy.py
@@ -98,8 +98,10 @@ class momentum_percentage_strategy(Strategy):
         subscription.Bind(momentum, sma, self.ProcessCandle).Start()
 
         # Enable stop loss protection
-        self.StartProtection(None, Unit(self.stop_loss_percent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
+        )
         # Setup chart visualization
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0022_ADX_DI/adx_di_strategy.py
+++ b/API/0022_ADX_DI/adx_di_strategy.py
@@ -100,8 +100,10 @@ class adx_di_strategy(Strategy):
         subscription.BindEx(adx, atr, self.ProcessCandle).Start()
 
         # Enable position protection
-        self.StartProtection(None, Unit(self.atr_multiplier, UnitTypes.Absolute))
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=Unit(self.atr_multiplier, UnitTypes.Absolute)
+        )
         # Setup chart visualization
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0023_Elder_Impulse/elder_impulse_strategy.py
+++ b/API/0023_Elder_Impulse/elder_impulse_strategy.py
@@ -137,8 +137,10 @@ class elder_impulse_strategy(Strategy):
         subscription.BindEx(ema, macd, self.ProcessCandle).Start()
 
         # Enable position protection
-        self.StartProtection(None, Unit(self.stop_loss_percent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
+        )
         # Setup chart visualization
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0024_RSI_Laguerre/laguerre_rsi_strategy.py
+++ b/API/0024_RSI_Laguerre/laguerre_rsi_strategy.py
@@ -85,8 +85,10 @@ class laguerre_rsi_strategy(Strategy):
         subscription.BindEx(rsi, self.ProcessCandle).Start()
 
         # Enable position protection
-        self.StartProtection(None, Unit(self.stop_loss_percent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
+        )
         # Setup chart visualization
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0025_Stochastic_RSI_Cross/stochastic_rsi_cross_strategy.py
+++ b/API/0025_Stochastic_RSI_Cross/stochastic_rsi_cross_strategy.py
@@ -138,8 +138,10 @@ class stochastic_rsi_cross_strategy(Strategy):
         subscription.BindEx(stoch, rsi, self.ProcessCandle).Start()
 
         # Enable position protection
-        self.StartProtection(None, Unit(self.stop_loss_percent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
+        )
         # Setup chart visualization
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0026_RSI_Reversion/rsi_reversion_strategy.py
+++ b/API/0026_RSI_Reversion/rsi_reversion_strategy.py
@@ -119,8 +119,10 @@ class rsi_reversion_strategy(Strategy):
         subscription.BindEx(rsi, self.ProcessCandle).Start()
 
         # Enable position protection
-        self.StartProtection(None, Unit(self.stop_loss_percent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
+        )
         # Setup chart visualization
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0027_Bollinger_Reversion/bollinger_reversion_strategy.py
+++ b/API/0027_Bollinger_Reversion/bollinger_reversion_strategy.py
@@ -99,8 +99,10 @@ class bollinger_reversion_strategy(Strategy):
         subscription.BindEx(bollinger_bands, atr, self.ProcessCandle).Start()
 
         # Enable position protection with ATR-based stop loss
-        self.StartProtection(None, Unit(self.atr_multiplier, UnitTypes.Absolute))
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=Unit(self.atr_multiplier, UnitTypes.Absolute)
+        )
         # Setup chart visualization
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0028_ZScore/z_score_strategy.py
+++ b/API/0028_ZScore/z_score_strategy.py
@@ -135,8 +135,10 @@ class z_score_strategy(Strategy):
             self.DrawOwnTrades(area)
 
         # Setup protection with stop-loss
-        self.StartProtection(Unit(0, UnitTypes.Absolute), Unit(self.stop_loss_percent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
+        )
     def ProcessCandle(self, candle, ma_value, std_dev_value):
         """
         Process candle and calculate Z-Score

--- a/API/0030_VWAP_Reversion/vwap_reversion_strategy.py
+++ b/API/0030_VWAP_Reversion/vwap_reversion_strategy.py
@@ -89,8 +89,10 @@ class vwap_reversion_strategy(Strategy):
             self.DrawOwnTrades(area)
 
         # Setup protection with stop-loss
-        self.StartProtection(Unit(0, UnitTypes.Absolute), Unit(self.stop_loss_percent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
+        )
     def ProcessCandle(self, candle, vwap_value):
         """
         Process candle and check for VWAP deviation signals

--- a/API/0032_ATR_Reversion/atr_reversion_strategy.py
+++ b/API/0032_ATR_Reversion/atr_reversion_strategy.py
@@ -125,8 +125,10 @@ class atr_reversion_strategy(Strategy):
             self.DrawOwnTrades(area)
 
         # Setup protection with stop-loss
-        self.StartProtection(Unit(0, UnitTypes.Absolute), Unit(self.stop_loss_percent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
+        )
     def ProcessCandle(self, candle, atr_value, sma_value):
         """
         Process candle and check for ATR-based signals

--- a/API/0033_MACD_Zero/macd_zero_strategy.py
+++ b/API/0033_MACD_Zero/macd_zero_strategy.py
@@ -123,8 +123,10 @@ class macd_zero_strategy(Strategy):
             self.DrawOwnTrades(area)
 
         # Setup protection with stop-loss
-        self.StartProtection(Unit(0, UnitTypes.Absolute), Unit(self.stop_loss_percent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
+        )
     def ProcessCandle(self, candle, macd_value):
         """
         Process candle and check for MACD signals

--- a/API/0035_Bollinger_B_Reversion/bollinger_percent_b_strategy.py
+++ b/API/0035_Bollinger_B_Reversion/bollinger_percent_b_strategy.py
@@ -115,8 +115,10 @@ class bollinger_percent_b_strategy(Strategy):
             self.DrawOwnTrades(area)
 
         # Setup protection with stop-loss
-        self.StartProtection(Unit(0, UnitTypes.Absolute), Unit(self.stop_loss_percent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
+        )
     def ProcessCandle(self, candle, bollinger_value):
         """
         Process candle and calculate Bollinger %B

--- a/API/0037_VIX_Trigger/vix_trigger_strategy.py
+++ b/API/0037_VIX_Trigger/vix_trigger_strategy.py
@@ -125,10 +125,9 @@ class vix_trigger_strategy(Strategy):
 
         # Setup protection with stop-loss
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit
-            Unit(self.StopLossPercent, UnitTypes.Percent)  # Stop loss as percentage
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
     def ProcessVixCandle(self, candle):
         """
         Process VIX candle to track VIX movements

--- a/API/0039_HV_Breakout/hv_breakout_strategy.py
+++ b/API/0039_HV_Breakout/hv_breakout_strategy.py
@@ -122,10 +122,9 @@ class hv_breakout_strategy(Strategy):
 
         # Setup protection with stop-loss
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit
-            Unit(self.StopLossPercent, UnitTypes.Percent)  # Stop loss as percentage
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, stdDevValue, smaValue):
         """
         Process candle and check for HV breakout signals

--- a/API/0041_Vol_Adjusted_MA/vol_adjusted_ma_strategy.py
+++ b/API/0041_Vol_Adjusted_MA/vol_adjusted_ma_strategy.py
@@ -109,10 +109,9 @@ class vol_adjusted_ma_strategy(Strategy):
 
         # Configure protection
         self.StartProtection(
-            Unit(3, UnitTypes.Percent),  # Take profit
-            Unit(2, UnitTypes.Percent)   # Stop loss
+            takeProfit=Unit(3, UnitTypes.Percent),
+            stopLoss=Unit(2, UnitTypes.Percent)
         )
-
         # Setup chart visualization
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0042_IV_Spike/iv_spike_strategy.py
+++ b/API/0042_IV_Spike/iv_spike_strategy.py
@@ -107,10 +107,9 @@ class iv_spike_strategy(Strategy):
 
         # Configure protection
         self.StartProtection(
-            Unit(3, UnitTypes.Percent),  # Take profit
-            Unit(2, UnitTypes.Percent)   # Stop loss
+            takeProfit=Unit(3, UnitTypes.Percent),
+            stopLoss=Unit(2, UnitTypes.Percent)
         )
-
         # Setup chart visualization
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0043_VCP/vcp_strategy.py
+++ b/API/0043_VCP/vcp_strategy.py
@@ -101,10 +101,9 @@ class vcp_strategy(Strategy):
 
         # Configure protection
         self.StartProtection(
-            Unit(3, UnitTypes.Percent),  # Take profit
-            Unit(2, UnitTypes.Percent)   # Stop loss
+            takeProfit=Unit(3, UnitTypes.Percent),
+            stopLoss=Unit(2, UnitTypes.Percent)
         )
-
         # Setup chart visualization
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0044_ATR_Range/atr_range_strategy.py
+++ b/API/0044_ATR_Range/atr_range_strategy.py
@@ -110,10 +110,9 @@ class atr_range_strategy(Strategy):
 
         # Configure protection
         self.StartProtection(
-            Unit(3, UnitTypes.Percent),  # Take profit
-            Unit(2, UnitTypes.Percent)   # Stop loss
+            takeProfit=Unit(3, UnitTypes.Percent),
+            stopLoss=Unit(2, UnitTypes.Percent)
         )
-
         # Setup chart visualization
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0045_Choppiness_Index_Breakout/choppiness_index_breakout_strategy.py
+++ b/API/0045_Choppiness_Index_Breakout/choppiness_index_breakout_strategy.py
@@ -119,10 +119,9 @@ class choppiness_index_breakout_strategy(Strategy):
 
         # Configure protection
         self.StartProtection(
-            Unit(3, UnitTypes.Percent),  # Take profit
-            Unit(2, UnitTypes.Percent)   # Stop loss
+            takeProfit=Unit(3, UnitTypes.Percent),
+            stopLoss=Unit(2, UnitTypes.Percent)
         )
-
         # Setup chart visualization
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0046_Volume_Spike/volume_spike_strategy.py
+++ b/API/0046_Volume_Spike/volume_spike_strategy.py
@@ -107,10 +107,9 @@ class volume_spike_strategy(Strategy):
 
         # Configure protection
         self.StartProtection(
-            Unit(3, UnitTypes.Percent),  # Take profit
-            Unit(2, UnitTypes.Percent)   # Stop loss
+            takeProfit=Unit(3, UnitTypes.Percent),
+            stopLoss=Unit(2, UnitTypes.Percent)
         )
-
         # Setup chart visualization
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0047_OBV_Breakout/obv_breakout_strategy.py
+++ b/API/0047_OBV_Breakout/obv_breakout_strategy.py
@@ -120,10 +120,9 @@ class obv_breakout_strategy(Strategy):
 
         # Configure protection
         self.StartProtection(
-            Unit(3, UnitTypes.Percent),  # Take profit
-            Unit(2, UnitTypes.Percent)   # Stop loss
+            takeProfit=Unit(3, UnitTypes.Percent),
+            stopLoss=Unit(2, UnitTypes.Percent)
         )
-
         # Setup chart visualization
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0048_VWAP_Breakout/vwap_breakout_strategy.py
+++ b/API/0048_VWAP_Breakout/vwap_breakout_strategy.py
@@ -77,10 +77,9 @@ class vwap_breakout_strategy(Strategy):
 
         # Configure protection
         self.StartProtection(
-            Unit(3, UnitTypes.Percent),  # Take profit
-            Unit(2, UnitTypes.Percent)   # Stop loss
+            takeProfit=Unit(3, UnitTypes.Percent),
+            stopLoss=Unit(2, UnitTypes.Percent)
         )
-
         # Setup chart visualization
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0049_VWMA/vwma_strategy.py
+++ b/API/0049_VWMA/vwma_strategy.py
@@ -89,10 +89,9 @@ class vwma_strategy(Strategy):
 
         # Configure protection
         self.StartProtection(
-            Unit(3, UnitTypes.Percent),  # Take profit
-            Unit(2, UnitTypes.Percent)   # Stop loss
+            takeProfit=Unit(3, UnitTypes.Percent),
+            stopLoss=Unit(2, UnitTypes.Percent)
         )
-
         # Setup chart visualization
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0050_AD/ad_strategy.py
+++ b/API/0050_AD/ad_strategy.py
@@ -90,10 +90,9 @@ class ad_strategy(Strategy):
 
         # Configure protection
         self.StartProtection(
-            Unit(3, UnitTypes.Percent),  # Take profit
-            Unit(2, UnitTypes.Percent)   # Stop loss
+            takeProfit=Unit(3, UnitTypes.Percent),
+            stopLoss=Unit(2, UnitTypes.Percent)
         )
-
         # Setup chart visualization
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0051_Volume_Weighted_Price_Breakout/volume_weighted_price_breakout_strategy.py
+++ b/API/0051_Volume_Weighted_Price_Breakout/volume_weighted_price_breakout_strategy.py
@@ -85,10 +85,9 @@ class volume_weighted_price_breakout_strategy(Strategy):
 
         # Configure protection
         self.StartProtection(
-            Unit(3, UnitTypes.Percent),  # Take profit
-            Unit(2, UnitTypes.Percent)   # Stop loss
+            takeProfit=Unit(3, UnitTypes.Percent),
+            stopLoss=Unit(2, UnitTypes.Percent)
         )
-
         # Setup chart visualization
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0052_Volume_Divergence/volume_divergence_strategy.py
+++ b/API/0052_Volume_Divergence/volume_divergence_strategy.py
@@ -103,10 +103,9 @@ class volume_divergence_strategy(Strategy):
 
         # Configure protection
         self.StartProtection(
-            Unit(3, UnitTypes.Percent),  # Take profit
-            Unit(2, UnitTypes.Percent)   # Stop loss
+            takeProfit=Unit(3, UnitTypes.Percent),
+            stopLoss=Unit(2, UnitTypes.Percent)
         )
-
         # Setup chart visualization
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0053_Volume_MA_Cross/volume_ma_cross_strategy.py
+++ b/API/0053_Volume_MA_Cross/volume_ma_cross_strategy.py
@@ -110,10 +110,9 @@ class volume_ma_cross_strategy(Strategy):
 
         # Configure protection
         self.StartProtection(
-            Unit(3, UnitTypes.Percent),  # Take profit
-            Unit(2, UnitTypes.Percent)   # Stop loss
+            takeProfit=Unit(3, UnitTypes.Percent),
+            stopLoss=Unit(2, UnitTypes.Percent)
         )
-
         # Setup chart visualization
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0054_Cumulative_Delta_Breakout/cumulative_delta_breakout_strategy.py
+++ b/API/0054_Cumulative_Delta_Breakout/cumulative_delta_breakout_strategy.py
@@ -98,10 +98,9 @@ class cumulative_delta_breakout_strategy(Strategy):
         
         # Configure protection
         self.StartProtection(
-            Unit(3, UnitTypes.Percent),  # Take profit
-            Unit(2, UnitTypes.Percent)   # Stop loss
+            takeProfit=Unit(3, UnitTypes.Percent),
+            stopLoss=Unit(2, UnitTypes.Percent)
         )
-
         # Setup chart visualization
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0055_Volume_Surge/volume_surge_strategy.py
+++ b/API/0055_Volume_Surge/volume_surge_strategy.py
@@ -101,10 +101,9 @@ class volume_surge_strategy(Strategy):
 
         # Configure protection
         self.StartProtection(
-            Unit(3, UnitTypes.Percent),  # Take profit
-            Unit(2, UnitTypes.Percent)   # Stop loss
+            takeProfit=Unit(3, UnitTypes.Percent),
+            stopLoss=Unit(2, UnitTypes.Percent)
         )
-
         # Setup chart visualization
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0056_Double_Bottom/double_bottom_strategy.py
+++ b/API/0056_Double_Bottom/double_bottom_strategy.py
@@ -115,11 +115,10 @@ class double_bottom_strategy(Strategy):
 
         # Enable position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit (manual exit)
-            Unit(self.StopLossPercent, UnitTypes.Percent),  # Stop loss at defined percentage
-            False  # No trailing
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent),
+            isStopTrailing=False
         )
-
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0057_Double_Top/double_top_strategy.py
+++ b/API/0057_Double_Top/double_top_strategy.py
@@ -115,11 +115,10 @@ class double_top_strategy(Strategy):
 
         # Enable position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit (manual exit)
-            Unit(self.StopLossPercent, UnitTypes.Percent),  # Stop loss at defined percentage
-            False  # No trailing
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent),
+            isStopTrailing=False
         )
-
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0058_RSI_Overbought_Oversold/rsi_overbought_oversold_strategy.py
+++ b/API/0058_RSI_Overbought_Oversold/rsi_overbought_oversold_strategy.py
@@ -113,11 +113,10 @@ class rsi_overbought_oversold_strategy(Strategy):
 
         # Enable position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit (will exit at neutral RSI)
-            Unit(self.StopLossPercent, UnitTypes.Percent),  # Stop loss at defined percentage
-            False  # No trailing stop
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent),
+            isStopTrailing=False
         )
-
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0059_Hammer_Candle/hammer_candle_strategy.py
+++ b/API/0059_Hammer_Candle/hammer_candle_strategy.py
@@ -63,10 +63,9 @@ class hammer_candle_strategy(Strategy):
 
         # Setup stop loss/take profit protection
         self.StartProtection(
-            Unit(2, UnitTypes.Percent),  # Take profit
-            Unit(1, UnitTypes.Percent)   # Stop loss
+            takeProfit=Unit(2, UnitTypes.Percent),
+            stopLoss=Unit(1, UnitTypes.Percent)
         )
-
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0060_Shooting_Star/shooting_star_strategy.py
+++ b/API/0060_Shooting_Star/shooting_star_strategy.py
@@ -111,11 +111,10 @@ class shooting_star_strategy(Strategy):
 
         # Enable position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit (manual exit)
-            Unit(self.StopLossPercent, UnitTypes.Percent),  # Stop loss above shooting star's high
-            False  # No trailing
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent),
+            isStopTrailing=False
         )
-
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0061_MACD_Divergence/macd_divergence_strategy.py
+++ b/API/0061_MACD_Divergence/macd_divergence_strategy.py
@@ -147,11 +147,10 @@ class macd_divergence_strategy(Strategy):
 
         # Enable position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit (managed by signal cross)
-            Unit(self.StopLossPercent, UnitTypes.Percent),  # Stop loss at defined percentage
-            False  # No trailing stop
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent),
+            isStopTrailing=False
         )
-
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0062_Stochastic_Overbought_Oversold/stochastic_overbought_oversold_strategy.py
+++ b/API/0062_Stochastic_Overbought_Oversold/stochastic_overbought_oversold_strategy.py
@@ -90,10 +90,9 @@ class stochastic_overbought_oversold_strategy(Strategy):
 
         # Setup stop loss/take profit protection
         self.StartProtection(
-            Unit(2, UnitTypes.Percent),  # Take profit
-            Unit(2, UnitTypes.Percent)   # Stop loss
+            takeProfit=Unit(2, UnitTypes.Percent),
+            stopLoss=Unit(2, UnitTypes.Percent)
         )
-
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0063_Engulfing_Bullish/engulfing_bullish_strategy.py
+++ b/API/0063_Engulfing_Bullish/engulfing_bullish_strategy.py
@@ -103,11 +103,10 @@ class engulfing_bullish_strategy(Strategy):
 
         # Enable position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit (manual exit)
-            Unit(self.StopLossPercent, UnitTypes.Percent),  # Stop loss below pattern's low
-            False  # No trailing
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent),
+            isStopTrailing=False
         )
-
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0064_Engulfing_Bearish/engulfing_bearish_strategy.py
+++ b/API/0064_Engulfing_Bearish/engulfing_bearish_strategy.py
@@ -103,11 +103,10 @@ class engulfing_bearish_strategy(Strategy):
 
         # Enable position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit (manual exit)
-            Unit(self.StopLossPercent, UnitTypes.Percent),  # Stop loss above pattern's high
-            False  # No trailing
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent),
+            isStopTrailing=False
         )
-
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0065_Pinbar_Reversal/pinbar_reversal_strategy.py
+++ b/API/0065_Pinbar_Reversal/pinbar_reversal_strategy.py
@@ -118,11 +118,10 @@ class pinbar_reversal_strategy(Strategy):
 
         # Enable position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit (managed by exit conditions)
-            Unit(self.StopLossPercent, UnitTypes.Percent),  # Stop loss at defined percentage
-            False  # No trailing
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent),
+            isStopTrailing=False
         )
-
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0066_Three_Bar_Reversal_Up/three_bar_reversal_up_strategy.py
+++ b/API/0066_Three_Bar_Reversal_Up/three_bar_reversal_up_strategy.py
@@ -111,11 +111,10 @@ class three_bar_reversal_up_strategy(Strategy):
 
         # Enable position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit (manual exit or on next pattern)
-            Unit(self.StopLossPercent, UnitTypes.Percent),  # Stop loss below pattern's low
-            False  # No trailing
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent),
+            isStopTrailing=False
         )
-
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0067_Three_Bar_Reversal_Down/three_bar_reversal_down_strategy.py
+++ b/API/0067_Three_Bar_Reversal_Down/three_bar_reversal_down_strategy.py
@@ -111,11 +111,10 @@ class three_bar_reversal_down_strategy(Strategy):
 
         # Enable position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit (manual exit or on next pattern)
-            Unit(self.StopLossPercent, UnitTypes.Percent),  # Stop loss above pattern's high
-            False  # No trailing
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent),
+            isStopTrailing=False
         )
-
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0068_CCI_Divergence/cci_divergence_strategy.py
+++ b/API/0068_CCI_Divergence/cci_divergence_strategy.py
@@ -145,11 +145,10 @@ class cci_divergence_strategy(Strategy):
 
         # Enable position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit (managed by exit signals)
-            Unit(self.StopLossPercent, UnitTypes.Percent),  # Stop loss at defined percentage
-            False  # No trailing stop
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent),
+            isStopTrailing=False
         )
-
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0069_Bollinger_Band_Reversal/bollinger_band_reversal_strategy.py
+++ b/API/0069_Bollinger_Band_Reversal/bollinger_band_reversal_strategy.py
@@ -107,10 +107,9 @@ class bollinger_band_reversal_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(10, UnitTypes.Percent),    # Take profit
-            Unit(self.AtrMultiplier, UnitTypes.Absolute)  # Stop loss
+            takeProfit=Unit(10, UnitTypes.Percent),
+            stopLoss=Unit(self.AtrMultiplier, UnitTypes.Absolute)
         )
-
     def ProcessCandle(self, candle, bollingerValue, atrValue):
         """
         Process candle and execute trading logic

--- a/API/0070_Morning_Star/morning_star_strategy.py
+++ b/API/0070_Morning_Star/morning_star_strategy.py
@@ -85,11 +85,10 @@ class morning_star_strategy(Strategy):
 
         # Setup trailing stop
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # no take profit, rely on exit signal
-            Unit(self.StopLossPercent, UnitTypes.Percent),  # stop loss
-            True  # trailing stop
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent),
+            isStopTrailing=True
         )
-
     def ProcessCandle(self, candle):
         """
         Process candle and execute trading logic

--- a/API/0071_Evening_Star/evening_star_strategy.py
+++ b/API/0071_Evening_Star/evening_star_strategy.py
@@ -85,11 +85,10 @@ class evening_star_strategy(Strategy):
 
         # Setup trailing stop
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # no take profit, rely on exit signal
-            Unit(self.StopLossPercent, UnitTypes.Percent),  # stop loss
-            True  # trailing stop
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent),
+            isStopTrailing=True
         )
-
     def ProcessCandle(self, candle):
         """
         Process candle and execute trading logic

--- a/API/0072_Doji_Reversal/doji_reversal_strategy.py
+++ b/API/0072_Doji_Reversal/doji_reversal_strategy.py
@@ -96,10 +96,9 @@ class doji_reversal_strategy(Strategy):
         
         # Start protection with dynamic stop-loss
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit, relying on exit signal
-            Unit(self.StopLossPercent, UnitTypes.Percent)  # Stop loss
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle):
         """
         Process candle and execute trading logic

--- a/API/0073_Keltner_Channel_Reversal/keltner_channel_reversal_strategy.py
+++ b/API/0073_Keltner_Channel_Reversal/keltner_channel_reversal_strategy.py
@@ -116,10 +116,9 @@ class keltner_channel_reversal_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit
-            Unit(self.StopLossAtrMultiplier, UnitTypes.Absolute)  # Stop loss
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossAtrMultiplier, UnitTypes.Absolute)
         )
-
     def ProcessCandle(self, candle, keltnerValue, atrValue):
         """
         Process each finished candle and execute trading logic.

--- a/API/0074_Williams_R_Divergence/williams_r_strategy.py
+++ b/API/0074_Williams_R_Divergence/williams_r_strategy.py
@@ -110,10 +110,9 @@ class williams_percent_r_divergence_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit
-            Unit(self.StopLossPercent, UnitTypes.Percent)  # Stop loss
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, williamsRValue):
         """
         Process each finished candle and execute trading logic.

--- a/API/0075_OBV_Divergence/obv_strategy.py
+++ b/API/0075_OBV_Divergence/obv_strategy.py
@@ -115,10 +115,9 @@ class obv_divergence_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit
-            Unit(self.StopLossPercent, UnitTypes.Percent)  # Stop loss
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, obvValue, maValue):
         """
         Process each finished candle and execute trading logic.

--- a/API/0076_Fibonacci_Retracement_Reversal/fibonacci_strategy.py
+++ b/API/0076_Fibonacci_Retracement_Reversal/fibonacci_strategy.py
@@ -106,10 +106,9 @@ class fibonacci_retracement_reversal_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit
-            Unit(self.StopLossPercent, UnitTypes.Percent)  # Stop loss
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle):
         """
         Process each finished candle and execute trading logic.

--- a/API/0077_Inside_Bar_Breakout/inside_bar_strategy.py
+++ b/API/0077_Inside_Bar_Breakout/inside_bar_strategy.py
@@ -78,10 +78,9 @@ class inside_bar_breakout_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(),  # No take profit
-            Unit(self.StopLossPercent, UnitTypes.Percent)  # Stop loss
+            takeProfit=Unit(),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle):
         """
         Process each finished candle and execute trading logic.

--- a/API/0078_Outside_Bar_Reversal/outside_bar_strategy.py
+++ b/API/0078_Outside_Bar_Reversal/outside_bar_strategy.py
@@ -74,10 +74,9 @@ class outside_bar_reversal_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(),  # No take profit
-            Unit(self.StopLossPercent, UnitTypes.Percent)  # Stop loss
+            takeProfit=Unit(),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle):
         """
         Process each finished candle and execute trading logic.

--- a/API/0079_Trendline_Bounce/trendline_strategy.py
+++ b/API/0079_Trendline_Bounce/trendline_strategy.py
@@ -131,10 +131,9 @@ class trendline_bounce_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit
-            Unit(self.StopLossPercent, UnitTypes.Percent)  # Stop loss
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, maPrice):
         """
         Process each finished candle and execute trading logic.

--- a/API/0080_Pivot_Point_Reversal/pivot_point_strategy.py
+++ b/API/0080_Pivot_Point_Reversal/pivot_point_strategy.py
@@ -103,10 +103,9 @@ class pivot_point_reversal_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit
-            Unit(self.StopLossPercent, UnitTypes.Percent)  # Stop loss
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
     def ProcessDailyCandle(self, candle):
         """
         Process daily candles to get previous day's OHLC data.

--- a/API/0081_VWAP_Bounce/vwap_bounce_strategy.py
+++ b/API/0081_VWAP_Bounce/vwap_bounce_strategy.py
@@ -61,12 +61,11 @@ class vwap_bounce_strategy(Strategy):
 
         # Enable position protection using stop-loss
         self.StartProtection(
-            None,  # No take profit
-            self.StopLoss,  # Stop loss
-            False,  # Not trailing
-            True   # Use market orders
+            takeProfit=None,
+            stopLoss=self.StopLoss,
+            isStopTrailing=False,
+            useMarketOrders=True
         )
-
         # Initialize VWAP
         self._prevVwap = 0.0
 

--- a/API/0082_Volume_Exhaustion/volume_exhaustion_strategy.py
+++ b/API/0082_Volume_Exhaustion/volume_exhaustion_strategy.py
@@ -131,11 +131,10 @@ class volume_exhaustion_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(),  # No take profit
-            Unit(self.StopLossPercent, UnitTypes.Percent),  # Stop loss
-            True  # Use market orders
+            takeProfit=Unit(),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent),
+            isStopTrailing=True
         )
-
     def ProcessCandle(self, candle, maValue, atrValue, volumeAvgValue):
         """
         Process candle with indicator values.

--- a/API/0083_ADX_Weakening/adx_weakening_strategy.py
+++ b/API/0083_ADX_Weakening/adx_weakening_strategy.py
@@ -93,12 +93,11 @@ class adx_weakening_strategy(Strategy):
 
         # Enable position protection using stop-loss
         self.StartProtection(
-            None,            # takeProfit: null
-            self.StopLoss,   # stopLoss
-            False,           # isStopTrailing
-            True             # useMarketOrders
+            takeProfit=None,
+            stopLoss=self.StopLoss,
+            isStopTrailing=False,
+            useMarketOrders=True
         )
-
         # Initialize previous ADX value
         self._prevAdxValue = 0.0
 

--- a/API/0084_ATR_Exhaustion/atr_exhaustion_strategy.py
+++ b/API/0084_ATR_Exhaustion/atr_exhaustion_strategy.py
@@ -117,8 +117,10 @@ class atr_exhaustion_strategy(Strategy):
         super(atr_exhaustion_strategy, self).OnStarted(time)
 
         # Enable position protection using stop-loss
-        self.StartProtection(None, self.StopLoss)
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=self.StopLoss
+        )
         # Create indicators
         ma = SimpleMovingAverage()
         ma.Length = self.MaPeriod

--- a/API/0085_Ichimoku_Tenkan/ichimoku_tenkan_kijun_strategy.py
+++ b/API/0085_Ichimoku_Tenkan/ichimoku_tenkan_kijun_strategy.py
@@ -119,8 +119,10 @@ class ichimoku_tenkan_kijun_strategy(Strategy):
             self.DrawIndicator(area, self._ichimoku)
             self.DrawOwnTrades(area)
 
-        self.StartProtection(None, Unit(self.stop_loss_percent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
+        )
     def ProcessCandle(self, candle, ichimoku_value):
         """Process candle with Ichimoku indicator values.
 

--- a/API/0086_Heikin_Ashi_Reversal/heikin_ashi_reversal_strategy.py
+++ b/API/0086_Heikin_Ashi_Reversal/heikin_ashi_reversal_strategy.py
@@ -55,8 +55,12 @@ class heikin_ashi_reversal_strategy(Strategy):
         super(heikin_ashi_reversal_strategy, self).OnStarted(time)
 
         # Enable position protection using stop-loss
-        self.StartProtection(None, self.StopLoss, False, True)
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=self.StopLoss,
+            isStopTrailing=False,
+            useMarketOrders=True
+        )
         # Initialize previous value
         self._prevIsBullish = None
 

--- a/API/0089_Hull_MA_Reversal/hull_ma_reversal_strategy.py
+++ b/API/0089_Hull_MA_Reversal/hull_ma_reversal_strategy.py
@@ -102,11 +102,10 @@ class hull_ma_reversal_strategy(Strategy):
             self.DrawOwnTrades(area)
 
         self.StartProtection(
-            Unit(0),
-            Unit(self.StopLossPercent, UnitTypes.Percent),
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent),
             useMarketOrders=True
         )
-
     def ProcessCandle(self, candle: ICandleMessage, hmaValue: float, atrValue: float):
         """
         Process candle with indicator values.

--- a/API/0090_Donchian_Reversal/donchian_reversal_strategy.py
+++ b/API/0090_Donchian_Reversal/donchian_reversal_strategy.py
@@ -82,12 +82,11 @@ class donchian_reversal_strategy(Strategy):
 
         # Enable position protection using stop-loss
         self.StartProtection(
-            None,
-            self.StopLoss,
-            False,
-            True
+            takeProfit=None,
+            stopLoss=self.StopLoss,
+            isStopTrailing=False,
+            useMarketOrders=True
         )
-
         # Initialize state
         self._previous_close = 0.0
         self._is_first_candle = True

--- a/API/0091_MACD_Histogram_Reversal/macd_histogram_reversal_strategy.py
+++ b/API/0091_MACD_Histogram_Reversal/macd_histogram_reversal_strategy.py
@@ -104,8 +104,10 @@ class macd_histogram_reversal_strategy(Strategy):
         super(macd_histogram_reversal_strategy, self).OnStarted(time)
 
         # Enable position protection using stop-loss
-        self.StartProtection(None, self.StopLoss)
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=self.StopLoss
+        )
         # Initialize state
         self._prevHistogram = None
 

--- a/API/0092_RSI_Hook_Reversal/rsi_hook_reversal_strategy.py
+++ b/API/0092_RSI_Hook_Reversal/rsi_hook_reversal_strategy.py
@@ -102,8 +102,12 @@ class rsi_hook_reversal_strategy(Strategy):
         super(rsi_hook_reversal_strategy, self).OnStarted(time)
 
         # Enable position protection using stop-loss
-        self.StartProtection(None, self.stop_loss, False, True)
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=self.stop_loss,
+            isStopTrailing=False,
+            useMarketOrders=True
+        )
         # Initialize previous RSI value
         self._prev_rsi = 0.0
 

--- a/API/0093_Stochastic_Hook_Reversal/stochastic_hook_reversal_strategy.py
+++ b/API/0093_Stochastic_Hook_Reversal/stochastic_hook_reversal_strategy.py
@@ -130,8 +130,10 @@ class stochastic_hook_reversal_strategy(Strategy):
         super(stochastic_hook_reversal_strategy, self).OnStarted(time)
 
         # Enable position protection using stop-loss
-        self.StartProtection(None, self.StopLoss)
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=self.StopLoss
+        )
         # Initialize previous K value
         self._prev_k = 0.0
 

--- a/API/0094_CCI_Hook_Reversal/cci_hook_reversal_strategy.py
+++ b/API/0094_CCI_Hook_Reversal/cci_hook_reversal_strategy.py
@@ -98,12 +98,11 @@ class cci_hook_reversal_strategy(Strategy):
 
         # Enable position protection using stop-loss
         self.StartProtection(
-            None,
-            Unit(self.stop_loss_percent, UnitTypes.Percent),
-            False,
-            True
+            takeProfit=None,
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent),
+            isStopTrailing=False,
+            useMarketOrders=True
         )
-
         # Initialize previous CCI value
         self._prev_cci = 0.0
 

--- a/API/0095_Williams_R_Hook_Reversal/williams_r_hook_reversal_strategy.py
+++ b/API/0095_Williams_R_Hook_Reversal/williams_r_hook_reversal_strategy.py
@@ -120,7 +120,6 @@ class williams_r_hook_reversal_strategy(Strategy):
             isStopTrailing=False,
             useMarketOrders=True
         )
-
         # Initialize previous Williams %R value
         self._prevWillR = 0.0
 

--- a/API/0096_Three_White_Soldiers/three_white_soldiers_strategy.py
+++ b/API/0096_Three_White_Soldiers/three_white_soldiers_strategy.py
@@ -99,7 +99,6 @@ class three_white_soldiers_strategy(Strategy):
             stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent),
             isStopTrailing=False
         )
-
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0097_Three_Black_Crows/three_black_crows_strategy.py
+++ b/API/0097_Three_Black_Crows/three_black_crows_strategy.py
@@ -99,8 +99,10 @@ class three_black_crows_strategy(Strategy):
         subscription.Bind(ma, self.ProcessCandle).Start()
 
         # Setup protection with stop loss
-        self.StartProtection(None, Unit(self.StopLossPercent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
+        )
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0098_Gap_Fill_Reversal/gap_fill_reversal_strategy.py
+++ b/API/0098_Gap_Fill_Reversal/gap_fill_reversal_strategy.py
@@ -85,7 +85,6 @@ class gap_fill_reversal_strategy(Strategy):
             stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent),
             isStopTrailing=False
         )
-
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0099_Tweezer_Bottom/tweezer_bottom_strategy.py
+++ b/API/0099_Tweezer_Bottom/tweezer_bottom_strategy.py
@@ -81,7 +81,6 @@ class tweezer_bottom_strategy(Strategy):
             stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent),
             isStopTrailing=False
         )
-
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0100_Tweezer_Top/tweezer_top_strategy.py
+++ b/API/0100_Tweezer_Top/tweezer_top_strategy.py
@@ -90,7 +90,6 @@ class tweezer_top_strategy(Strategy):
             stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent),
             isStopTrailing=False
         )
-
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0101_Harami_Bullish/harami_bullish_strategy.py
+++ b/API/0101_Harami_Bullish/harami_bullish_strategy.py
@@ -75,8 +75,10 @@ class harami_bullish_strategy(Strategy):
         subscription.Bind(self.ProcessCandle).Start()
 
         # Enable stop-loss protection
-        self.StartProtection(Unit(0), Unit(self.StopLossPercent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
+        )
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0102_Harami_Bearish/harami_bearish_strategy.py
+++ b/API/0102_Harami_Bearish/harami_bearish_strategy.py
@@ -64,8 +64,10 @@ class harami_bearish_strategy(Strategy):
         subscription.Bind(self.ProcessCandle).Start()
 
         # Enable stop-loss protection
-        self.StartProtection(Unit(0), Unit(self.StopLossPercent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
+        )
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0103_Dark_Pool_Prints/dark_pool_prints_strategy.py
+++ b/API/0103_Dark_Pool_Prints/dark_pool_prints_strategy.py
@@ -111,8 +111,10 @@ class dark_pool_prints_strategy(Strategy):
         subscription.BindEx(self._ma, self._volume_average, self._adx, self._atr, self.ProcessCandle).Start()
 
         # Enable stop-loss protection
-        self.StartProtection(Unit(0), Unit(self.AtrMultiplier, UnitTypes.Absolute))
-
+        self.StartProtection(
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.AtrMultiplier, UnitTypes.Absolute)
+        )
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0104_Rejection_Candle/rejection_candle_strategy.py
+++ b/API/0104_Rejection_Candle/rejection_candle_strategy.py
@@ -80,8 +80,10 @@ class rejection_candle_strategy(Strategy):
         subscription.Bind(self.ProcessCandle).Start()
 
         # Enable stop-loss protection
-        self.StartProtection(Unit(0), Unit(self.stop_loss_percent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
+        )
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0105_False_Breakout_Trap/false_breakout_trap_strategy.py
+++ b/API/0105_False_Breakout_Trap/false_breakout_trap_strategy.py
@@ -120,8 +120,10 @@ class false_breakout_trap_strategy(Strategy):
         subscription.Bind(self._ma, self._highest, self._lowest, self.ProcessCandle).Start()
 
         # Enable stop-loss protection
-        self.StartProtection(Unit(0), Unit(self.stop_loss_percent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
+        )
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0106_Spring_Reversal/spring_reversal_strategy.py
+++ b/API/0106_Spring_Reversal/spring_reversal_strategy.py
@@ -95,8 +95,10 @@ class spring_reversal_strategy(Strategy):
         subscription.Bind(self._ma, self._lowest, self.ProcessCandle).Start()
 
         # Enable stop-loss protection
-        self.StartProtection(Unit(0), Unit(self.StopLossPercent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
+        )
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0107_Upthrust_Reversal/upthrust_reversal_strategy.py
+++ b/API/0107_Upthrust_Reversal/upthrust_reversal_strategy.py
@@ -108,8 +108,10 @@ class upthrust_reversal_strategy(Strategy):
         subscription.Bind(self._ma, self._highest, self.ProcessCandle).Start()
 
         # Enable stop-loss protection
-        self.StartProtection(Unit(0), Unit(self.StopLossPercent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
+        )
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0108_Wyckoff_Accumulation/wyckoff_accumulation_strategy.py
+++ b/API/0108_Wyckoff_Accumulation/wyckoff_accumulation_strategy.py
@@ -142,8 +142,10 @@ class wyckoff_accumulation_strategy(Strategy):
         subscription.Bind(self._ma, self._volumeAvg, self._highest, self._lowest, self.ProcessCandle).Start()
 
         # Enable stop-loss protection
-        self.StartProtection(Unit(0), Unit(self.StopLossPercent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
+        )
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0109_Wyckoff_Distribution/wyckoff_distribution_strategy.py
+++ b/API/0109_Wyckoff_Distribution/wyckoff_distribution_strategy.py
@@ -128,8 +128,10 @@ class wyckoff_distribution_strategy(Strategy):
         subscription.Bind(self._ma, self._volume_avg, self._highest, self._lowest, self.ProcessCandle).Start()
 
         # Enable stop-loss protection
-        self.StartProtection(Unit(0), Unit(self.stop_loss_percent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
+        )
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0110_RSI_Failure_Swing/rsi_failure_swing_strategy.py
+++ b/API/0110_RSI_Failure_Swing/rsi_failure_swing_strategy.py
@@ -108,8 +108,10 @@ class rsi_failure_swing_strategy(Strategy):
         subscription.Bind(self._rsi, self.ProcessCandle).Start()
 
         # Enable stop-loss protection
-        self.StartProtection(Unit(0, UnitTypes.Absolute), Unit(self.StopLossPercent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
+        )
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0111_Stochastic_Failure_Swing/stochastic_failure_swing_strategy.py
+++ b/API/0111_Stochastic_Failure_Swing/stochastic_failure_swing_strategy.py
@@ -144,8 +144,10 @@ class stochastic_failure_swing_strategy(Strategy):
         subscription.BindEx(self._stochastic, self.ProcessCandle).Start()
 
         # Enable stop-loss protection
-        self.StartProtection(Unit(0), Unit(self.stop_loss_percent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
+        )
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0112_CCI_Failure_Swing/cci_failure_swing_strategy.py
+++ b/API/0112_CCI_Failure_Swing/cci_failure_swing_strategy.py
@@ -125,8 +125,10 @@ class cci_failure_swing_strategy(Strategy):
         subscription.Bind(self._cci, self.ProcessCandle).Start()
 
         # Enable stop-loss protection
-        self.StartProtection(Unit(0), Unit(self.stop_loss_percent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
+        )
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0113_Bullish_Abandoned_Baby/bullish_abandoned_baby_strategy.py
+++ b/API/0113_Bullish_Abandoned_Baby/bullish_abandoned_baby_strategy.py
@@ -66,11 +66,10 @@ class bullish_abandoned_baby_strategy(Strategy):
 
         # Configure protection for open positions
         self.StartProtection(
-            Unit(0),  # No take profit, using exit logic in the strategy
-            Unit(self.StopLossPercent, UnitTypes.Percent),
-            False
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent),
+            isStopTrailing=False
         )
-
         # Set up chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0114_Bearish_Abandoned_Baby/bearish_abandoned_baby_strategy.py
+++ b/API/0114_Bearish_Abandoned_Baby/bearish_abandoned_baby_strategy.py
@@ -70,11 +70,10 @@ class bearish_abandoned_baby_strategy(Strategy):
 
         # Configure protection for open positions
         self.StartProtection(
-            takeProfit=Unit(0),  # No take profit, using exit logic in the strategy
+            takeProfit=Unit(0),
             stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent),
             isStopTrailing=False
         )
-
         # Set up chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0116_Day_of_Week/day_of_week_strategy.py
+++ b/API/0116_Day_of_Week/day_of_week_strategy.py
@@ -78,10 +78,9 @@ class day_of_week_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit
-            Unit(self.stop_loss_percent, UnitTypes.Percent)
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, ma_value):
         """
         Processes candles and executes trading logic.

--- a/API/0117_Month_of_Year/month_of_year_strategy.py
+++ b/API/0117_Month_of_Year/month_of_year_strategy.py
@@ -79,10 +79,9 @@ class month_of_year_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(0),  # No take profit
-            Unit(self.stop_loss_percent, UnitTypes.Percent),
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, ma_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0118_Turnaround_Tuesday/turnaround_tuesday_strategy.py
+++ b/API/0118_Turnaround_Tuesday/turnaround_tuesday_strategy.py
@@ -84,8 +84,10 @@ class turnaround_tuesday_strategy(Strategy):
             self.DrawOwnTrades(area)
 
         # Start position protection
-        self.StartProtection(Unit(0), Unit(self.stop_loss_percent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
+        )
     def ProcessCandle(self, candle, ma_value):
         """Process each finished candle."""
         # Skip unfinished candles

--- a/API/0119_End_of_Month_Strength/end_of_month_strength_strategy.py
+++ b/API/0119_End_of_Month_Strength/end_of_month_strength_strategy.py
@@ -85,10 +85,9 @@ class end_of_month_strength_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(0),  # No take profit
-            Unit(self.StopLossPercent, UnitTypes.Percent)
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, maValue):
         """Process finished candle and execute trading logic."""
         # Skip unfinished candles

--- a/API/0120_First_Day_of_Month/first_day_of_month_strategy.py
+++ b/API/0120_First_Day_of_Month/first_day_of_month_strategy.py
@@ -86,10 +86,9 @@ class first_day_of_month_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            takeProfit=Unit(0),  # No take profit
-            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent),
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, ma_value):
         """Process candle and execute trading logic."""
         # Skip unfinished candles

--- a/API/0121_Santa_Claus_Rally/santa_claus_rally_strategy.py
+++ b/API/0121_Santa_Claus_Rally/santa_claus_rally_strategy.py
@@ -87,10 +87,9 @@ class santa_claus_rally_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(0),  # No take profit
-            Unit(self.StopLossPercent, UnitTypes.Percent)
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, ma_value):
         """
         Process candle and execute trading logic

--- a/API/0122_January_Effect/january_effect_strategy.py
+++ b/API/0122_January_Effect/january_effect_strategy.py
@@ -84,10 +84,9 @@ class january_effect_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            takeProfit=Unit(0),  # No take profit
+            takeProfit=Unit(0),
             stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, ma_value):
         """
         Processes each finished candle and executes January Effect trading logic.

--- a/API/0123_Monday_Weakness/monday_weakness_strategy.py
+++ b/API/0123_Monday_Weakness/monday_weakness_strategy.py
@@ -81,10 +81,9 @@ class monday_weakness_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(0),  # No take profit
-            Unit(self.stop_loss_percent, UnitTypes.Percent)
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, ma_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0124_Pre-Holiday_Strength/pre_holiday_strength_strategy.py
+++ b/API/0124_Pre-Holiday_Strength/pre_holiday_strength_strategy.py
@@ -99,10 +99,9 @@ class pre_holiday_strength_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(0),  # No take profit
-            Unit(self.StopLossPercent, UnitTypes.Percent)
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, ma_value):
         """Process candle and execute trading logic"""
         # Skip unfinished candles

--- a/API/0125_Post-Holiday_Weakness/post_holiday_weakness_strategy.py
+++ b/API/0125_Post-Holiday_Weakness/post_holiday_weakness_strategy.py
@@ -95,10 +95,9 @@ class post_holiday_weakness_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            takeProfit=Unit(0),  # No take profit
+            takeProfit=Unit(0),
             stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, ma_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0126_Quarterly_Expiry/quarterly_expiry_strategy.py
+++ b/API/0126_Quarterly_Expiry/quarterly_expiry_strategy.py
@@ -82,10 +82,9 @@ class quarterly_expiry_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            takeProfit=Unit(0),  # No take profit
+            takeProfit=Unit(0),
             stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, ma_value):
         """
         Processes each finished candle and executes trading logic for quarterly expiry days.

--- a/API/0127_Open_Drive/open_drive_strategy.py
+++ b/API/0127_Open_Drive/open_drive_strategy.py
@@ -101,11 +101,10 @@ class open_drive_strategy(Strategy):
 
         # Start position protection using ATR for stops
         self.StartProtection(
-            Unit(0),  # No take profit
-            Unit(2 * self.atr_multiplier, UnitTypes.Absolute),  # 2 * ATR for stop loss
-            True
+            takeProfit=Unit(0),
+            stopLoss=Unit(2 * self.atr_multiplier, UnitTypes.Absolute),
+            isStopTrailing=True
         )
-
     def ProcessCandle(self, candle, sma_value, atr_value):
         """Process candle and execute trading logic."""
         # Skip if we don't have the previous close price yet

--- a/API/0128_Midday_Reversal/midday_reversal_strategy.py
+++ b/API/0128_Midday_Reversal/midday_reversal_strategy.py
@@ -70,10 +70,9 @@ class midday_reversal_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            takeProfit=Unit(0),  # No take profit
-            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent),
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0129_Overnight_Gap/overnight_gap_strategy.py
+++ b/API/0129_Overnight_Gap/overnight_gap_strategy.py
@@ -91,10 +91,9 @@ class overnight_gap_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            takeProfit=Unit(0, UnitTypes.Absolute),  # No take profit
-            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent),
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, ma_value):
         """Processes each finished candle and executes trading logic.
 

--- a/API/0130_Lunch_Break_Fade/lunch_break_fade_strategy.py
+++ b/API/0130_Lunch_Break_Fade/lunch_break_fade_strategy.py
@@ -73,10 +73,9 @@ class lunch_break_fade_strategy(Strategy):
 
         # Set up stop loss protection
         self.StartProtection(
-            Unit(0),  # No take profit
-            Unit(self.StopLossPercent, UnitTypes.Percent)  # Stop loss based on parameter
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
         # Create candle subscription for the specified timeframe
         subscription = self.SubscribeCandles(self.CandleType)
 

--- a/API/0131_MACD_RSI/macd_rsi_strategy.py
+++ b/API/0131_MACD_RSI/macd_rsi_strategy.py
@@ -142,10 +142,9 @@ class macd_rsi_strategy(Strategy):
 
         # Set up stop loss protection
         self.StartProtection(
-            Unit(0),  # No take profit
-            Unit(self.stop_loss_percent, UnitTypes.Percent)  # Stop loss based on parameter
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
         )
-
         # Create indicators
         macd = MovingAverageConvergenceDivergenceSignal()
         macd.Macd.ShortMa.Length = self.macd_fast

--- a/API/0133_MA_Volume/ma_volume_strategy.py
+++ b/API/0133_MA_Volume/ma_volume_strategy.py
@@ -101,10 +101,9 @@ class ma_volume_strategy(Strategy):
 
         # Set up stop loss protection
         self.StartProtection(
-            Unit(0),  # No take profit
-            Unit(self.stop_loss_percent, UnitTypes.Percent)  # Stop loss based on parameter
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
         )
-
         # Initialize indicators
         self._price_sma = SimpleMovingAverage()
         self._price_sma.Length = self.ma_period

--- a/API/0135_Ichimoku_RSI/ichimoku_rsi_strategy.py
+++ b/API/0135_Ichimoku_RSI/ichimoku_rsi_strategy.py
@@ -143,10 +143,9 @@ class ichimoku_rsi_strategy(Strategy):
 
         # Set up stop loss protection
         self.StartProtection(
-            Unit(0),  # No take profit
-            Unit(self.StopLossPercent, UnitTypes.Percent)  # Stop loss based on parameter
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
         # Create indicators
         ichimoku = Ichimoku()
         ichimoku.Tenkan.Length = self.TenkanPeriod

--- a/API/0137_Bollinger_RSI/bollinger_rsi_strategy.py
+++ b/API/0137_Bollinger_RSI/bollinger_rsi_strategy.py
@@ -145,10 +145,9 @@ class bollinger_rsi_strategy(Strategy):
 
         # Setup position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit
-            Unit(self.StopLossAtr, UnitTypes.Absolute)  # Stop loss as ATR multiplier
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossAtr, UnitTypes.Absolute)
         )
-
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0138_MA_Stochastic/ma_stochastic_strategy.py
+++ b/API/0138_MA_Stochastic/ma_stochastic_strategy.py
@@ -154,10 +154,9 @@ class ma_stochastic_strategy(Strategy):
 
         # Setup position protection
         self.StartProtection(
-            takeProfit=Unit(0, UnitTypes.Absolute),  # No take profit
-            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)  # Stop loss as percentage
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0139_ATR_MACD/atr_macd_strategy.py
+++ b/API/0139_ATR_MACD/atr_macd_strategy.py
@@ -187,10 +187,9 @@ class atr_macd_strategy(Strategy):
 
         # Setup position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit
-            Unit(self.StopLossAtr, UnitTypes.Absolute)  # Stop loss as ATR multiplier
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossAtr, UnitTypes.Absolute)
         )
-
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0140_VWAP_RSI/vwap_rsi_strategy.py
+++ b/API/0140_VWAP_RSI/vwap_rsi_strategy.py
@@ -100,10 +100,9 @@ class vwap_rsi_strategy(Strategy):
 
         # Setup position protection
         self.StartProtection(
-            takeProfit=Unit(0, UnitTypes.Absolute),  # No take profit
-            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)  # Stop loss as percentage
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0141_Donchian_Volume/donchian_volume_strategy.py
+++ b/API/0141_Donchian_Volume/donchian_volume_strategy.py
@@ -120,10 +120,9 @@ class donchian_volume_strategy(Strategy):
 
         # Setup position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit
-            Unit(self.stop_loss_percent, UnitTypes.Percent)  # Stop loss as percentage
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
         )
-
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0142_Keltner_Stochastic/keltner_stochastic_strategy.py
+++ b/API/0142_Keltner_Stochastic/keltner_stochastic_strategy.py
@@ -192,10 +192,9 @@ class keltner_stochastic_strategy(Strategy):
 
         # Setup position protection
         self.StartProtection(
-            takeProfit=Unit(0, UnitTypes.Absolute),  # No take profit
-            stopLoss=Unit(self.StopLossAtr, UnitTypes.Absolute)  # Stop loss as ATR multiplier
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossAtr, UnitTypes.Absolute)
         )
-
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0143_Parabolic_SAR_RSI/parabolic_sar_rsi_strategy.py
+++ b/API/0143_Parabolic_SAR_RSI/parabolic_sar_rsi_strategy.py
@@ -130,10 +130,9 @@ class parabolic_sar_rsi_strategy(Strategy):
 
         # Enable dynamic stop-loss using Parabolic SAR
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit
-            Unit(0, UnitTypes.Absolute)   # No fixed stop loss - using dynamic SAR
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(0, UnitTypes.Absolute)
         )
-
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0144_Hull_MA_Volume/hull_ma_volume_strategy.py
+++ b/API/0144_Hull_MA_Volume/hull_ma_volume_strategy.py
@@ -141,8 +141,10 @@ class hull_ma_volume_strategy(Strategy):
         subscription.Bind(volume_avg, hull_ma, atr, self.ProcessIndicators).Start()
 
         # Setup position protection with ATR-based stop loss
-        self.StartProtection(Unit(0, UnitTypes.Absolute), Unit(self.stop_loss_atr, UnitTypes.Absolute))
-
+        self.StartProtection(
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.stop_loss_atr, UnitTypes.Absolute)
+        )
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0145_ADX_Stochastic/adx_stochastic_strategy.py
+++ b/API/0145_ADX_Stochastic/adx_stochastic_strategy.py
@@ -176,10 +176,9 @@ class adx_stochastic_strategy(Strategy):
 
         # Setup position protection
         self.StartProtection(
-            takeProfit=Unit(0, UnitTypes.Absolute),  # No take profit
-            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)  # Percentage-based stop loss
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0146_MACD_Volume/macd_volume_strategy.py
+++ b/API/0146_MACD_Volume/macd_volume_strategy.py
@@ -161,10 +161,9 @@ class macd_volume_strategy(Strategy):
 
         # Setup position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit
-            Unit(self.stop_loss_percent, UnitTypes.Percent)  # Percentage-based stop loss
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
         )
-
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0147_Bollinger_Volume/bollinger_volume_strategy.py
+++ b/API/0147_Bollinger_Volume/bollinger_volume_strategy.py
@@ -141,10 +141,9 @@ class bollinger_volume_strategy(Strategy):
 
         # Setup position protection with ATR-based stop loss
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit
-            Unit(self.StopLossAtr, UnitTypes.Absolute)  # ATR-based stop loss
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossAtr, UnitTypes.Absolute)
         )
-
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0148_RSI_Stochastic/rsi_stochastic_strategy.py
+++ b/API/0148_RSI_Stochastic/rsi_stochastic_strategy.py
@@ -191,10 +191,9 @@ class rsi_stochastic_strategy(Strategy):
 
         # Setup position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit
-            Unit(self.stop_loss_percent, UnitTypes.Percent)  # Percentage-based stop loss
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
         )
-
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0149_MA_ADX/ma_adx_strategy.py
+++ b/API/0149_MA_ADX/ma_adx_strategy.py
@@ -133,10 +133,9 @@ class ma_adx_strategy(Strategy):
 
         # Enable stop-loss and take-profit
         self.StartProtection(
-            Unit(self.take_profit_atr_multiplier, UnitTypes.Absolute),
-            Unit(self.stop_loss_percent, UnitTypes.Percent)
+            takeProfit=Unit(self.take_profit_atr_multiplier, UnitTypes.Absolute),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
         )
-
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0150_VWAP_Stochastic/vwap_stochastic_strategy.py
+++ b/API/0150_VWAP_Stochastic/vwap_stochastic_strategy.py
@@ -142,11 +142,10 @@ class vwap_stochastic_strategy(Strategy):
 
         # Enable stop-loss and take-profit protection
         self.StartProtection(
-            None,
-            Unit(self.StopLossPercent, UnitTypes.Percent),
-            True
+            takeProfit=None,
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent),
+            isStopTrailing=True
         )
-
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0151_Ichimoku_Volume/ichimoku_volume_strategy.py
+++ b/API/0151_Ichimoku_Volume/ichimoku_volume_strategy.py
@@ -135,8 +135,10 @@ class ichimoku_volume_strategy(Strategy):
             self.DrawOwnTrades(area)
 
         # Start protective orders (stop-loss)
-        self.StartProtection(None, self.stop_loss)
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=self.stop_loss
+        )
     def ProcessCandle(self, candle, ichimoku_value):
         """Processes each finished candle and executes Ichimoku + Volume trading logic."""
         # Skip unfinished candles

--- a/API/0153_Bollinger_ADX/bollinger_adx_strategy.py
+++ b/API/0153_Bollinger_ADX/bollinger_adx_strategy.py
@@ -131,12 +131,11 @@ class bollinger_adx_strategy(Strategy):
 
         # Enable stop-loss using ATR
         self.StartProtection(
-            None,
-            Unit(self.atr_multiplier, UnitTypes.Absolute),
-            False,
-            True
+            takeProfit=None,
+            stopLoss=Unit(self.atr_multiplier, UnitTypes.Absolute),
+            isStopTrailing=False,
+            useMarketOrders=True
         )
-
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0154_MA_CCI/ma_cci_strategy.py
+++ b/API/0154_MA_CCI/ma_cci_strategy.py
@@ -134,10 +134,9 @@ class ma_cci_strategy(Strategy):
 
         # Enable stop-loss
         self.StartProtection(
-            None,
-            Unit(self.StopLossPercent, UnitTypes.Percent)
+            takeProfit=None,
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0155_VWAP_Volume/vwap_volume_strategy.py
+++ b/API/0155_VWAP_Volume/vwap_volume_strategy.py
@@ -108,7 +108,6 @@ class vwap_volume_strategy(Strategy):
             isStopTrailing=False,
             useMarketOrders=True
         )
-
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0156_Donchian_RSI/donchian_rsi_strategy.py
+++ b/API/0156_Donchian_RSI/donchian_rsi_strategy.py
@@ -133,12 +133,11 @@ class donchian_rsi_strategy(Strategy):
 
         # Enable stop-loss
         self.StartProtection(
-            None,
-            Unit(self.stop_loss_percent, UnitTypes.Percent),
-            False,
-            True
+            takeProfit=None,
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent),
+            isStopTrailing=False,
+            useMarketOrders=True
         )
-
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0157_Keltner_Volume/keltner_volume_strategy.py
+++ b/API/0157_Keltner_Volume/keltner_volume_strategy.py
@@ -155,8 +155,10 @@ class keltner_volume_strategy(Strategy):
             self.DrawOwnTrades(area)
 
         # Start protective orders
-        self.StartProtection(None, self.StopLoss)
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=self.StopLoss
+        )
     def ProcessCandle(self, candle, emaValue, atrValue):
         if candle.State != CandleStates.Finished:
             return

--- a/API/0159_Hull_MA_RSI/hull_ma_rsi_strategy.py
+++ b/API/0159_Hull_MA_RSI/hull_ma_rsi_strategy.py
@@ -148,8 +148,10 @@ class hull_ma_rsi_strategy(Strategy):
             self.DrawOwnTrades(area)
 
         # Start protective orders
-        self.StartProtection(None, self.stop_loss)
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=self.stop_loss
+        )
     def ProcessCandle(self, candle, hma_value, rsi_value):
         """Process candle and apply trading rules."""
         if candle.State != CandleStates.Finished:

--- a/API/0160_ADX_Volume/adx_volume_strategy.py
+++ b/API/0160_ADX_Volume/adx_volume_strategy.py
@@ -119,8 +119,10 @@ class adx_volume_strategy(Strategy):
             self.DrawOwnTrades(area)
 
         # Start protective orders
-        self.StartProtection(Unit(0, UnitTypes.Absolute), self.stop_loss)
-
+        self.StartProtection(
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=self.stop_loss
+        )
     def ProcessCandle(self, candle, adx_value):
         if candle.State != CandleStates.Finished:
             return

--- a/API/0161_MACD_CCI/macd_cci_strategy.py
+++ b/API/0161_MACD_CCI/macd_cci_strategy.py
@@ -159,8 +159,10 @@ class macd_cci_strategy(Strategy):
             self.DrawOwnTrades(area)
 
         # Start protective orders
-        self.StartProtection(Unit(0, UnitTypes.Absolute), self.StopLoss)
-
+        self.StartProtection(
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=self.StopLoss
+        )
     def ProcessCandle(self, candle, macdValue, cciValue):
         """
         Processes a finished candle and performs trading logic.

--- a/API/0162_Bollinger_CCI/bollinger_cci_strategy.py
+++ b/API/0162_Bollinger_CCI/bollinger_cci_strategy.py
@@ -141,8 +141,10 @@ class bollinger_cci_strategy(Strategy):
             self.DrawOwnTrades(area)
 
         # Start protective orders
-        self.StartProtection(Unit(0, UnitTypes.Absolute), self.StopLoss)
-
+        self.StartProtection(
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=self.StopLoss
+        )
     def ProcessCandle(self, candle, bollingerValue, cciValue):
         if candle.State != CandleStates.Finished:
             return

--- a/API/0163_RSI_Williams_R/rsi_williams_r_strategy.py
+++ b/API/0163_RSI_Williams_R/rsi_williams_r_strategy.py
@@ -159,8 +159,10 @@ class rsi_williams_r_strategy(Strategy):
             self.DrawOwnTrades(area)
 
         # Start protective orders
-        self.StartProtection(Unit(0, UnitTypes.Absolute), self.stop_loss)
-
+        self.StartProtection(
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=self.stop_loss
+        )
     def ProcessCandle(self, candle, rsi_value, williams_r_value):
         if candle.State != CandleStates.Finished:
             return

--- a/API/0164_MA_Williams_R/ma_williams_r_strategy.py
+++ b/API/0164_MA_Williams_R/ma_williams_r_strategy.py
@@ -164,8 +164,10 @@ class ma_williams_r_strategy(Strategy):
             self.DrawOwnTrades(area)
 
         # Start protective orders
-        self.StartProtection(None, self.StopLoss)
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=self.StopLoss
+        )
     def ProcessCandle(self, candle, maValue, williamsRValue):
         if candle.State != CandleStates.Finished:
             return

--- a/API/0165_VWAP_CCI/vwap_cci_strategy.py
+++ b/API/0165_VWAP_CCI/vwap_cci_strategy.py
@@ -120,8 +120,10 @@ class vwap_cci_strategy(Strategy):
             self.DrawOwnTrades(area)
 
         # Start protective orders
-        self.StartProtection(None, self.stop_loss)
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=self.stop_loss
+        )
     def ProcessCandle(self, candle, vwap_value, cci_value):
         if candle.State != CandleStates.Finished:
             return

--- a/API/0166_Donchian_Stochastic/donchian_stochastic_strategy.py
+++ b/API/0166_Donchian_Stochastic/donchian_stochastic_strategy.py
@@ -117,8 +117,10 @@ class donchian_stochastic_strategy(Strategy):
         # Enable position protection
         take_profit = Unit(0, UnitTypes.Absolute)  # No take profit - we'll exit based on strategy rules
         stop_loss = Unit(self.StopLossPercent, UnitTypes.Percent)
-        self.StartProtection(take_profit, stop_loss)
-
+        self.StartProtection(
+            takeProfit=take_profit,
+            stopLoss=stop_loss
+        )
         # Subscribe to candles and bind indicators
         subscription = self.SubscribeCandles(self.CandleType)
         subscription.BindEx(self._donchian, self._stochastic, self.ProcessCandle).Start()

--- a/API/0167_Keltner_RSI/keltner_rsi_strategy.py
+++ b/API/0167_Keltner_RSI/keltner_rsi_strategy.py
@@ -154,7 +154,6 @@ class keltner_rsi_strategy(Strategy):
             isStopTrailing=False,
             useMarketOrders=True
         )
-
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0169_Hull_MA_Stochastic/hull_ma_stochastic_strategy.py
+++ b/API/0169_Hull_MA_Stochastic/hull_ma_stochastic_strategy.py
@@ -153,10 +153,9 @@ class hull_ma_stochastic_strategy(Strategy):
 
         # Start protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),
-            Unit(self.stop_loss_percent, UnitTypes.Percent)
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, hma_value, stoch_value, atr_value):
         """Processes each finished candle and executes trading logic."""
         # Skip unfinished candles

--- a/API/0170_ADX_CCI/adx_cci_strategy.py
+++ b/API/0170_ADX_CCI/adx_cci_strategy.py
@@ -87,10 +87,9 @@ class adx_cci_strategy(Strategy):
 
         # Enable position protection with stop-loss
         self.StartProtection(
-            Unit(0),  # No take profit
-            Unit(self.StopLossPercent, UnitTypes.Percent)
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
         # Subscribe to candles and bind indicators
         subscription = self.SubscribeCandles(self.CandleType)
         subscription.BindEx(adx, cci, self.ProcessCandle).Start()

--- a/API/0171_MACD_Williams_R/macd_williams_r_strategy.py
+++ b/API/0171_MACD_Williams_R/macd_williams_r_strategy.py
@@ -123,10 +123,9 @@ class macd_williams_r_strategy(Strategy):
 
         # Enable position protection with stop-loss
         self.StartProtection(
-            Unit(0),  # No take profit
-            Unit(self.stop_loss_percent, UnitTypes.Percent),
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
         )
-
         # Subscribe to candles and bind indicators
         subscription = self.SubscribeCandles(self.candle_type)
         subscription.BindEx(macd, williams_r, self.ProcessCandle).Start()

--- a/API/0174_MACD_VWAP/macd_vwap_strategy.py
+++ b/API/0174_MACD_VWAP/macd_vwap_strategy.py
@@ -93,8 +93,10 @@ class macd_vwap_strategy(Strategy):
         vwap = VolumeWeightedMovingAverage()
 
         # Enable position protection with stop-loss
-        self.StartProtection(Unit(0), Unit(self.stop_loss_percent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
+        )
         # Subscribe to candles and bind indicators
         subscription = self.SubscribeCandles(self.candle_type)
         subscription.BindEx(macd, vwap, self.ProcessCandle).Start()

--- a/API/0185_Supertrend_Stochastic/supertrend_stochastic_strategy.py
+++ b/API/0185_Supertrend_Stochastic/supertrend_stochastic_strategy.py
@@ -152,10 +152,9 @@ class supertrend_stochastic_strategy(Strategy):
             self.DrawOwnTrades(area)
 
         self.StartProtection(
-            Unit(),
-            Unit(self.StopLossPercent, UnitTypes.Percent)
+            takeProfit=Unit(),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, supertrend_value, stochastic_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0187_Donchian_MACD/donchian_macd_strategy.py
+++ b/API/0187_Donchian_MACD/donchian_macd_strategy.py
@@ -137,8 +137,10 @@ class donchian_macd_strategy(Strategy):
         subscription.BindEx(self._donchian, self._macd, self.ProcessCandle).Start()
 
         # Setup position protection
-        self.StartProtection(Unit(0, UnitTypes.Absolute), Unit(self.StopLossPercent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
+        )
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0188_Parabolic_SAR_Volume/parabolic_sar_volume_strategy.py
+++ b/API/0188_Parabolic_SAR_Volume/parabolic_sar_volume_strategy.py
@@ -128,7 +128,6 @@ class parabolic_sar_volume_strategy(Strategy):
             stopLoss=Unit(0, UnitTypes.Absolute),
             isStopTrailing=True
         )
-
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0190_VWAP_ADX/vwap_adx_strategy.py
+++ b/API/0190_VWAP_ADX/vwap_adx_strategy.py
@@ -81,10 +81,9 @@ class vwap_adx_strategy(Strategy):
 
         # Enable position protection
         self.StartProtection(
-            Unit(self.StopLossPercent, UnitTypes.Percent),
-            Unit(self.StopLossPercent, UnitTypes.Percent)
+            takeProfit=Unit(self.StopLossPercent, UnitTypes.Percent),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
         # Create subscription and subscribe to VWAP
         subscription = self.SubscribeCandles(self.CandleType)
 

--- a/API/0194_Keltner_MACD/keltner_macd_strategy.py
+++ b/API/0194_Keltner_MACD/keltner_macd_strategy.py
@@ -189,10 +189,9 @@ class keltner_macd_strategy(Strategy):
             self.DrawOwnTrades(area)
 
         self.StartProtection(
-            Unit(0),  # No take profit - use MACD cross for exit
-            Unit(self.StopLossPercent, UnitTypes.Absolute)
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Absolute)
         )
-
     def ProcessCandle(self, candle, ema_value, atr_value, macd_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0197_Hull_MA_ADX/hull_ma_adx_strategy.py
+++ b/API/0197_Hull_MA_ADX/hull_ma_adx_strategy.py
@@ -143,10 +143,9 @@ class hull_ma_adx_strategy(Strategy):
                 self.DrawIndicator(adx_area, self._adx)
 
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit
-            Unit(self.stop_loss_percent, UnitTypes.Absolute),
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Absolute)
         )
-
     def ProcessCandle(self, candle, hma_value, adx_value, atr_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0198_VWAP_MACD/vwap_macd_strategy.py
+++ b/API/0198_VWAP_MACD/vwap_macd_strategy.py
@@ -105,9 +105,10 @@ class vwap_macd_strategy(Strategy):
         self._prev_signal = 0
 
         # Enable position protection
-        self.StartProtection(Unit(self.stop_loss_percent, UnitTypes.Percent),
-                             Unit(self.stop_loss_percent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=Unit(self.stop_loss_percent, UnitTypes.Percent),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
+        )
         # Create subscription
         subscription = self.SubscribeCandles(self.candle_type)
 

--- a/API/0201_VWAP_Williams_R/vwap_williams_r_strategy.py
+++ b/API/0201_VWAP_Williams_R/vwap_williams_r_strategy.py
@@ -82,8 +82,10 @@ class vwap_williams_r_strategy(Strategy):
         subscription.Bind(vwap, williams_r, self.ProcessCandle).Start()
 
         # Enable stop-loss protection
-        self.StartProtection(Unit(self.stop_loss_percent, UnitTypes.Percent), None)
-
+        self.StartProtection(
+            takeProfit=Unit(self.stop_loss_percent, UnitTypes.Percent),
+            stopLoss=None
+        )
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0203_Keltner_Williams_R/keltner_williams_r_strategy.py
+++ b/API/0203_Keltner_Williams_R/keltner_williams_r_strategy.py
@@ -104,8 +104,10 @@ class keltner_williams_r_strategy(Strategy):
         subscription.BindEx(keltner, williams_r, self.ProcessIndicators).Start()
 
         # Enable stop-loss protection based on ATR
-        self.StartProtection(None, Unit(2, UnitTypes.Absolute))
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=Unit(2, UnitTypes.Absolute)
+        )
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0205_Hull_MA_CCI/hull_ma_cci_strategy.py
+++ b/API/0205_Hull_MA_CCI/hull_ma_cci_strategy.py
@@ -113,8 +113,10 @@ class hull_ma_cci_strategy(Strategy):
         subscription.Bind(hull_ma, cci, atr, self.ProcessIndicators).Start()
 
         # Enable ATR-based stop protection
-        self.StartProtection(Unit(0, UnitTypes.Absolute), Unit(self.atr_multiplier, UnitTypes.Absolute))
-
+        self.StartProtection(
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.atr_multiplier, UnitTypes.Absolute)
+        )
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0206_MACD_Bollinger/macd_bollinger_strategy.py
+++ b/API/0206_MACD_Bollinger/macd_bollinger_strategy.py
@@ -159,8 +159,10 @@ class macd_bollinger_strategy(Strategy):
         subscription.BindEx(bollinger, macd, atr, self.ProcessIndicators).Start()
 
         # Enable ATR-based stop protection
-        self.StartProtection(Unit(0), Unit(self.AtrMultiplier, UnitTypes.Absolute))
-
+        self.StartProtection(
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.AtrMultiplier, UnitTypes.Absolute)
+        )
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0207_RSI_Hull_MA/rsi_hull_ma_strategy.py
+++ b/API/0207_RSI_Hull_MA/rsi_hull_ma_strategy.py
@@ -111,8 +111,10 @@ class rsi_hull_ma_strategy(Strategy):
         subscription.Bind(rsi, hull_ma, atr, self.ProcessIndicators).Start()
 
         # Enable ATR-based stop protection
-        self.StartProtection(None, Unit(self.AtrMultiplier, UnitTypes.Absolute))
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=Unit(self.AtrMultiplier, UnitTypes.Absolute)
+        )
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0208_Stochastic_Keltner/stochastic_keltner_strategy.py
+++ b/API/0208_Stochastic_Keltner/stochastic_keltner_strategy.py
@@ -149,8 +149,10 @@ class stochastic_keltner_strategy(Strategy):
         subscription.BindEx(keltner, stochastic, atr, self.ProcessIndicators).Start()
 
         # Enable ATR-based stop protection
-        self.StartProtection(Unit(0), Unit(self.AtrMultiplier, UnitTypes.Absolute))
-
+        self.StartProtection(
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.AtrMultiplier, UnitTypes.Absolute)
+        )
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0209_Volume_Supertrend/volume_supertrend_strategy.py
+++ b/API/0209_Volume_Supertrend/volume_supertrend_strategy.py
@@ -148,8 +148,8 @@ class volume_supertrend_strategy(Strategy):
         subscription.Bind(atr, handle_candle).Start()
 
         # Enable dynamic stop protection based on Supertrend value
-        self.StartProtection()
-
+        self.StartProtection(
+        )
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0210_ADX_Donchian/adx_donchian_strategy.py
+++ b/API/0210_ADX_Donchian/adx_donchian_strategy.py
@@ -119,8 +119,10 @@ class adx_donchian_strategy(Strategy):
         subscription.BindEx(donchian, adx, self.ProcessCandle).Start()
 
         # Enable percentage-based stop-loss protection
-        self.StartProtection(Unit(self.stop_loss_percent, UnitTypes.Percent), None)
-
+        self.StartProtection(
+            takeProfit=Unit(self.stop_loss_percent, UnitTypes.Percent),
+            stopLoss=None
+        )
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0211_CCI_VWAP/cci_vwap_strategy.py
+++ b/API/0211_CCI_VWAP/cci_vwap_strategy.py
@@ -98,10 +98,9 @@ class cci_vwap_strategy(Strategy):
 
         # Enable position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take-profit
-            Unit(self.stop_loss_percent, UnitTypes.Percent)  # Stop-loss as percentage
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
         )
-
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0212_Williams_R_Ichimoku/williams_ichimoku_strategy.py
+++ b/API/0212_Williams_R_Ichimoku/williams_ichimoku_strategy.py
@@ -129,10 +129,9 @@ class williams_ichimoku_strategy(Strategy):
         # Set stop-loss at Kijun-sen level
         # The actual stop level will be updated in the ProcessCandle method
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take-profit
-            Unit(0, UnitTypes.Absolute)   # Will be dynamic based on Kijun-sen
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(0, UnitTypes.Absolute)
         )
-
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0213_MA_Parabolic_SAR/ma_parabolic_sar_strategy.py
+++ b/API/0213_MA_Parabolic_SAR/ma_parabolic_sar_strategy.py
@@ -138,8 +138,10 @@ class ma_parabolic_sar_strategy(Strategy):
             self.DrawOwnTrades(area)
 
         # Start protection by take profit and stop loss (like SmaStrategy)
-        self.StartProtection(self.TakeValue, self.StopValue)
-
+        self.StartProtection(
+            takeProfit=self.TakeValue,
+            stopLoss=self.StopValue
+        )
     def ProcessCandle(self, candle, ma_value, sar_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0215_RSI_Donchian/rsi_donchian_strategy.py
+++ b/API/0215_RSI_Donchian/rsi_donchian_strategy.py
@@ -122,10 +122,9 @@ class rsi_donchian_strategy(Strategy):
 
         # Enable position protection with stop-loss
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take-profit
-            Unit(self.StopLossPercent, UnitTypes.Percent)  # Stop-loss as percentage
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0216_Mean_Reversion/mean_reversion_strategy.py
+++ b/API/0216_Mean_Reversion/mean_reversion_strategy.py
@@ -103,10 +103,9 @@ class mean_reversion_strategy(Strategy):
 
         # Enable position protection with stop-loss
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take-profit
-            Unit(self.StopLossPercent, UnitTypes.Percent)  # Stop-loss as percentage
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0217_Pairs_Trading/pairs_trading_strategy.py
+++ b/API/0217_Pairs_Trading/pairs_trading_strategy.py
@@ -138,10 +138,9 @@ class pairs_trading_strategy(Strategy):
 
         # Enable position protection with stop-loss
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take-profit
-            Unit(self.stop_loss_percent, UnitTypes.Percent)  # Stop-loss as percentage
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
         )
-
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0218_ZScore_Reversal/z_score_reversal_strategy.py
+++ b/API/0218_ZScore_Reversal/z_score_reversal_strategy.py
@@ -106,10 +106,9 @@ class z_score_reversal_strategy(Strategy):
 
         # Enable position protection with stop-loss
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take-profit
-            Unit(self.stop_loss_percent, UnitTypes.Percent)  # Stop-loss as percentage
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
         )
-
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0219_Statistical_Arbitrage/statistical_arbitrage_strategy.py
+++ b/API/0219_Statistical_Arbitrage/statistical_arbitrage_strategy.py
@@ -126,10 +126,9 @@ class statistical_arbitrage_strategy(Strategy):
 
         # Enable position protection with stop-loss
         self.StartProtection(
-            takeProfit=Unit(0, UnitTypes.Absolute),  # No take-profit
-            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)  # Stop-loss as percentage
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0220_Volatility_Breakout/volatility_breakout_strategy.py
+++ b/API/0220_Volatility_Breakout/volatility_breakout_strategy.py
@@ -99,10 +99,9 @@ class volatility_breakout_strategy(Strategy):
 
         # Enable position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit
-            Unit(self.Multiplier, UnitTypes.Absolute)  # Stop loss at 2*ATR
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.Multiplier, UnitTypes.Absolute)
         )
-
     def ProcessCandle(self, candle: ICandleMessage, sma_value: float, atr_value: float):
         """Process candle with SMA and ATR values."""
         # Skip unfinished candles

--- a/API/0221_Bollinger_Band_Squeeze/bollinger_band_squeeze_strategy.py
+++ b/API/0221_Bollinger_Band_Squeeze/bollinger_band_squeeze_strategy.py
@@ -122,10 +122,9 @@ class bollinger_band_squeeze_strategy(Strategy):
 
         # Enable position protection
         self.StartProtection(
-            takeProfit=Unit(0, UnitTypes.Absolute),  # No take profit
-            stopLoss=Unit(2, UnitTypes.Absolute)     # Stop loss at 2*ATR
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(2, UnitTypes.Absolute)
         )
-
     def ProcessCandle(self, candle, bollingerValue, atrValue):
         if candle.State != CandleStates.Finished:
             return

--- a/API/0222_Cointegration_Pairs/cointegration_pairs_strategy.py
+++ b/API/0222_Cointegration_Pairs/cointegration_pairs_strategy.py
@@ -153,10 +153,9 @@ class cointegration_pairs_strategy(Strategy):
 
         # Enable position protection with stop loss
         self.StartProtection(
-            takeProfit=Unit(0, UnitTypes.Absolute),  # No take profit
-            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)  # Stop loss percentage
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
     def ProcessAsset1Candle(self, candle):
         if candle.State != CandleStates.Finished:
             return

--- a/API/0223_Momentum_Divergence/momentum_divergence_strategy.py
+++ b/API/0223_Momentum_Divergence/momentum_divergence_strategy.py
@@ -108,10 +108,9 @@ class momentum_divergence_strategy(Strategy):
 
         # Enable position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit
-            Unit(2, UnitTypes.Percent)    # 2% stop loss
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(2, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, momentumValue, smaValue):
         """
         Process candle and execute divergence-based trading logic.

--- a/API/0224_ATR_Mean_Reversion/atr_mean_reversion_strategy.py
+++ b/API/0224_ATR_Mean_Reversion/atr_mean_reversion_strategy.py
@@ -101,10 +101,9 @@ class atr_mean_reversion_strategy(Strategy):
 
         # Enable position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit
-            Unit(2, UnitTypes.Absolute)   # Stop loss at 2*ATR
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(2, UnitTypes.Absolute)
         )
-
     def ProcessCandle(self, candle, sma_value, atr_value):
         if candle.State != CandleStates.Finished:
             return

--- a/API/0225_Kalman_Filter_Trend/kalman_filter_trend_strategy.py
+++ b/API/0225_Kalman_Filter_Trend/kalman_filter_trend_strategy.py
@@ -87,10 +87,9 @@ class kalman_filter_trend_strategy(Strategy):
 
         # Enable position protection
         self.StartProtection(
-            takeProfit=Unit(0, UnitTypes.Absolute),  # No take profit
-            stopLoss=Unit(2, UnitTypes.Absolute)     # Stop loss at 2*ATR
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(2, UnitTypes.Absolute)
         )
-
     def ProcessCandle(self, candle, kalman_value, atr_value):
         if candle.State != CandleStates.Finished:
             return

--- a/API/0226_Volatility_Adjusted_Mean_Reversion/volatility_adjusted_mean_reversion_strategy.py
+++ b/API/0226_Volatility_Adjusted_Mean_Reversion/volatility_adjusted_mean_reversion_strategy.py
@@ -95,10 +95,9 @@ class volatility_adjusted_mean_reversion_strategy(Strategy):
 
         # Enable position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit
-            Unit(2, UnitTypes.Absolute)   # Stop loss at 2*ATR
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(2, UnitTypes.Absolute)
         )
-
     def ProcessCandle(self, candle, sma_value, atr_value, std_dev_value):
         if candle.State != CandleStates.Finished:
             return

--- a/API/0227_Hurst_Exponent_Trend/hurst_exponent_trend_strategy.py
+++ b/API/0227_Hurst_Exponent_Trend/hurst_exponent_trend_strategy.py
@@ -109,10 +109,9 @@ class hurst_exponent_trend_strategy(Strategy):
 
         # Enable position protection
         self.StartProtection(
-            takeProfit=Unit(0, UnitTypes.Absolute),  # No take profit
-            stopLoss=Unit(2, UnitTypes.Percent)       # 2% stop loss
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(2, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, hurstValue, smaValue):
         if candle.State != CandleStates.Finished:
             return

--- a/API/0228_Hurst_Exponent_Reversion/hurst_exponent_reversion_strategy.py
+++ b/API/0228_Hurst_Exponent_Reversion/hurst_exponent_reversion_strategy.py
@@ -101,10 +101,9 @@ class hurst_exponent_reversion_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(self.StopLossPercent, UnitTypes.Percent),
-            Unit(self.StopLossPercent * 1.5, UnitTypes.Percent)
+            takeProfit=Unit(self.StopLossPercent, UnitTypes.Percent),
+            stopLoss=Unit(self.StopLossPercent * 1.5, UnitTypes.Percent)
         )
-
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0229_Autocorrelation_Reversal/autocorrelation_reversion_strategy.py
+++ b/API/0229_Autocorrelation_Reversal/autocorrelation_reversion_strategy.py
@@ -106,10 +106,9 @@ class autocorrelation_reversion_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(self.StopLossPercent, UnitTypes.Percent),
-            Unit(self.StopLossPercent * 1.5, UnitTypes.Percent)
+            takeProfit=Unit(self.StopLossPercent, UnitTypes.Percent),
+            stopLoss=Unit(self.StopLossPercent * 1.5, UnitTypes.Percent)
         )
-
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0231_Volatility_Skew_Arbitrage/volatility_skew_arbitrage_strategy.py
+++ b/API/0231_Volatility_Skew_Arbitrage/volatility_skew_arbitrage_strategy.py
@@ -118,10 +118,9 @@ class volatility_skew_arbitrage_strategy(Strategy):
 
         # Start position protection with stop-loss
         self.StartProtection(
-            None,
-            Unit(self.stop_loss_percent, UnitTypes.Percent)
+            takeProfit=None,
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
         )
-
     def ProcessLowOptionImpliedVolatility(self, data):
         low_iv = data.TryGetDecimal(Level1Fields.ImpliedVolatility) or 0
         high_iv = self._current_vol_skew + low_iv

--- a/API/0232_Correlation_Breakout/correlation_breakout_strategy.py
+++ b/API/0232_Correlation_Breakout/correlation_breakout_strategy.py
@@ -151,10 +151,9 @@ class correlation_breakout_strategy(Strategy):
 
         # Start position protection with stop-loss
         self.StartProtection(
-            None,
-            Unit(self.StopLossPercent, UnitTypes.Percent)
+            takeProfit=None,
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
     def ProcessAsset1Candle(self, candle):
         if candle.State != CandleStates.Finished:
             return

--- a/API/0233_Beta_Neutral_Arbitrage/beta_neutral_arbitrage_strategy.py
+++ b/API/0233_Beta_Neutral_Arbitrage/beta_neutral_arbitrage_strategy.py
@@ -156,8 +156,10 @@ class beta_neutral_arbitrage_strategy(Strategy):
         else:
             self.LogWarning("Assets or market index not specified. Strategy won't work properly.")
 
-        self.StartProtection(None, Unit(self.stop_loss_percent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
+        )
     def ProcessAsset1Candle(self, candle):
         if candle.State != CandleStates.Finished:
             return

--- a/API/0235_VWAP_Mean_Reversion/vwap_mean_reversion_strategy.py
+++ b/API/0235_VWAP_Mean_Reversion/vwap_mean_reversion_strategy.py
@@ -103,7 +103,6 @@ class vwap_mean_reversion_strategy(Strategy):
             takeProfit=Unit(5, UnitTypes.Percent),
             stopLoss=Unit(2, UnitTypes.Percent)
         )
-
     def ProcessATR(self, candle, atr_value):
         if candle.State != CandleStates.Finished:
             return

--- a/API/0236_RSI_Mean_Reversion/rsi_mean_reversion_strategy.py
+++ b/API/0236_RSI_Mean_Reversion/rsi_mean_reversion_strategy.py
@@ -111,10 +111,9 @@ class rsi_mean_reversion_strategy(Strategy):
 
         # Enable position protection
         self.StartProtection(
-            Unit(5, UnitTypes.Percent),
-            Unit(2, UnitTypes.Percent)
+            takeProfit=Unit(5, UnitTypes.Percent),
+            stopLoss=Unit(2, UnitTypes.Percent)
         )
-
     def ProcessRsi(self, candle, rsi_value):
         if candle.State != CandleStates.Finished:
             return

--- a/API/0237_Stochastic_Mean_Reversion/stochastic_mean_reversion_strategy.py
+++ b/API/0237_Stochastic_Mean_Reversion/stochastic_mean_reversion_strategy.py
@@ -135,10 +135,9 @@ class stochastic_mean_reversion_strategy(Strategy):
 
         # Enable position protection
         self.StartProtection(
-            Unit(5, UnitTypes.Percent),
-            Unit(2, UnitTypes.Percent)
+            takeProfit=Unit(5, UnitTypes.Percent),
+            stopLoss=Unit(2, UnitTypes.Percent)
         )
-
     def ProcessStochastic(self, candle, stoch_value):
         if candle.State != CandleStates.Finished:
             return

--- a/API/0238_CCI_Mean_Reversion/cci_mean_reversion_strategy.py
+++ b/API/0238_CCI_Mean_Reversion/cci_mean_reversion_strategy.py
@@ -132,10 +132,9 @@ class cci_mean_reversion_strategy(Strategy):
 
         # Enable position protection
         self.StartProtection(
-            takeProfit=Unit(0),  # We'll manage exits ourselves based on CCI
-            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent),
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
         super(cci_mean_reversion_strategy, self).OnStarted(time)
 
     def ProcessCandle(self, candle, cci_value):

--- a/API/0239_Williams_R_Mean_Reversion/williams_r_mean_reversion_strategy.py
+++ b/API/0239_Williams_R_Mean_Reversion/williams_r_mean_reversion_strategy.py
@@ -130,10 +130,9 @@ class williams_r_mean_reversion_strategy(Strategy):
 
         # Enable position protection
         self.StartProtection(
-            Unit(0),  # We'll manage exits ourselves based on Williams %R
-            Unit(self.StopLossPercent, UnitTypes.Percent)
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, williams_r_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0240_MACD_Mean_Reversion/macd_mean_reversion_strategy.py
+++ b/API/0240_MACD_Mean_Reversion/macd_mean_reversion_strategy.py
@@ -167,10 +167,9 @@ class macd_mean_reversion_strategy(Strategy):
 
         # Enable position protection
         self.StartProtection(
-            Unit(0),  # We'll manage exits ourselves based on MACD Histogram
-            Unit(self.stop_loss_percent, UnitTypes.Percent)
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
         )
-
         super(macd_mean_reversion_strategy, self).OnStarted(time)
 
     def ProcessCandle(self, candle, macd_value):

--- a/API/0241_ADX_Mean_Reversion/adx_mean_reversion_strategy.py
+++ b/API/0241_ADX_Mean_Reversion/adx_mean_reversion_strategy.py
@@ -131,10 +131,9 @@ class adx_mean_reversion_strategy(Strategy):
 
         # Enable position protection
         self.StartProtection(
-            takeProfit=None,  # We'll manage exits ourselves based on ADX
-            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent),
+            takeProfit=None,
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, adx_value):
         """
         Process candle with ADX indicator value.

--- a/API/0242_Volatility_Mean_Reversion/volatility_mean_reversion_strategy.py
+++ b/API/0242_Volatility_Mean_Reversion/volatility_mean_reversion_strategy.py
@@ -135,11 +135,10 @@ class volatility_mean_reversion_strategy(Strategy):
             self.DrawOwnTrades(area)
 
         self.StartProtection(
-            Unit(0),
-            Unit(self.StopLossPercent, UnitTypes.Percent),
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent),
             useMarketOrders=True
         )
-
     def ProcessCandle(self, candle, atrValue):
         """Process candle and ATR value."""
         # Skip unfinished candles

--- a/API/0243_Volume_Mean_Reversion/volume_mean_reversion_strategy.py
+++ b/API/0243_Volume_Mean_Reversion/volume_mean_reversion_strategy.py
@@ -124,10 +124,9 @@ class volume_mean_reversion_strategy(Strategy):
 
         # Enable position protection
         self.StartProtection(
-            takeProfit=Unit(0),  # We'll manage exits ourselves based on Volume
-            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent),
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle):
         """
         Process candle and execute trading logic based on volume statistics.

--- a/API/0244_OBV_Mean_Reversion/obv_mean_reversion_strategy.py
+++ b/API/0244_OBV_Mean_Reversion/obv_mean_reversion_strategy.py
@@ -105,7 +105,6 @@ class obv_mean_reversion_strategy(Strategy):
             takeProfit=Unit(5, UnitTypes.Percent),
             stopLoss=Unit(2, UnitTypes.Percent)
         )
-
     def ProcessObv(self, candle, obv_value):
         if candle.State != CandleStates.Finished:
             return

--- a/API/0245_Momentum_Breakout/momentum_breakout_strategy.py
+++ b/API/0245_Momentum_Breakout/momentum_breakout_strategy.py
@@ -118,10 +118,9 @@ class momentum_breakout_strategy(Strategy):
 
         # Enable position protection
         self.StartProtection(
-            Unit(5, UnitTypes.Percent),
-            Unit(2, UnitTypes.Percent)
+            takeProfit=Unit(5, UnitTypes.Percent),
+            stopLoss=Unit(2, UnitTypes.Percent)
         )
-
     def ProcessMomentum(self, candle, momentum_value):
         if candle.State != CandleStates.Finished:
             return

--- a/API/0247_RSI_Breakout/rsi_breakout_strategy.py
+++ b/API/0247_RSI_Breakout/rsi_breakout_strategy.py
@@ -135,10 +135,9 @@ class rsi_breakout_strategy(Strategy):
 
         # Enable position protection
         self.StartProtection(
-            Unit(5, UnitTypes.Percent),
-            Unit(2, UnitTypes.Percent)
+            takeProfit=Unit(5, UnitTypes.Percent),
+            stopLoss=Unit(2, UnitTypes.Percent)
         )
-
     def ProcessRsi(self, candle, rsi_value):
         if candle.State != CandleStates.Finished:
             return

--- a/API/0248_Stochastic_Breakout/stochastic_breakout_strategy.py
+++ b/API/0248_Stochastic_Breakout/stochastic_breakout_strategy.py
@@ -146,7 +146,6 @@ class stochastic_breakout_strategy(Strategy):
             takeProfit=Unit(2, UnitTypes.Percent),
             stopLoss=Unit(2, UnitTypes.Percent)
         )
-
     def ProcessStochastic(self, candle, stochValue):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0250_Williams_R_Breakout/williams_r_breakout_strategy.py
+++ b/API/0250_Williams_R_Breakout/williams_r_breakout_strategy.py
@@ -122,10 +122,9 @@ class williams_r_breakout_strategy(Strategy):
 
         # Enable stop loss protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),
-            Unit(self.StopLoss, UnitTypes.Percent)
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLoss, UnitTypes.Percent)
         )
-
         # Create chart area for visualization
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0251_MACD_Breakout/macd_breakout_strategy.py
+++ b/API/0251_MACD_Breakout/macd_breakout_strategy.py
@@ -155,10 +155,9 @@ class macd_breakout_strategy(Strategy):
 
         # Enable position protection
         self.StartProtection(
-            Unit(self.stop_loss_percent, UnitTypes.Percent),
-            Unit(self.stop_loss_percent * 1.5, UnitTypes.Percent)
+            takeProfit=Unit(self.stop_loss_percent, UnitTypes.Percent),
+            stopLoss=Unit(self.stop_loss_percent * 1.5, UnitTypes.Percent)
         )
-
         # Setup chart visualization
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0252_ADX_Breakout/adx_breakout_strategy.py
+++ b/API/0252_ADX_Breakout/adx_breakout_strategy.py
@@ -124,7 +124,6 @@ class adx_breakout_strategy(Strategy):
             takeProfit=Unit(0, UnitTypes.Absolute),
             stopLoss=Unit(self.StopLoss, UnitTypes.Percent)
         )
-
         # Create chart area for visualization
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0254_Volume_Breakout/volume_breakout_strategy.py
+++ b/API/0254_Volume_Breakout/volume_breakout_strategy.py
@@ -108,7 +108,6 @@ class volume_breakout_strategy(Strategy):
             takeProfit=Unit(0, UnitTypes.Absolute),
             stopLoss=Unit(self.stop_loss, UnitTypes.Percent)
         )
-
         # Create chart area for visualization
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0258_Donchian_Channel_Width_Breakout/donchian_width_breakout_strategy.py
+++ b/API/0258_Donchian_Channel_Width_Breakout/donchian_width_breakout_strategy.py
@@ -134,7 +134,6 @@ class donchian_width_breakout_strategy(Strategy):
             takeProfit=Unit(0, UnitTypes.Absolute),
             stopLoss=Unit(self.StopLoss, UnitTypes.Percent)
         )
-
         # Create chart area for visualization
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0259_Ichimoku_Cloud_Width_Breakout/ichimoku_width_breakout_strategy.py
+++ b/API/0259_Ichimoku_Cloud_Width_Breakout/ichimoku_width_breakout_strategy.py
@@ -149,8 +149,10 @@ class ichimoku_width_breakout_strategy(Strategy):
         subscription.BindEx(self._ichimoku, self.ProcessIchimoku).Start()
 
         # Enable stop loss protection
-        self.StartProtection(Unit(0, UnitTypes.Absolute), Unit(self.stop_loss, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.stop_loss, UnitTypes.Percent)
+        )
         # Create chart area for visualization
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0260_Supertrend_Distance_Breakout/supertrend_distance_breakout_strategy.py
+++ b/API/0260_Supertrend_Distance_Breakout/supertrend_distance_breakout_strategy.py
@@ -134,10 +134,9 @@ class supertrend_distance_breakout_strategy(Strategy):
 
         # Set up position protection with dynamic stop-loss
         self.StartProtection(
-            takeProfit=None,  # We'll handle exits via our strategy logic
-            stopLoss=Unit(2, UnitTypes.Percent)  # 2% stop-loss
+            takeProfit=None,
+            stopLoss=Unit(2, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, supertrendPrice):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0261_Parabolic_SAR_Distance_Breakout/parabolic_sar_distance_breakout_strategy.py
+++ b/API/0261_Parabolic_SAR_Distance_Breakout/parabolic_sar_distance_breakout_strategy.py
@@ -133,11 +133,10 @@ class parabolic_sar_distance_breakout_strategy(Strategy):
 
         # Set up position protection using the dynamic Parabolic SAR
         self.StartProtection(
-            takeProfit=None,  # We'll handle exits via strategy logic
-            stopLoss=None,    # The dynamic SAR will act as our stop
+            takeProfit=None,
+            stopLoss=None,
             isStopTrailing=True
         )
-
         super(parabolic_sar_distance_breakout_strategy, self).OnStarted(time)
 
     def ProcessCandle(self, candle, sar_value):

--- a/API/0262_Hull_MA_Slope_Breakout/hull_ma_slope_breakout_strategy.py
+++ b/API/0262_Hull_MA_Slope_Breakout/hull_ma_slope_breakout_strategy.py
@@ -129,7 +129,6 @@ class hull_ma_slope_breakout_strategy(Strategy):
             stopLoss=self.StopLoss,
             isStopTrailing=False
         )
-
         super(hull_ma_slope_breakout_strategy, self).OnStarted(time)
 
     def ProcessCandle(self, candle: ICandleMessage, hullValue: float, atrValue: float):

--- a/API/0263_MA_Slope_Breakout/ma_slope_breakout_strategy.py
+++ b/API/0263_MA_Slope_Breakout/ma_slope_breakout_strategy.py
@@ -130,10 +130,9 @@ class ma_slope_breakout_strategy(Strategy):
 
         # Set up position protection
         self.StartProtection(
-            None,  # we'll handle take-profit separately
-            Unit(self.stop_loss_percent, UnitTypes.Percent)
+            takeProfit=None,
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, ma_value):
         """Process new candle values and generate trading signals."""
         # Skip unfinished candles

--- a/API/0264_EMA_Slope_Breakout/ema_slope_breakout_strategy.py
+++ b/API/0264_EMA_Slope_Breakout/ema_slope_breakout_strategy.py
@@ -128,10 +128,9 @@ class ema_slope_breakout_strategy(Strategy):
 
         # Set up position protection
         self.StartProtection(
-            None,  # takeProfit: null, we handle exits via strategy logic
-            Unit(self.stop_loss_percent, UnitTypes.Percent),
+            takeProfit=None,
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, ema_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0265_Volatility_Adjusted_Momentum/volatility_adjusted_momentum_strategy.py
+++ b/API/0265_Volatility_Adjusted_Momentum/volatility_adjusted_momentum_strategy.py
@@ -153,11 +153,10 @@ class volatility_adjusted_momentum_strategy(Strategy):
 
         # Set up position protection
         self.StartProtection(
-            None,  # We'll handle exits via strategy logic
-            self.StopLoss,
-            True
+            takeProfit=None,
+            stopLoss=self.StopLoss,
+            isStopTrailing=True
         )
-
     def ProcessCandle(self, candle, momentum_value, atr_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0266_VWAP_Slope_Breakout/vwap_slope_breakout_strategy.py
+++ b/API/0266_VWAP_Slope_Breakout/vwap_slope_breakout_strategy.py
@@ -127,10 +127,9 @@ class vwap_slope_breakout_strategy(Strategy):
 
         # Set up position protection
         self.StartProtection(
-            None,  # takeProfit: we'll handle exits via strategy logic
-            Unit(self.stop_loss_percent, UnitTypes.Percent)
+            takeProfit=None,
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
         )
-
         super(vwap_slope_breakout_strategy, self).OnStarted(time)
 
     def ProcessCandle(self, candle, vwap_value):

--- a/API/0267_RSI_Slope_Breakout/rsi_slope_breakout_strategy.py
+++ b/API/0267_RSI_Slope_Breakout/rsi_slope_breakout_strategy.py
@@ -125,10 +125,9 @@ class rsi_slope_breakout_strategy(Strategy):
 
         # Set up position protection
         self.StartProtection(
-            takeProfit=None,  # We'll handle exits via strategy logic
-            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent),
+            takeProfit=None,
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, rsi_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0268_Stochastic_Slope_Breakout/stochastic_slope_breakout_strategy.py
+++ b/API/0268_Stochastic_Slope_Breakout/stochastic_slope_breakout_strategy.py
@@ -160,10 +160,9 @@ class stochastic_slope_breakout_strategy(Strategy):
 
         # Set up position protection
         self.StartProtection(
-            takeProfit=None,  # We'll handle exits via strategy logic
+            takeProfit=None,
             stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, stochValue):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0269_CCI_Slope_Breakout/cci_slope_breakout_strategy.py
+++ b/API/0269_CCI_Slope_Breakout/cci_slope_breakout_strategy.py
@@ -123,8 +123,10 @@ class cci_slope_breakout_strategy(Strategy):
             self.DrawOwnTrades(area)
 
         # Enable position protection
-        self.StartProtection(None, Unit(self.StopLossPercent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
+        )
     def ProcessCandle(self, candle, cciValue):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0270_Williams_R_Slope_Breakout/williams_r_slope_breakout_strategy.py
+++ b/API/0270_Williams_R_Slope_Breakout/williams_r_slope_breakout_strategy.py
@@ -126,8 +126,10 @@ class williams_r_slope_breakout_strategy(Strategy):
             self.DrawOwnTrades(area)
 
         # Enable position protection
-        self.StartProtection(None, Unit(self.stop_loss_percent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
+        )
     def ProcessCandle(self, candle, williams_r_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0271_MACD_Slope_Breakout/macd_slope_breakout_strategy.py
+++ b/API/0271_MACD_Slope_Breakout/macd_slope_breakout_strategy.py
@@ -155,8 +155,10 @@ class macd_slope_breakout_strategy(Strategy):
             self.DrawOwnTrades(area)
 
         # Enable position protection
-        self.StartProtection(None, Unit(self.stop_loss_percent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=None,
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
+        )
     def ProcessCandle(self, candle, macd_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0272_ADX_Slope_Breakout/adx_slope_breakout_strategy.py
+++ b/API/0272_ADX_Slope_Breakout/adx_slope_breakout_strategy.py
@@ -132,8 +132,10 @@ class adx_slope_breakout_strategy(Strategy):
             self.DrawOwnTrades(area)
 
         # Enable position protection
-        self.StartProtection(Unit(0), Unit(self.StopLossPercent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
+        )
     def ProcessCandle(self, candle, adxValue):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0274_Volume_Slope_Breakout/volume_slope_breakout_strategy.py
+++ b/API/0274_Volume_Slope_Breakout/volume_slope_breakout_strategy.py
@@ -140,8 +140,10 @@ class volume_slope_breakout_strategy(Strategy):
             self.DrawOwnTrades(area)
 
         # Enable position protection
-        self.StartProtection(Unit(0), Unit(self.StopLossPercent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
+        )
     def ProcessCandle(self, candle, volumeValue):
         # Check if strategy is ready to trade
         if not self.IsFormedAndOnlineAndAllowTrading():

--- a/API/0275_OBV_Slope_Breakout/obv_slope_breakout_strategy.py
+++ b/API/0275_OBV_Slope_Breakout/obv_slope_breakout_strategy.py
@@ -125,8 +125,10 @@ class obv_slope_breakout_strategy(Strategy):
         subscription.Bind(self._obv, self.ProcessObv).Start()
 
         # Set up position protection
-        self.StartProtection(Unit(), Unit(self.StopLoss, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=Unit(),
+            stopLoss=Unit(self.StopLoss, UnitTypes.Percent)
+        )
         # Create chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0278_Donchian_Width_Mean_Reversion/donchian_width_mean_reversion_strategy.py
+++ b/API/0278_Donchian_Width_Mean_Reversion/donchian_width_mean_reversion_strategy.py
@@ -134,10 +134,9 @@ class donchian_width_mean_reversion_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),
-            Unit(self.stop_loss_percent, UnitTypes.Percent)
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
         )
-
     def ProcessDonchian(self, candle, donchian_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0279_Ichimoku_Cloud_Width_Mean_Reversion/ichimoku_cloud_width_mean_reversion_strategy.py
+++ b/API/0279_Ichimoku_Cloud_Width_Mean_Reversion/ichimoku_cloud_width_mean_reversion_strategy.py
@@ -152,7 +152,6 @@ class ichimoku_cloud_width_mean_reversion_strategy(Strategy):
             takeProfit=None,
             stopLoss=None
         )
-
     def ProcessIchimoku(self, candle, ichimokuValue):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0283_MA_Slope_Mean_Reversion/ma_slope_mean_reversion_strategy.py
+++ b/API/0283_MA_Slope_Mean_Reversion/ma_slope_mean_reversion_strategy.py
@@ -116,10 +116,9 @@ class ma_slope_mean_reversion_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit (use exit rule instead)
-            Unit(self.StopLossPercent, UnitTypes.Percent)  # Stop loss
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0284_EMA_Slope_Mean_Reversion/ema_slope_mean_reversion_strategy.py
+++ b/API/0284_EMA_Slope_Mean_Reversion/ema_slope_mean_reversion_strategy.py
@@ -121,10 +121,9 @@ class ema_slope_mean_reversion_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit (use exit rule instead)
-            Unit(self.StopLossPercent, UnitTypes.Percent)  # Stop loss
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0285_VWAP_Slope_Mean_Reversion/vwap_slope_mean_reversion_strategy.py
+++ b/API/0285_VWAP_Slope_Mean_Reversion/vwap_slope_mean_reversion_strategy.py
@@ -101,10 +101,9 @@ class vwap_slope_mean_reversion_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit (use exit rule instead)
-            Unit(self.stop_loss_percent, UnitTypes.Percent)  # Stop loss
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
         )
-
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0286_RSI_Slope_Mean_Reversion/rsi_slope_mean_reversion_strategy.py
+++ b/API/0286_RSI_Slope_Mean_Reversion/rsi_slope_mean_reversion_strategy.py
@@ -129,10 +129,9 @@ class rsi_slope_mean_reversion_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit (use exit rule instead)
-            Unit(self.stop_loss_percent, UnitTypes.Percent)  # Stop loss
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
         )
-
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0287_Stochastic_Slope_Mean_Reversion/stochastic_slope_mean_reversion_strategy.py
+++ b/API/0287_Stochastic_Slope_Mean_Reversion/stochastic_slope_mean_reversion_strategy.py
@@ -148,10 +148,9 @@ class stochastic_slope_mean_reversion_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit (use exit rule instead)
-            Unit(self.StopLossPercent, UnitTypes.Percent)  # Stop loss
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0288_CCI_Slope_Mean_Reversion/cci_slope_mean_reversion_strategy.py
+++ b/API/0288_CCI_Slope_Mean_Reversion/cci_slope_mean_reversion_strategy.py
@@ -120,10 +120,9 @@ class cci_slope_mean_reversion_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit (use exit rule instead)
-            Unit(self.stop_loss_percent, UnitTypes.Percent)  # Stop loss
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
         )
-
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0289_Williams_R_Slope_Mean_Reversion/williams_r_slope_mean_reversion_strategy.py
+++ b/API/0289_Williams_R_Slope_Mean_Reversion/williams_r_slope_mean_reversion_strategy.py
@@ -151,10 +151,9 @@ class williams_r_slope_mean_reversion_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(self.stop_loss_percent, UnitTypes.Percent),
-            Unit(self.stop_loss_percent, UnitTypes.Percent)
+            takeProfit=Unit(self.stop_loss_percent, UnitTypes.Percent),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, williams_r_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0290_MACD_Slope_Mean_Reversion/macd_slope_mean_reversion_strategy.py
+++ b/API/0290_MACD_Slope_Mean_Reversion/macd_slope_mean_reversion_strategy.py
@@ -167,10 +167,9 @@ class macd_slope_mean_reversion_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(self.stop_loss_percent, UnitTypes.Percent),
-            Unit(self.stop_loss_percent, UnitTypes.Percent)
+            takeProfit=Unit(self.stop_loss_percent, UnitTypes.Percent),
+            stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, macd_value):
         """Processes each finished candle and executes trading logic."""
         # Skip unfinished candles

--- a/API/0291_ADX_Slope_Mean_Reversion/adx_slope_mean_reversion_strategy.py
+++ b/API/0291_ADX_Slope_Mean_Reversion/adx_slope_mean_reversion_strategy.py
@@ -153,10 +153,9 @@ class adx_slope_mean_reversion_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(self.StopLossPercent, UnitTypes.Percent),
-            Unit(self.StopLossPercent, UnitTypes.Percent)
+            takeProfit=Unit(self.StopLossPercent, UnitTypes.Percent),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, adx_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0292_ATR_Slope_Mean_Reversion/atr_slope_mean_reversion_strategy.py
+++ b/API/0292_ATR_Slope_Mean_Reversion/atr_slope_mean_reversion_strategy.py
@@ -152,8 +152,10 @@ class atr_slope_mean_reversion_strategy(Strategy):
             self.DrawIndicator(area, self._atr)
             self.DrawOwnTrades(area)
 
-        self.StartProtection(Unit(0, UnitTypes.Absolute), Unit(self.StopLossPercent, UnitTypes.Percent))
-
+        self.StartProtection(
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
+        )
     def ProcessCandle(self, candle: ICandleMessage, atrValue):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0293_Volume_Slope_Mean_Reversion/volume_slope_mean_reversion_strategy.py
+++ b/API/0293_Volume_Slope_Mean_Reversion/volume_slope_mean_reversion_strategy.py
@@ -140,9 +140,9 @@ class volume_slope_mean_reversion_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(self.StopLossPercent, UnitTypes.Percent),
-            Unit(self.StopLossPercent, UnitTypes.Percent))
-
+            takeProfit=Unit(self.StopLossPercent, UnitTypes.Percent),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
+        )
         super(volume_slope_mean_reversion_strategy, self).OnStarted(time)
 
     def ProcessCandle(self, candle, volume_ma_value):

--- a/API/0294_OBV_Slope_Mean_Reversion/obv_slope_mean_reversion_strategy.py
+++ b/API/0294_OBV_Slope_Mean_Reversion/obv_slope_mean_reversion_strategy.py
@@ -147,10 +147,9 @@ class obv_slope_mean_reversion_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(self.StopLossPercent, UnitTypes.Percent),
-            Unit(self.StopLossPercent, UnitTypes.Percent)
+            takeProfit=Unit(self.StopLossPercent, UnitTypes.Percent),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
         super(obv_slope_mean_reversion_strategy, self).OnStarted(time)
 
     def ProcessCandle(self, candle):

--- a/API/0295_Pairs_Trading_Volatility_Filter/pairs_trading_volatility_filter_strategy.py
+++ b/API/0295_Pairs_Trading_Volatility_Filter/pairs_trading_volatility_filter_strategy.py
@@ -189,11 +189,10 @@ class pairs_trading_volatility_filter_strategy(Strategy):
 
         # Setup position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit
-            Unit(self.StopLossPercent, UnitTypes.Percent),  # Stop loss in percent
-            False  # No trailing stop
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent),
+            isStopTrailing=False
         )
-
     # Helper methods to store last prices
     def _set_last_price1(self, price):
         self._last_price1 = price

--- a/API/0296_Z-Score_Volume_Filter/zscore_volume_filter_strategy.py
+++ b/API/0296_Z-Score_Volume_Filter/zscore_volume_filter_strategy.py
@@ -121,11 +121,10 @@ class zscore_volume_filter_strategy(Strategy):
 
         # Setup position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit
-            Unit(self.StopLossPercent, UnitTypes.Percent),  # Stop loss in percent
-            False  # No trailing stop
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent),
+            isStopTrailing=False
         )
-
     def ProcessCandle(self, candle, price_sma_value, price_std_dev_value, volume_sma_value):
         """Process candle and compute indicator values."""
         if candle.State != CandleStates.Finished:

--- a/API/0298_Correlation_Mean_Reversion/correlation_mean_reversion_strategy.py
+++ b/API/0298_Correlation_Mean_Reversion/correlation_mean_reversion_strategy.py
@@ -180,11 +180,10 @@ class correlation_mean_reversion_strategy(Strategy):
 
         # Setup position protection
         self.StartProtection(
-            Unit(0, UnitTypes.Absolute),  # No take profit
-            Unit(self.StopLossPercent, UnitTypes.Percent),  # Stop loss in percent
-            False  # No trailing stop
+            takeProfit=Unit(0, UnitTypes.Absolute),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent),
+            isStopTrailing=False
         )
-
     def ProcessSecurity1Candle(self, candle):
         if candle.State != CandleStates.Finished:
             return

--- a/API/0300_Hurst_Exponent_Volatility_Filter/hurst_volatility_filter_strategy.py
+++ b/API/0300_Hurst_Exponent_Volatility_Filter/hurst_volatility_filter_strategy.py
@@ -138,10 +138,9 @@ class hurst_volatility_filter_strategy(Strategy):
 
         # Enable position protection with stop loss
         self.StartProtection(
-            takeProfit=Unit(0),  # No take-profit, using custom exit conditions
-            stopLoss=Unit(self.StopLoss, UnitTypes.Percent),
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.StopLoss, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle: ICandleMessage, sma_value: float, atr_value: float):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0301_Adaptive_EMA_Breakout/adaptive_ema_breakout_strategy.py
+++ b/API/0301_Adaptive_EMA_Breakout/adaptive_ema_breakout_strategy.py
@@ -121,11 +121,10 @@ class adaptive_ema_breakout_strategy(Strategy):
 
         # Enable position protection
         self.StartProtection(
-            Unit(0),  # We'll handle exits in the strategy logic
-            Unit(0),  # We'll handle stops in the strategy logic
-            True       # Use market orders
+            takeProfit=Unit(0),
+            stopLoss=Unit(0),
+            isStopTrailing=True
         )
-
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0302_Volatility_Cluster_Breakout/volatility_cluster_breakout_strategy.py
+++ b/API/0302_Volatility_Cluster_Breakout/volatility_cluster_breakout_strategy.py
@@ -125,11 +125,10 @@ class volatility_cluster_breakout_strategy(Strategy):
 
         # Enable position protection with dynamic stops
         self.StartProtection(
-            takeProfit=Unit(0),  # We'll handle exits in the strategy logic
-            stopLoss=Unit(0),    # We'll handle stops in the strategy logic
+            takeProfit=Unit(0),
+            stopLoss=Unit(0),
             useMarketOrders=True
         )
-
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0303_Seasonality_Adjusted_Momentum/seasonality_adjusted_momentum_strategy.py
+++ b/API/0303_Seasonality_Adjusted_Momentum/seasonality_adjusted_momentum_strategy.py
@@ -114,11 +114,10 @@ class seasonality_adjusted_momentum_strategy(Strategy):
 
         # Enable position protection with percentage stop-loss
         self.StartProtection(
-            takeProfit=Unit(0),  # We'll handle exits in the strategy logic
+            takeProfit=Unit(0),
             stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent),
             useMarketOrders=True
         )
-
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0305_RSI_Dynamic_Overbought_Oversold/rsi_dynamic_overbought_oversold_strategy.py
+++ b/API/0305_RSI_Dynamic_Overbought_Oversold/rsi_dynamic_overbought_oversold_strategy.py
@@ -119,11 +119,10 @@ class rsi_dynamic_overbought_oversold_strategy(Strategy):
 
         # Enable position protection with percentage stop-loss
         self.StartProtection(
-            Unit(0),  # we'll handle exits in the strategy logic
-            Unit(self.StopLossPercent, UnitTypes.Percent),
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent),
             useMarketOrders=True
         )
-
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0306_Bollinger_Volatility_Breakout/bollinger_volatility_breakout_strategy.py
+++ b/API/0306_Bollinger_Volatility_Breakout/bollinger_volatility_breakout_strategy.py
@@ -131,11 +131,10 @@ class bollinger_volatility_breakout_strategy(Strategy):
 
         # Enable position protection
         self.StartProtection(
-            Unit(0),  # We'll handle exits in the strategy logic
-            Unit(0),   # We'll handle stops in the strategy logic
-            True
+            takeProfit=Unit(0),
+            stopLoss=Unit(0),
+            isStopTrailing=True
         )
-
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0307_MACD_Adaptive_Histogram/macd_adaptive_histogram_strategy.py
+++ b/API/0307_MACD_Adaptive_Histogram/macd_adaptive_histogram_strategy.py
@@ -174,11 +174,10 @@ class macd_adaptive_histogram_strategy(Strategy):
 
         # Enable position protection with percentage stop-loss
         self.StartProtection(
-            Unit(0),  # We'll handle exits in the strategy logic
-            Unit(self.StopLossPercent, UnitTypes.Percent),
-            True,
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent),
+            isStopTrailing=True
         )
-
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0308_Ichimoku_Volume_Cluster/ichimoku_volume_cluster_strategy.py
+++ b/API/0308_Ichimoku_Volume_Cluster/ichimoku_volume_cluster_strategy.py
@@ -135,11 +135,10 @@ class ichimoku_volume_cluster_strategy(Strategy):
 
         # Setup stop-loss at Kijun-sen level
         self.StartProtection(
-            Unit(0),  # We'll handle exits in the strategy logic
-            Unit(0),   # Using Kijun-sen as dynamic stop-loss
-            True
+            takeProfit=Unit(0),
+            stopLoss=Unit(0),
+            isStopTrailing=True
         )
-
         # Setup chart if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0309_Supertrend_Momentum_Filter/supertrend_momentum_filter_strategy.py
+++ b/API/0309_Supertrend_Momentum_Filter/supertrend_momentum_filter_strategy.py
@@ -113,9 +113,8 @@ class supertrend_momentum_filter_strategy(Strategy):
         # Setup position protection
         self.StartProtection(
             takeProfit=Unit(2, UnitTypes.Percent),
-            stopLoss=Unit(1, UnitTypes.Percent),
+            stopLoss=Unit(1, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, supertrend_value, momentum_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0310_Donchian_Volatility_Contraction/donchian_volatility_contraction_strategy.py
+++ b/API/0310_Donchian_Volatility_Contraction/donchian_volatility_contraction_strategy.py
@@ -169,9 +169,8 @@ class donchian_volatility_contraction_strategy(Strategy):
         # Setup position protection
         self.StartProtection(
             takeProfit=Unit(2, UnitTypes.Percent),
-            stopLoss=Unit(1, UnitTypes.Percent),
+            stopLoss=Unit(1, UnitTypes.Percent)
         )
-
     def ProcessStrategy(self, candle, donchian_high, donchian_low, atr_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0311_Keltner_RSI_Divergence/keltner_rsi_divergence_strategy.py
+++ b/API/0311_Keltner_RSI_Divergence/keltner_rsi_divergence_strategy.py
@@ -134,10 +134,9 @@ class keltner_rsi_divergence_strategy(Strategy):
 
         # Setup position protection
         self.StartProtection(
-            Unit(2, UnitTypes.Percent),
-            Unit(1, UnitTypes.Percent)
+            takeProfit=Unit(2, UnitTypes.Percent),
+            stopLoss=Unit(1, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, ema_value, atr_value, rsi_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0312_Hull_MA_Volume_Spike/hull_ma_volume_spike_strategy.py
+++ b/API/0312_Hull_MA_Volume_Spike/hull_ma_volume_spike_strategy.py
@@ -135,7 +135,6 @@ class hull_ma_volume_spike_strategy(Strategy):
             takeProfit=Unit(2, UnitTypes.Percent),
             stopLoss=Unit(1, UnitTypes.Percent)
         )
-
     def ProcessStrategy(self, candle, hma_value, volume, volume_avg, volume_std_dev):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0313_VWAP_ADX_Trend_Strength/vwap_adx_trend_strength_strategy.py
+++ b/API/0313_VWAP_ADX_Trend_Strength/vwap_adx_trend_strength_strategy.py
@@ -87,7 +87,6 @@ class vwap_adx_trend_strength_strategy(Strategy):
             takeProfit=Unit(2, UnitTypes.Percent),
             stopLoss=Unit(1, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, adx_value, vwap_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0315_Stochastic_Dynamic_Zones/stochastic_with_dynamic_zones_strategy.py
+++ b/API/0315_Stochastic_Dynamic_Zones/stochastic_with_dynamic_zones_strategy.py
@@ -148,7 +148,6 @@ class stochastic_with_dynamic_zones_strategy(Strategy):
             takeProfit=Unit(2, UnitTypes.Percent),
             stopLoss=Unit(1, UnitTypes.Percent)
         )
-
     def ProcessStochastic(self, candle, stoch_value):
         stoch_typed = stoch_value if isinstance(stoch_value, StochasticOscillatorValue) else None
         if stoch_typed is None or stoch_typed.K is None:

--- a/API/0316_ADX_Volume_Breakout/adx_with_volume_breakout_strategy.py
+++ b/API/0316_ADX_Volume_Breakout/adx_with_volume_breakout_strategy.py
@@ -142,7 +142,6 @@ class adx_with_volume_breakout_strategy(Strategy):
             takeProfit=Unit(2, UnitTypes.Percent),
             stopLoss=Unit(1, UnitTypes.Percent)
         )
-
     def ProcessStrategy(self, candle, adx, di_plus, di_minus, volume, volume_avg, volume_std_dev):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0317_CCI_Volatility_Filter/cci_with_volatility_filter_strategy.py
+++ b/API/0317_CCI_Volatility_Filter/cci_with_volatility_filter_strategy.py
@@ -123,7 +123,6 @@ class cci_with_volatility_filter_strategy(Strategy):
             takeProfit=Unit(2, UnitTypes.Percent),
             stopLoss=Unit(1, UnitTypes.Percent)
         )
-
     def _on_candle(self, candle, cci_value, atr_value):
         # Calculate ATR average
         atr_avg = to_float(self._atrSma.Process(

--- a/API/0318_Williams_R_Momentum/williams_percent_r_with_momentum_strategy.py
+++ b/API/0318_Williams_R_Momentum/williams_percent_r_with_momentum_strategy.py
@@ -134,7 +134,6 @@ class williams_percent_r_with_momentum_strategy(Strategy):
             takeProfit=Unit(2, UnitTypes.Percent),
             stopLoss=Unit(1, UnitTypes.Percent)
         )
-
     def ProcessStrategy(self, candle, williamsRValue, momentumValue, momentumAvg):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0319_Bollinger_K-Means_Cluster/bollinger_kmeans_strategy.py
+++ b/API/0319_Bollinger_K-Means_Cluster/bollinger_kmeans_strategy.py
@@ -128,10 +128,9 @@ class bollinger_kmeans_strategy(Strategy):
 
         # Setup position protection
         self.StartProtection(
-            Unit(2, UnitTypes.Percent),
-            Unit(2, UnitTypes.Percent)
+            takeProfit=Unit(2, UnitTypes.Percent),
+            stopLoss=Unit(2, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, bollinger_value, rsi_value, atr_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0320_MACD_Hidden_Markov_Model/macd_hidden_markov_model_strategy.py
+++ b/API/0320_MACD_Hidden_Markov_Model/macd_hidden_markov_model_strategy.py
@@ -129,10 +129,9 @@ class macd_hidden_markov_model_strategy(Strategy):
 
         # Setup position protection
         self.StartProtection(
-            Unit(2, UnitTypes.Percent),
-            Unit(2, UnitTypes.Percent)
+            takeProfit=Unit(2, UnitTypes.Percent),
+            stopLoss=Unit(2, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, macd_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0323_Donchian_Seasonal_Filter/donchian_seasonal_filter_strategy.py
+++ b/API/0323_Donchian_Seasonal_Filter/donchian_seasonal_filter_strategy.py
@@ -138,10 +138,9 @@ class donchian_seasonal_filter_strategy(Strategy):
 
         # Setup position protection
         self.StartProtection(
-            Unit(2, UnitTypes.Percent),
-            Unit(2, UnitTypes.Percent)
+            takeProfit=Unit(2, UnitTypes.Percent),
+            stopLoss=Unit(2, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, donchian_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0324_Keltner_Kalman_Filter/keltner_kalman_strategy.py
+++ b/API/0324_Keltner_Kalman_Filter/keltner_kalman_strategy.py
@@ -153,10 +153,9 @@ class keltner_kalman_strategy(Strategy):
 
         # Setup position protection
         self.StartProtection(
-            Unit(2, UnitTypes.Percent),
-            Unit(2, UnitTypes.Percent)
+            takeProfit=Unit(2, UnitTypes.Percent),
+            stopLoss=Unit(2, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, ema_value, atr_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0325_Hull_MA_Volatility_Contraction/hull_ma_volatility_contraction_strategy.py
+++ b/API/0325_Hull_MA_Volatility_Contraction/hull_ma_volatility_contraction_strategy.py
@@ -117,10 +117,9 @@ class hull_ma_volatility_contraction_strategy(Strategy):
 
         # Setup position protection
         self.StartProtection(
-            Unit(2, UnitTypes.Percent),
-            Unit(2, UnitTypes.Percent)
+            takeProfit=Unit(2, UnitTypes.Percent),
+            stopLoss=Unit(2, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, hma_value, atr_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0326_VWAP_Stochastic_Divergence/vwap_adx_trend_strategy.py
+++ b/API/0326_VWAP_Stochastic_Divergence/vwap_adx_trend_strategy.py
@@ -117,10 +117,9 @@ class vwap_adx_trend_strategy(Strategy):
 
         # Setup position protection
         self.StartProtection(
-            Unit(2, UnitTypes.Percent),
-            Unit(2, UnitTypes.Percent)
+            takeProfit=Unit(2, UnitTypes.Percent),
+            stopLoss=Unit(2, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, vwap_value, adx_value, di_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0327_Parabolic_SAR_Hurst_Filter/parabolic_sar_hurst_strategy.py
+++ b/API/0327_Parabolic_SAR_Hurst_Filter/parabolic_sar_hurst_strategy.py
@@ -109,10 +109,9 @@ class parabolic_sar_hurst_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(2, UnitTypes.Percent),
-            Unit(1, UnitTypes.Percent)
+            takeProfit=Unit(2, UnitTypes.Percent),
+            stopLoss=Unit(1, UnitTypes.Percent)
         )
-
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0328_Bollinger_Kalman_Filter/bollinger_kalman_filter_strategy.py
+++ b/API/0328_Bollinger_Kalman_Filter/bollinger_kalman_filter_strategy.py
@@ -119,7 +119,6 @@ class bollinger_kalman_filter_strategy(Strategy):
             takeProfit=Unit(2, UnitTypes.Percent),
             stopLoss=Unit(1, UnitTypes.Percent)
         )
-
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0329_MACD_Volume_Cluster/macd_volume_cluster_strategy.py
+++ b/API/0329_MACD_Volume_Cluster/macd_volume_cluster_strategy.py
@@ -161,10 +161,9 @@ class macd_volume_cluster_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(2, UnitTypes.Percent),
-            Unit(1, UnitTypes.Percent)
+            takeProfit=Unit(2, UnitTypes.Percent),
+            stopLoss=Unit(1, UnitTypes.Percent)
         )
-
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0330_Ichimoku_Volatility_Contraction/ichimoku_volatility_contraction_strategy.py
+++ b/API/0330_Ichimoku_Volatility_Contraction/ichimoku_volatility_contraction_strategy.py
@@ -145,7 +145,6 @@ class ichimoku_volatility_contraction_strategy(Strategy):
             takeProfit=Unit(2, UnitTypes.Percent),
             stopLoss=Unit(1, UnitTypes.Percent)
         )
-
         # Setup chart visualization if available
         area = self.CreateChartArea()
         if area is not None:

--- a/API/0332_Donchian_Hurst_Exponent/donchian_hurst_strategy.py
+++ b/API/0332_Donchian_Hurst_Exponent/donchian_hurst_strategy.py
@@ -124,10 +124,9 @@ class donchian_hurst_strategy(Strategy):
 
         # Start position protection with percentage-based stop-loss
         self.StartProtection(
-            takeProfit=Unit(0),  # No take profit, using Donchian Channel for exit
+            takeProfit=Unit(0),
             stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
     def ProcessIndicators(self, candle, donchianValue, fractalDimensionValue):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0333_Keltner_Seasonal_Filter/keltner_seasonal_strategy.py
+++ b/API/0333_Keltner_Seasonal_Filter/keltner_seasonal_strategy.py
@@ -124,8 +124,10 @@ class keltner_seasonal_strategy(Strategy):
             self.DrawOwnTrades(area)
 
         # Start position protection with ATR-based stop-loss
-        self.StartProtection(Unit(0), Unit(self.atr_multiplier, UnitTypes.Absolute))
-
+        self.StartProtection(
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.atr_multiplier, UnitTypes.Absolute)
+        )
     def ProcessKeltner(self, candle, ema_value, atr_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0334_Hull_MA_K-Means_Cluster/hull_kmeans_cluster_strategy.py
+++ b/API/0334_Hull_MA_K-Means_Cluster/hull_kmeans_cluster_strategy.py
@@ -123,10 +123,9 @@ class hull_kmeans_cluster_strategy(Strategy):
 
         # Start position protection with ATR-based stop-loss
         self.StartProtection(
-            takeProfit=Unit(0),  # No fixed take profit
-            stopLoss=Unit(2, UnitTypes.Absolute)  # 2 ATR stop-loss
+            takeProfit=Unit(0),
+            stopLoss=Unit(2, UnitTypes.Absolute)
         )
-
     def ProcessCandle(self, candle, hull_value, rsi_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0335_VWAP_Hidden_Markov_Model/vwap_hidden_markov_model_strategy.py
+++ b/API/0335_VWAP_Hidden_Markov_Model/vwap_hidden_markov_model_strategy.py
@@ -104,10 +104,9 @@ class vwap_hidden_markov_model_strategy(Strategy):
 
         # Start position protection with percentage-based stop-loss
         self.StartProtection(
-            takeProfit=Unit(0),  # No fixed take profit
-            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent),
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
-
     def ProcessVwap(self, candle, vwap_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0337_Adaptive_RSI_Volume_Filter/adaptive_rsi_volume_strategy.py
+++ b/API/0337_Adaptive_RSI_Volume_Filter/adaptive_rsi_volume_strategy.py
@@ -135,10 +135,9 @@ class adaptive_rsi_volume_strategy(Strategy):
 
         # Start position protection with percentage-based stop-loss
         self.StartProtection(
-            takeProfit=Unit(0),  # No fixed take profit
-            stopLoss=Unit(2, UnitTypes.Percent)  # 2% stop-loss
+            takeProfit=Unit(0),
+            stopLoss=Unit(2, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, atr_value, rsi_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0338_Adaptive_Bollinger_Breakout/adaptive_bollinger_breakout_strategy.py
+++ b/API/0338_Adaptive_Bollinger_Breakout/adaptive_bollinger_breakout_strategy.py
@@ -141,10 +141,9 @@ class adaptive_bollinger_breakout_strategy(Strategy):
 
         # Start position protection with ATR-based stop-loss
         self.StartProtection(
-            takeProfit=Unit(0),  # No fixed take profit
-            stopLoss=Unit(2, UnitTypes.Absolute)  # 2 ATR stop-loss
+            takeProfit=Unit(0),
+            stopLoss=Unit(2, UnitTypes.Absolute)
         )
-
     def ProcessIndicators(self, candle, atr_value, bollinger_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0339_MACD_Sentiment_Filter/macd_with_sentiment_filter_strategy.py
+++ b/API/0339_MACD_Sentiment_Filter/macd_with_sentiment_filter_strategy.py
@@ -157,10 +157,9 @@ class macd_with_sentiment_filter_strategy(Strategy):
 
         # Enable position protection with stop-loss
         self.StartProtection(
-            Unit(0),  # No take profit
-            Unit(self.stop_loss, UnitTypes.Percent)  # Stop-loss as percentage
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.stop_loss, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, macd_value):
         """Process each candle and MACD values."""
         # Skip unfinished candles

--- a/API/0340_Ichimoku_Implied_Volatility/ichimoku_implied_volatility_strategy.py
+++ b/API/0340_Ichimoku_Implied_Volatility/ichimoku_implied_volatility_strategy.py
@@ -143,10 +143,9 @@ class ichimoku_implied_volatility_strategy(Strategy):
 
         # Enable position protection using Kijun-Sen as stop-loss
         self.StartProtection(
-            Unit(0),  # No take profit
-            Unit(0)   # Dynamic stop-loss will be handled manually
+            takeProfit=Unit(0),
+            stopLoss=Unit(0)
         )
-
     def ProcessCandle(self, candle, ichimoku_value):
         """Process each candle and Ichimoku values."""
         # Skip unfinished candles

--- a/API/0342_Donchian_Sentiment_Spike/donchian_with_sentiment_spike_strategy.py
+++ b/API/0342_Donchian_Sentiment_Spike/donchian_with_sentiment_spike_strategy.py
@@ -133,10 +133,9 @@ class donchian_with_sentiment_spike_strategy(Strategy):
 
         # Enable position protection with stop-loss
         self.StartProtection(
-            Unit(0),  # No take profit
-            Unit(self.stop_loss, UnitTypes.Percent)  # Stop-loss as percentage
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.stop_loss, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, donchian_value):
         """Process each candle and Donchian Channel values."""
         # Skip unfinished candles

--- a/API/0345_VWAP_Behavioral_Bias_Filter/vwap_with_behavioral_bias_filter_strategy.py
+++ b/API/0345_VWAP_Behavioral_Bias_Filter/vwap_with_behavioral_bias_filter_strategy.py
@@ -124,10 +124,9 @@ class vwap_with_behavioral_bias_filter_strategy(Strategy):
 
         # Enable position protection with stop-loss
         self.StartProtection(
-            Unit(0),  # No take profit
-            Unit(self.StopLoss, UnitTypes.Percent)
+            takeProfit=Unit(0),
+            stopLoss=Unit(self.StopLoss, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, vwapValue):
         """Process each candle and VWAP value."""
         # Skip unfinished candles

--- a/API/0346_Parabolic_SAR_Sentiment_Divergence/parabolic_sar_sentiment_divergence_strategy.py
+++ b/API/0346_Parabolic_SAR_Sentiment_Divergence/parabolic_sar_sentiment_divergence_strategy.py
@@ -94,11 +94,10 @@ class parabolic_sar_sentiment_divergence_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(2, UnitTypes.Percent),   # Take profit 2%
-            Unit(2, UnitTypes.Percent),   # Stop loss 2%
-            True  # Use trailing stop
+            takeProfit=Unit(2, UnitTypes.Percent),
+            stopLoss=Unit(2, UnitTypes.Percent),
+            isStopTrailing=True
         )
-
     def ProcessCandle(self, candle, sar_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0347_RSI_Option_Open_Interest/rsi_with_option_open_interest_strategy.py
+++ b/API/0347_RSI_Option_Open_Interest/rsi_with_option_open_interest_strategy.py
@@ -155,10 +155,9 @@ class rsi_with_option_open_interest_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(2, UnitTypes.Percent),   # Take profit 2%
-            Unit(self.StopLoss, UnitTypes.Percent)  # Stop loss based on parameter
+            takeProfit=Unit(2, UnitTypes.Percent),
+            stopLoss=Unit(self.StopLoss, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, rsi_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0348_Stochastic_Implied_Volatility_Skew/stochastic_implied_volatility_skew_strategy.py
+++ b/API/0348_Stochastic_Implied_Volatility_Skew/stochastic_implied_volatility_skew_strategy.py
@@ -143,10 +143,9 @@ class stochastic_implied_volatility_skew_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(2, UnitTypes.Percent),   # Take profit 2%
-            Unit(self.StopLoss, UnitTypes.Percent)  # Stop loss based on parameter
+            takeProfit=Unit(2, UnitTypes.Percent),
+            stopLoss=Unit(self.StopLoss, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle: ICandleMessage, stoch_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0349_ADX_Sentiment_Momentum/adx_sentiment_momentum_strategy.py
+++ b/API/0349_ADX_Sentiment_Momentum/adx_sentiment_momentum_strategy.py
@@ -124,10 +124,9 @@ class adx_sentiment_momentum_strategy(Strategy):
 
         # Start position protection
         self.StartProtection(
-            Unit(2, UnitTypes.Percent),   # Take profit 2%
-            Unit(self.StopLoss, UnitTypes.Percent)  # Stop loss based on parameter
+            takeProfit=Unit(2, UnitTypes.Percent),
+            stopLoss=Unit(self.StopLoss, UnitTypes.Percent)
         )
-
     def ProcessCandle(self, candle, adx_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:


### PR DESCRIPTION
## Summary
- update StartProtection calls in all Python strategies to use named parameters

## Testing
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6877f06d21d88323a16eaacf91c61569