### PR TITLE
Refactor strategies to use Subscribe methods

### DIFF
--- a/API/0211_CCI_VWAP/cci_vwap_strategy.py
+++ b/API/0211_CCI_VWAP/cci_vwap_strategy.py
@@ -8,7 +8,6 @@ from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes, Level1Fields
 from StockSharp.Algo.Indicators import CommodityChannelIndex
 from StockSharp.Algo.Strategies import Strategy
-from StockSharp.BusinessEntities import Subscription
 from datatype_extensions import *
 
 class cci_vwap_strategy(Strategy):
@@ -88,14 +87,11 @@ class cci_vwap_strategy(Strategy):
         candles_subscription = self.SubscribeCandles(self.candle_type)
 
         # Create subscription for Level1 to get VWAP
-        level1_subscription = Subscription(DataType.Level1, self.Security)
-        level1_subscription.WhenLevel1Received(self).Do(self.ProcessLevel1).Apply(self)
+        level1_subscription = self.SubscribeLevel1()
+        level1_subscription.Bind(self.ProcessLevel1).Start()
 
         # Bind CCI to candle subscription
         candles_subscription.Bind(self._cci, self.ProcessCandle).Start()
-
-        # Start Level1 subscription
-        self.Subscribe(level1_subscription)
 
         # Enable position protection
         self.StartProtection(

--- a/API/0217_Pairs_Trading/pairs_trading_strategy.py
+++ b/API/0217_Pairs_Trading/pairs_trading_strategy.py
@@ -10,7 +10,7 @@ from StockSharp.Algo.Indicators import SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
 from datatype_extensions import *
 from indicator_extensions import *
-from StockSharp.BusinessEntities import Security, Subscription
+from StockSharp.BusinessEntities import Security
 
 class pairs_trading_strategy(Strategy):
     """
@@ -128,7 +128,7 @@ class pairs_trading_strategy(Strategy):
 
         # Create subscriptions for both securities
         first_subscription = self.SubscribeCandles(self.candle_type)
-        second_subscription = self.SubscribeCandles(Subscription(self.candle_type, self.second_security))
+        second_subscription = self.SubscribeCandles(self.candle_type, self.second_security)
 
         # Bind to first security candles
         first_subscription.Bind(self.ProcessFirstSecurityCandle).Start()

--- a/API/0222_Cointegration_Pairs/cointegration_pairs_strategy.py
+++ b/API/0222_Cointegration_Pairs/cointegration_pairs_strategy.py
@@ -8,7 +8,7 @@ from System import TimeSpan, Math
 from System.Collections.Generic import Queue
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates, Sides
 from StockSharp.Algo.Strategies import Strategy
-from StockSharp.BusinessEntities import Order, Security, Subscription
+from StockSharp.BusinessEntities import Order, Security
 from datatype_extensions import *
 
 class cointegration_pairs_strategy(Strategy):
@@ -136,14 +136,14 @@ class cointegration_pairs_strategy(Strategy):
         self._asset2Price = 0
 
         # Create subscriptions for both assets
-        asset1Subscription = Subscription(self.CandleType, self.Security)
-        asset2Subscription = Subscription(self.CandleType, self.Asset2)
+        asset1Subscription = self.SubscribeCandles(self.CandleType)
+        asset2Subscription = self.SubscribeCandles(self.CandleType, self.Asset2)
 
         # Subscribe to Asset1 candles
-        self.SubscribeCandles(asset1Subscription).Bind(self.ProcessAsset1Candle).Start()
+        asset1Subscription.Bind(self.ProcessAsset1Candle).Start()
 
         # Subscribe to Asset2 candles
-        self.SubscribeCandles(asset2Subscription).Bind(self.ProcessAsset2Candle).Start()
+        asset2Subscription.Bind(self.ProcessAsset2Candle).Start()
 
         # Setup chart visualization if available
         area = self.CreateChartArea()

--- a/API/0299_Beta_Adjusted_Pairs_Trading/beta_adjusted_pairs_strategy.py
+++ b/API/0299_Beta_Adjusted_Pairs_Trading/beta_adjusted_pairs_strategy.py
@@ -8,7 +8,7 @@ from System import Math
 from StockSharp.Messages import DataType, Level1Fields, Level1ChangeMessage
 from StockSharp.Messages import Sides, OrderTypes
 from StockSharp.Algo.Strategies import Strategy
-from StockSharp.BusinessEntities import Security, Portfolio, Subscription, Order
+from StockSharp.BusinessEntities import Security, Portfolio, Order
 from datatype_extensions import *
 
 class beta_adjusted_pairs_strategy(Strategy):
@@ -178,14 +178,14 @@ class beta_adjusted_pairs_strategy(Strategy):
         self._entrySpread = 0
 
         # Create subscriptions for both assets
-        asset1Subscription = Subscription(DataType.Level1, self.Asset1)
-        asset2Subscription = Subscription(DataType.Level1, self.Asset2)
+        asset1Subscription = self.SubscribeLevel1(self.Asset1)
+        asset2Subscription = self.SubscribeLevel1(self.Asset2)
 
         # Handle price updates for Asset1
-        self.SubscribeLevel1(asset1Subscription).Bind(self.OnAsset1Subscription).Start()
+        asset1Subscription.Bind(self.OnAsset1Subscription).Start()
 
         # Handle price updates for Asset2
-        self.SubscribeLevel1(asset2Subscription).Bind(self.OnAsset2Subscription).Start()
+        asset2Subscription.Bind(self.OnAsset2Subscription).Start()
 
         # Setup chart visualization if available
         area = self.CreateChartArea()


### PR DESCRIPTION
## Summary
- refactor Python strategies to use Subscribe* helpers instead of constructing `Subscription` manually

## Testing
- `pytest` *(no tests found)*
- `dotnet test --no-build` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68781285fbb483239f0209cec1c28c11