### PR TITLE
Remove StockSharp example comment from Python strategies

### DIFF
--- a/API/0001_MA_CrossOver/ma_crossover_strategy.py
+++ b/API/0001_MA_CrossOver/ma_crossover_strategy.py
@@ -19,7 +19,6 @@ class ma_crossover_strategy(Strategy):
     Enters short when fast MA crosses below slow MA.
     Implements stop-loss as a percentage of entry price.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0002_NDay_Breakout/nday_breakout_strategy.py
+++ b/API/0002_NDay_Breakout/nday_breakout_strategy.py
@@ -18,7 +18,6 @@ class nday_breakout_strategy(Strategy):
     Enters short when price breaks below the N-day low.
     Exits when price crosses the moving average.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0003_ADX_Trend/adx_trend_strategy.py
+++ b/API/0003_ADX_Trend/adx_trend_strategy.py
@@ -17,7 +17,6 @@ class adx_trend_strategy(Strategy):
     It enters long position when ADX > 25 and price > MA, 
     and short position when ADX > 25 and price < MA.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0004_Parabolic_SAR_Trend/parabolic_sar_trend_strategy.py
+++ b/API/0004_Parabolic_SAR_Trend/parabolic_sar_trend_strategy.py
@@ -16,7 +16,6 @@ class parabolic_sar_trend_strategy(Strategy):
     Strategy based on Parabolic SAR indicator.
     It enters long position when price is above SAR and short position when price is below SAR.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0005_Donchian_Channel/donchian_channel_strategy.py
+++ b/API/0005_Donchian_Channel/donchian_channel_strategy.py
@@ -17,7 +17,6 @@ class donchian_channel_strategy(Strategy):
     It enters long position when price breaks through the upper band 
     and short position when price breaks through the lower band.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0006_Tripple_MA/triple_ma_strategy.py
+++ b/API/0006_Tripple_MA/triple_ma_strategy.py
@@ -17,7 +17,6 @@ class triple_ma_strategy(Strategy):
     It enters long position when short MA > middle MA > long MA 
     and short position when short MA < middle MA < long MA.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0007_Keltner_Channel_Breakout/keltner_channel_breakout_strategy.py
+++ b/API/0007_Keltner_Channel_Breakout/keltner_channel_breakout_strategy.py
@@ -17,7 +17,6 @@ class keltner_channel_breakout_strategy(Strategy):
     It enters long position when price breaks through the upper band 
     and short position when price breaks through the lower band.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0008_Hull_MA_Trend/hull_ma_trend_strategy.py
+++ b/API/0008_Hull_MA_Trend/hull_ma_trend_strategy.py
@@ -17,7 +17,6 @@ class hull_ma_trend_strategy(Strategy):
     It enters long position when Hull MA is rising 
     and short position when Hull MA is falling.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0009_MACD_Trend/macd_trend_strategy.py
+++ b/API/0009_MACD_Trend/macd_trend_strategy.py
@@ -17,7 +17,6 @@ class macd_trend_strategy(Strategy):
     It enters long position when MACD crosses above signal line 
     and short position when MACD crosses below signal line.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0010_Super_Trend/supertrend_strategy.py
+++ b/API/0010_Super_Trend/supertrend_strategy.py
@@ -17,7 +17,6 @@ class supertrend_strategy(Strategy):
     It enters long position when price is above Supertrend line 
     and short position when price is below Supertrend line.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0011_Ichimoku_Kumo_Breakout/ichimoku_kumo_breakout_strategy.py
+++ b/API/0011_Ichimoku_Kumo_Breakout/ichimoku_kumo_breakout_strategy.py
@@ -17,7 +17,6 @@ class ichimoku_kumo_breakout_strategy(Strategy):
     It enters long position when price breaks above the cloud and Tenkan-sen crosses above Kijun-sen.
     It enters short position when price breaks below the cloud and Tenkan-sen crosses below Kijun-sen.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0012_Heikin_Ashi_Consecutive/heikin_ashi_consecutive_strategy.py
+++ b/API/0012_Heikin_Ashi_Consecutive/heikin_ashi_consecutive_strategy.py
@@ -16,7 +16,6 @@ class heikin_ashi_consecutive_strategy(Strategy):
     It enters long position after a sequence of bullish Heikin Ashi candles 
     and short position after a sequence of bearish Heikin Ashi candles.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0013_DMI_Power_Move/dmi_power_move_strategy.py
+++ b/API/0013_DMI_Power_Move/dmi_power_move_strategy.py
@@ -17,7 +17,6 @@ class dmi_power_move_strategy(Strategy):
     It enters long position when +DI exceeds -DI by a specified threshold and ADX is strong.
     It enters short position when -DI exceeds +DI by a specified threshold and ADX is strong.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0014_TradingView_Supertrend_Flip/tradingview_supertrend_flip_strategy.py
+++ b/API/0014_TradingView_Supertrend_Flip/tradingview_supertrend_flip_strategy.py
@@ -18,7 +18,6 @@ class tradingview_supertrend_flip_strategy(Strategy):
     It detects when Supertrend flips from above price to below (bullish) or 
     from below price to above (bearish) and confirms the signal with above-average volume.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0015_Gann_Swing_Breakout/gann_swing_breakout_strategy.py
+++ b/API/0015_Gann_Swing_Breakout/gann_swing_breakout_strategy.py
@@ -17,7 +17,6 @@ class gann_swing_breakout_strategy(Strategy):
     It detects swing highs and lows, then enters positions when price breaks out
     after a pullback to a moving average.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0016_RSI_Divergence/rsi_divergence_strategy.py
+++ b/API/0016_RSI_Divergence/rsi_divergence_strategy.py
@@ -17,7 +17,6 @@ class rsi_divergence_strategy(Strategy):
     It detects bullish divergence (price makes lower low, RSI makes higher low) 
     and bearish divergence (price makes higher high, RSI makes lower high).
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0017_Williams_R/williams_percent_r_strategy.py
+++ b/API/0017_Williams_R/williams_percent_r_strategy.py
@@ -17,7 +17,6 @@ class williams_percent_r_strategy(Strategy):
     It uses Williams %R overbought/oversold levels to generate trading signals.
     Williams %R values are negative, typically from 0 to -100.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0018_ROC_Impulce/roc_impulse_strategy.py
+++ b/API/0018_ROC_Impulce/roc_impulse_strategy.py
@@ -17,7 +17,6 @@ class roc_impulse_strategy(Strategy):
     It enters long when ROC is positive and increasing (positive momentum),
     and short when ROC is negative and decreasing (negative momentum).
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0019_CCI_Breakout/cci_breakout_strategy.py
+++ b/API/0019_CCI_Breakout/cci_breakout_strategy.py
@@ -17,7 +17,6 @@ class cci_breakout_strategy(Strategy):
     It enters long when CCI breaks above +100 (strong upward momentum)
     and short when CCI breaks below -100 (strong downward momentum).
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0020_Momentum_Percentage/momentum_percentage_strategy.py
+++ b/API/0020_Momentum_Percentage/momentum_percentage_strategy.py
@@ -17,7 +17,6 @@ class momentum_percentage_strategy(Strategy):
     It enters positions when momentum percentage exceeds threshold 
     and price is on the correct side of the moving average.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0021_Bollinger_Squeeze/bollinger_squeeze_strategy.py
+++ b/API/0021_Bollinger_Squeeze/bollinger_squeeze_strategy.py
@@ -17,7 +17,6 @@ class bollinger_squeeze_strategy(Strategy):
     It detects when Bollinger Bands narrow (squeeze) and then trades the breakout 
     when the bands start expanding again.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0022_ADX_DI/adx_di_strategy.py
+++ b/API/0022_ADX_DI/adx_di_strategy.py
@@ -17,7 +17,6 @@ class adx_di_strategy(Strategy):
     It enters long when ADX is strong and +DI > -DI,
     and short when ADX is strong and -DI > +DI.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0023_Elder_Impulse/elder_impulse_strategy.py
+++ b/API/0023_Elder_Impulse/elder_impulse_strategy.py
@@ -18,7 +18,6 @@ class elder_impulse_strategy(Strategy):
     Green bar: EMA rising and MACD histogram positive
     Red bar: EMA falling and MACD histogram negative
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0024_RSI_Laguerre/laguerre_rsi_strategy.py
+++ b/API/0024_RSI_Laguerre/laguerre_rsi_strategy.py
@@ -17,7 +17,6 @@ class laguerre_rsi_strategy(Strategy):
     Note: Since StockSharp doesn't have built-in Laguerre RSI, this implementation 
     uses regular RSI but applies Laguerre RSI trading logic with 0-1 scale.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0025_Stochastic_RSI_Cross/stochastic_rsi_cross_strategy.py
