### PR TITLE
Fix ADX MA checks

### DIFF
--- a/API/0003_ADX_Trend/adx_trend_strategy.py
+++ b/API/0003_ADX_Trend/adx_trend_strategy.py
@@ -156,17 +156,9 @@ class adx_trend_strategy(Strategy):
             return
 
         # Extract ADX moving average value
-        # In Python, we need to handle the ADX value properly
-        try:
-            # ADX indicator returns AverageDirectionalIndexValue with MovingAverage property
-            if hasattr(adx_value, 'MovingAverage') and adx_value.MovingAverage is not None:
-                adx_ma = float(adx_value.MovingAverage)
-            else:
-                # Fallback to direct value if MovingAverage is not available
-                adx_ma = float(adx_value)
-        except:
-            # If we can't get ADX value, skip this candle
+        if adx_value.MovingAverage is None:
             return
+        adx_ma = float(adx_value.MovingAverage)
 
         # Convert ma_value to decimal
         ma_decimal = float(ma_value)

--- a/API/0013_DMI_Power_Move/dmi_power_move_strategy.py
+++ b/API/0013_DMI_Power_Move/dmi_power_move_strategy.py
@@ -150,28 +150,13 @@ class dmi_power_move_strategy(Strategy):
             return
 
         # Extract ADX and DI values
-        try:
-            # Get individual components from DMI indicator value
-            if hasattr(adx_value, 'MovingAverage') and adx_value.MovingAverage is not None:
-                adx = float(adx_value.MovingAverage)
-            else:
-                return
-                
-            if hasattr(adx_value, 'Dx') and adx_value.Dx is not None:
-                if hasattr(adx_value.Dx, 'Plus') and adx_value.Dx.Plus is not None:
-                    plus_di_value = float(adx_value.Dx.Plus)
-                else:
-                    return
-                    
-                if hasattr(adx_value.Dx, 'Minus') and adx_value.Dx.Minus is not None:
-                    minus_di_value = float(adx_value.Dx.Minus)
-                else:
-                    return
-            else:
-                return
-        except:
-            # If we can't extract values, skip this candle
+        if adx_value.MovingAverage is None:
             return
+        if adx_value.Dx is None or adx_value.Dx.Plus is None or adx_value.Dx.Minus is None:
+            return
+        adx = float(adx_value.MovingAverage)
+        plus_di_value = float(adx_value.Dx.Plus)
+        minus_di_value = float(adx_value.Dx.Minus)
 
         # Calculate the difference between +DI and -DI
         di_difference = plus_di_value - minus_di_value

--- a/API/0022_ADX_DI/adx_di_strategy.py
+++ b/API/0022_ADX_DI/adx_di_strategy.py
@@ -129,27 +129,13 @@ class adx_di_strategy(Strategy):
             return
 
         # Get ADX and +DI/-DI values
-        try:
-            if hasattr(adx_value, 'MovingAverage') and adx_value.MovingAverage is not None:
-                adx_main = float(adx_value.MovingAverage)
-            else:
-                return
-                
-            if hasattr(adx_value, 'Dx') and adx_value.Dx is not None:
-                if hasattr(adx_value.Dx, 'Plus') and adx_value.Dx.Plus is not None:
-                    plus_di = float(adx_value.Dx.Plus)
-                else:
-                    return
-                    
-                if hasattr(adx_value.Dx, 'Minus') and adx_value.Dx.Minus is not None:
-                    minus_di = float(adx_value.Dx.Minus)
-                else:
-                    return
-            else:
-                return
-        except:
-            # If we can't extract values, skip this candle
+        if adx_value.MovingAverage is None:
             return
+        if adx_value.Dx is None or adx_value.Dx.Plus is None or adx_value.Dx.Minus is None:
+            return
+        adx_main = float(adx_value.MovingAverage)
+        plus_di = float(adx_value.Dx.Plus)
+        minus_di = float(adx_value.Dx.Minus)
 
         # Trading logic
         if adx_main >= self.adx_threshold:

--- a/API/0083_ADX_Weakening/adx_weakening_strategy.py
+++ b/API/0083_ADX_Weakening/adx_weakening_strategy.py
@@ -141,12 +141,12 @@ class adx_weakening_strategy(Strategy):
         ma = to_float(maValue)
 
         adxTyped = adxValue
-        if not hasattr(adxTyped, 'MovingAverage') or adxTyped.MovingAverage is None:
+        if adxTyped.MovingAverage is None:
             return
         adx_val = float(adxTyped.MovingAverage)
 
         dx = adxTyped.Dx
-        if not hasattr(dx, 'Plus') or dx.Plus is None or not hasattr(dx, 'Minus') or dx.Minus is None:
+        if dx.Plus is None or dx.Minus is None:
             return
 
         # If this is the first calculation, just store the ADX value

