### PR TITLE
Remove numbering from strategy comments

### DIFF
--- a/API/0201_VWAP_Williams_R/VwapWilliamsRStrategy.cs
+++ b/API/0201_VWAP_Williams_R/VwapWilliamsRStrategy.cs
@@ -9,7 +9,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Strategy based on VWAP and Williams %R indicators (#201)
+	/// Strategy based on VWAP and Williams %R indicators
 	/// </summary>
 	public class VwapWilliamsRStrategy : Strategy
 	{

--- a/API/0201_VWAP_Williams_R/vwap_williams_r_strategy.py
+++ b/API/0201_VWAP_Williams_R/vwap_williams_r_strategy.py
@@ -12,7 +12,7 @@ from datatype_extensions import *
 
 class vwap_williams_r_strategy(Strategy):
     """
-    Strategy based on VWAP and Williams %R indicators (#201)
+    Strategy based on VWAP and Williams %R indicators
     """
 
     def __init__(self):

--- a/API/0202_Donchian_CCI/DonchianCciStrategy.cs
+++ b/API/0202_Donchian_CCI/DonchianCciStrategy.cs
@@ -9,7 +9,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Strategy based on Donchian Channels and CCI indicators (#202)
+	/// Strategy based on Donchian Channels and CCI indicators
 	/// </summary>
 	public class DonchianCciStrategy : Strategy
 	{

--- a/API/0202_Donchian_CCI/donchian_cci_strategy.py
+++ b/API/0202_Donchian_CCI/donchian_cci_strategy.py
@@ -11,7 +11,7 @@ from datatype_extensions import *
 
 class donchian_cci_strategy(Strategy):
     """
-    Strategy based on Donchian Channels and CCI indicators (#202)
+    Strategy based on Donchian Channels and CCI indicators
     """
 
     def __init__(self):

--- a/API/0203_Keltner_Williams_R/KeltnerWilliamsRStrategy.cs
+++ b/API/0203_Keltner_Williams_R/KeltnerWilliamsRStrategy.cs
@@ -9,7 +9,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Strategy based on Keltner Channels and Williams %R indicators (#203)
+	/// Strategy based on Keltner Channels and Williams %R indicators
 	/// </summary>
 	public class KeltnerWilliamsRStrategy : Strategy
 	{

--- a/API/0203_Keltner_Williams_R/keltner_williams_r_strategy.py
+++ b/API/0203_Keltner_Williams_R/keltner_williams_r_strategy.py
@@ -11,7 +11,7 @@ from datatype_extensions import *
 from indicator_extensions import *
 
 class keltner_williams_r_strategy(Strategy):
-    """Strategy based on Keltner Channels and Williams %R indicators (#203)"""
+    """Strategy based on Keltner Channels and Williams %R indicators"""
 
     def __init__(self):
         super(keltner_williams_r_strategy, self).__init__()

--- a/API/0204_Parabolic_SAR_CCI/ParabolicSarCciStrategy.cs
+++ b/API/0204_Parabolic_SAR_CCI/ParabolicSarCciStrategy.cs
@@ -9,7 +9,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Strategy based on Parabolic SAR and CCI indicators (#204)
+	/// Strategy based on Parabolic SAR and CCI indicators
 	/// </summary>
 	public class ParabolicSarCciStrategy : Strategy
 	{

--- a/API/0204_Parabolic_SAR_CCI/parabolic_sar_cci_strategy.py
+++ b/API/0204_Parabolic_SAR_CCI/parabolic_sar_cci_strategy.py
@@ -11,7 +11,7 @@ from datatype_extensions import *
 
 
 class parabolic_sar_cci_strategy(Strategy):
-    """Strategy based on Parabolic SAR and CCI indicators (#204)"""
+    """Strategy based on Parabolic SAR and CCI indicators"""
 
     def __init__(self):
         super(parabolic_sar_cci_strategy, self).__init__()

--- a/API/0205_Hull_MA_CCI/HullMaCciStrategy.cs
+++ b/API/0205_Hull_MA_CCI/HullMaCciStrategy.cs
@@ -9,7 +9,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Strategy based on Hull Moving Average and CCI indicators (#205)
+	/// Strategy based on Hull Moving Average and CCI indicators
 	/// </summary>
 	public class HullMaCciStrategy : Strategy
 	{

--- a/API/0205_Hull_MA_CCI/hull_ma_cci_strategy.py
+++ b/API/0205_Hull_MA_CCI/hull_ma_cci_strategy.py
@@ -11,7 +11,7 @@ from datatype_extensions import *
 
 
 class hull_ma_cci_strategy(Strategy):
-    """Strategy based on Hull Moving Average and CCI indicators (#205)."""
+    """Strategy based on Hull Moving Average and CCI indicators."""
 
     # Constructor
     def __init__(self):

--- a/API/0206_MACD_Bollinger/MacdBollingerStrategy.cs
+++ b/API/0206_MACD_Bollinger/MacdBollingerStrategy.cs
@@ -9,7 +9,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Strategy based on MACD and Bollinger Bands indicators (#206)
+	/// Strategy based on MACD and Bollinger Bands indicators
 	/// </summary>
 	public class MacdBollingerStrategy : Strategy
 	{

--- a/API/0206_MACD_Bollinger/macd_bollinger_strategy.py
+++ b/API/0206_MACD_Bollinger/macd_bollinger_strategy.py
@@ -11,7 +11,7 @@ from datatype_extensions import *
 
 class macd_bollinger_strategy(Strategy):
     """
-    Strategy based on MACD and Bollinger Bands indicators (#206)
+    Strategy based on MACD and Bollinger Bands indicators
     """
 
     def __init__(self):

--- a/API/0207_RSI_Hull_MA/RsiHullMaStrategy.cs
+++ b/API/0207_RSI_Hull_MA/RsiHullMaStrategy.cs
@@ -9,7 +9,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Strategy based on RSI and Hull Moving Average indicators (#207)
+	/// Strategy based on RSI and Hull Moving Average indicators
 	/// </summary>
 	public class RsiHullMaStrategy : Strategy
 	{

--- a/API/0207_RSI_Hull_MA/rsi_hull_ma_strategy.py
+++ b/API/0207_RSI_Hull_MA/rsi_hull_ma_strategy.py
@@ -12,7 +12,7 @@ from datatype_extensions import *
 
 class rsi_hull_ma_strategy(Strategy):
     """
-    Strategy based on RSI and Hull Moving Average indicators (#207)
+    Strategy based on RSI and Hull Moving Average indicators
     """
 
     def __init__(self):

--- a/API/0208_Stochastic_Keltner/StochasticKeltnerStrategy.cs
+++ b/API/0208_Stochastic_Keltner/StochasticKeltnerStrategy.cs
@@ -9,7 +9,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Strategy based on Stochastic Oscillator and Keltner Channels indicators (#208)
+	/// Strategy based on Stochastic Oscillator and Keltner Channels indicators
 	/// </summary>
 	public class StochasticKeltnerStrategy : Strategy
 	{

--- a/API/0208_Stochastic_Keltner/stochastic_keltner_strategy.py
+++ b/API/0208_Stochastic_Keltner/stochastic_keltner_strategy.py
@@ -11,7 +11,7 @@ from datatype_extensions import *
 
 class stochastic_keltner_strategy(Strategy):
     """
-    Strategy based on Stochastic Oscillator and Keltner Channels indicators (#208)
+    Strategy based on Stochastic Oscillator and Keltner Channels indicators
     """
 
     def __init__(self):

--- a/API/0209_Volume_Supertrend/VolumeSupertrendStrategy.cs
+++ b/API/0209_Volume_Supertrend/VolumeSupertrendStrategy.cs
@@ -9,7 +9,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Strategy based on Volume and Supertrend indicators (#209)
+	/// Strategy based on Volume and Supertrend indicators
 	/// </summary>
 	public class VolumeSupertrendStrategy : Strategy
 	{

--- a/API/0209_Volume_Supertrend/volume_supertrend_strategy.py
+++ b/API/0209_Volume_Supertrend/volume_supertrend_strategy.py
@@ -11,7 +11,7 @@ from datatype_extensions import *
 from indicator_extensions import *
 
 class volume_supertrend_strategy(Strategy):
-    """Strategy based on Volume and Supertrend indicators (#209)"""
+    """Strategy based on Volume and Supertrend indicators"""
 
     def __init__(self):
         """Constructor"""

--- a/API/0210_ADX_Donchian/AdxDonchianStrategy.cs
+++ b/API/0210_ADX_Donchian/AdxDonchianStrategy.cs
@@ -9,7 +9,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies
 {
 	/// <summary>
-	/// Strategy based on ADX and Donchian Channel indicators (#210)
+	/// Strategy based on ADX and Donchian Channel indicators
 	/// </summary>
 	public class AdxDonchianStrategy : Strategy
 	{

--- a/API/0210_ADX_Donchian/adx_donchian_strategy.py
+++ b/API/0210_ADX_Donchian/adx_donchian_strategy.py
@@ -11,7 +11,7 @@ from datatype_extensions import *
 
 class adx_donchian_strategy(Strategy):
     """
-    Strategy based on ADX and Donchian Channel indicators (#210)
+    Strategy based on ADX and Donchian Channel indicators
     
     """
 


### PR DESCRIPTION
## Summary
- strip obsolete strategy numbers from code comments for clarity

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687952844460832399b3b968949b89ba