+++ b/API/0025_Stochastic_RSI_Cross/stochastic_rsi_cross_strategy.py
@@ -17,7 +17,6 @@ class stochastic_rsi_cross_strategy(Strategy):
     It trades the crossover of %K and %D lines in overbought/oversold zones.
     Note: This uses regular Stochastic as StockSharp doesn't have built-in Stochastic RSI.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0026_RSI_Reversion/rsi_reversion_strategy.py
+++ b/API/0026_RSI_Reversion/rsi_reversion_strategy.py
@@ -17,7 +17,6 @@ class rsi_reversion_strategy(Strategy):
     It buys when RSI is oversold and sells when RSI is overbought,
     expecting prices to revert to the mean (exit level).
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0027_Bollinger_Reversion/bollinger_reversion_strategy.py
+++ b/API/0027_Bollinger_Reversion/bollinger_reversion_strategy.py
@@ -17,7 +17,6 @@ class bollinger_reversion_strategy(Strategy):
     It buys when price touches the lower band and sells when price touches the upper band,
     expecting prices to revert to the middle band (mean).
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0028_ZScore/z_score_strategy.py
+++ b/API/0028_ZScore/z_score_strategy.py
@@ -16,7 +16,6 @@ class z_score_strategy(Strategy):
     Strategy based on Z-Score indicator for mean reversion trading.
     Z-Score measures the distance from the price to its moving average in standard deviations.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0029_MA_Deviation/ma_deviation_strategy.py
+++ b/API/0029_MA_Deviation/ma_deviation_strategy.py
@@ -17,7 +17,6 @@ class ma_deviation_strategy(Strategy):
     It opens positions when price deviates by a specified percentage from MA
     and closes when price returns to MA.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0030_VWAP_Reversion/vwap_reversion_strategy.py
+++ b/API/0030_VWAP_Reversion/vwap_reversion_strategy.py
@@ -17,7 +17,6 @@ class vwap_reversion_strategy(Strategy):
     It opens positions when price deviates by a specified percentage from VWAP
     and exits when price returns to VWAP.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0031_Keltner_Reversion/keltner_reversion_strategy.py
+++ b/API/0031_Keltner_Reversion/keltner_reversion_strategy.py
@@ -17,7 +17,6 @@ class keltner_reversion_strategy(Strategy):
     It opens positions when price touches or breaks through the upper or lower Keltner Channel bands
     and exits when price reverts to the middle band (EMA).
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0032_ATR_Reversion/atr_reversion_strategy.py
+++ b/API/0032_ATR_Reversion/atr_reversion_strategy.py
@@ -17,7 +17,6 @@ class atr_reversion_strategy(Strategy):
     It enters positions when price makes a significant move in one direction (N * ATR)
     and expects a reversion to the mean.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0033_MACD_Zero/macd_zero_strategy.py
+++ b/API/0033_MACD_Zero/macd_zero_strategy.py
@@ -17,7 +17,6 @@ class macd_zero_strategy(Strategy):
     It enters when MACD is below/above zero and trending back towards zero line,
     and exits when MACD crosses its signal line.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0034_Low_Vol_Reversion/low_vol_reversion_strategy.py
+++ b/API/0034_Low_Vol_Reversion/low_vol_reversion_strategy.py
@@ -17,7 +17,6 @@ class low_vol_reversion_strategy(Strategy):
     It identifies periods of low ATR (Average True Range) and opens positions when price
     deviates from its moving average, expecting a return to the mean.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0035_Bollinger_B_Reversion/bollinger_percent_b_strategy.py
+++ b/API/0035_Bollinger_B_Reversion/bollinger_percent_b_strategy.py
@@ -17,7 +17,6 @@ class bollinger_percent_b_strategy(Strategy):
     Bollinger %B shows where price is relative to the Bollinger Bands.
     Values below 0 or above 1 indicate price outside the bands.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0036_ATR_Expansion/atr_expansion_strategy.py
+++ b/API/0036_ATR_Expansion/atr_expansion_strategy.py
@@ -17,7 +17,6 @@ class atr_expansion_strategy(Strategy):
     It enters positions when ATR is increasing (volatility expansion) and price is above/below MA,
     and exits when volatility starts to contract (ATR decreasing).
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     
     def __init__(self):

--- a/API/0037_VIX_Trigger/vix_trigger_strategy.py
+++ b/API/0037_VIX_Trigger/vix_trigger_strategy.py
@@ -25,7 +25,6 @@ class vix_trigger_strategy(Strategy):
     It enters positions when VIX is rising (indicating increasing fear/volatility in the market)
     and price is moving in an expected direction relative to its moving average.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(vix_trigger_strategy, self).__init__()

--- a/API/0038_BB_Width/bollinger_band_width_strategy.py
+++ b/API/0038_BB_Width/bollinger_band_width_strategy.py
@@ -25,7 +25,6 @@ class bollinger_band_width_strategy(Strategy):
     It identifies periods of increasing volatility (widening Bollinger Bands)
     and trades in the direction of the trend as identified by price position relative to the middle band.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(bollinger_band_width_strategy, self).__init__()

--- a/API/0039_HV_Breakout/hv_breakout_strategy.py
+++ b/API/0039_HV_Breakout/hv_breakout_strategy.py
@@ -24,7 +24,6 @@ class hv_breakout_strategy(Strategy):
     It calculates price levels for breakouts using the historical volatility of the instrument
     and enters positions when price breaks above or below those levels.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(hv_breakout_strategy, self).__init__()

--- a/API/0040_ATR_Trailing/atr_trailing_strategy.py
+++ b/API/0040_ATR_Trailing/atr_trailing_strategy.py
@@ -24,7 +24,6 @@ class atr_trailing_strategy(Strategy):
     It enters positions using a simple moving average and manages exits with a dynamic
     trailing stop calculated as a multiple of ATR.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(atr_trailing_strategy, self).__init__()

--- a/API/0041_Vol_Adjusted_MA/vol_adjusted_ma_strategy.py
+++ b/API/0041_Vol_Adjusted_MA/vol_adjusted_ma_strategy.py
@@ -23,7 +23,6 @@ class vol_adjusted_ma_strategy(Strategy):
     Vol Adjusted MA strategy
     Strategy enters long when price is above MA + k*ATR, and short when price is below MA - k*ATR
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(vol_adjusted_ma_strategy, self).__init__()

--- a/API/0042_IV_Spike/iv_spike_strategy.py
+++ b/API/0042_IV_Spike/iv_spike_strategy.py
@@ -24,7 +24,6 @@ class iv_spike_strategy(Strategy):
     This strategy enters long when IV increases by 50% and price is below MA,
     or short when IV increases by 50% and price is above MA
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(iv_spike_strategy, self).__init__()

--- a/API/0043_VCP/vcp_strategy.py
+++ b/API/0043_VCP/vcp_strategy.py
@@ -26,7 +26,6 @@ class vcp_strategy(Strategy):
     Long entry: Range contraction followed by a break above previous high
     Short entry: Range contraction followed by a break below previous low
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(vcp_strategy, self).__init__()

--- a/API/0044_ATR_Range/atr_range_strategy.py
+++ b/API/0044_ATR_Range/atr_range_strategy.py
@@ -24,7 +24,6 @@ class atr_range_strategy(Strategy):
     Enters long when price moves up by at least ATR over N candles
     Enters short when price moves down by at least ATR over N candles
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(atr_range_strategy, self).__init__()

--- a/API/0045_Choppiness_Index_Breakout/choppiness_index_breakout_strategy.py
+++ b/API/0045_Choppiness_Index_Breakout/choppiness_index_breakout_strategy.py
@@ -25,7 +25,6 @@ class choppiness_index_breakout_strategy(Strategy):
     Long entry: Choppiness Index falls below 38.2 and price is above MA
     Short entry: Choppiness Index falls below 38.2 and price is below MA
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(choppiness_index_breakout_strategy, self).__init__()

--- a/API/0046_Volume_Spike/volume_spike_strategy.py
+++ b/API/0046_Volume_Spike/volume_spike_strategy.py
@@ -24,7 +24,6 @@ class volume_spike_strategy(Strategy):
     Short entry: Volume increases 2x above previous candle and price is below MA
     Exit when volume falls below average volume
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(volume_spike_strategy, self).__init__()

