### PR TITLE
Use Python random in algorithm strategies

### DIFF
--- a/API/0228_Hurst_Exponent_Reversion/hurst_exponent_reversion_strategy.py
+++ b/API/0228_Hurst_Exponent_Reversion/hurst_exponent_reversion_strategy.py
@@ -3,11 +3,13 @@ import clr
 clr.AddReference("StockSharp.Messages")
 clr.AddReference("StockSharp.Algo")
 
-from System import TimeSpan, Math, Random
+from System import TimeSpan, Math
 from StockSharp.Messages import DataType, UnitTypes, Unit, CandleStates
 from StockSharp.Algo.Indicators import SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
 from datatype_extensions import *
+
+import random
 
 class hurst_exponent_reversion_strategy(Strategy):
     """
@@ -150,8 +152,7 @@ class hurst_exponent_reversion_strategy(Strategy):
 
         # For demonstration only - in a real implementation,
         # use a proper Hurst exponent calculation based on R/S analysis or similar method
-        rand = Random(int(candle.OpenTime.Ticks))
-        return 0.3 + rand.NextDouble() * 0.4  # Returns value between 0.3 and 0.7
+        return 0.3 + random.random() * 0.4  # Returns value between 0.3 and 0.7
 
     def CreateClone(self):
         """!! REQUIRED!! Creates a new instance of the strategy."""

--- a/API/0347_RSI_Option_Open_Interest/rsi_with_option_open_interest_strategy.py
+++ b/API/0347_RSI_Option_Open_Interest/rsi_with_option_open_interest_strategy.py
@@ -3,13 +3,14 @@ import clr
 clr.AddReference("StockSharp.Messages")
 clr.AddReference("StockSharp.Algo")
 
-from System import TimeSpan, Math, Random
+from System import TimeSpan, Math
 from StockSharp.Messages import DataType, Unit, UnitTypes, CandleStates
 from StockSharp.Algo.Indicators import RelativeStrengthIndex, SimpleMovingAverage, StandardDeviation
 from StockSharp.Algo.Strategies import Strategy
 from datatype_extensions import *
 from indicator_extensions import *
 
+import random
 
 class rsi_with_option_open_interest_strategy(Strategy):
     """
@@ -217,23 +218,22 @@ class rsi_with_option_open_interest_strategy(Strategy):
 
         # Base OI values on price movement
         price_up = candle.OpenPrice < candle.ClosePrice
-        rand = Random(int(candle.ServerTime.Ticks))
 
         # Simulate bullish sentiment with higher call OI when price is rising
         # Simulate bearish sentiment with higher put OI when price is falling
         if price_up:
-            self._current_call_oi = float(candle.TotalVolume * (1 + rand.NextDouble() * 0.5))
-            self._current_put_oi = float(candle.TotalVolume * (0.7 + rand.NextDouble() * 0.3))
+            self._current_call_oi = float(candle.TotalVolume * (1 + random.random() * 0.5))
+            self._current_put_oi = float(candle.TotalVolume * (0.7 + random.random() * 0.3))
         else:
-            self._current_call_oi = float(candle.TotalVolume * (0.7 + rand.NextDouble() * 0.3))
-            self._current_put_oi = float(candle.TotalVolume * (1 + rand.NextDouble() * 0.5))
+            self._current_call_oi = float(candle.TotalVolume * (0.7 + random.random() * 0.3))
+            self._current_put_oi = float(candle.TotalVolume * (1 + random.random() * 0.5))
 
         # Add some randomness for spikes
-        if rand.NextDouble() > 0.9:
+        if random.random() > 0.9:
             # Occasional spikes in OI
             self._current_call_oi *= 1.5
 
-        if rand.NextDouble() > 0.9:
+        if random.random() > 0.9:
             # Occasional spikes in OI
             self._current_put_oi *= 1.5
 

