### PR TITLE
Fix float conversions to use to_float

### DIFF
--- a/API/0016_RSI_Divergence/rsi_divergence_strategy.py
+++ b/API/0016_RSI_Divergence/rsi_divergence_strategy.py
@@ -120,7 +120,7 @@ class rsi_divergence_strategy(Strategy):
             return
 
         current_price = float(candle.ClosePrice)
-        current_rsi = float(rsi_value)
+        current_rsi = to_float(rsi_value)
 
         # For the first candle, just store values and return
         if self._is_first_candle:

--- a/API/0017_Williams_R/williams_percent_r_strategy.py
+++ b/API/0017_Williams_R/williams_percent_r_strategy.py
@@ -106,7 +106,7 @@ class williams_percent_r_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        williams_r_value = float(value)
+        williams_r_value = to_float(value)
 
         # Note: Williams %R values are negative, typically from 0 to -100
         # Oversold: Below -80

--- a/API/0019_CCI_Breakout/cci_breakout_strategy.py
+++ b/API/0019_CCI_Breakout/cci_breakout_strategy.py
@@ -106,7 +106,7 @@ class cci_breakout_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        cci_value = float(value)
+        cci_value = to_float(value)
 
         # Entry logic
         if cci_value > 100 and self.Position <= 0:

--- a/API/0023_Elder_Impulse/elder_impulse_strategy.py
+++ b/API/0023_Elder_Impulse/elder_impulse_strategy.py
@@ -162,7 +162,7 @@ class elder_impulse_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        ema_decimal = float(ema_value)
+        ema_decimal = to_float(ema_value)
 
         if self._is_first_candle:
             self._previous_ema = ema_decimal

--- a/API/0026_RSI_Reversion/rsi_reversion_strategy.py
+++ b/API/0026_RSI_Reversion/rsi_reversion_strategy.py
@@ -143,7 +143,7 @@ class rsi_reversion_strategy(Strategy):
             return
 
         # Get RSI value
-        rsi = float(rsi_value)
+        rsi = to_float(rsi_value)
 
         # Entry logic for mean reversion
         if rsi < self.oversold_threshold and self.Position <= 0:

--- a/API/0138_MA_Stochastic/ma_stochastic_strategy.py
+++ b/API/0138_MA_Stochastic/ma_stochastic_strategy.py
@@ -175,7 +175,7 @@ class ma_stochastic_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        ma_dec = float(ma_value)
+        ma_dec = to_float(ma_value)
         stoch_typed = stoch_value
         stoch_k_value = stoch_typed.K
 

--- a/API/0244_OBV_Mean_Reversion/obv_mean_reversion_strategy.py
+++ b/API/0244_OBV_Mean_Reversion/obv_mean_reversion_strategy.py
@@ -109,14 +109,14 @@ class obv_mean_reversion_strategy(Strategy):
             return
 
         # Extract OBV value
-        self._current_obv = float(obv_value)
+        self._current_obv = to_float(obv_value)
 
         # Process OBV through average and standard deviation indicators
         avg_indicator_value = self._obv_average.Process(obv_value)
         std_dev_indicator_value = self._obv_std_dev.Process(obv_value)
 
-        self._obv_avg_value = float(avg_indicator_value)
-        self._obv_std_dev_value = float(std_dev_indicator_value)
+        self._obv_avg_value = to_float(avg_indicator_value)
+        self._obv_std_dev_value = to_float(std_dev_indicator_value)
 
         # Check if strategy is ready for trading
         if not self.IsFormedAndOnlineAndAllowTrading() or not self._obv_average.IsFormed or not self._obv_std_dev.IsFormed:

--- a/API/0251_MACD_Breakout/macd_breakout_strategy.py
+++ b/API/0251_MACD_Breakout/macd_breakout_strategy.py
@@ -183,8 +183,22 @@ class macd_breakout_strategy(Strategy):
         macd = float(macd_typed.Macd)
 
         # Process indicators for MACD histogram
-        macd_hist_sma_value = float(to_float(process_float(self._macd_hist_sma, macd, candle.ServerTime, candle.State == CandleStates.Finished)))
-        macd_hist_stddev_value = float(to_float(process_float(self._macd_hist_stddev, macd, candle.ServerTime, candle.State == CandleStates.Finished)))
+        macd_hist_sma_value = to_float(
+            process_float(
+                self._macd_hist_sma,
+                macd,
+                candle.ServerTime,
+                candle.State == CandleStates.Finished,
+            )
+        )
+        macd_hist_stddev_value = to_float(
+            process_float(
+                self._macd_hist_stddev,
+                macd,
+                candle.ServerTime,
+                candle.State == CandleStates.Finished,
+            )
+        )
 
         # Store previous values on first call
         if self._prev_macd_hist_value == 0 and self._prev_macd_hist_sma_value == 0:

--- a/API/0254_Volume_Breakout/volume_breakout_strategy.py
+++ b/API/0254_Volume_Breakout/volume_breakout_strategy.py
@@ -123,12 +123,12 @@ class volume_breakout_strategy(Strategy):
 
         # Calculate volume average
         avg_value = process_float(self._volume_average, volume, candle.ServerTime, candle.State == CandleStates.Finished)
-        avg_volume = float(avg_value)
+        avg_volume = to_float(avg_value)
 
         # Calculate standard deviation approximation
         deviation = Math.Abs(volume - avg_volume)
         std_dev_value = process_float(self._volume_std_dev, deviation, candle.ServerTime, candle.State == CandleStates.Finished)
-        std_dev = float(std_dev_value)
+        std_dev = to_float(std_dev_value)
 
         # Skip the first N candles until we have enough data
         if not self._volume_average.IsFormed or not self._volume_std_dev.IsFormed:

--- a/API/0257_Keltner_Channel_Width_Breakout/keltner_width_breakout_strategy.py
+++ b/API/0257_Keltner_Channel_Width_Breakout/keltner_width_breakout_strategy.py
@@ -192,7 +192,7 @@ class keltner_width_breakout_strategy(Strategy):
 
         # Process width through average
         widthAvgValue = process_float(self._widthAverage, width, candle.ServerTime, candle.State == CandleStates.Finished)
-        avgWidth = widthAvgValue
+        avgWidth = to_float(widthAvgValue)
 
         # For first values, just save and skip
         if self._lastWidth == 0:


### PR DESCRIPTION
## Summary
- convert indicator values using `to_float` instead of `float`
- update strategies accordingly

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878c05735dc832380e9e049d6996f34