--- a/API/0047_OBV_Breakout/obv_breakout_strategy.py
+++ b/API/0047_OBV_Breakout/obv_breakout_strategy.py
@@ -28,7 +28,6 @@ class obv_breakout_strategy(Strategy):
     Short entry: OBV breaks below its lowest level over N periods
     Exit when OBV crosses below/above its moving average
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(obv_breakout_strategy, self).__init__()

--- a/API/0048_VWAP_Breakout/vwap_breakout_strategy.py
+++ b/API/0048_VWAP_Breakout/vwap_breakout_strategy.py
@@ -25,7 +25,6 @@ class vwap_breakout_strategy(Strategy):
     Short entry: Price breaks below VWAP
     Exit when price crosses back through VWAP
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(vwap_breakout_strategy, self).__init__()

--- a/API/0049_VWMA/vwma_strategy.py
+++ b/API/0049_VWMA/vwma_strategy.py
@@ -25,7 +25,6 @@ class vwma_strategy(Strategy):
     Short entry: Price crosses below VWMA
     Exit: Price crosses back through VWMA
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(vwma_strategy, self).__init__()

--- a/API/0050_AD/ad_strategy.py
+++ b/API/0050_AD/ad_strategy.py
@@ -25,7 +25,6 @@ class ad_strategy(Strategy):
     Short entry: A/D falling and price below MA
     Exit: A/D changes direction
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(ad_strategy, self).__init__()

--- a/API/0051_Volume_Weighted_Price_Breakout/volume_weighted_price_breakout_strategy.py
+++ b/API/0051_Volume_Weighted_Price_Breakout/volume_weighted_price_breakout_strategy.py
@@ -25,7 +25,6 @@ class volume_weighted_price_breakout_strategy(Strategy):
     Short entry: Price falls below the volume-weighted average price over N periods
     Exit: Price crosses MA in the opposite direction
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(volume_weighted_price_breakout_strategy, self).__init__()

--- a/API/0052_Volume_Divergence/volume_divergence_strategy.py
+++ b/API/0052_Volume_Divergence/volume_divergence_strategy.py
@@ -25,7 +25,6 @@ class volume_divergence_strategy(Strategy):
     Short entry: Price rises but volume increases (possible distribution)
     Exit: Price crosses MA
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(volume_divergence_strategy, self).__init__()

--- a/API/0053_Volume_MA_Cross/volume_ma_cross_strategy.py
+++ b/API/0053_Volume_MA_Cross/volume_ma_cross_strategy.py
@@ -25,7 +25,6 @@ class volume_ma_cross_strategy(Strategy):
     Short entry: Fast volume MA crosses below slow volume MA
     Exit: Reverse crossover
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(volume_ma_cross_strategy, self).__init__()

--- a/API/0054_Cumulative_Delta_Breakout/cumulative_delta_breakout_strategy.py
+++ b/API/0054_Cumulative_Delta_Breakout/cumulative_delta_breakout_strategy.py
@@ -26,7 +26,6 @@ class cumulative_delta_breakout_strategy(Strategy):
     Short entry: Cumulative Delta breaks below its N-period lowest
     Exit: Cumulative Delta changes sign (crosses zero)
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(cumulative_delta_breakout_strategy, self).__init__()

--- a/API/0055_Volume_Surge/volume_surge_strategy.py
+++ b/API/0055_Volume_Surge/volume_surge_strategy.py
@@ -25,7 +25,6 @@ class volume_surge_strategy(Strategy):
     Short entry: Volume exceeds average volume by k times and price is below MA
     Exit when volume falls below average
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(volume_surge_strategy, self).__init__()

--- a/API/0056_Double_Bottom/double_bottom_strategy.py
+++ b/API/0056_Double_Bottom/double_bottom_strategy.py
@@ -23,7 +23,6 @@ class double_bottom_strategy(Strategy):
     Double Bottom reversal strategy: looks for two similar bottoms with confirmation.
     This pattern often indicates a trend reversal from bearish to bullish.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(double_bottom_strategy, self).__init__()

--- a/API/0057_Double_Top/double_top_strategy.py
+++ b/API/0057_Double_Top/double_top_strategy.py
@@ -23,7 +23,6 @@ class double_top_strategy(Strategy):
     Double Top reversal strategy: looks for two similar tops with confirmation.
     This pattern often indicates a trend reversal from bullish to bearish.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(double_top_strategy, self).__init__()

--- a/API/0058_RSI_Overbought_Oversold/rsi_overbought_oversold_strategy.py
+++ b/API/0058_RSI_Overbought_Oversold/rsi_overbought_oversold_strategy.py
@@ -21,7 +21,6 @@ class rsi_overbought_oversold_strategy(Strategy):
     """
     RSI Overbought/Oversold strategy that buys when RSI is oversold and sells when RSI is overbought.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(rsi_overbought_oversold_strategy, self).__init__()

--- a/API/0059_Hammer_Candle/hammer_candle_strategy.py
+++ b/API/0059_Hammer_Candle/hammer_candle_strategy.py
@@ -20,7 +20,6 @@ class hammer_candle_strategy(Strategy):
     """
     Hammer Candle strategy that enters long positions when a hammer candlestick pattern appears.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(hammer_candle_strategy, self).__init__()

--- a/API/0060_Shooting_Star/shooting_star_strategy.py
+++ b/API/0060_Shooting_Star/shooting_star_strategy.py
@@ -23,7 +23,6 @@ class shooting_star_strategy(Strategy):
     Shooting Star is a bearish reversal pattern that forms after an advance
     and is characterized by a small body with a long upper shadow.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(shooting_star_strategy, self).__init__()

--- a/API/0061_MACD_Divergence/macd_divergence_strategy.py
+++ b/API/0061_MACD_Divergence/macd_divergence_strategy.py
@@ -22,7 +22,6 @@ class macd_divergence_strategy(Strategy):
     MACD Divergence strategy that looks for divergences between price and MACD
     as potential reversal signals.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(macd_divergence_strategy, self).__init__()