--- a/API/0103_Dark_Pool_Prints/dark_pool_prints_strategy.py
+++ b/API/0103_Dark_Pool_Prints/dark_pool_prints_strategy.py
@@ -133,13 +133,9 @@ class dark_pool_prints_strategy(Strategy):
             return
 
         # Retrieve ADX moving average value
-        try:
-            if hasattr(adx, 'MovingAverage') and adx.MovingAverage is not None:
-                adx_ma = float(adx.MovingAverage)
-            else:
-                adx_ma = float(adx)
-        except:
+        if adx.MovingAverage is None:
             return
+        adx_ma = float(adx.MovingAverage)
 
         ma_decimal = float(ma)
 

--- a/API/0134_ADX_MACD/adx_macd_strategy.py
+++ b/API/0134_ADX_MACD/adx_macd_strategy.py
@@ -174,10 +174,9 @@ class adx_macd_strategy(Strategy):
             return
 
         typedAdx = adxValue
-        try:
-            adxIndicatorValue = typedAdx.MovingAverage
-        except AttributeError:
+        if typedAdx.MovingAverage is None:
             return
+        adxIndicatorValue = typedAdx.MovingAverage
 
         macdTyped = macdValue
         try:

--- a/API/0145_ADX_Stochastic/adx_stochastic_strategy.py
+++ b/API/0145_ADX_Stochastic/adx_stochastic_strategy.py
@@ -200,10 +200,9 @@ class adx_stochastic_strategy(Strategy):
             return
 
         # Extract ADX value from indicator
-        if hasattr(adxValue, 'MovingAverage') and adxValue.MovingAverage is not None:
-            adx = float(adxValue.MovingAverage)
-        else:
+        if adxValue.MovingAverage is None:
             return
+        adx = float(adxValue.MovingAverage)
 
         stoch = stochValue
         stochK = stoch.K

--- a/API/0149_MA_ADX/ma_adx_strategy.py
+++ b/API/0149_MA_ADX/ma_adx_strategy.py
@@ -164,14 +164,9 @@ class ma_adx_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        try:
-            if hasattr(adx_value, 'MovingAverage') and adx_value.MovingAverage is not None:
-                adx_ma = float(adx_value.MovingAverage)
-            else:
-                return
-        except:
-            # If we can't extract ADX value, skip this candle
+        if adx_value.MovingAverage is None:
             return
+        adx_ma = float(adx_value.MovingAverage)
 
         # Trading logic
         if adx_ma > 25:

--- a/API/0153_Bollinger_ADX/bollinger_adx_strategy.py
+++ b/API/0153_Bollinger_ADX/bollinger_adx_strategy.py
@@ -162,13 +162,12 @@ class bollinger_adx_strategy(Strategy):
             bollinger_up = float(bollinger_value.UpBand)
             bollinger_down = float(bollinger_value.LowBand)
             middle_band = float(bollinger_value.MovingAverage)
-        except:
+        except Exception:
             return
 
-        try:
-            adx_ma = float(adx_value.MovingAverage)
-        except:
-            adx_ma = 0.0
+        if adx_value.MovingAverage is None:
+            return
+        adx_ma = float(adx_value.MovingAverage)
 
         if adx_ma > self.adx_threshold:
             # Strong trend detected

--- a/API/0170_ADX_CCI/adx_cci_strategy.py
+++ b/API/0170_ADX_CCI/adx_cci_strategy.py
@@ -126,13 +126,9 @@ class adx_cci_strategy(Strategy):
         self._prev_cci_value = float(cci_value)
 
         # Extract ADX moving average value
-        try:
-            if hasattr(adx_value, 'MovingAverage') and adx_value.MovingAverage is not None:
-                adx_ma = float(adx_value.MovingAverage)
-            else:
-                adx_ma = float(adx_value)
-        except Exception:
+        if adx_value.MovingAverage is None:
             return
+        adx_ma = float(adx_value.MovingAverage)
 
         # Trading logic
         if adx_ma > 25:

--- a/API/0190_VWAP_ADX/vwap_adx_strategy.py
+++ b/API/0190_VWAP_ADX/vwap_adx_strategy.py
@@ -106,10 +106,9 @@ class vwap_adx_strategy(Strategy):
 
         # Get current ADX value
         typed_adx = adx_value
-        try:
-            current_adx_value = typed_adx.MovingAverage
-        except AttributeError:
+        if typed_adx.MovingAverage is None:
             return
+        current_adx_value = typed_adx.MovingAverage
 
         # Skip if not formed or online
         if not self.IsFormedAndOnlineAndAllowTrading():

--- a/API/0197_Hull_MA_ADX/hull_ma_adx_strategy.py
+++ b/API/0197_Hull_MA_ADX/hull_ma_adx_strategy.py
@@ -152,10 +152,9 @@ class hull_ma_adx_strategy(Strategy):
             return
 
         typed_adx = adx_value