--- a/API/0348_Stochastic_Implied_Volatility_Skew/stochastic_implied_volatility_skew_strategy.py
+++ b/API/0348_Stochastic_Implied_Volatility_Skew/stochastic_implied_volatility_skew_strategy.py
@@ -3,12 +3,14 @@ import clr
 clr.AddReference("StockSharp.Messages")
 clr.AddReference("StockSharp.Algo")
 
-from System import TimeSpan, Math, Random
+from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates, Unit, UnitTypes, ICandleMessage
 from StockSharp.Algo.Indicators import StochasticOscillator, SimpleMovingAverage
 from StockSharp.Algo.Strategies import Strategy
 from datatype_extensions import *
 from indicator_extensions import *
+
+import random
 
 class stochastic_implied_volatility_skew_strategy(Strategy):
     """Stochastic strategy with Implied Volatility Skew."""
@@ -192,7 +194,6 @@ class stochastic_implied_volatility_skew_strategy(Strategy):
         # IV Skew measures the difference in IV between calls and puts at equidistant strikes
 
         # Create pseudo-random but somewhat realistic values
-        random = Random()
 
         # Base IV Skew values on price movement and volatility
         price_up = candle.OpenPrice < candle.ClosePrice
@@ -202,13 +203,13 @@ class stochastic_implied_volatility_skew_strategy(Strategy):
         # When prices are falling, calls become relatively cheaper (positive skew)
         if price_up:
             # During uptrends, skew tends to be more negative
-            self._current_iv_skew = -0.1 - candle_range - random.NextDouble() * 0.2
+            self._current_iv_skew = -0.1 - candle_range - random.random() * 0.2
         else:
             # During downtrends, skew can become less negative or even positive
-            self._current_iv_skew = 0.05 - candle_range + random.NextDouble() * 0.2
+            self._current_iv_skew = 0.05 - candle_range + random.random() * 0.2
 
         # Add some randomness for market events
-        if random.NextDouble() > 0.95:
+        if random.random() > 0.95:
             # Occasional extreme skew events (e.g., market fear or greed)
             self._current_iv_skew *= 1.5
 

--- a/API/0350_CCI_Put_Call_Ratio_Divergence/cci_put_call_ratio_divergence_strategy.py
+++ b/API/0350_CCI_Put_Call_Ratio_Divergence/cci_put_call_ratio_divergence_strategy.py
@@ -3,12 +3,13 @@ import clr
 clr.AddReference("StockSharp.Messages")
 clr.AddReference("StockSharp.Algo")
 
-from System import TimeSpan, Math, Random
+from System import TimeSpan, Math
 from StockSharp.Messages import DataType, CandleStates
 from StockSharp.Algo.Indicators import CommodityChannelIndex, AverageTrueRange
 from StockSharp.Algo.Strategies import Strategy
 from datatype_extensions import *
 
+import random
 
 class cci_put_call_ratio_divergence_strategy(Strategy):
     """CCI strategy with Put/Call Ratio Divergence."""
@@ -169,16 +170,15 @@ class cci_put_call_ratio_divergence_strategy(Strategy):
         price_up = candle.OpenPrice < candle.ClosePrice
         price_change = float(Math.Abs((candle.ClosePrice - candle.OpenPrice) / candle.OpenPrice))
 
-        rand = Random(int(candle.OpenTime.Ticks))
         if price_up:
             # When price rises, PCR often falls (less put buying)
-            self._current_pcr = 0.7 - price_change + rand.NextDouble() * 0.2
+            self._current_pcr = 0.7 - price_change + random.random() * 0.2
         else:
             # When price falls, PCR often rises (more put buying for protection)
-            self._current_pcr = 1.0 + price_change + rand.NextDouble() * 0.3
+            self._current_pcr = 1.0 + price_change + random.random() * 0.3
 
         # Add some randomness for market events
-        if rand.NextDouble() > 0.9:
+        if random.random() > 0.9:
             # Occasional PCR spikes
             self._current_pcr *= 1.3
 


### PR DESCRIPTION
## Summary
- replace System.Random instances seeded by candle times with Python's `random` module
- update imports in several strategies

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687964cb8d8483239d674ec3b56fe7a0