--- a/API/0062_Stochastic_Overbought_Oversold/stochastic_overbought_oversold_strategy.py
+++ b/API/0062_Stochastic_Overbought_Oversold/stochastic_overbought_oversold_strategy.py
@@ -21,7 +21,6 @@ class stochastic_overbought_oversold_strategy(Strategy):
     """
     Strategy based on Stochastic Oscillator's overbought/oversold conditions.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(stochastic_overbought_oversold_strategy, self).__init__()

--- a/API/0063_Engulfing_Bullish/engulfing_bullish_strategy.py
+++ b/API/0063_Engulfing_Bullish/engulfing_bullish_strategy.py
@@ -22,7 +22,6 @@ class engulfing_bullish_strategy(Strategy):
     This pattern occurs when a bullish (white) candlestick completely engulfs
     the previous bearish (black) candlestick, signaling a potential bullish reversal.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(engulfing_bullish_strategy, self).__init__()

--- a/API/0064_Engulfing_Bearish/engulfing_bearish_strategy.py
+++ b/API/0064_Engulfing_Bearish/engulfing_bearish_strategy.py
@@ -22,7 +22,6 @@ class engulfing_bearish_strategy(Strategy):
     This pattern occurs when a bearish (black) candlestick completely engulfs
     the previous bullish (white) candlestick, signaling a potential bearish reversal.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(engulfing_bearish_strategy, self).__init__()

--- a/API/0065_Pinbar_Reversal/pinbar_reversal_strategy.py
+++ b/API/0065_Pinbar_Reversal/pinbar_reversal_strategy.py
@@ -23,7 +23,6 @@ class pinbar_reversal_strategy(Strategy):
     A pinbar is characterized by a small body with a long wick/tail, 
     signaling a potential reversal in the market.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(pinbar_reversal_strategy, self).__init__()

--- a/API/0066_Three_Bar_Reversal_Up/three_bar_reversal_up_strategy.py
+++ b/API/0066_Three_Bar_Reversal_Up/three_bar_reversal_up_strategy.py
@@ -27,7 +27,6 @@ class three_bar_reversal_up_strategy(Strategy):
     2. Second bar is bearish with a lower low than the first
     3. Third bar is bullish and closes above the high of the second bar
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(three_bar_reversal_up_strategy, self).__init__()

--- a/API/0067_Three_Bar_Reversal_Down/three_bar_reversal_down_strategy.py
+++ b/API/0067_Three_Bar_Reversal_Down/three_bar_reversal_down_strategy.py
@@ -27,7 +27,6 @@ class three_bar_reversal_down_strategy(Strategy):
     2. Second bar is bullish with a higher high than the first
     3. Third bar is bearish and closes below the low of the second bar
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(three_bar_reversal_down_strategy, self).__init__()

--- a/API/0068_CCI_Divergence/cci_divergence_strategy.py
+++ b/API/0068_CCI_Divergence/cci_divergence_strategy.py
@@ -22,7 +22,6 @@ class cci_divergence_strategy(Strategy):
     CCI Divergence strategy that looks for divergences between price and CCI
     as potential reversal signals.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(cci_divergence_strategy, self).__init__()

--- a/API/0069_Bollinger_Band_Reversal/bollinger_band_reversal_strategy.py
+++ b/API/0069_Bollinger_Band_Reversal/bollinger_band_reversal_strategy.py
@@ -24,7 +24,6 @@ class bollinger_band_reversal_strategy(Strategy):
     The strategy enters long position when price is below the lower Bollinger Band and the candle is bullish,
     enters short position when price is above the upper Bollinger Band and the candle is bearish.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(bollinger_band_reversal_strategy, self).__init__()

--- a/API/0070_Morning_Star/morning_star_strategy.py
+++ b/API/0070_Morning_Star/morning_star_strategy.py
@@ -21,7 +21,6 @@ class morning_star_strategy(Strategy):
     Morning Star candle pattern strategy.
     The strategy looks for a Morning Star pattern - first bearish candle, second small candle (doji), third bullish candle that closes above the midpoint of the first.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(morning_star_strategy, self).__init__()

--- a/API/0071_Evening_Star/evening_star_strategy.py
+++ b/API/0071_Evening_Star/evening_star_strategy.py
@@ -21,7 +21,6 @@ class evening_star_strategy(Strategy):
     Evening Star candle pattern strategy.
     The strategy looks for an Evening Star pattern - first bullish candle, second small candle (doji), third bearish candle that closes below the midpoint of the first.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(evening_star_strategy, self).__init__()

--- a/API/0072_Doji_Reversal/doji_reversal_strategy.py
+++ b/API/0072_Doji_Reversal/doji_reversal_strategy.py
@@ -21,7 +21,6 @@ class doji_reversal_strategy(Strategy):
     Doji Reversal strategy.
     The strategy looks for doji candlestick patterns after a trend and takes a reversal position.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(doji_reversal_strategy, self).__init__()

--- a/API/0073_Keltner_Channel_Reversal/keltner_channel_reversal_strategy.py
+++ b/API/0073_Keltner_Channel_Reversal/keltner_channel_reversal_strategy.py
@@ -24,7 +24,6 @@ class keltner_channel_reversal_strategy(Strategy):
     The strategy enters long when price is below lower Keltner Channel and a bullish candle appears,
     enters short when price is above upper Keltner Channel and a bearish candle appears.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(keltner_channel_reversal_strategy, self).__init__()

--- a/API/0074_Williams_R_Divergence/williams_percent_r_divergence_strategy.py
+++ b/API/0074_Williams_R_Divergence/williams_percent_r_divergence_strategy.py
@@ -22,7 +22,6 @@ class williams_percent_r_divergence_strategy(Strategy):
     Williams %R Divergence strategy.
     The strategy looks for divergences between price and Williams %R indicator to identify potential reversal points.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(williams_percent_r_divergence_strategy, self).__init__()

--- a/API/0075_OBV_Divergence/obv_divergence_strategy.py
+++ b/API/0075_OBV_Divergence/obv_divergence_strategy.py
@@ -23,7 +23,6 @@ class obv_divergence_strategy(Strategy):
     OBV (On-Balance Volume) Divergence strategy.
     The strategy uses divergence between price and OBV indicator to identify potential reversal points.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(obv_divergence_strategy, self).__init__()

--- a/API/0076_Fibonacci_Retracement_Reversal/fibonacci_retracement_reversal_strategy.py
+++ b/API/0076_Fibonacci_Retracement_Reversal/fibonacci_retracement_reversal_strategy.py
@@ -21,7 +21,6 @@ class fibonacci_retracement_reversal_strategy(Strategy):
     Fibonacci Retracement Reversal strategy.
     The strategy identifies significant swings in price and looks for reversals at key Fibonacci retracement levels.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(fibonacci_retracement_reversal_strategy, self).__init__()

--- a/API/0077_Inside_Bar_Breakout/inside_bar_breakout_strategy.py
+++ b/API/0077_Inside_Bar_Breakout/inside_bar_breakout_strategy.py
@@ -22,7 +22,6 @@ class inside_bar_breakout_strategy(Strategy):
     The strategy looks for inside bar patterns (a bar with high lower than the previous bar's high and low higher than the previous bar's low)
     and enters positions on breakouts of the inside bar's high or low.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(inside_bar_breakout_strategy, self).__init__()

--- a/API/0078_Outside_Bar_Reversal/outside_bar_reversal_strategy.py
+++ b/API/0078_Outside_Bar_Reversal/outside_bar_reversal_strategy.py
@@ -22,7 +22,6 @@ class outside_bar_reversal_strategy(Strategy):
     The strategy looks for outside bar patterns (a bar with higher high and lower low than the previous bar)
     and takes positions based on the direction (bullish or bearish) of the outside bar.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(outside_bar_reversal_strategy, self).__init__()

--- a/API/0079_Trendline_Bounce/trendline_bounce_strategy.py
+++ b/API/0079_Trendline_Bounce/trendline_bounce_strategy.py
@@ -26,7 +26,6 @@ class trendline_bounce_strategy(Strategy):
     The strategy automatically identifies trendlines by connecting highs or lows
     and enters positions when price bounces off a trendline with confirmation.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(trendline_bounce_strategy, self).__init__()

--- a/API/0080_Pivot_Point_Reversal/pivot_point_reversal_strategy.py
+++ b/API/0080_Pivot_Point_Reversal/pivot_point_reversal_strategy.py
@@ -23,7 +23,6 @@ class pivot_point_reversal_strategy(Strategy):
     The strategy calculates daily pivot points and their support/resistance levels,
     and enters positions when price bounces off these levels with confirmation.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(pivot_point_reversal_strategy, self).__init__()

--- a/API/0081_VWAP_Bounce/vwap_bounce_strategy.py
+++ b/API/0081_VWAP_Bounce/vwap_bounce_strategy.py
@@ -22,7 +22,6 @@ class vwap_bounce_strategy(Strategy):
     Enters long when price is below VWAP and a bullish candle forms.
     Enters short when price is above VWAP and a bearish candle forms.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(vwap_bounce_strategy, self).__init__()

--- a/API/0082_Volume_Exhaustion/volume_exhaustion_strategy.py
+++ b/API/0082_Volume_Exhaustion/volume_exhaustion_strategy.py
@@ -23,7 +23,6 @@ class volume_exhaustion_strategy(Strategy):
     Volume Exhaustion Strategy.
     Looks for volume spikes with corresponding bullish/bearish candles.
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(volume_exhaustion_strategy, self).__init__()

--- a/API/0083_ADX_Weakening/adx_weakening_strategy.py
+++ b/API/0083_ADX_Weakening/adx_weakening_strategy.py
@@ -23,7 +23,6 @@ class adx_weakening_strategy(Strategy):
     Enters long when ADX weakens and price is above MA.
     Enters short when ADX weakens and price is below MA.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         """Initializes a new instance of the ``adx_weakening_strategy``."""

--- a/API/0086_Heikin_Ashi_Reversal/heikin_ashi_reversal_strategy.py
+++ b/API/0086_Heikin_Ashi_Reversal/heikin_ashi_reversal_strategy.py
@@ -15,7 +15,6 @@ class heikin_ashi_reversal_strategy(Strategy):
     Enters long when Heikin-Ashi candles change from bearish to bullish.
     Enters short when Heikin-Ashi candles change from bullish to bearish.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         """Initializes a new instance of the HeikinAshiReversalStrategy."""

--- a/API/0090_Donchian_Reversal/donchian_reversal_strategy.py
+++ b/API/0090_Donchian_Reversal/donchian_reversal_strategy.py
@@ -15,7 +15,6 @@ class donchian_reversal_strategy(Strategy):
     Enters long when price bounces from the lower Donchian Channel band.
     Enters short when price bounces from the upper Donchian Channel band.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0091_MACD_Histogram_Reversal/macd_histogram_reversal_strategy.py
+++ b/API/0091_MACD_Histogram_Reversal/macd_histogram_reversal_strategy.py
@@ -16,7 +16,6 @@ class macd_histogram_reversal_strategy(Strategy):
     Enters long when MACD histogram crosses above zero.
     Enters short when MACD histogram crosses below zero.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0092_RSI_Hook_Reversal/rsi_hook_reversal_strategy.py
+++ b/API/0092_RSI_Hook_Reversal/rsi_hook_reversal_strategy.py
@@ -15,7 +15,6 @@ class rsi_hook_reversal_strategy(Strategy):
     Enters long when RSI forms an upward hook from oversold conditions.
     Enters short when RSI forms a downward hook from overbought conditions.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0093_Stochastic_Hook_Reversal/stochastic_hook_reversal_strategy.py
+++ b/API/0093_Stochastic_Hook_Reversal/stochastic_hook_reversal_strategy.py
@@ -17,7 +17,6 @@ class stochastic_hook_reversal_strategy(Strategy):
     Enters long when %K forms an upward hook from oversold conditions.
     Enters short when %K forms a downward hook from overbought conditions.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0094_CCI_Hook_Reversal/cci_hook_reversal_strategy.py
+++ b/API/0094_CCI_Hook_Reversal/cci_hook_reversal_strategy.py
@@ -17,7 +17,6 @@ class cci_hook_reversal_strategy(Strategy):
     Enters long when CCI forms an upward hook from oversold conditions.
     Enters short when CCI forms a downward hook from overbought conditions.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0096_Three_White_Soldiers/three_white_soldiers_strategy.py
+++ b/API/0096_Three_White_Soldiers/three_white_soldiers_strategy.py
@@ -15,7 +15,6 @@ class three_white_soldiers_strategy(Strategy):
     This strategy looks for three consecutive bullish candles with
     closing prices higher than previous candle, indicating a strong uptrend.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0097_Three_Black_Crows/three_black_crows_strategy.py
+++ b/API/0097_Three_Black_Crows/three_black_crows_strategy.py
@@ -24,7 +24,6 @@ class three_black_crows_strategy(Strategy):
     It can also be used to exit longs that were opened by other systems if the pattern forms at resistance.
     Risk is managed with a tight percent stop above the pattern high, and trades exit if price closes back above that level.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0100_Tweezer_Top/tweezer_top_strategy.py
+++ b/API/0100_Tweezer_Top/tweezer_top_strategy.py
@@ -15,7 +15,6 @@ class tweezer_top_strategy(Strategy):
     This pattern forms when two candlesticks have nearly identical highs, with the first
     being bullish and the second being bearish, indicating a potential reversal.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0101_Harami_Bullish/harami_bullish_strategy.py
+++ b/API/0101_Harami_Bullish/harami_bullish_strategy.py
@@ -15,7 +15,6 @@ class harami_bullish_strategy(Strategy):
     Harami Bullish pattern strategy.
     Strategy enters long position when a bullish harami pattern is detected.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0102_Harami_Bearish/harami_bearish_strategy.py
+++ b/API/0102_Harami_Bearish/harami_bearish_strategy.py
@@ -14,7 +14,6 @@ class harami_bearish_strategy(Strategy):
     Harami Bearish pattern strategy.
     Strategy enters short position when a bearish harami pattern is detected.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0103_Dark_Pool_Prints/dark_pool_prints_strategy.py
+++ b/API/0103_Dark_Pool_Prints/dark_pool_prints_strategy.py
@@ -15,7 +15,6 @@ class dark_pool_prints_strategy(Strategy):
     """
     Strategy that detects unusually high volume (dark pool prints) and enters positions based on that.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0104_Rejection_Candle/rejection_candle_strategy.py