-        if hasattr(typed_adx, 'MovingAverage') and typed_adx.MovingAverage is not None:
-            adx = float(typed_adx.MovingAverage)
-        else:
+        if typed_adx.MovingAverage is None:
             return
+        adx = float(typed_adx.MovingAverage)
 
         hma = float(hma_value)
 

--- a/API/0200_Ichimoku_ADX/ichimoku_adx_strategy.py
+++ b/API/0200_Ichimoku_ADX/ichimoku_adx_strategy.py
@@ -170,10 +170,9 @@ class ichimoku_adx_strategy(Strategy):
         if candle.State != CandleStates.Finished:
             return
 
-        try:
-            adx = adx_value.MovingAverage
-        except AttributeError:
+        if adx_value.MovingAverage is None:
             return
+        adx = adx_value.MovingAverage
 
         self._last_adx_value = adx
 

--- a/API/0210_ADX_Donchian/adx_donchian_strategy.py
+++ b/API/0210_ADX_Donchian/adx_donchian_strategy.py
@@ -144,10 +144,9 @@ class adx_donchian_strategy(Strategy):
             return
 
         # Process ADX
-        try:
-            adx_ma = float(adx_value.MovingAverage)
-        except Exception:
+        if adx_value.MovingAverage is None:
             return
+        adx_ma = float(adx_value.MovingAverage)
 
         # Get Donchian Channel values
         upper_band = donchian_value.UpperBand

--- a/API/0241_ADX_Mean_Reversion/adx_mean_reversion_strategy.py
+++ b/API/0241_ADX_Mean_Reversion/adx_mean_reversion_strategy.py
@@ -147,12 +147,12 @@ class adx_mean_reversion_strategy(Strategy):
             return
 
         adx_typed = adx_value
-        if not hasattr(adx_typed, 'MovingAverage') or adx_typed.MovingAverage is None:
+        if adx_typed.MovingAverage is None:
             return
         current_adx = float(adx_typed.MovingAverage)
 
         dx = getattr(adx_typed, 'Dx', None)
-        if dx is None or not hasattr(dx, 'Plus') or dx.Plus is None or not hasattr(dx, 'Minus') or dx.Minus is None:
+        if dx is None or dx.Plus is None or dx.Minus is None:
             return
         plus_di = float(dx.Plus)
         minus_di = float(dx.Minus)

--- a/API/0252_ADX_Breakout/adx_breakout_strategy.py
+++ b/API/0252_ADX_Breakout/adx_breakout_strategy.py
@@ -139,10 +139,9 @@ class adx_breakout_strategy(Strategy):
             return
 
         # Get current ADX value
-        try:
-            currentAdx = float(adxValue.MovingAverage)
-        except Exception:
+        if adxValue.MovingAverage is None:
             return
+        currentAdx = float(adxValue.MovingAverage)
 
         # Process ADX through average indicator
         adxAvgValue = process_float(self._adx_average, currentAdx, candle.ServerTime, candle.State == CandleStates.Finished)

--- a/API/0291_ADX_Slope_Mean_Reversion/adx_slope_mean_reversion_strategy.py
+++ b/API/0291_ADX_Slope_Mean_Reversion/adx_slope_mean_reversion_strategy.py
@@ -166,7 +166,7 @@ class adx_slope_mean_reversion_strategy(Strategy):
             return
 
         adx_typed = adx_value
-        if not hasattr(adx_typed, 'MovingAverage') or adx_typed.MovingAverage is None:
+        if adx_typed.MovingAverage is None:
             return
 
         adx = float(adx_typed.MovingAverage)

--- a/API/0316_ADX_Volume_Breakout/adx_with_volume_breakout_strategy.py
+++ b/API/0316_ADX_Volume_Breakout/adx_with_volume_breakout_strategy.py
@@ -104,11 +104,11 @@ class adx_with_volume_breakout_strategy(Strategy):
 
         def process(candle, adx_value):
             adx_typed = adx_value
-            if getattr(adx_typed, 'MovingAverage', None) is None:
+            if adx_typed.MovingAverage is None:
                 return
             adx_ma = adx_typed.MovingAverage
             dx = getattr(adx_typed, 'Dx', None)
-            if dx is None or getattr(dx, 'Plus', None) is None or getattr(dx, 'Minus', None) is None:
+            if dx is None or dx.Plus is None or dx.Minus is None:
                 return
             plus_di = dx.Plus
             minus_di = dx.Minus


### PR DESCRIPTION
## Summary
- fix ADX moving average access in many strategies

## Testing
- `dotnet test AlgoTrading.sln --no-build --configuration Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877fd6f2d108323b1e6d9b5a0a30d33