### PR TITLE
Update candle indicator usage

### DIFF
--- a/API/0056_Double_Bottom/double_bottom_strategy.py
+++ b/API/0056_Double_Bottom/double_bottom_strategy.py
@@ -136,7 +136,7 @@ class double_bottom_strategy(Strategy):
             return
 
         # Process the candle with the Lowest indicator
-        lowestValue = to_float(self._lowestIndicator.Process(candle))
+        lowestValue = to_float(process_candle(self._lowestIndicator, candle))
 
         # If strategy is not ready yet, return
         if not self.IsFormedAndOnlineAndAllowTrading():

--- a/API/0057_Double_Top/double_top_strategy.py
+++ b/API/0057_Double_Top/double_top_strategy.py
@@ -136,7 +136,7 @@ class double_top_strategy(Strategy):
             return
 
         # Process the candle with the Highest indicator
-        highestValue = to_float(self._highestIndicator.Process(candle))
+        highestValue = to_float(process_candle(self._highestIndicator, candle))
 
         # If strategy is not ready yet, return
         if not self.IsFormedAndOnlineAndAllowTrading():

--- a/API/0133_MA_Volume/ma_volume_strategy.py
+++ b/API/0133_MA_Volume/ma_volume_strategy.py
@@ -137,7 +137,7 @@ class ma_volume_strategy(Strategy):
             return
 
         # Process indicators