+++ b/API/0104_Rejection_Candle/rejection_candle_strategy.py
@@ -17,7 +17,6 @@ class rejection_candle_strategy(Strategy):
     """
     Strategy based on rejection candles that indicate potential reversals.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0105_False_Breakout_Trap/false_breakout_trap_strategy.py
+++ b/API/0105_False_Breakout_Trap/false_breakout_trap_strategy.py
@@ -13,7 +13,6 @@ class false_breakout_trap_strategy(Strategy):
     """
     Strategy that trades false breakouts of support and resistance levels.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0107_Upthrust_Reversal/upthrust_reversal_strategy.py
+++ b/API/0107_Upthrust_Reversal/upthrust_reversal_strategy.py
@@ -19,7 +19,6 @@ class upthrust_reversal_strategy(Strategy):
     Strategy based on Upthrust Reversal pattern, which occurs when price makes a new high above resistance
     but immediately reverses and closes below the resistance level, indicating a bearish reversal.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0110_RSI_Failure_Swing/rsi_failure_swing_strategy.py
+++ b/API/0110_RSI_Failure_Swing/rsi_failure_swing_strategy.py
@@ -16,7 +16,6 @@ class rsi_failure_swing_strategy(Strategy):
     Strategy that trades based on RSI Failure Swing pattern.
     A failure swing occurs when RSI reverses direction without crossing through centerline.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(rsi_failure_swing_strategy, self).__init__()

--- a/API/0112_CCI_Failure_Swing/cci_failure_swing_strategy.py
+++ b/API/0112_CCI_Failure_Swing/cci_failure_swing_strategy.py
@@ -14,7 +14,6 @@ class cci_failure_swing_strategy(Strategy):
     Strategy that trades based on CCI (Commodity Channel Index) Failure Swing pattern.
     A failure swing occurs when CCI reverses direction without crossing through centerline.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0115_Volume_Climax_Reversal/volume_climax_reversal_strategy.py
+++ b/API/0115_Volume_Climax_Reversal/volume_climax_reversal_strategy.py
@@ -18,7 +18,6 @@ class volume_climax_reversal_strategy(Strategy):
     """
     Volume Climax Reversal strategy.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0118_Turnaround_Tuesday/turnaround_tuesday_strategy.py
+++ b/API/0118_Turnaround_Tuesday/turnaround_tuesday_strategy.py
@@ -14,7 +14,6 @@ class turnaround_tuesday_strategy(Strategy):
     Implementation of Turnaround Tuesday trading strategy.
     The strategy enters long position on Tuesday after a price decline on Monday.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0119_End_of_Month_Strength/end_of_month_strength_strategy.py
+++ b/API/0119_End_of_Month_Strength/end_of_month_strength_strategy.py
@@ -19,7 +19,6 @@ class end_of_month_strength_strategy(Strategy):
     Implementation of End of Month Strength trading strategy.
     The strategy enters long position on the 25th day of the month and exits on the 5th day of the next month.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0120_First_Day_of_Month/first_day_of_month_strategy.py
+++ b/API/0120_First_Day_of_Month/first_day_of_month_strategy.py
@@ -15,7 +15,6 @@ class first_day_of_month_strategy(Strategy):
     Implementation of First Day of Month trading strategy.
     The strategy enters long position on the 1st day of the month and exits on the 5th day.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0121_Santa_Claus_Rally/santa_claus_rally_strategy.py
+++ b/API/0121_Santa_Claus_Rally/santa_claus_rally_strategy.py
@@ -16,7 +16,6 @@ class santa_claus_rally_strategy(Strategy):
     The strategy enters long position between December 20 and December 31,
     and exits on January 5 of the following year.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0122_January_Effect/january_effect_strategy.py
+++ b/API/0122_January_Effect/january_effect_strategy.py
@@ -16,7 +16,6 @@ class january_effect_strategy(Strategy):
     Implementation of January Effect trading strategy.
     The strategy enters long position in January and exits in February.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0124_Pre-Holiday_Strength/pre_holiday_strength_strategy.py
+++ b/API/0124_Pre-Holiday_Strength/pre_holiday_strength_strategy.py
@@ -14,7 +14,6 @@ class pre_holiday_strength_strategy(Strategy):
     Implementation of Pre-Holiday Strength trading strategy.
     The strategy enters long position before a holiday and exits after the holiday.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0126_Quarterly_Expiry/quarterly_expiry_strategy.py
+++ b/API/0126_Quarterly_Expiry/quarterly_expiry_strategy.py
@@ -14,7 +14,6 @@ class quarterly_expiry_strategy(Strategy):
     Implementation of Quarterly Expiry trading strategy.
     The strategy trades on quarterly expiration days based on price relative to MA.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0128_Midday_Reversal/midday_reversal_strategy.py
+++ b/API/0128_Midday_Reversal/midday_reversal_strategy.py
@@ -13,7 +13,6 @@ class midday_reversal_strategy(Strategy):
     Implementation of Midday Reversal trading strategy.
     The strategy trades on price reversals that occur around noon (12:00).
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0129_Overnight_Gap/overnight_gap_strategy.py
+++ b/API/0129_Overnight_Gap/overnight_gap_strategy.py
@@ -14,7 +14,6 @@ class overnight_gap_strategy(Strategy):
     Implementation of Overnight Gap trading strategy.
     The strategy trades on gaps between the current open and previous close prices.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0130_Lunch_Break_Fade/lunch_break_fade_strategy.py
+++ b/API/0130_Lunch_Break_Fade/lunch_break_fade_strategy.py
@@ -12,7 +12,6 @@ class lunch_break_fade_strategy(Strategy):
     """
     Strategy that trades on the price movement fade during the lunch break.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0131_MACD_RSI/macd_rsi_strategy.py
