### PR TITLE
Revert to Ichimoku-only checks

### DIFF
--- a/API/0135_Ichimoku_RSI/ichimoku_rsi_strategy.py
+++ b/API/0135_Ichimoku_RSI/ichimoku_rsi_strategy.py
@@ -189,9 +189,20 @@ class ichimoku_rsi_strategy(Strategy):
 
         # Extract values from Ichimoku indicator
         try:
+            if ichimoku_value.Tenkan is None:
+                return
             tenkan = float(ichimoku_value.Tenkan)
+
+            if ichimoku_value.Kijun is None:
+                return
             kijun = float(ichimoku_value.Kijun)
+
+            if ichimoku_value.SenkouA is None:
+                return
             senkou_span_a = float(ichimoku_value.SenkouA)
+
+            if ichimoku_value.SenkouB is None:
+                return
             senkou_span_b = float(ichimoku_value.SenkouB)
         except Exception:
             return

--- a/API/0200_Ichimoku_ADX/ichimoku_adx_strategy.py
+++ b/API/0200_Ichimoku_ADX/ichimoku_adx_strategy.py
@@ -177,9 +177,20 @@ class ichimoku_adx_strategy(Strategy):
 
         # Get Ichimoku values
         try:
+            if ichimoku_value.Tenkan is None:
+                return
             tenkan = ichimoku_value.Tenkan
+
+            if ichimoku_value.Kijun is None:
+                return
             kijun = ichimoku_value.Kijun
+
+            if ichimoku_value.SenkouA is None:
+                return
             senkou_a = ichimoku_value.SenkouA
+
+            if ichimoku_value.SenkouB is None:
+                return
             senkou_b = ichimoku_value.SenkouB
         except AttributeError:
             return

--- a/API/0321_Ichimoku_Hurst_Exponent/ichimoku_hurst_exponent_strategy.py
+++ b/API/0321_Ichimoku_Hurst_Exponent/ichimoku_hurst_exponent_strategy.py
@@ -140,9 +140,20 @@ class ichimoku_hurst_exponent_strategy(Strategy):
         # Store Ichimoku values
         ichimoku_typed = ichimoku_value
         try:
+            if ichimoku_typed.Tenkan is None:
+                return
             tenkan = float(ichimoku_typed.Tenkan)
+
+            if ichimoku_typed.Kijun is None:
+                return
             kijun = float(ichimoku_typed.Kijun)
+
+            if ichimoku_typed.SenkouA is None:
+                return
             senkou_a = float(ichimoku_typed.SenkouA)
+
+            if ichimoku_typed.SenkouB is None:
+                return
             senkou_b = float(ichimoku_typed.SenkouB)
         except Exception:
             return

--- a/API/0340_Ichimoku_Implied_Volatility/ichimoku_implied_volatility_strategy.py
+++ b/API/0340_Ichimoku_Implied_Volatility/ichimoku_implied_volatility_strategy.py
@@ -158,9 +158,20 @@ class ichimoku_implied_volatility_strategy(Strategy):
 
         # Get Ichimoku values
         try:
+            if ichimoku_value.Tenkan is None:
+                return
             tenkan = float(ichimoku_value.Tenkan)
+
+            if ichimoku_value.Kijun is None:
+                return
             kijun = float(ichimoku_value.Kijun)
+
+            if ichimoku_value.SenkouA is None:
+                return
             senkou_a = float(ichimoku_value.SenkouA)
+
+            if ichimoku_value.SenkouB is None:
+                return
             senkou_b = float(ichimoku_value.SenkouB)
         except Exception:
             return


### PR DESCRIPTION
## Summary
- revert recent None checks in non-Ichimoku strategies
- keep Ichimoku strategies validated for missing indicator values

## Testing
- `python3 -m py_compile API/0004_Parabolic_SAR_Trend/parabolic_sar_trend_strategy.py API/0016_RSI_Divergence/rsi_divergence_strategy.py API/0112_CCI_Failure_Swing/cci_failure_swing_strategy.py API/0138_MA_Stochastic/ma_stochastic_strategy.py API/0139_ATR_MACD/atr_macd_strategy.py API/0161_MACD_CCI/macd_cci_strategy.py API/0204_Parabolic_SAR_CCI/parabolic_sar_cci_strategy.py API/0251_MACD_Breakout/macd_breakout_strategy.py API/0286_RSI_Slope_Mean_Reversion/rsi_slope_mean_reversion_strategy.py API/0303_Seasonality_Adjusted_Momentum/seasonality_adjusted_momentum_strategy.py API/0135_Ichimoku_RSI/ichimoku_rsi_strategy.py API/0200_Ichimoku_ADX/ichimoku_adx_strategy.py API/0321_Ichimoku_Hurst_Exponent/ichimoku_hurst_exponent_strategy.py API/0340_Ichimoku_Implied_Volatility/ichimoku_implied_volatility_strategy.py`

------
https://chatgpt.com/codex/tasks/task_e_6878194316688323ad1d2ec7fbf4db83