### PR TITLE
Ensure candle data assigned as float in Python strategies

### DIFF
--- a/API/0001_MA_CrossOver/ma_crossover_strategy.py
+++ b/API/0001_MA_CrossOver/ma_crossover_strategy.py
@@ -163,7 +163,7 @@ class ma_crossover_strategy(Strategy):
             if not is_fast_less_than_slow:  # Fast MA crossed above Slow MA
                 # Buy signal
                 if self.Position <= 0:
-                    self._entry_price = candle.ClosePrice
+                    self._entry_price = float(candle.ClosePrice)
                     self._is_long_position = True
                     volume = self.Volume + Math.Abs(self.Position)
                     self.BuyMarket(volume)
@@ -171,7 +171,7 @@ class ma_crossover_strategy(Strategy):
             else:  # Fast MA crossed below Slow MA
                 # Sell signal
                 if self.Position >= 0:
-                    self._entry_price = candle.ClosePrice
+                    self._entry_price = float(candle.ClosePrice)
                     self._is_long_position = False
                     volume = self.Volume + Math.Abs(self.Position)
                     self.SellMarket(volume)

--- a/API/0005_Donchian_Channel/donchian_channel_strategy.py
+++ b/API/0005_Donchian_Channel/donchian_channel_strategy.py
@@ -117,7 +117,7 @@ class donchian_channel_strategy(Strategy):
 
         # Skip the first received value for proper comparison
         if self._prev_upper_band == 0:
-            self._prev_close_price = candle.ClosePrice
+            self._prev_close_price = float(candle.ClosePrice)
             self._prev_upper_band = upper_value
             self._prev_lower_band = lower_value
             return
@@ -154,7 +154,7 @@ class donchian_channel_strategy(Strategy):
                 candle.ClosePrice, mid_value))
 
         # Update previous values
-        self._prev_close_price = candle.ClosePrice
+        self._prev_close_price = float(candle.ClosePrice)
         self._prev_upper_band = upper_value
         self._prev_lower_band = lower_value
 

--- a/API/0007_Keltner_Channel_Breakout/keltner_channel_breakout_strategy.py
+++ b/API/0007_Keltner_Channel_Breakout/keltner_channel_breakout_strategy.py
@@ -145,7 +145,7 @@ class keltner_channel_breakout_strategy(Strategy):
 
         # Skip the first received value for proper comparison
         if self._prev_upper_band == 0:
-            self._prev_close_price = candle.ClosePrice
+            self._prev_close_price = float(candle.ClosePrice)
             self._prev_upper_band = upper_value
             self._prev_lower_band = lower_value
             self._prev_ema = middle_value
@@ -183,7 +183,7 @@ class keltner_channel_breakout_strategy(Strategy):
                 candle.ClosePrice, self._prev_ema))
 
         # Update previous values
-        self._prev_close_price = candle.ClosePrice
+        self._prev_close_price = float(candle.ClosePrice)
         self._prev_upper_band = upper_value
         self._prev_lower_band = lower_value
         self._prev_ema = middle_value

--- a/API/0016_RSI_Divergence/rsi_divergence_strategy.py
+++ b/API/0016_RSI_Divergence/rsi_divergence_strategy.py
@@ -119,7 +119,7 @@ class rsi_divergence_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        current_price = candle.ClosePrice
+        current_price = float(candle.ClosePrice)
         current_rsi = float(rsi_value)
 
         # For the first candle, just store values and return

--- a/API/0020_Momentum_Percentage/momentum_percentage_strategy.py
+++ b/API/0020_Momentum_Percentage/momentum_percentage_strategy.py
@@ -130,7 +130,7 @@ class momentum_percentage_strategy(Strategy):
         # Calculate the percentage change
         # Momentum indicator returns the difference between current price and price N periods ago
         # To get percentage change: (momentum / (close - momentum)) * 100
-        close_price = candle.ClosePrice
+        close_price = float(candle.ClosePrice)
         previous_price = close_price - momentum_decimal
         
         if previous_price == 0:

--- a/API/0027_Bollinger_Reversion/bollinger_reversion_strategy.py
+++ b/API/0027_Bollinger_Reversion/bollinger_reversion_strategy.py
@@ -138,7 +138,7 @@ class bollinger_reversion_strategy(Strategy):
         middle = float(bollinger_value.MovingAverage)
 
         # Get current price
-        close_price = candle.ClosePrice
+        close_price = float(candle.ClosePrice)
 
         # Entry logic
         if close_price < lower and self.Position <= 0:

--- a/API/0032_ATR_Reversion/atr_reversion_strategy.py
+++ b/API/0032_ATR_Reversion/atr_reversion_strategy.py
@@ -148,7 +148,7 @@ class atr_reversion_strategy(Strategy):
 
         # Initialize _prev_close on first formed candle
         if self._prev_close == 0:
-            self._prev_close = candle.ClosePrice
+            self._prev_close = float(candle.ClosePrice)
             return
 
         # Calculate price change from previous candle
@@ -187,7 +187,7 @@ class atr_reversion_strategy(Strategy):
                     candle.ClosePrice, sma_decimal))
 
         # Update previous close price