+++ b/API/0131_MACD_RSI/macd_rsi_strategy.py
@@ -16,7 +16,6 @@ class macd_rsi_strategy(Strategy):
     Strategy that combines MACD and RSI indicators to identify potential trading opportunities.
     It looks for trend direction with MACD and enters on extreme RSI values in the trend direction.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0132_Bollinger_Stochastic/bollinger_stochastic_strategy.py
+++ b/API/0132_Bollinger_Stochastic/bollinger_stochastic_strategy.py
@@ -16,7 +16,6 @@ class bollinger_stochastic_strategy(Strategy):
     Strategy that combines Bollinger Bands and Stochastic oscillator to identify
     potential mean-reversion trading opportunities when price is at extremes.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0134_ADX_MACD/adx_macd_strategy.py
+++ b/API/0134_ADX_MACD/adx_macd_strategy.py
@@ -23,7 +23,6 @@ class adx_macd_strategy(Strategy):
     Strategy that combines ADX and MACD indicators to identify strong trends
     and potential entry points.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0136_Supertrend_Volume/supertrend_volume_strategy.py
+++ b/API/0136_Supertrend_Volume/supertrend_volume_strategy.py
@@ -16,7 +16,6 @@ class supertrend_volume_strategy(Strategy):
     Strategy that combines the Supertrend indicator with volume analysis to identify
     strong trend-following trading opportunities.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0140_VWAP_RSI/vwap_rsi_strategy.py
+++ b/API/0140_VWAP_RSI/vwap_rsi_strategy.py
@@ -17,7 +17,6 @@ class vwap_rsi_strategy(Strategy):
     Enters positions when price is below VWAP and RSI is oversold (for longs)
     or when price is above VWAP and RSI is overbought (for shorts).
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0141_Donchian_Volume/donchian_volume_strategy.py
+++ b/API/0141_Donchian_Volume/donchian_volume_strategy.py
@@ -15,7 +15,6 @@ class donchian_volume_strategy(Strategy):
     and volume confirmation to filter signals.
     Enters positions when price breaks above/below Donchian Channel with increased volume.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0144_Hull_MA_Volume/hull_ma_volume_strategy.py
+++ b/API/0144_Hull_MA_Volume/hull_ma_volume_strategy.py
@@ -14,7 +14,6 @@ class hull_ma_volume_strategy(Strategy):
     Strategy that uses Hull Moving Average for trend direction
     and volume confirmation for trade entries.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0145_ADX_Stochastic/adx_stochastic_strategy.py
+++ b/API/0145_ADX_Stochastic/adx_stochastic_strategy.py
@@ -16,7 +16,6 @@ class adx_stochastic_strategy(Strategy):
     Strategy that combines ADX (Average Directional Index) for trend strength
     and Stochastic Oscillator for entry timing with oversold/overbought conditions.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0146_MACD_Volume/macd_volume_strategy.py
+++ b/API/0146_MACD_Volume/macd_volume_strategy.py
@@ -14,7 +14,6 @@ class macd_volume_strategy(Strategy):
     Strategy combining MACD (Moving Average Convergence Divergence) with volume confirmation.
     Enters positions when MACD line crosses the Signal line and confirms with increased volume.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0148_RSI_Stochastic/rsi_stochastic_strategy.py
+++ b/API/0148_RSI_Stochastic/rsi_stochastic_strategy.py
@@ -15,7 +15,6 @@ class rsi_stochastic_strategy(Strategy):
     Strategy that combines RSI and Stochastic Oscillator for double confirmation
     of oversold and overbought conditions.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0150_VWAP_Stochastic/vwap_stochastic_strategy.py
+++ b/API/0150_VWAP_Stochastic/vwap_stochastic_strategy.py
@@ -18,7 +18,6 @@ class vwap_stochastic_strategy(Strategy):
     Buys when price is below VWAP and Stochastic is oversold.
     Sells when price is above VWAP and Stochastic is overbought.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0151_Ichimoku_Volume/ichimoku_volume_strategy.py
+++ b/API/0151_Ichimoku_Volume/ichimoku_volume_strategy.py
@@ -15,7 +15,6 @@ class ichimoku_volume_strategy(Strategy):
     Buy when price is above Kumo cloud, Tenkan-sen is above Kijun-sen, and volume is above average.
     Sell when price is below Kumo cloud, Tenkan-sen is below Kijun-sen, and volume is above average.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0154_MA_CCI/ma_cci_strategy.py
+++ b/API/0154_MA_CCI/ma_cci_strategy.py
@@ -16,7 +16,6 @@ class ma_cci_strategy(Strategy):
     Buys when price is above MA and CCI is oversold.
     Sells when price is below MA and CCI is overbought.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0155_VWAP_Volume/vwap_volume_strategy.py
+++ b/API/0155_VWAP_Volume/vwap_volume_strategy.py
@@ -15,7 +15,6 @@ class vwap_volume_strategy(Strategy):
     Strategy combining VWAP and Volume indicators.
     Buys/sells on VWAP breakouts confirmed by above-average volume.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0157_Keltner_Volume/keltner_volume_strategy.py
+++ b/API/0157_Keltner_Volume/keltner_volume_strategy.py
@@ -20,7 +20,6 @@ class keltner_volume_strategy(Strategy):
     Buy when price breaks above upper Keltner Channel with above average volume.
     Sell when price breaks below lower Keltner Channel with above average volume.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(keltner_volume_strategy, self).__init__()

--- a/API/0158_Parabolic_SAR_Stochastic/parabolic_sar_stochastic_strategy.py
+++ b/API/0158_Parabolic_SAR_Stochastic/parabolic_sar_stochastic_strategy.py
@@ -19,7 +19,6 @@ class parabolic_sar_stochastic_strategy(Strategy):
     Buy when price is above SAR and Stochastic %K is below 20 (oversold).
     Sell when price is below SAR and Stochastic %K is above 80 (overbought).
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(parabolic_sar_stochastic_strategy, self).__init__()

--- a/API/0159_Hull_MA_RSI/hull_ma_rsi_strategy.py
+++ b/API/0159_Hull_MA_RSI/hull_ma_rsi_strategy.py
@@ -20,7 +20,6 @@ class hull_ma_rsi_strategy(Strategy):
     Buy when HMA is rising and RSI is below 30 (oversold).
     Sell when HMA is falling and RSI is above 70 (overbought).
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0161_MACD_CCI/macd_cci_strategy.py
+++ b/API/0161_MACD_CCI/macd_cci_strategy.py
@@ -21,7 +21,6 @@ class macd_cci_strategy(Strategy):
     Buy when MACD is above Signal line and CCI is below -100 (oversold).
     Sell when MACD is below Signal line and CCI is above 100 (overbought).
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0163_RSI_Williams_R/rsi_williams_r_strategy.py
+++ b/API/0163_RSI_Williams_R/rsi_williams_r_strategy.py
@@ -16,7 +16,6 @@ class rsi_williams_r_strategy(Strategy):
     Buy when RSI is below 30 and Williams %R is below -80 (double oversold condition).
     Sell when RSI is above 70 and Williams %R is above -20 (double overbought condition).
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0166_Donchian_Stochastic/donchian_stochastic_strategy.py
+++ b/API/0166_Donchian_Stochastic/donchian_stochastic_strategy.py
@@ -19,7 +19,6 @@ class donchian_stochastic_strategy(Strategy):
     Donchian Channel + Stochastic strategy.
     Strategy enters the market when the price breaks out of Donchian Channel with Stochastic confirming oversold/overbought conditions.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0167_Keltner_RSI/keltner_rsi_strategy.py
+++ b/API/0167_Keltner_RSI/keltner_rsi_strategy.py
@@ -17,7 +17,6 @@ class keltner_rsi_strategy(Strategy):
     Looks for mean reversion opportunities when price touches channel boundaries
     and RSI confirms oversold/overbought conditions.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0169_Hull_MA_Stochastic/hull_ma_stochastic_strategy.py