-        sma_value = to_float(self._price_sma.Process(candle))
+        sma_value = to_float(process_candle(self._price_sma, candle))
 
         # Handle volume
         volume_sma_value = to_float(

--- a/API/0190_VWAP_ADX/vwap_adx_strategy.py
+++ b/API/0190_VWAP_ADX/vwap_adx_strategy.py
@@ -102,7 +102,7 @@ class vwap_adx_strategy(Strategy):
         if candle.State != CandleStates.Finished:
             return
 
-        vwap = to_float(self._vwap.Process(candle))
+        vwap = to_float(process_candle(self._vwap, candle))
 
         # Get current ADX value
         typed_adx = adx_value

--- a/API/0198_VWAP_MACD/vwap_macd_strategy.py
+++ b/API/0198_VWAP_MACD/vwap_macd_strategy.py
@@ -132,7 +132,7 @@ class vwap_macd_strategy(Strategy):
             return
 
         # Get VWAP value (calculated per day)
-        vwap = to_float(self._vwap.Process(candle))
+        vwap = to_float(process_candle(self._vwap, candle))
 
         macd_typed = macd_value
 

--- a/API/0235_VWAP_Mean_Reversion/vwap_mean_reversion_strategy.py
+++ b/API/0235_VWAP_Mean_Reversion/vwap_mean_reversion_strategy.py
@@ -107,7 +107,7 @@ class vwap_mean_reversion_strategy(Strategy):
         if candle.State != CandleStates.Finished:
             return
 
-        self._current_vwap = self._vwap.Process(candle)
+        self._current_vwap = process_candle(self._vwap, candle)
         self._current_vwap = float(self._current_vwap) if self._current_vwap is not None else 0
 
         self._current_atr = atr_value

--- a/API/0257_Keltner_Channel_Width_Breakout/keltner_width_breakout_strategy.py
+++ b/API/0257_Keltner_Channel_Width_Breakout/keltner_width_breakout_strategy.py
@@ -171,8 +171,8 @@ class keltner_width_breakout_strategy(Strategy):
             return
 
         # Process candle through EMA and ATR
-        emaValue = self._ema.Process(candle)
-        atrValue = self._atr.Process(candle)
+        emaValue = process_candle(self._ema, candle)
+        atrValue = process_candle(self._atr, candle)
 
         self._currentEma = float(emaValue)
         self._currentAtr = float(atrValue)

--- a/API/0258_Donchian_Channel_Width_Breakout/donchian_width_breakout_strategy.py
+++ b/API/0258_Donchian_Channel_Width_Breakout/donchian_width_breakout_strategy.py
@@ -145,8 +145,8 @@ class donchian_width_breakout_strategy(Strategy):
             return
 
         # Process candle through Highest and Lowest indicators
-        highest_value = to_float(self._highest.Process(candle))
-        lowest_value = to_float(self._lowest.Process(candle))
+        highest_value = to_float(process_candle(self._highest, candle))
+        lowest_value = to_float(process_candle(self._lowest, candle))
 
         # Calculate Donchian Channel width
         width = highest_value - lowest_value

--- a/API/0273_ATR_Slope_Breakout/atr_slope_breakout_strategy.py
+++ b/API/0273_ATR_Slope_Breakout/atr_slope_breakout_strategy.py
@@ -151,7 +151,7 @@ class atr_slope_breakout_strategy(Strategy):
         self._last_atr = atr
 
         # Process price for trend direction
-        ema_value = to_float(self._price_ema.Process(candle))
+        ema_value = to_float(process_candle(self._price_ema, candle))
         price_above_ema = candle.ClosePrice > ema_value
 
         # Calculate ATR slope

--- a/API/0274_Volume_Slope_Breakout/volume_slope_breakout_strategy.py
+++ b/API/0274_Volume_Slope_Breakout/volume_slope_breakout_strategy.py
@@ -153,7 +153,7 @@ class volume_slope_breakout_strategy(Strategy):
         volumeSma = to_float(process_float(self._volumeSma, volumeValue, candle.ServerTime, candle.State == CandleStates.Finished))
 
         # Process price EMA for trend direction
-        priceEma = to_float(self._priceEma.Process(candle))
+        priceEma = to_float(process_candle(self._priceEma, candle))
         priceAboveEma = candle.ClosePrice > priceEma
 
         # Calculate volume slope (current volume relative to SMA)

--- a/API/0277_Keltner_Width_Mean_Reversion/keltner_width_mean_reversion_strategy.py
+++ b/API/0277_Keltner_Width_Mean_Reversion/keltner_width_mean_reversion_strategy.py
@@ -179,12 +179,12 @@ class keltner_width_mean_reversion_strategy(Strategy):
             return
 
         # Process EMA
-        emaValue = self._ema.Process(candle)
+        emaValue = process_candle(self._ema, candle)
         if emaValue.IsFinal:
             self._lastEma = to_float(emaValue)
 
         # Process ATR
-        atrValue = self._atr.Process(candle)
+        atrValue = process_candle(self._atr, candle)
         if atrValue.IsFinal:
             self._lastAtr = to_float(atrValue)
 

--- a/API/0294_OBV_Slope_Mean_Reversion/obv_slope_mean_reversion_strategy.py
+++ b/API/0294_OBV_Slope_Mean_Reversion/obv_slope_mean_reversion_strategy.py
@@ -162,7 +162,7 @@ class obv_slope_mean_reversion_strategy(Strategy):
             return
 
         # Process the candle with OBV indicator
-        obv_value = to_float(self._obv.Process(candle))
+        obv_value = to_float(process_candle(self._obv, candle))
 
         # Process OBV through SMA
         obv_sma_value = to_float(process_float(self._obv_sma, obv_value, candle.ServerTime, candle.State == CandleStates.Finished))

--- a/API/0300_Hurst_Exponent_Volatility_Filter/hurst_volatility_filter_strategy.py
+++ b/API/0300_Hurst_Exponent_Volatility_Filter/hurst_volatility_filter_strategy.py
@@ -170,7 +170,7 @@ class hurst_volatility_filter_strategy(Strategy):
         # logic that estimates the Hurst exponent based on recent price behavior.
 
         # Process current price through the displacement indicator
-        hurst_value = self._hurst_exponent.Process(candle)
+        hurst_value = process_candle(self._hurst_exponent, candle)
 
         # For demonstration purposes - in a real implementation you'd use
         # a proper Hurst exponent calculation library or algorithm

--- a/API/0310_Donchian_Volatility_Contraction/donchian_volatility_contraction_strategy.py
+++ b/API/0310_Donchian_Volatility_Contraction/donchian_volatility_contraction_strategy.py
@@ -131,11 +131,11 @@ class donchian_volatility_contraction_strategy(Strategy):
             high_price = to_float(high_value)
 
             # Process Donchian Low separately
-            low_value = donchian_low.Process(candle)
+            low_value = process_candle(donchian_low, candle)
             low_price = to_float(low_value)
 
             # Process ATR
-            atr_value = atr.Process(candle)
+            atr_value = process_candle(atr, candle)
 
             # Calculate Donchian Channel width
             self._current_dc_width = high_price - low_price

--- a/API/indicator_extensions.py
+++ b/API/indicator_extensions.py
@@ -21,3 +21,8 @@ def to_float(value):
 def process_float(indicator, value, time, is_final):
     """Wrapper for indicator.Process accepting Python float."""
     return indicator.Process(float(value), time, is_final)
+
+
+def process_candle(indicator, candle):
+    """Wrapper for indicator.Process accepting a candle."""
+    return indicator.Process(candle)


### PR DESCRIPTION
## Summary
- add `process_candle` helper to wrap indicator.Process
- update strategies to use `process_candle()` when passing candles to indicators

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877fafb4a388323ab61ed65556eac7e