-        self._prev_close = candle.ClosePrice
+        self._prev_close = float(candle.ClosePrice)
 
     def CreateClone(self):
         """

--- a/API/0037_VIX_Trigger/vix_trigger_strategy.py
+++ b/API/0037_VIX_Trigger/vix_trigger_strategy.py
@@ -132,7 +132,7 @@ class vix_trigger_strategy(Strategy):
             return
 
         # Store latest VIX value
-        self._latestVix = candle.ClosePrice
+        self._latestVix = float(candle.ClosePrice)
 
         # Initialize _prevVix on first VIX candle
         if self._prevVix == 0:

--- a/API/0039_HV_Breakout/hv_breakout_strategy.py
+++ b/API/0039_HV_Breakout/hv_breakout_strategy.py
@@ -140,7 +140,7 @@ class hv_breakout_strategy(Strategy):
 
         # On first formed candle, set reference price
         if not self._isReferenceSet:
-            self._referencePrice = candle.ClosePrice
+            self._referencePrice = float(candle.ClosePrice)
             self._isReferenceSet = True
             return
 
@@ -155,13 +155,13 @@ class hv_breakout_strategy(Strategy):
                 self.BuyMarket(self.Volume)
                 
                 # Update reference price after breakout
-                self._referencePrice = candle.ClosePrice
+                self._referencePrice = float(candle.ClosePrice)
             elif candle.ClosePrice < lowerBreakoutLevel:
                 # Price broke below lower level - sell (short)
                 self.SellMarket(self.Volume)
                 
                 # Update reference price after breakout
-                self._referencePrice = candle.ClosePrice
+                self._referencePrice = float(candle.ClosePrice)
         elif self.Position > 0:
             # Long position - check for exit signal
             if candle.ClosePrice < smaValue:

--- a/API/0040_ATR_Trailing/atr_trailing_strategy.py
+++ b/API/0040_ATR_Trailing/atr_trailing_strategy.py
@@ -135,7 +135,7 @@ class atr_trailing_strategy(Strategy):
                 self.BuyMarket(self.Volume)
                 
                 # Record entry price
-                self._entryPrice = candle.ClosePrice
+                self._entryPrice = float(candle.ClosePrice)
                 
                 # Set initial trailing stop
                 self._trailingStopLevel = self._entryPrice - trailingStopDistance
@@ -144,7 +144,7 @@ class atr_trailing_strategy(Strategy):
                 self.SellMarket(self.Volume)
                 
                 # Record entry price
-                self._entryPrice = candle.ClosePrice
+                self._entryPrice = float(candle.ClosePrice)
                 
                 # Set initial trailing stop
                 self._trailingStopLevel = self._entryPrice + trailingStopDistance

--- a/API/0044_ATR_Range/atr_range_strategy.py
+++ b/API/0044_ATR_Range/atr_range_strategy.py
@@ -134,7 +134,7 @@ class atr_range_strategy(Strategy):
 
         # Store price for first bar of lookback period
         if self._barCounter == 1 or self._barCounter % self.LookbackPeriod == 1:
-            self._nBarsAgoPrice = candle.ClosePrice
+            self._nBarsAgoPrice = float(candle.ClosePrice)
             self.LogInfo("Storing reference price: {0} at bar {1}".format(self._nBarsAgoPrice, self._barCounter))
             return
 

--- a/API/0048_VWAP_Breakout/vwap_breakout_strategy.py
+++ b/API/0048_VWAP_Breakout/vwap_breakout_strategy.py
@@ -100,7 +100,7 @@ class vwap_breakout_strategy(Strategy):
         
         # Skip the first candle, just initialize values
         if self._isFirstCandle:
-            self._previousClosePrice = candle.ClosePrice
+            self._previousClosePrice = float(candle.ClosePrice)
             self._previousVWAP = vwapPrice
             self._isFirstCandle = False
             return
@@ -138,7 +138,7 @@ class vwap_breakout_strategy(Strategy):
             self.BuyMarket(Math.Abs(self.Position))
 
         # Store current values for next comparison
-        self._previousClosePrice = candle.ClosePrice
+        self._previousClosePrice = float(candle.ClosePrice)
         self._previousVWAP = vwapPrice
 
     def CreateClone(self):

--- a/API/0049_VWMA/vwma_strategy.py
+++ b/API/0049_VWMA/vwma_strategy.py
@@ -112,7 +112,7 @@ class vwma_strategy(Strategy):
         
         # Skip the first candle, just initialize values
         if self._isFirstCandle:
-            self._previousClosePrice = candle.ClosePrice
+            self._previousClosePrice = float(candle.ClosePrice)
             self._previousVWMA = vwmaPrice
             self._isFirstCandle = False
             return
@@ -152,7 +152,7 @@ class vwma_strategy(Strategy):
             self.BuyMarket(Math.Abs(self.Position))
 
         # Store current values for next comparison
-        self._previousClosePrice = candle.ClosePrice
+        self._previousClosePrice = float(candle.ClosePrice)
         self._previousVWMA = vwmaPrice
 
     def CreateClone(self):

--- a/API/0052_Volume_Divergence/volume_divergence_strategy.py
+++ b/API/0052_Volume_Divergence/volume_divergence_strategy.py
@@ -124,7 +124,7 @@ class volume_divergence_strategy(Strategy):
         
         # Skip the first candle, just initialize values
         if self._isFirstCandle:
-            self._previousClose = candle.ClosePrice
+            self._previousClose = float(candle.ClosePrice)
             self._previousVolume = candle.TotalVolume
             self._isFirstCandle = False
             return
@@ -165,7 +165,7 @@ class volume_divergence_strategy(Strategy):
             self.BuyMarket(Math.Abs(self.Position))
 
         # Store current values for next comparison
-        self._previousClose = candle.ClosePrice
+        self._previousClose = float(candle.ClosePrice)
         self._previousVolume = candle.TotalVolume
 
     def CreateClone(self):

--- a/API/0061_MACD_Divergence/macd_divergence_strategy.py
+++ b/API/0061_MACD_Divergence/macd_divergence_strategy.py
@@ -180,7 +180,7 @@ class macd_divergence_strategy(Strategy):
             self._previousMacd = self._currentMacd
 
         # Update current values
-        self._currentPrice = candle.ClosePrice
+        self._currentPrice = float(candle.ClosePrice)
         self._currentMacd = macd
 
         self.LogInfo("Candle: {0}, Close: {1}, MACD: {2:F4}, Signal: {3:F4}".format(

--- a/API/0068_CCI_Divergence/cci_divergence_strategy.py
+++ b/API/0068_CCI_Divergence/cci_divergence_strategy.py
@@ -169,7 +169,7 @@ class cci_divergence_strategy(Strategy):
             self._previousCci = self._currentCci
 
         # Update current values
-        self._currentPrice = candle.ClosePrice
+        self._currentPrice = float(candle.ClosePrice)
         self._currentCci = cciValue
 
         self.LogInfo("Candle: {0}, Close: {1}, CCI: {2:F2}".format(

--- a/API/0074_Williams_R_Divergence/williams_percent_r_divergence_strategy.py
+++ b/API/0074_Williams_R_Divergence/williams_percent_r_divergence_strategy.py
@@ -123,7 +123,7 @@ class williams_percent_r_divergence_strategy(Strategy):
         self._previousPrice = self._currentPrice
         self._previousWilliamsR = self._currentWilliamsR
         
-        self._currentPrice = candle.ClosePrice
+        self._currentPrice = float(candle.ClosePrice)
         self._currentWilliamsR = williamsRValue
 
         # We need at least two points to detect divergence

--- a/API/0075_OBV_Divergence/obv_divergence_strategy.py
+++ b/API/0075_OBV_Divergence/obv_divergence_strategy.py
@@ -127,7 +127,7 @@ class obv_divergence_strategy(Strategy):
         self._previousPrice = self._currentPrice
         self._previousObv = self._currentObv
         
-        self._currentPrice = candle.ClosePrice
+        self._currentPrice = float(candle.ClosePrice)
         self._currentObv = obvValue
         
         maPrice = maValue

--- a/API/0076_Fibonacci_Retracement_Reversal/fibonacci_retracement_reversal_strategy.py
+++ b/API/0076_Fibonacci_Retracement_Reversal/fibonacci_retracement_reversal_strategy.py
@@ -207,7 +207,7 @@ class fibonacci_retracement_reversal_strategy(Strategy):
 
         swingHigh = self._swingHigh
         swingLow = self._swingLow
-        currentPrice = candle.ClosePrice
+        currentPrice = float(candle.ClosePrice)
         isBullish = candle.ClosePrice > candle.OpenPrice
         isBearish = candle.ClosePrice < candle.OpenPrice
 

--- a/API/0080_Pivot_Point_Reversal/pivot_point_reversal_strategy.py
+++ b/API/0080_Pivot_Point_Reversal/pivot_point_reversal_strategy.py
@@ -108,7 +108,7 @@ class pivot_point_reversal_strategy(Strategy):
         # Store previous day's OHLC for pivot point calculation
         self._prevHigh = candle.HighPrice
         self._prevLow = candle.LowPrice
-        self._prevClose = candle.ClosePrice
+        self._prevClose = float(candle.ClosePrice)
         
         # Calculate pivot points for the new day
         self.CalculatePivotPoints()

--- a/API/0081_VWAP_Bounce/vwap_bounce_strategy.py
+++ b/API/0081_VWAP_Bounce/vwap_bounce_strategy.py
@@ -90,7 +90,7 @@ class vwap_bounce_strategy(Strategy):
         if candle.TotalVolume != 0:
             vwap = candle.TotalPrice / candle.TotalVolume
         else:
-            vwap = candle.ClosePrice
+            vwap = float(candle.ClosePrice)
 
         # If VWAP is not initialized yet
         if self._prevVwap == 0:

--- a/API/0088_Supertrend_Reversal/supertrend_reversal_strategy.py
+++ b/API/0088_Supertrend_Reversal/supertrend_reversal_strategy.py
@@ -122,7 +122,7 @@ class supertrend_reversal_strategy(Strategy):
             self._prev_highest = upper_band
             self._prev_lowest = lower_band
             self._prev_supertrend = upper_band if candle.ClosePrice <= upper_band else lower_band
-            self._prev_close = candle.ClosePrice
+            self._prev_close = float(candle.ClosePrice)
             self._is_first_update = False
             return
 
@@ -164,7 +164,7 @@ class supertrend_reversal_strategy(Strategy):
             self._prev_highest = current_upper_band
             self._prev_lowest = current_lower_band
             self._prev_supertrend = supertrend
-            self._prev_close = candle.ClosePrice
+            self._prev_close = float(candle.ClosePrice)
             return
 
         # Check for Supertrend reversal
@@ -185,7 +185,7 @@ class supertrend_reversal_strategy(Strategy):
         self._prev_highest = current_upper_band
         self._prev_lowest = current_lower_band
         self._prev_supertrend = supertrend
-        self._prev_close = candle.ClosePrice
+        self._prev_close = float(candle.ClosePrice)
 
     def CreateClone(self):
         """!! REQUIRED!! Creates a new instance of the strategy."""

--- a/API/0090_Donchian_Reversal/donchian_reversal_strategy.py
+++ b/API/0090_Donchian_Reversal/donchian_reversal_strategy.py
@@ -118,7 +118,7 @@ class donchian_reversal_strategy(Strategy):
 
         # If this is the first candle, just store the close price
         if self._is_first_candle:
-            self._previous_close = candle.ClosePrice
+            self._previous_close = float(candle.ClosePrice)
             self._is_first_candle = False
             return
 
@@ -142,7 +142,7 @@ class donchian_reversal_strategy(Strategy):
             self.LogInfo(f"Short entry: Price bounced from upper Donchian band ({upper_band})")
 
         # Store current close price for next candle comparison
-        self._previous_close = candle.ClosePrice
+        self._previous_close = float(candle.ClosePrice)
 
     def CreateClone(self):
         """!! REQUIRED!! Creates a new instance of the strategy."""

--- a/API/0099_Tweezer_Bottom/tweezer_bottom_strategy.py
+++ b/API/0099_Tweezer_Bottom/tweezer_bottom_strategy.py
@@ -108,7 +108,7 @@ class tweezer_bottom_strategy(Strategy):
         if is_tweezer_bottom and self.Position == 0:
             self.LogInfo("Tweezer Bottom pattern detected. Going long.")
             self.BuyMarket(self.Volume)
-            self._entry_price = candle.ClosePrice
+            self._entry_price = float(candle.ClosePrice)
         # Check for exit condition
         elif self.Position > 0 and candle.HighPrice > self._entry_price:
             self.LogInfo("Price exceeded entry high. Taking profit.")

--- a/API/0100_Tweezer_Top/tweezer_top_strategy.py
+++ b/API/0100_Tweezer_Top/tweezer_top_strategy.py
@@ -116,7 +116,7 @@ class tweezer_top_strategy(Strategy):
         if isTweezerTop and self.Position == 0:
             self.LogInfo("Tweezer Top pattern detected. Going short.")
             self.SellMarket(self.Volume)
-            self._entryPrice = candle.ClosePrice
+            self._entryPrice = float(candle.ClosePrice)
         # Check for exit condition
         elif self.Position < 0 and candle.LowPrice < self._entryPrice:
             self.LogInfo("Price below entry low. Taking profit.")

--- a/API/0105_False_Breakout_Trap/false_breakout_trap_strategy.py
+++ b/API/0105_False_Breakout_Trap/false_breakout_trap_strategy.py
@@ -188,7 +188,7 @@ class false_breakout_trap_strategy(Strategy):
                 # Potential upside breakout
                 self._breakoutDetected = True
                 self._breakoutSide = Sides.Buy
-                self._breakoutPrice = candle.ClosePrice
+                self._breakoutPrice = float(candle.ClosePrice)
 
                 self.LogInfo("Potential upside breakout detected at {0}. Watching for false breakout pattern.".format(
                     candle.HighPrice))
@@ -196,7 +196,7 @@ class false_breakout_trap_strategy(Strategy):
                 # Potential downside breakout
                 self._breakoutDetected = True
                 self._breakoutSide = Sides.Sell
-                self._breakoutPrice = candle.ClosePrice
+                self._breakoutPrice = float(candle.ClosePrice)
 
                 self.LogInfo("Potential downside breakout detected at {0}. Watching for false breakout pattern.".format(
                     candle.LowPrice))

--- a/API/0118_Turnaround_Tuesday/turnaround_tuesday_strategy.py
+++ b/API/0118_Turnaround_Tuesday/turnaround_tuesday_strategy.py
@@ -119,7 +119,7 @@ class turnaround_tuesday_strategy(Strategy):
             self.LogInfo("Closing position on Friday: Position={0}".format(self.Position))
 
         # Store current close price for next candle
-        self._prev_close_price = candle.ClosePrice
+        self._prev_close_price = float(candle.ClosePrice)
 
     def CreateClone(self):
         """!! REQUIRED!! Creates a new instance of the strategy."""

--- a/API/0127_Open_Drive/open_drive_strategy.py
+++ b/API/0127_Open_Drive/open_drive_strategy.py
@@ -108,7 +108,7 @@ class open_drive_strategy(Strategy):
         """Process candle and execute trading logic."""
         # Skip if we don't have the previous close price yet
         if self._prev_close_price == 0:
-            self._prev_close_price = candle.ClosePrice
+            self._prev_close_price = float(candle.ClosePrice)
             return
 
         # Skip unfinished candles
@@ -148,7 +148,7 @@ class open_drive_strategy(Strategy):
                 self.Position, candle.ClosePrice, sma_value))
 
         # Update previous close price for next candle
-        self._prev_close_price = candle.ClosePrice
+        self._prev_close_price = float(candle.ClosePrice)
 
     def CreateClone(self):
         """!! REQUIRED!! Creates a new instance of the strategy."""

--- a/API/0128_Midday_Reversal/midday_reversal_strategy.py
+++ b/API/0128_Midday_Reversal/midday_reversal_strategy.py
@@ -86,12 +86,12 @@ class midday_reversal_strategy(Strategy):
 
         # Initialize price history first
         if self._prev_candle_close == 0:
-            self._prev_candle_close = candle.ClosePrice
+            self._prev_candle_close = float(candle.ClosePrice)
             return
 
         if self._prev_prev_candle_close == 0:
             self._prev_prev_candle_close = self._prev_candle_close
-            self._prev_candle_close = candle.ClosePrice
+            self._prev_candle_close = float(candle.ClosePrice)
             return
 
         # Check for midday reversal conditions
@@ -133,7 +133,7 @@ class midday_reversal_strategy(Strategy):
 
         # Update price history
         self._prev_prev_candle_close = self._prev_candle_close
-        self._prev_candle_close = candle.ClosePrice
+        self._prev_candle_close = float(candle.ClosePrice)
 
     def CreateClone(self):
         """!! REQUIRED!! Creates a new instance of the strategy."""

--- a/API/0129_Overnight_Gap/overnight_gap_strategy.py
+++ b/API/0129_Overnight_Gap/overnight_gap_strategy.py
@@ -101,7 +101,7 @@ class overnight_gap_strategy(Strategy):
         """
         # Skip if we don't have previous close price yet
         if self._prev_close_price == 0:
-            self._prev_close_price = candle.ClosePrice
+            self._prev_close_price = float(candle.ClosePrice)
             return
 
         # Skip unfinished candles
@@ -141,7 +141,7 @@ class overnight_gap_strategy(Strategy):
                     self.Position, self._prev_close_price))
 
         # Update previous close price for next candle
-        self._prev_close_price = candle.ClosePrice
+        self._prev_close_price = float(candle.ClosePrice)
 
     def CreateClone(self):
         """!! REQUIRED!! Creates a new instance of the strategy."""

--- a/API/0130_Lunch_Break_Fade/lunch_break_fade_strategy.py
+++ b/API/0130_Lunch_Break_Fade/lunch_break_fade_strategy.py
@@ -103,13 +103,13 @@ class lunch_break_fade_strategy(Strategy):
         if candle.OpenTime.Hour != self.LunchHour:
             # Update previous candles data
             self._twoCandlesBackClose = self._previousCandleClose
-            self._previousCandleClose = candle.ClosePrice
+            self._previousCandleClose = float(candle.ClosePrice)
             return
 
         # Trading logic can only be applied if we have enough historical data
         if self._previousCandleClose is None or self._twoCandlesBackClose is None:
             self._twoCandlesBackClose = self._previousCandleClose
-            self._previousCandleClose = candle.ClosePrice
+            self._previousCandleClose = float(candle.ClosePrice)
             return
 
         # Lunch break fade logic:
@@ -136,7 +136,7 @@ class lunch_break_fade_strategy(Strategy):
 
         # Update previous candles data
         self._twoCandlesBackClose = self._previousCandleClose
-        self._previousCandleClose = candle.ClosePrice
+        self._previousCandleClose = float(candle.ClosePrice)
 
     def OnStopped(self):
         self._previousCandleClose = None

--- a/API/0157_Keltner_Volume/keltner_volume_strategy.py
+++ b/API/0157_Keltner_Volume/keltner_volume_strategy.py
@@ -183,7 +183,7 @@ class keltner_volume_strategy(Strategy):
             upperBand, lowerBand, currentVolume, self._averageVolume))
 
         # Check crossovers - only valid after we have a last price
-        currentPrice = candle.ClosePrice
+        currentPrice = float(candle.ClosePrice)
 
         # Skip if this is the first processed candle
         if self._lastPrice != 0:

--- a/API/0158_Parabolic_SAR_Stochastic/parabolic_sar_stochastic_strategy.py
+++ b/API/0158_Parabolic_SAR_Stochastic/parabolic_sar_stochastic_strategy.py
@@ -181,7 +181,7 @@ class parabolic_sar_stochastic_strategy(Strategy):
 
         sarDec = to_float(sarValue)
 
-        currentPrice = candle.ClosePrice
+        currentPrice = float(candle.ClosePrice)
         priceAboveSar = currentPrice > sarDec
 
         self.LogInfo(

--- a/API/0162_Bollinger_CCI/bollinger_cci_strategy.py
+++ b/API/0162_Bollinger_CCI/bollinger_cci_strategy.py
@@ -163,7 +163,7 @@ class bollinger_cci_strategy(Strategy):
         cciTyped = float(cciValue)
 
         # Current price
-        price = candle.ClosePrice
+        price = float(candle.ClosePrice)
 
         self.LogInfo(
             "Candle: {0}, Close: {1}, Upper Band: {2}, Middle Band: {3}, Lower Band: {4}, CCI: {5}".format(

--- a/API/0164_MA_Williams_R/ma_williams_r_strategy.py
+++ b/API/0164_MA_Williams_R/ma_williams_r_strategy.py
@@ -176,7 +176,7 @@ class ma_williams_r_strategy(Strategy):
             return
 
         # Current price
-        price = candle.ClosePrice
+        price = float(candle.ClosePrice)
 
         # Determine if price is above or below MA
         isPriceAboveMA = price > maValue

--- a/API/0165_VWAP_CCI/vwap_cci_strategy.py
+++ b/API/0165_VWAP_CCI/vwap_cci_strategy.py
@@ -132,7 +132,7 @@ class vwap_cci_strategy(Strategy):
             return
 
         # Current price
-        price = candle.ClosePrice
+        price = float(candle.ClosePrice)
 
         # Determine if price is above or below VWAP
         is_price_above_vwap = price > vwap_value

--- a/API/0172_Bollinger_Williams_R/bollinger_williams_r_strategy.py
+++ b/API/0172_Bollinger_Williams_R/bollinger_williams_r_strategy.py
@@ -140,7 +140,7 @@ class bollinger_williams_r_strategy(Strategy):
         lower_band = bollinger_typed.LowBand
 
         # Current price (close of the candle)
-        price = candle.ClosePrice
+        price = float(candle.ClosePrice)
 
         # Stop-loss size based on ATR
         stop_size = to_float(atr_value) * self.AtrMultiplier

--- a/API/0174_MACD_VWAP/macd_vwap_strategy.py
+++ b/API/0174_MACD_VWAP/macd_vwap_strategy.py
@@ -123,7 +123,7 @@ class macd_vwap_strategy(Strategy):
         vwap = to_float(vwap_value)
 
         # Current price (close of the candle)
-        price = candle.ClosePrice
+        price = float(candle.ClosePrice)
 
         # Trading logic
         if macd_line > signal_line and price > vwap and self.Position <= 0:

--- a/API/0175_RSI_Supertrend/rsi_supertrend_strategy.py
+++ b/API/0175_RSI_Supertrend/rsi_supertrend_strategy.py
@@ -164,7 +164,7 @@ class rsi_supertrend_strategy(Strategy):
             return
 
         # Calculate Supertrend
-        close_price = candle.ClosePrice
+        close_price = float(candle.ClosePrice)
         high_price = candle.HighPrice
         low_price = candle.LowPrice
 

--- a/API/0176_ADX_Bollinger/adx_bollinger_strategy.py
+++ b/API/0176_ADX_Bollinger/adx_bollinger_strategy.py
@@ -154,7 +154,7 @@ class adx_bollinger_strategy(Strategy):
         middle_band = (upper_band - lower_band) / 2 + lower_band
 
         # Current price (close of the candle)
-        price = candle.ClosePrice
+        price = float(candle.ClosePrice)
 
         # Stop-loss size based on ATR
         stop_size = float(atr_value) * self.atr_multiplier

--- a/API/0177_Ichimoku_Stochastic/ichimoku_stochastic_strategy.py
+++ b/API/0177_Ichimoku_Stochastic/ichimoku_stochastic_strategy.py
@@ -182,7 +182,7 @@ class ichimoku_stochastic_strategy(Strategy):
         senkou_b = float(ichimoku_typed.SenkouB)
 
         # Current price (close of the candle)
-        price = candle.ClosePrice
+        price = float(candle.ClosePrice)
 
         # Check if price is above/below Kumo cloud
         is_above_kumo = price > Math.Max(senkou_a, senkou_b)

--- a/API/0187_Donchian_MACD/donchian_macd_strategy.py
+++ b/API/0187_Donchian_MACD/donchian_macd_strategy.py
@@ -164,7 +164,7 @@ class donchian_macd_strategy(Strategy):
             # Enter long position
             volume = self.Volume + Math.Abs(self.Position)
             self.BuyMarket(volume)
-            self._entryPrice = candle.ClosePrice
+            self._entryPrice = float(candle.ClosePrice)
 
             self.LogInfo("Long entry signal: Price {0} broke above Donchian high {1} with MACD confirmation".format(candle.ClosePrice, self._previousHighest))
         # Short entry: Price breaks below Donchian low and MACD < Signal
@@ -175,7 +175,7 @@ class donchian_macd_strategy(Strategy):
             # Enter short position
             volume = self.Volume + Math.Abs(self.Position)
             self.SellMarket(volume)
-            self._entryPrice = candle.ClosePrice
+            self._entryPrice = float(candle.ClosePrice)
 
             self.LogInfo("Short entry signal: Price {0} broke below Donchian low {1} with MACD confirmation".format(candle.ClosePrice, self._previousLowest))
         # MACD trend reversal exit

--- a/API/0188_Parabolic_SAR_Volume/parabolic_sar_volume_strategy.py
+++ b/API/0188_Parabolic_SAR_Volume/parabolic_sar_volume_strategy.py
@@ -145,7 +145,7 @@ class parabolic_sar_volume_strategy(Strategy):
             return
 
         # Get current price and volume
-        currentPrice = candle.ClosePrice
+        currentPrice = float(candle.ClosePrice)
         currentVolume = candle.TotalVolume
         isPriceAboveSar = currentPrice > sarValue
 

--- a/API/0201_VWAP_Williams_R/vwap_williams_r_strategy.py
+++ b/API/0201_VWAP_Williams_R/vwap_williams_r_strategy.py
@@ -111,7 +111,7 @@ class vwap_williams_r_strategy(Strategy):
         # Long: Price < VWAP && Williams %R < -80 (oversold below VWAP)
         # Short: Price > VWAP && Williams %R > -20 (overbought above VWAP)
 
-        price = candle.ClosePrice
+        price = float(candle.ClosePrice)
 
         if price < vwap_value and williams_r_value < -80 and self.Position <= 0:
             # Buy signal - oversold condition below VWAP

--- a/API/0202_Donchian_CCI/donchian_cci_strategy.py
+++ b/API/0202_Donchian_CCI/donchian_cci_strategy.py
@@ -118,7 +118,7 @@ class donchian_cci_strategy(Strategy):
         middle_band = donchian_typed.Middle
 
         cci_dec = cci_value
-        price = candle.ClosePrice
+        price = float(candle.ClosePrice)
 
         # Trading logic:
         # Long: Price > Donchian Upper && CCI < -100 (breakout up with oversold conditions)

--- a/API/0203_Keltner_Williams_R/keltner_williams_r_strategy.py
+++ b/API/0203_Keltner_Williams_R/keltner_williams_r_strategy.py
@@ -131,7 +131,7 @@ class keltner_williams_r_strategy(Strategy):
 
         williams_r = float(williams_r_value)
 
-        price = candle.ClosePrice
+        price = float(candle.ClosePrice)
 
         # Trading logic:
         # Long: Price < lower Keltner band && Williams %R < -80 (oversold at lower band)

--- a/API/0204_Parabolic_SAR_CCI/parabolic_sar_cci_strategy.py
+++ b/API/0204_Parabolic_SAR_CCI/parabolic_sar_cci_strategy.py
@@ -106,7 +106,7 @@ class parabolic_sar_cci_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        price = candle.ClosePrice
+        price = float(candle.ClosePrice)
 
         # Trading logic:
         # Long: Price > SAR && CCI < -100 (trend up with oversold conditions)

--- a/API/0206_MACD_Bollinger/macd_bollinger_strategy.py
+++ b/API/0206_MACD_Bollinger/macd_bollinger_strategy.py
@@ -187,7 +187,7 @@ class macd_bollinger_strategy(Strategy):
         macd_line = macdValue.Macd
         signal_line = macdValue.Signal
 
-        price = candle.ClosePrice
+        price = float(candle.ClosePrice)
 
         # Trading logic:
         # Long: MACD > Signal && Price < BB_lower (trend up with oversold conditions)

--- a/API/0208_Stochastic_Keltner/stochastic_keltner_strategy.py
+++ b/API/0208_Stochastic_Keltner/stochastic_keltner_strategy.py
@@ -171,7 +171,7 @@ class stochastic_keltner_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        price = candle.ClosePrice
+        price = float(candle.ClosePrice)
 
         upperBand = float(keltnerValue.Upper)
         lowerBand = float(keltnerValue.Lower)

--- a/API/0209_Volume_Supertrend/volume_supertrend_strategy.py
+++ b/API/0209_Volume_Supertrend/volume_supertrend_strategy.py
@@ -104,7 +104,7 @@ class volume_supertrend_strategy(Strategy):
 
             high_price = candle.HighPrice
             low_price = candle.LowPrice
-            close_price = candle.ClosePrice
+            close_price = float(candle.ClosePrice)
 
             # Calculate bands
             multiplier = self.supertrend_multiplier

--- a/API/0210_ADX_Donchian/adx_donchian_strategy.py
+++ b/API/0210_ADX_Donchian/adx_donchian_strategy.py
@@ -152,7 +152,7 @@ class adx_donchian_strategy(Strategy):
         middle_band = donchian_value.Middle
         lower_band = donchian_value.LowerBand
 
-        price = candle.ClosePrice
+        price = float(candle.ClosePrice)
 
         # Trading logic:
         # Long: ADX > AdxThreshold && Price >= upperBorder (strong trend with breakout up)

--- a/API/0214_Bollinger_Supertrend/bollinger_supertrend_strategy.py
+++ b/API/0214_Bollinger_Supertrend/bollinger_supertrend_strategy.py
@@ -185,7 +185,7 @@ class bollinger_supertrend_strategy(Strategy):
                     # Trend remains down, adjust supertrend value
                     self._supertrend_value = min(upper_band2, self._supertrend_value)
 
-        self._last_close = candle.ClosePrice
+        self._last_close = float(candle.ClosePrice)
 
         # Trading logic
         is_price_above_supertrend = candle.ClosePrice > self._supertrend_value

--- a/API/0217_Pairs_Trading/pairs_trading_strategy.py
+++ b/API/0217_Pairs_Trading/pairs_trading_strategy.py
@@ -214,7 +214,7 @@ class pairs_trading_strategy(Strategy):
     def ProcessSecondSecurityCandle(self, candle):
         # Store the close price of the second security for spread calculation
         if candle.State == CandleStates.Finished:
-            self._last_second_price = candle.ClosePrice
+            self._last_second_price = float(candle.ClosePrice)
 
     def CreateClone(self):
         """!! REQUIRED!! Creates a new instance of the strategy."""

--- a/API/0219_Statistical_Arbitrage/statistical_arbitrage_strategy.py
+++ b/API/0219_Statistical_Arbitrage/statistical_arbitrage_strategy.py
@@ -152,7 +152,7 @@ class statistical_arbitrage_strategy(Strategy):
             return
 
         # Store current price
-        self._last_first_price = candle.ClosePrice
+        self._last_first_price = float(candle.ClosePrice)
 
         # Skip if we don't have both prices or if indicators aren't formed
         if self._last_second_price == 0 or not self._first_ma.IsFormed or not self._second_ma.IsFormed:
@@ -218,7 +218,7 @@ class statistical_arbitrage_strategy(Strategy):
             return
 
         # Store current price
-        self._last_second_price = candle.ClosePrice
+        self._last_second_price = float(candle.ClosePrice)
 
         # Process through MA indicator
         process_float(self._second_ma, candle.ClosePrice, candle.ServerTime, candle.State == CandleStates.Finished)

--- a/API/0222_Cointegration_Pairs/cointegration_pairs_strategy.py
+++ b/API/0222_Cointegration_Pairs/cointegration_pairs_strategy.py
@@ -160,14 +160,14 @@ class cointegration_pairs_strategy(Strategy):
         if candle.State != CandleStates.Finished:
             return
 
-        self._asset1Price = candle.ClosePrice
+        self._asset1Price = float(candle.ClosePrice)
         self.ProcessPair()
 
     def ProcessAsset2Candle(self, candle):
         if candle.State != CandleStates.Finished:
             return
 
-        self._asset2Price = candle.ClosePrice
+        self._asset2Price = float(candle.ClosePrice)
         self.ProcessPair()
 
     def ProcessPair(self):

--- a/API/0223_Momentum_Divergence/momentum_divergence_strategy.py
+++ b/API/0223_Momentum_Divergence/momentum_divergence_strategy.py
@@ -121,7 +121,7 @@ class momentum_divergence_strategy(Strategy):
         self._prevMomentum = self._currentMomentum
 
         # Update current values
-        self._currentPrice = candle.ClosePrice
+        self._currentPrice = float(candle.ClosePrice)
         self._currentMomentum = momentumValue
 
         # Skip first candle after indicators become formed

--- a/API/0228_Hurst_Exponent_Reversion/hurst_exponent_reversion_strategy.py
+++ b/API/0228_Hurst_Exponent_Reversion/hurst_exponent_reversion_strategy.py
@@ -121,7 +121,7 @@ class hurst_exponent_reversion_strategy(Strategy):
             return
 
         # Store current price
-        self._current_price = candle.ClosePrice
+        self._current_price = float(candle.ClosePrice)
 
         # Calculate Hurst exponent (simplified approach)
         # In a real implementation, you would use a proper Hurst exponent calculation

--- a/API/0229_Autocorrelation_Reversal/autocorrelation_reversion_strategy.py
+++ b/API/0229_Autocorrelation_Reversal/autocorrelation_reversion_strategy.py
@@ -120,7 +120,7 @@ class autocorrelation_reversion_strategy(Strategy):
             return
 
         # Update current price and price history
-        self._current_price = candle.ClosePrice
+        self._current_price = float(candle.ClosePrice)
 
         # Update price history queue
         self._price_history.append(self._current_price)

--- a/API/0230_Delta_Neutral_Arbitrage/delta_neutral_arbitrage_strategy.py
+++ b/API/0230_Delta_Neutral_Arbitrage/delta_neutral_arbitrage_strategy.py
@@ -175,7 +175,7 @@ class delta_neutral_arbitrage_strategy(Strategy):
             return
 
         # Update asset1 price
-        self._last_asset1_price = candle.ClosePrice
+        self._last_asset1_price = float(candle.ClosePrice)
 
         # Process spread if we have both prices
         self.ProcessSpreadIfReady(candle)
@@ -186,7 +186,7 @@ class delta_neutral_arbitrage_strategy(Strategy):
             return
 
         # Update asset2 price
-        self._last_asset2_price = candle.ClosePrice
+        self._last_asset2_price = float(candle.ClosePrice)
 
         # Process spread if we have both prices
         self.ProcessSpreadIfReady(candle)

--- a/API/0232_Correlation_Breakout/correlation_breakout_strategy.py
+++ b/API/0232_Correlation_Breakout/correlation_breakout_strategy.py
@@ -158,14 +158,14 @@ class correlation_breakout_strategy(Strategy):
         if candle.State != CandleStates.Finished:
             return
 
-        self._asset1_prices[self._current_index] = candle.ClosePrice
+        self._asset1_prices[self._current_index] = float(candle.ClosePrice)
         self.CalculateCorrelation(candle)
 
     def ProcessAsset2Candle(self, candle):
         if candle.State != CandleStates.Finished:
             return
 
-        self._asset2_prices[self._current_index] = candle.ClosePrice
+        self._asset2_prices[self._current_index] = float(candle.ClosePrice)
         self.CalculateCorrelation(candle)
 
     def CalculateCorrelation(self, candle):

--- a/API/0233_Beta_Neutral_Arbitrage/beta_neutral_arbitrage_strategy.py
+++ b/API/0233_Beta_Neutral_Arbitrage/beta_neutral_arbitrage_strategy.py
@@ -165,14 +165,14 @@ class beta_neutral_arbitrage_strategy(Strategy):
         if candle.State != CandleStates.Finished:
             return
 
-        self._asset1_last_price = candle.ClosePrice
+        self._asset1_last_price = float(candle.ClosePrice)
         self.UpdateSpread(candle)
 
     def ProcessAsset2Candle(self, candle):
         if candle.State != CandleStates.Finished:
             return
 
-        self._asset2_last_price = candle.ClosePrice
+        self._asset2_last_price = float(candle.ClosePrice)
         self.UpdateSpread(candle)
 
     def ProcessMarketCandle(self, candle):

--- a/API/0257_Keltner_Channel_Width_Breakout/keltner_width_breakout_strategy.py
+++ b/API/0257_Keltner_Channel_Width_Breakout/keltner_width_breakout_strategy.py
@@ -159,8 +159,16 @@ class keltner_width_breakout_strategy(Strategy):
 
     def OnOrderBookReceived(self, orderBook):
         # Get best bid and ask from order book
-        bestBid = orderBook.Bids is not None and len(orderBook.Bids) > 0 and orderBook.Bids[0].Price or 0
-        bestAsk = orderBook.Asks is not None and len(orderBook.Asks) > 0 and orderBook.Asks[0].Price or 0
+        bestBid = (
+            float(orderBook.Bids[0].Price)
+            if orderBook.Bids is not None and len(orderBook.Bids) > 0
+            else 0
+        )
+        bestAsk = (
+            float(orderBook.Asks[0].Price)
+            if orderBook.Asks is not None and len(orderBook.Asks) > 0
+            else 0
+        )
         self._lastBid = bestBid
         self._lastAsk = bestAsk
 

--- a/API/0296_Z-Score_Volume_Filter/zscore_volume_filter_strategy.py
+++ b/API/0296_Z-Score_Volume_Filter/zscore_volume_filter_strategy.py
@@ -131,7 +131,7 @@ class zscore_volume_filter_strategy(Strategy):
             return
 
         # Store current values
-        self._current_price = candle.ClosePrice
+        self._current_price = float(candle.ClosePrice)
         self._current_volume = candle.TotalVolume
 
         # Process indicators

--- a/API/0298_Correlation_Mean_Reversion/correlation_mean_reversion_strategy.py
+++ b/API/0298_Correlation_Mean_Reversion/correlation_mean_reversion_strategy.py
@@ -189,7 +189,7 @@ class correlation_mean_reversion_strategy(Strategy):
             return
 
         # Store the last price
-        self._security1_last_price = candle.ClosePrice
+        self._security1_last_price = float(candle.ClosePrice)
         self._security1_updated = True
 
         # Update correlation and check for signals
@@ -200,7 +200,7 @@ class correlation_mean_reversion_strategy(Strategy):
             return
 
         # Store the last price
-        self._security2_last_price = candle.ClosePrice
+        self._security2_last_price = float(candle.ClosePrice)
         self._security2_updated = True
 
         # Update correlation and check for signals

--- a/API/0311_Keltner_RSI_Divergence/keltner_rsi_divergence_strategy.py
+++ b/API/0311_Keltner_RSI_Divergence/keltner_rsi_divergence_strategy.py
@@ -148,7 +148,7 @@ class keltner_rsi_divergence_strategy(Strategy):
 
         # Skip if it's the first valid candle
         if self._prev_price == 0:
-            self._prev_price = candle.ClosePrice
+            self._prev_price = float(candle.ClosePrice)
             self._prev_rsi = rsi_value
             return
 
@@ -188,7 +188,7 @@ class keltner_rsi_divergence_strategy(Strategy):
 
         # Update previous values
         self._prev_rsi = rsi_value
-        self._prev_price = candle.ClosePrice
+        self._prev_price = float(candle.ClosePrice)
 
     def CreateClone(self):
         """!! REQUIRED!! Creates a new instance of the strategy."""

--- a/API/0320_MACD_Hidden_Markov_Model/macd_hidden_markov_model_strategy.py
+++ b/API/0320_MACD_Hidden_Markov_Model/macd_hidden_markov_model_strategy.py
@@ -177,7 +177,7 @@ class macd_hidden_markov_model_strategy(Strategy):
                 self._price_changes.pop(0)
                 self._volumes.pop(0)
 
-        self._prev_price = candle.ClosePrice
+        self._prev_price = float(candle.ClosePrice)
 
     def CalculateMarketState(self):
         # Only perform state calculation when we have enough data

--- a/API/0334_Hull_MA_K-Means_Cluster/hull_kmeans_cluster_strategy.py
+++ b/API/0334_Hull_MA_K-Means_Cluster/hull_kmeans_cluster_strategy.py
@@ -163,7 +163,7 @@ class hull_kmeans_cluster_strategy(Strategy):
         self._prev_hull_value = hull_value
 
         # Update last price
-        self._last_price = candle.ClosePrice
+        self._last_price = float(candle.ClosePrice)
 
     def UpdateFeatureData(self, candle, rsi_value):
         # Calculate price change percentage

--- a/API/0336_Parabolic_SAR_RSI_Divergence/parabolic_sar_rsi_divergence_strategy.py
+++ b/API/0336_Parabolic_SAR_RSI_Divergence/parabolic_sar_rsi_divergence_strategy.py
@@ -141,7 +141,7 @@ class parabolic_sar_rsi_divergence_strategy(Strategy):
 
         # Store previous values for next comparison
         self._prev_rsi = rsi_value
-        self._prev_price = candle.ClosePrice
+        self._prev_price = float(candle.ClosePrice)
 
     def CheckRsiDivergence(self, current_price, current_rsi):
         # If we have previous values to compare

--- a/API/0340_Ichimoku_Implied_Volatility/ichimoku_implied_volatility_strategy.py
+++ b/API/0340_Ichimoku_Implied_Volatility/ichimoku_implied_volatility_strategy.py
@@ -190,7 +190,7 @@ class ichimoku_implied_volatility_strategy(Strategy):
 
         # First run, just store values
         if self._prev_price == 0:
-            self._prev_price = candle.ClosePrice
+            self._prev_price = float(candle.ClosePrice)
             self._prev_above_kumo = price_above_kumo
             self._prev_tenkan_above_kijun = tenkan_above_kijun
             return
@@ -221,7 +221,7 @@ class ichimoku_implied_volatility_strategy(Strategy):
         self.ApplyKijunAsStop(candle.ClosePrice, kijun)
 
         # Update previous values
-        self._prev_price = candle.ClosePrice
+        self._prev_price = float(candle.ClosePrice)
         self._prev_above_kumo = price_above_kumo
         self._prev_tenkan_above_kijun = tenkan_above_kijun
 

--- a/API/0341_Supertrend_Put_Call_Ratio/supertrend_put_call_ratio_strategy.py
+++ b/API/0341_Supertrend_Put_Call_Ratio/supertrend_put_call_ratio_strategy.py
@@ -154,7 +154,7 @@ class supertrend_put_call_ratio_strategy(Strategy):
         bullishPcrThreshold = self._pcrAverage - self.PCRMultiplier * self._pcrStdDev
         bearishPcrThreshold = self._pcrAverage + self.PCRMultiplier * self._pcrStdDev
 
-        price = candle.ClosePrice
+        price = float(candle.ClosePrice)
         priceAboveSupertrend = price > supertrend_value
         priceBelowSupertrend = price < supertrend_value
 

--- a/API/0342_Donchian_Sentiment_Spike/donchian_with_sentiment_spike_strategy.py
+++ b/API/0342_Donchian_Sentiment_Spike/donchian_with_sentiment_spike_strategy.py
@@ -161,7 +161,7 @@ class donchian_with_sentiment_spike_strategy(Strategy):
         bullish_threshold = self._sentiment_average + self.sentiment_multiplier * self._sentiment_std_dev
         bearish_threshold = self._sentiment_average - self.sentiment_multiplier * self._sentiment_std_dev
 
-        price = candle.ClosePrice
+        price = float(candle.ClosePrice)
 
         # Trading logic
         # Entry conditions

--- a/API/0343_Keltner_Reinforcement_Learning_Signal/keltner_with_rl_signal_strategy.py
+++ b/API/0343_Keltner_Reinforcement_Learning_Signal/keltner_with_rl_signal_strategy.py
@@ -177,13 +177,13 @@ class keltner_with_rl_signal_strategy(Strategy):
         current_atr = (upper_band - middle_band) / self.AtrMultiplier
 
         # Update price and RL state
-        self._last_price = candle.ClosePrice
+        self._last_price = float(candle.ClosePrice)
 
         # Generate RL signal based on current state
         self.UpdateRLSignal(candle, middle_band, current_atr)
 
         # Trading logic
-        price = candle.ClosePrice
+        price = float(candle.ClosePrice)
         price_above_upper_band = price > upper_band
         price_below_lower_band = price < lower_band
 

--- a/API/0344_Hull_MA_Implied_Volatility_Breakout/hull_ma_implied_volatility_breakout_strategy.py
+++ b/API/0344_Hull_MA_Implied_Volatility_Breakout/hull_ma_implied_volatility_breakout_strategy.py
@@ -168,7 +168,7 @@ class hull_ma_implied_volatility_breakout_strategy(Strategy):
             self._prevHmaValue = hmaValue
             return
 
-        price = candle.ClosePrice
+        price = float(candle.ClosePrice)
 
         # Determine HMA direction
         hmaRising = hmaValue > self._prevHmaValue

--- a/API/0345_VWAP_Behavioral_Bias_Filter/vwap_with_behavioral_bias_filter_strategy.py
+++ b/API/0345_VWAP_Behavioral_Bias_Filter/vwap_with_behavioral_bias_filter_strategy.py
@@ -135,7 +135,7 @@ class vwap_with_behavioral_bias_filter_strategy(Strategy):
         # Update behavioral bias score
         self.UpdateBehavioralBias(candle)
 
-        price = candle.ClosePrice
+        price = float(candle.ClosePrice)
         priceBelowVwap = price < vwapValue
         priceAboveVwap = price > vwapValue
 

--- a/API/0346_Parabolic_SAR_Sentiment_Divergence/parabolic_sar_sentiment_divergence_strategy.py
+++ b/API/0346_Parabolic_SAR_Sentiment_Divergence/parabolic_sar_sentiment_divergence_strategy.py
@@ -107,7 +107,7 @@ class parabolic_sar_sentiment_divergence_strategy(Strategy):
         sar_price = to_float(sar_value)
 
         # Get current price and sentiment
-        price = candle.ClosePrice
+        price = float(candle.ClosePrice)
         sentiment = self.GetSentiment()  # In real implementation, this would come from external API
 
         # Skip first candle to initialize previous values

--- a/API/0350_CCI_Put_Call_Ratio_Divergence/cci_put_call_ratio_divergence_strategy.py
+++ b/API/0350_CCI_Put_Call_Ratio_Divergence/cci_put_call_ratio_divergence_strategy.py
@@ -106,7 +106,7 @@ class cci_put_call_ratio_divergence_strategy(Strategy):
             return
 
         # Get current price
-        price = candle.ClosePrice
+        price = float(candle.ClosePrice)
 
         # Simulate Put/Call Ratio (in real implementation, this would come from options data)
         self.UpdatePutCallRatio(candle)


### PR DESCRIPTION
## Summary
- convert candle `ClosePrice` assignments to `float` in multiple Python strategies
- convert order book price data to float in `keltner_width_breakout_strategy`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68788f0f60388323bf625093c4b87686