+++ b/API/0169_Hull_MA_Stochastic/hull_ma_stochastic_strategy.py
@@ -15,7 +15,6 @@ class hull_ma_stochastic_strategy(Strategy):
     Hull Moving Average + Stochastic Oscillator strategy.
     Strategy enters when HMA trend direction changes with Stochastic confirming oversold/overbought conditions.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0171_MACD_Williams_R/macd_williams_r_strategy.py
+++ b/API/0171_MACD_Williams_R/macd_williams_r_strategy.py
@@ -16,7 +16,6 @@ class macd_williams_r_strategy(Strategy):
     Enters long when MACD > Signal and Williams %R is oversold (< -80)
     Enters short when MACD < Signal and Williams %R is overbought (> -20)
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0175_RSI_Supertrend/rsi_supertrend_strategy.py
+++ b/API/0175_RSI_Supertrend/rsi_supertrend_strategy.py
@@ -15,7 +15,6 @@ class rsi_supertrend_strategy(Strategy):
     Enters long when RSI is oversold (< 30) and price is above Supertrend
     Enters short when RSI is overbought (> 70) and price is below Supertrend
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0176_ADX_Bollinger/adx_bollinger_strategy.py
+++ b/API/0176_ADX_Bollinger/adx_bollinger_strategy.py
@@ -15,7 +15,6 @@ class adx_bollinger_strategy(Strategy):
     Enters long when ADX > 25 and price breaks above upper Bollinger band
     Enters short when ADX > 25 and price breaks below lower Bollinger band
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0177_Ichimoku_Stochastic/ichimoku_stochastic_strategy.py
+++ b/API/0177_Ichimoku_Stochastic/ichimoku_stochastic_strategy.py
@@ -15,7 +15,6 @@ class ichimoku_stochastic_strategy(Strategy):
     Enters long when price is above Kumo (cloud), Tenkan > Kijun, and Stochastic is oversold (< 20)
     Enters short when price is below Kumo, Tenkan < Kijun, and Stochastic is overbought (> 80)
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0185_Supertrend_Stochastic/supertrend_stochastic_strategy.py
+++ b/API/0185_Supertrend_Stochastic/supertrend_stochastic_strategy.py
@@ -15,7 +15,6 @@ class supertrend_stochastic_strategy(Strategy):
     Supertrend + Stochastic strategy.
     Strategy enters trades when Supertrend indicates trend direction and Stochastic confirms with oversold/overbought conditions.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0188_Parabolic_SAR_Volume/parabolic_sar_volume_strategy.py
+++ b/API/0188_Parabolic_SAR_Volume/parabolic_sar_volume_strategy.py
@@ -23,7 +23,6 @@ class parabolic_sar_volume_strategy(Strategy):
     Strategy that combines Parabolic SAR with volume confirmation.
     Enters trades when price crosses the Parabolic SAR with above-average volume.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
     def __init__(self):
         super(parabolic_sar_volume_strategy, self).__init__()

--- a/API/0190_VWAP_ADX/vwap_adx_strategy.py
+++ b/API/0190_VWAP_ADX/vwap_adx_strategy.py
@@ -17,7 +17,6 @@ class vwap_adx_strategy(Strategy):
     Enters short when price is below VWAP and ADX > 25.
     Exits when ADX < 20.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0194_Keltner_MACD/keltner_macd_strategy.py
+++ b/API/0194_Keltner_MACD/keltner_macd_strategy.py
@@ -16,7 +16,6 @@ class keltner_macd_strategy(Strategy):
     Enters short when price breaks below lower Keltner Channel with MACD < Signal.
     Exits when MACD crosses its signal line in the opposite direction.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0197_Hull_MA_ADX/hull_ma_adx_strategy.py
+++ b/API/0197_Hull_MA_ADX/hull_ma_adx_strategy.py
@@ -16,7 +16,6 @@ class hull_ma_adx_strategy(Strategy):
     Enters short when HMA decreases and ADX > 25 (strong trend).
     Exits when ADX < 20 (weakening trend).
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0200_Ichimoku_ADX/ichimoku_adx_strategy.py
+++ b/API/0200_Ichimoku_ADX/ichimoku_adx_strategy.py
@@ -21,7 +21,6 @@ class ichimoku_adx_strategy(Strategy):
     Long: Price < Kumo (price falls below cloud)
     Short: Price > Kumo (price rises above cloud)
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0210_ADX_Donchian/adx_donchian_strategy.py
+++ b/API/0210_ADX_Donchian/adx_donchian_strategy.py
@@ -13,7 +13,6 @@ class adx_donchian_strategy(Strategy):
     """
     Strategy based on ADX and Donchian Channel indicators (#210)
     
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0211_CCI_VWAP/cci_vwap_strategy.py
+++ b/API/0211_CCI_VWAP/cci_vwap_strategy.py
@@ -17,7 +17,6 @@ class cci_vwap_strategy(Strategy):
     Enters long when CCI is below -100 and price is below VWAP.
     Enters short when CCI is above 100 and price is above VWAP.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0215_RSI_Donchian/rsi_donchian_strategy.py
+++ b/API/0215_RSI_Donchian/rsi_donchian_strategy.py
@@ -17,7 +17,6 @@ class rsi_donchian_strategy(Strategy):
     Enters short when RSI is above 70 (overbought) and price breaks below Donchian low.
     Uses middle line of Donchian Channel for exit signals.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0218_ZScore_Reversal/z_score_reversal_strategy.py
+++ b/API/0218_ZScore_Reversal/z_score_reversal_strategy.py
@@ -16,7 +16,6 @@ class z_score_reversal_strategy(Strategy):
     Enters short when Z-Score is above a positive threshold (price significantly above mean).
     Exits when Z-Score returns to zero (price returns to mean).
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0223_Momentum_Divergence/momentum_divergence_strategy.py
+++ b/API/0223_Momentum_Divergence/momentum_divergence_strategy.py
@@ -19,7 +19,6 @@ class momentum_divergence_strategy(Strategy):
     Momentum Divergence strategy.
     Trades based on divergence between price and momentum.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0226_Volatility_Adjusted_Mean_Reversion/volatility_adjusted_mean_reversion_strategy.py
+++ b/API/0226_Volatility_Adjusted_Mean_Reversion/volatility_adjusted_mean_reversion_strategy.py
@@ -14,7 +14,6 @@ class volatility_adjusted_mean_reversion_strategy(Strategy):
     Volatility Adjusted Mean Reversion strategy.
     Uses ATR and Standard Deviation to create adaptive entry thresholds.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0229_Autocorrelation_Reversal/autocorrelation_reversion_strategy.py
+++ b/API/0229_Autocorrelation_Reversal/autocorrelation_reversion_strategy.py
@@ -18,7 +18,6 @@ class autocorrelation_reversion_strategy(Strategy):
     Buys when autocorrelation is negative and price is below average.
     Sells when autocorrelation is negative and price is above average.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0233_Beta_Neutral_Arbitrage/beta_neutral_arbitrage_strategy.py
+++ b/API/0233_Beta_Neutral_Arbitrage/beta_neutral_arbitrage_strategy.py
@@ -16,7 +16,6 @@ class beta_neutral_arbitrage_strategy(Strategy):
     """
     Beta Neutral Arbitrage strategy that trades pairs of assets based on their beta-adjusted prices.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0237_Stochastic_Mean_Reversion/stochastic_mean_reversion_strategy.py
+++ b/API/0237_Stochastic_Mean_Reversion/stochastic_mean_reversion_strategy.py
@@ -19,7 +19,6 @@ class stochastic_mean_reversion_strategy(Strategy):
     Enter when Stochastic %K deviates from its average by a certain multiple of standard deviation.
     Exit when Stochastic %K returns to its average.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0241_ADX_Mean_Reversion/adx_mean_reversion_strategy.py
+++ b/API/0241_ADX_Mean_Reversion/adx_mean_reversion_strategy.py
@@ -15,7 +15,6 @@ class adx_mean_reversion_strategy(Strategy):
     ADX Mean Reversion strategy. This strategy enters positions when ADX is
     significantly below or above its average value.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0243_Volume_Mean_Reversion/volume_mean_reversion_strategy.py
+++ b/API/0243_Volume_Mean_Reversion/volume_mean_reversion_strategy.py
@@ -14,7 +14,6 @@ class volume_mean_reversion_strategy(Strategy):
     Volume Mean Reversion strategy.
     This strategy enters positions when trading volume is significantly below or above its average value.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0244_OBV_Mean_Reversion/obv_mean_reversion_strategy.py
