### PR TITLE
Remove type checks from Python strategies

### DIFF
--- a/API/0093_Stochastic_Hook_Reversal/stochastic_hook_reversal_strategy.py
+++ b/API/0093_Stochastic_Hook_Reversal/stochastic_hook_reversal_strategy.py
@@ -169,12 +169,9 @@ class stochastic_hook_reversal_strategy(Strategy):
             return
 
         # Extract %K value
-        if isinstance(stoch_value, StochasticOscillatorValue):
-            if stoch_value.K is None:
-                return
-            stoch_k = float(stoch_value.K)
-        else:
-            stoch_k = float(stoch_value)
+        if stoch_value.K is None:
+            return
+        stoch_k = float(stoch_value.K)
 
         # If this is the first calculation, just store the value
         if self._prev_k == 0:

--- a/API/0198_VWAP_MACD/vwap_macd_strategy.py
+++ b/API/0198_VWAP_MACD/vwap_macd_strategy.py
@@ -137,8 +137,6 @@ class vwap_macd_strategy(Strategy):
         macd_typed = macd_value
 
         # Extract MACD and Signal values
-        if not isinstance(macd_typed.Macd, float) or not isinstance(macd_typed.Signal, float):
-            return
         macd = macd_typed.Macd
         signal = macd_typed.Signal
 

--- a/API/0240_MACD_Mean_Reversion/macd_mean_reversion_strategy.py
+++ b/API/0240_MACD_Mean_Reversion/macd_mean_reversion_strategy.py
@@ -182,8 +182,6 @@ class macd_mean_reversion_strategy(Strategy):
             return
 
         # Extract MACD Histogram value
-        if not isinstance(macd_value, MovingAverageConvergenceDivergenceHistogramValue):
-            return
         macd = float(macd_value.Macd)
         signal = float(macd_value.Signal)
 

--- a/API/0248_Stochastic_Breakout/stochastic_breakout_strategy.py
+++ b/API/0248_Stochastic_Breakout/stochastic_breakout_strategy.py
@@ -155,8 +155,8 @@ class stochastic_breakout_strategy(Strategy):
             return
 
         # Get stochastic value (K line)
-        stochTyped = stochValue if isinstance(stochValue, StochasticOscillatorValue) else None
-        if stochTyped is None or stochTyped.K is None:
+        stochTyped = stochValue
+        if stochTyped.K is None:
             return
 
         stochK = stochTyped.K

--- a/API/0274_Volume_Slope_Breakout/volume_slope_breakout_strategy.py
+++ b/API/0274_Volume_Slope_Breakout/volume_slope_breakout_strategy.py
@@ -162,7 +162,7 @@ class volume_slope_breakout_strategy(Strategy):
         # We use LinearRegression to calculate slope of this ratio
         currentSlopeTyped = process_float(self._volumeSlope, volumeRatio, candle.ServerTime, candle.State == CandleStates.Finished)
 
-        if not isinstance(currentSlopeTyped, LinearRegressionValue) or currentSlopeTyped.LinearReg is None:
+        if currentSlopeTyped.LinearReg is None:
             return  # Skip if slope is not available
         currentSlopeValue = currentSlopeTyped.LinearReg
 

--- a/API/0279_Ichimoku_Cloud_Width_Mean_Reversion/ichimoku_cloud_width_mean_reversion_strategy.py
+++ b/API/0279_Ichimoku_Cloud_Width_Mean_Reversion/ichimoku_cloud_width_mean_reversion_strategy.py
@@ -164,16 +164,16 @@ class ichimoku_cloud_width_mean_reversion_strategy(Strategy):
         # Extract values from the Ichimoku indicator
         ichimokuTyped = ichimokuValue
 
-        tenkan = ichimokuTyped.Tenkan if isinstance(ichimokuTyped.Tenkan, float) or isinstance(ichimokuTyped.Tenkan, int) else None
+        tenkan = ichimokuTyped.Tenkan
         if tenkan is None:
             return
-        kijun = ichimokuTyped.Kijun if isinstance(ichimokuTyped.Kijun, float) or isinstance(ichimokuTyped.Kijun, int) else None
+        kijun = ichimokuTyped.Kijun
         if kijun is None:
             return
-        senkouA = ichimokuTyped.SenkouA if isinstance(ichimokuTyped.SenkouA, float) or isinstance(ichimokuTyped.SenkouA, int) else None
+        senkouA = ichimokuTyped.SenkouA
         if senkouA is None:
             return
-        senkouB = ichimokuTyped.SenkouB if isinstance(ichimokuTyped.SenkouB, float) or isinstance(ichimokuTyped.SenkouB, int) else None
+        senkouB = ichimokuTyped.SenkouB
         if senkouB is None:
             return
 

--- a/API/0287_Stochastic_Slope_Mean_Reversion/stochastic_slope_mean_reversion_strategy.py
+++ b/API/0287_Stochastic_Slope_Mean_Reversion/stochastic_slope_mean_reversion_strategy.py
@@ -165,8 +165,8 @@ class stochastic_slope_mean_reversion_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        stoch_typed = stoch_value if isinstance(stoch_value, StochasticOscillatorValue) else None
-        if stoch_typed is None or stoch_typed.K is None:
+        stoch_typed = stoch_value
+        if stoch_typed.K is None:
             return
 
         stoch_k = float(stoch_typed.K)

--- a/API/0315_Stochastic_Dynamic_Zones/stochastic_with_dynamic_zones_strategy.py
+++ b/API/0315_Stochastic_Dynamic_Zones/stochastic_with_dynamic_zones_strategy.py
@@ -148,8 +148,8 @@ class stochastic_with_dynamic_zones_strategy(Strategy):
             stopLoss=Unit(1, UnitTypes.Percent)
         )
     def ProcessStochastic(self, candle, stoch_value):
-        stoch_typed = stoch_value if isinstance(stoch_value, StochasticOscillatorValue) else None
-        if stoch_typed is None or stoch_typed.K is None:
+        stoch_typed = stoch_value
+        if stoch_typed.K is None:
             return
 
         # Calculate dynamic zones


### PR DESCRIPTION
## Summary
- simplified Python strategies by removing redundant `isinstance` checks for indicator values

## Testing
- `python -m py_compile API/0093_Stochastic_Hook_Reversal/stochastic_hook_reversal_strategy.py API/0198_VWAP_MACD/vwap_macd_strategy.py API/0240_MACD_Mean_Reversion/macd_mean_reversion_strategy.py API/0248_Stochastic_Breakout/stochastic_breakout_strategy.py API/0274_Volume_Slope_Breakout/volume_slope_breakout_strategy.py API/0279_Ichimoku_Cloud_Width_Mean_Reversion/ichimoku_cloud_width_mean_reversion_strategy.py API/0287_Stochastic_Slope_Mean_Reversion/stochastic_slope_mean_reversion_strategy.py API/0315_Stochastic_Dynamic_Zones/stochastic_with_dynamic_zones_strategy.py`
- ❌ `dotnet test AlgoTrading.sln --no-build --configuration Release` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68789a74410483239f0539b9f1b09dc2