+++ b/API/0244_OBV_Mean_Reversion/obv_mean_reversion_strategy.py
@@ -15,7 +15,6 @@ class obv_mean_reversion_strategy(Strategy):
     Enter when OBV deviates from its average by a certain multiple of standard deviation.
     Exit when OBV returns to its average.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0248_Stochastic_Breakout/stochastic_breakout_strategy.py
+++ b/API/0248_Stochastic_Breakout/stochastic_breakout_strategy.py
@@ -15,7 +15,6 @@ class stochastic_breakout_strategy(Strategy):
     Stochastic Breakout Strategy.
     This strategy identifies breakouts based on the Stochastic oscillator values compared to their historical average.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0252_ADX_Breakout/adx_breakout_strategy.py
+++ b/API/0252_ADX_Breakout/adx_breakout_strategy.py
@@ -15,7 +15,6 @@ class adx_breakout_strategy(Strategy):
     Strategy that trades on ADX breakouts.
     When ADX breaks out above its average, it enters position in the direction determined by price.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0257_Keltner_Channel_Width_Breakout/keltner_width_breakout_strategy.py
+++ b/API/0257_Keltner_Channel_Width_Breakout/keltner_width_breakout_strategy.py
@@ -17,7 +17,6 @@ class keltner_width_breakout_strategy(Strategy):
     When Keltner Channel width increases significantly above its average,
     it enters position in the direction determined by price movement.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0258_Donchian_Channel_Width_Breakout/donchian_width_breakout_strategy.py
+++ b/API/0258_Donchian_Channel_Width_Breakout/donchian_width_breakout_strategy.py
@@ -16,7 +16,6 @@ class donchian_width_breakout_strategy(Strategy):
     When Donchian Channel width increases significantly above its average,
     it enters position in the direction determined by price movement.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0272_ADX_Slope_Breakout/adx_slope_breakout_strategy.py
+++ b/API/0272_ADX_Slope_Breakout/adx_slope_breakout_strategy.py
@@ -16,7 +16,6 @@ class adx_slope_breakout_strategy(Strategy):
     """
     ADX Slope Breakout Strategy
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0276_Bollinger_Width_Mean_Reversion/bollinger_width_mean_reversion_strategy.py
+++ b/API/0276_Bollinger_Width_Mean_Reversion/bollinger_width_mean_reversion_strategy.py
@@ -16,7 +16,6 @@ class bollinger_width_mean_reversion_strategy(Strategy):
     Bollinger Width Mean Reversion Strategy.
     Strategy trades based on mean reversion of Bollinger Bands width.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0277_Keltner_Width_Mean_Reversion/keltner_width_mean_reversion_strategy.py
+++ b/API/0277_Keltner_Width_Mean_Reversion/keltner_width_mean_reversion_strategy.py
@@ -16,7 +16,6 @@ class keltner_width_mean_reversion_strategy(Strategy):
     Keltner Width Mean Reversion Strategy.
     Strategy trades based on mean reversion of Keltner Channel width.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0278_Donchian_Width_Mean_Reversion/donchian_width_mean_reversion_strategy.py
+++ b/API/0278_Donchian_Width_Mean_Reversion/donchian_width_mean_reversion_strategy.py
@@ -15,7 +15,6 @@ class donchian_width_mean_reversion_strategy(Strategy):
     Donchian Width Mean Reversion Strategy.
     This strategy trades based on the mean reversion of the Donchian Channel width.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0280_Supertrend_Distance_Mean_Reversion/supertrend_distance_mean_reversion_strategy.py
+++ b/API/0280_Supertrend_Distance_Mean_Reversion/supertrend_distance_mean_reversion_strategy.py
@@ -15,7 +15,6 @@ class supertrend_distance_mean_reversion_strategy(Strategy):
     """Supertrend Distance Mean Reversion Strategy.
     This strategy trades based on the mean reversion of the distance between price and Supertrend indicator.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0284_EMA_Slope_Mean_Reversion/ema_slope_mean_reversion_strategy.py
+++ b/API/0284_EMA_Slope_Mean_Reversion/ema_slope_mean_reversion_strategy.py
@@ -13,7 +13,6 @@ class ema_slope_mean_reversion_strategy(Strategy):
     """
     EMA Slope Mean Reversion Strategy - strategy based on mean reversion of exponential moving average slope.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0286_RSI_Slope_Mean_Reversion/rsi_slope_mean_reversion_strategy.py
+++ b/API/0286_RSI_Slope_Mean_Reversion/rsi_slope_mean_reversion_strategy.py
@@ -18,7 +18,6 @@ class rsi_slope_mean_reversion_strategy(Strategy):
 
     Suited for swing traders expecting oscillations, the strategy closes out once the RSI returns toward balance. Starting parameter `RsiPeriod` = 14.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0288_CCI_Slope_Mean_Reversion/cci_slope_mean_reversion_strategy.py
+++ b/API/0288_CCI_Slope_Mean_Reversion/cci_slope_mean_reversion_strategy.py
@@ -13,7 +13,6 @@ from datatype_extensions import *
 class cci_slope_mean_reversion_strategy(Strategy):
     """CCI Slope Mean Reversion Strategy - strategy based on mean reversion of CCI slope.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0291_ADX_Slope_Mean_Reversion/adx_slope_mean_reversion_strategy.py
+++ b/API/0291_ADX_Slope_Mean_Reversion/adx_slope_mean_reversion_strategy.py
@@ -14,7 +14,6 @@ class adx_slope_mean_reversion_strategy(Strategy):
     ADX Slope Mean Reversion Strategy.
     This strategy trades based on ADX slope reversions to the mean.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0305_RSI_Dynamic_Overbought_Oversold/rsi_dynamic_overbought_oversold_strategy.py
+++ b/API/0305_RSI_Dynamic_Overbought_Oversold/rsi_dynamic_overbought_oversold_strategy.py
@@ -15,7 +15,6 @@ class rsi_dynamic_overbought_oversold_strategy(Strategy):
     """
     Strategy based on RSI with dynamic overbought/oversold levels.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0315_Stochastic_Dynamic_Zones/stochastic_with_dynamic_zones_strategy.py
+++ b/API/0315_Stochastic_Dynamic_Zones/stochastic_with_dynamic_zones_strategy.py
@@ -15,7 +15,6 @@ class stochastic_with_dynamic_zones_strategy(Strategy):
     """
     Strategy based on Stochastic Oscillator with Dynamic Overbought/Oversold Zones.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0327_Parabolic_SAR_Hurst_Filter/parabolic_sar_hurst_strategy.py
+++ b/API/0327_Parabolic_SAR_Hurst_Filter/parabolic_sar_hurst_strategy.py
@@ -16,7 +16,6 @@ class parabolic_sar_hurst_strategy(Strategy):
     Parabolic SAR with Hurst Filter Strategy.
     Enters a position when price crosses SAR and Hurst exponent indicates a persistent trend.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0329_MACD_Volume_Cluster/macd_volume_cluster_strategy.py
+++ b/API/0329_MACD_Volume_Cluster/macd_volume_cluster_strategy.py
@@ -19,7 +19,6 @@ class macd_volume_cluster_strategy(Strategy):
     MACD with Volume Cluster strategy.
     Enters positions when MACD signal coincides with abnormal volume spike.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0332_Donchian_Hurst_Exponent/donchian_hurst_strategy.py
+++ b/API/0332_Donchian_Hurst_Exponent/donchian_hurst_strategy.py
@@ -15,7 +15,6 @@ class donchian_hurst_strategy(Strategy):
     Strategy that trades based on Donchian Channel breakouts with Hurst Exponent filter.
     Enters position when price breaks Donchian Channel with Hurst Exponent indicating trend persistence.
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):

--- a/API/0345_VWAP_Behavioral_Bias_Filter/vwap_with_behavioral_bias_filter_strategy.py
+++ b/API/0345_VWAP_Behavioral_Bias_Filter/vwap_with_behavioral_bias_filter_strategy.py
@@ -23,7 +23,6 @@ class vwap_with_behavioral_bias_filter_strategy(Strategy):
     Long: Price > VWAP
     Short: Price < VWAP
 
-    See more examples: https://github.com/StockSharp/AlgoTrading
     """
 
     def __init__(self):


### PR DESCRIPTION
## Summary
- remove `See more examples: https://github.com/StockSharp/AlgoTrading` lines from all Python strategy docstrings

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687807bb50508323910cfed785c7d6c4