### PR TITLE
Remove unnecessary typed variables

### DIFF
--- a/API/0061_MACD_Divergence/macd_divergence_strategy.py
+++ b/API/0061_MACD_Divergence/macd_divergence_strategy.py
@@ -166,13 +166,12 @@ class macd_divergence_strategy(Strategy):
             return
 
         # Extract MACD values - be careful with the order of indexes
-        macdTyped = macdValue
         
-        if macdTyped.Macd is None or macdTyped.Signal is None:
+        if macdValue.Macd is None or macdValue.Signal is None:
             return
         
-        macd = macdTyped.Macd
-        signal = macdTyped.Signal
+        macd = macdValue.Macd
+        signal = macdValue.Signal
 
         # Store previous values before updating
         if self._currentPrice is not None and self._currentMacd is not None:

--- a/API/0062_Stochastic_Overbought_Oversold/stochastic_overbought_oversold_strategy.py
+++ b/API/0062_Stochastic_Overbought_Oversold/stochastic_overbought_oversold_strategy.py
@@ -108,9 +108,8 @@ class stochastic_overbought_oversold_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        stochTyped = stochValue
-        kValue = stochTyped.K
-        dValue = stochTyped.D
+        kValue = stochValue.K
+        dValue = stochValue.D
 
         self.LogInfo("Stochastic %K: {0}, %D: {1}".format(kValue, dValue))
 

--- a/API/0069_Bollinger_Band_Reversal/bollinger_band_reversal_strategy.py
+++ b/API/0069_Bollinger_Band_Reversal/bollinger_band_reversal_strategy.py
@@ -117,19 +117,18 @@ class bollinger_band_reversal_strategy(Strategy):
             return
 
         # Get current Bollinger Bands values
-        bollingerTyped = bollingerValue
 
-        if bollingerTyped.UpBand is None:
+        if bollingerValue.UpBand is None:
             return
-        upperBand = float(bollingerTyped.UpBand)
+        upperBand = float(bollingerValue.UpBand)
 
-        if bollingerTyped.LowBand is None:
+        if bollingerValue.LowBand is None:
             return
-        lowerBand = float(bollingerTyped.LowBand)
+        lowerBand = float(bollingerValue.LowBand)
 
-        if bollingerTyped.MovingAverage is None:
+        if bollingerValue.MovingAverage is None:
             return
-        middleBand = float(bollingerTyped.MovingAverage)
+        middleBand = float(bollingerValue.MovingAverage)
 
         # Determine if the candle is bullish or bearish
         isBullish = candle.ClosePrice > candle.OpenPrice

--- a/API/0083_ADX_Weakening/adx_weakening_strategy.py
+++ b/API/0083_ADX_Weakening/adx_weakening_strategy.py
@@ -134,12 +134,11 @@ class adx_weakening_strategy(Strategy):
 
         ma = to_float(maValue)
 
-        adxTyped = adxValue
-        if adxTyped.MovingAverage is None:
+        if adxValue.MovingAverage is None:
             return
-        adx_val = float(adxTyped.MovingAverage)
+        adx_val = float(adxValue.MovingAverage)
 
-        dx = adxTyped.Dx
+        dx = adxValue.Dx
         if dx.Plus is None or dx.Minus is None:
             return
 

--- a/API/0132_Bollinger_Stochastic/bollinger_stochastic_strategy.py
+++ b/API/0132_Bollinger_Stochastic/bollinger_stochastic_strategy.py
@@ -195,9 +195,8 @@ class bollinger_stochastic_strategy(Strategy):
             return
         lower_band = float(bb.LowBand)
 
-        stochastic_typed = stochastic_value
-        k = stochastic_typed.K
-        d = stochastic_typed.D
+        k = stochastic_value.K
+        d = stochastic_value.D
 
         atr_val = to_float(atr_value)
 

--- a/API/0134_ADX_MACD/adx_macd_strategy.py
+++ b/API/0134_ADX_MACD/adx_macd_strategy.py
@@ -171,9 +171,8 @@ class adx_macd_strategy(Strategy):
             return
         adxIndicatorValue = typedAdx.MovingAverage
 
-        macdTyped = macdValue
-        macdLine = macdTyped.Macd
-        signalLine = macdTyped.Signal
+        macdLine = macdValue.Macd
+        signalLine = macdValue.Signal
 
         atrIndicatorValue = to_float(atrValue)
 

--- a/API/0137_Bollinger_RSI/bollinger_rsi_strategy.py
+++ b/API/0137_Bollinger_RSI/bollinger_rsi_strategy.py
@@ -165,27 +165,25 @@ class bollinger_rsi_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        bollingerTyped = bollingerValue
 
-        if bollingerTyped.UpBand is None:
+        if bollingerValue.UpBand is None:
             return
-        upperBand = float(bollingerTyped.UpBand)
+        upperBand = float(bollingerValue.UpBand)
 
-        if bollingerTyped.LowBand is None:
+        if bollingerValue.LowBand is None:
             return
-        lowerBand = float(bollingerTyped.LowBand)
+        lowerBand = float(bollingerValue.LowBand)
 
-        if bollingerTyped.MovingAverage is None:
+        if bollingerValue.MovingAverage is None:
             return
-        middleBand = float(bollingerTyped.MovingAverage)
-        rsiTyped = to_float(rsiValue)
+        middleBand = float(bollingerValue.MovingAverage)
 
         # Long entry: price below lower Bollinger Band and RSI oversold
-        if candle.ClosePrice < lowerBand and rsiTyped < self.RsiOversold and self.Position <= 0:
+        if candle.ClosePrice < lowerBand and rsiValue < self.RsiOversold and self.Position <= 0:
             volume = self.Volume + Math.Abs(self.Position)
             self.BuyMarket(volume)
         # Short entry: price above upper Bollinger Band and RSI overbought
-        elif candle.ClosePrice > upperBand and rsiTyped > self.RsiOverbought and self.Position >= 0:
+        elif candle.ClosePrice > upperBand and rsiValue > self.RsiOverbought and self.Position >= 0:
             volume = self.Volume + Math.Abs(self.Position)
             self.SellMarket(volume)
         # Long exit: price returns to middle band

--- a/API/0138_MA_Stochastic/ma_stochastic_strategy.py
+++ b/API/0138_MA_Stochastic/ma_stochastic_strategy.py
@@ -177,8 +177,7 @@ class ma_stochastic_strategy(Strategy):
             return
 
         ma_dec = to_float(ma_value)
-        stoch_typed = stoch_value
-        stoch_k_value = stoch_typed.K
+        stoch_k_value = stoch_value.K
 
         # Long entry: price above MA and Stochastic is oversold
         if candle.ClosePrice > ma_dec and stoch_k_value < self.StochOversold and self.Position <= 0:

--- a/API/0142_Keltner_Stochastic/keltner_stochastic_strategy.py
+++ b/API/0142_Keltner_Stochastic/keltner_stochastic_strategy.py
@@ -210,22 +210,20 @@ class keltner_stochastic_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        keltner_typed = keltner_value  # KeltnerChannelsValue
-        ema_value = keltner_typed.Middle
-        atr_value = keltner_typed.Upper - keltner_typed.Middle  # ATR is the distance from middle to upper band
+        ema_value = keltner_value.Middle
+        atr_value = keltner_value.Upper - keltner_value.Middle  # ATR is the distance from middle to upper band
 
-        stoch_typed = stoch_value  # StochasticOscillatorValue
 
         # Calculate Keltner Channel bands
         upper_band = ema_value + (atr_value * self.KeltnerMultiplier)
         lower_band = ema_value - (atr_value * self.KeltnerMultiplier)
 
         # Long entry: price below lower Keltner band and Stochastic oversold
-        if candle.ClosePrice < lower_band and stoch_typed.K < self.StochOversold and self.Position <= 0:
+        if candle.ClosePrice < lower_band and stoch_value.K < self.StochOversold and self.Position <= 0:
             volume = self.Volume + Math.Abs(self.Position)
             self.BuyMarket(volume)
         # Short entry: price above upper Keltner band and Stochastic overbought
-        elif candle.ClosePrice > upper_band and stoch_typed.K > self.StochOverbought and self.Position >= 0:
+        elif candle.ClosePrice > upper_band and stoch_value.K > self.StochOverbought and self.Position >= 0:
             volume = self.Volume + Math.Abs(self.Position)
             self.SellMarket(volume)
         # Long exit: price returns to EMA line (middle band)

--- a/API/0146_MACD_Volume/macd_volume_strategy.py
+++ b/API/0146_MACD_Volume/macd_volume_strategy.py
@@ -186,9 +186,8 @@ class macd_volume_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading() or self._avg_volume <= 0:
             return
 
-        macd_typed = macd_value
-        macd_line = macd_typed.Macd
-        signal_line = macd_typed.Signal
+        macd_line = macd_value.Macd
+        signal_line = macd_value.Signal
 
         # Check if we have previous values to compare
         if self._prev_macd is not None and self._prev_signal is not None:

--- a/API/0148_RSI_Stochastic/rsi_stochastic_strategy.py
+++ b/API/0148_RSI_Stochastic/rsi_stochastic_strategy.py
@@ -214,8 +214,7 @@ class rsi_stochastic_strategy(Strategy):
             return
 
         rsi = to_float(rsi_value)
-        stoch_typed = stoch_value
-        stoch_k = stoch_typed.K
+        stoch_k = stoch_value.K
 
         # Long entry: double confirmation of oversold condition
         if rsi < self.rsi_oversold and stoch_k < self.stoch_oversold and self.Position <= 0:

--- a/API/0150_VWAP_Stochastic/vwap_stochastic_strategy.py
+++ b/API/0150_VWAP_Stochastic/vwap_stochastic_strategy.py
@@ -171,8 +171,7 @@ class vwap_stochastic_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        stochTyped = stochValue
-        kValue = stochTyped.K
+        kValue = stochValue.K
 
         vwapDec = to_float(vwapValue)
 

--- a/API/0158_Parabolic_SAR_Stochastic/parabolic_sar_stochastic_strategy.py
+++ b/API/0158_Parabolic_SAR_Stochastic/parabolic_sar_stochastic_strategy.py
@@ -174,10 +174,9 @@ class parabolic_sar_stochastic_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        stochTyped = stochValue
-        if stochTyped.K is None:
+        if stochValue.K is None:
             return
-        stochK = float(stochTyped.K)
+        stochK = float(stochValue.K)
 
         sarDec = to_float(sarValue)
 

--- a/API/0161_MACD_CCI/macd_cci_strategy.py
+++ b/API/0161_MACD_CCI/macd_cci_strategy.py
@@ -174,9 +174,8 @@ class macd_cci_strategy(Strategy):
 
         # Get MACD line and Signal line values
         # This approach is not ideal - in a proper implementation, these values should come from the Bind parameters
-        macdTyped = macdValue
-        macdLine = macdTyped.Macd  # The main MACD line
-        signalLine = macdTyped.Signal  # Signal line
+        macdLine = macdValue.Macd  # The main MACD line
+        signalLine = macdValue.Signal  # Signal line
 
         # Determine if MACD is above or below signal line
         isMacdAboveSignal = macdLine > signalLine

--- a/API/0162_Bollinger_CCI/bollinger_cci_strategy.py
+++ b/API/0162_Bollinger_CCI/bollinger_cci_strategy.py
@@ -170,32 +170,31 @@ class bollinger_cci_strategy(Strategy):
         if bb.LowBand is None:
             return
         lowerBand = float(bb.LowBand)
-        cciTyped = to_float(cciValue)
 
         # Current price
         price = float(candle.ClosePrice)
 
         self.LogInfo(
             "Candle: {0}, Close: {1}, Upper Band: {2}, Middle Band: {3}, Lower Band: {4}, CCI: {5}".format(
-                candle.OpenTime, price, upperBand, middleBand, lowerBand, cciTyped))
+                candle.OpenTime, price, upperBand, middleBand, lowerBand, cciValue))
 
         # Trading rules
-        if price < lowerBand and cciTyped < self.CciOversold and self.Position <= 0:
+        if price < lowerBand and cciValue < self.CciOversold and self.Position <= 0:
             # Buy signal - price below lower band and CCI oversold
             volume = self.Volume + Math.Abs(self.Position)
             self.BuyMarket(volume)
 
             self.LogInfo(
                 "Buy signal: Price below lower Bollinger Band and CCI oversold ({0} < {1}). Volume: {2}".format(
-                    cciTyped, self.CciOversold, volume))
-        elif price > upperBand and cciTyped > self.CciOverbought and self.Position >= 0:
+                    cciValue, self.CciOversold, volume))
+        elif price > upperBand and cciValue > self.CciOverbought and self.Position >= 0:
             # Sell signal - price above upper band and CCI overbought
             volume = self.Volume + Math.Abs(self.Position)
             self.SellMarket(volume)
 
             self.LogInfo(
                 "Sell signal: Price above upper Bollinger Band and CCI overbought ({0} > {1}). Volume: {2}".format(
-                    cciTyped, self.CciOverbought, volume))
+                    cciValue, self.CciOverbought, volume))
         # Exit conditions
         elif price > middleBand and self.Position > 0:
             # Exit long position when price returns to the middle band

--- a/API/0169_Hull_MA_Stochastic/hull_ma_stochastic_strategy.py
+++ b/API/0169_Hull_MA_Stochastic/hull_ma_stochastic_strategy.py
@@ -168,10 +168,9 @@ class hull_ma_stochastic_strategy(Strategy):
         # Get indicator values
         hma = to_float(hma_value)
 
-        stoch_typed = stoch_value
-        if stoch_typed.K is None:
+        if stoch_value.K is None:
             return
-        stoch_k = float(stoch_typed.K)
+        stoch_k = float(stoch_value.K)
 
         atr = to_float(atr_value)
 

--- a/API/0172_Bollinger_Williams_R/bollinger_williams_r_strategy.py
+++ b/API/0172_Bollinger_Williams_R/bollinger_williams_r_strategy.py
@@ -134,19 +134,18 @@ class bollinger_williams_r_strategy(Strategy):
             return
 
         # Get additional values from Bollinger Bands
-        bollinger_typed = bollinger_value
 
-        if bollinger_typed.MovingAverage is None:
+        if bollinger_value.MovingAverage is None:
             return
-        middle_band = float(bollinger_typed.MovingAverage)  # Middle band is returned by default
+        middle_band = float(bollinger_value.MovingAverage)  # Middle band is returned by default
 
-        if bollinger_typed.UpBand is None:
+        if bollinger_value.UpBand is None:
             return
-        upper_band = float(bollinger_typed.UpBand)
+        upper_band = float(bollinger_value.UpBand)
 
-        if bollinger_typed.LowBand is None:
+        if bollinger_value.LowBand is None:
             return
-        lower_band = float(bollinger_typed.LowBand)
+        lower_band = float(bollinger_value.LowBand)
 
         # Current price (close of the candle)
         price = float(candle.ClosePrice)

--- a/API/0174_MACD_VWAP/macd_vwap_strategy.py
+++ b/API/0174_MACD_VWAP/macd_vwap_strategy.py
@@ -117,9 +117,8 @@ class macd_vwap_strategy(Strategy):
             return
 
         # Get additional values from MACD (signal line)
-        macd_typed = macd_value
-        macd_line = macd_typed.Macd
-        signal_line = macd_typed.Signal
+        macd_line = macd_value.Macd
+        signal_line = macd_value.Signal
         vwap = to_float(vwap_value)
 
         # Current price (close of the candle)

--- a/API/0176_ADX_Bollinger/adx_bollinger_strategy.py
+++ b/API/0176_ADX_Bollinger/adx_bollinger_strategy.py
@@ -148,13 +148,12 @@ class adx_bollinger_strategy(Strategy):
             return
 
         # Get additional values from Bollinger Bands
-        bollinger_typed = bollinger_value
 
-        if bollinger_typed.UpBand is None or bollinger_typed.LowBand is None:
+        if bollinger_value.UpBand is None or bollinger_value.LowBand is None:
             return
 
-        upper_band = float(bollinger_typed.UpBand)
-        lower_band = float(bollinger_typed.LowBand)
+        upper_band = float(bollinger_value.UpBand)
+        lower_band = float(bollinger_value.LowBand)
         middle_band = (upper_band - lower_band) / 2 + lower_band
 
         # Current price (close of the candle)
@@ -163,10 +162,9 @@ class adx_bollinger_strategy(Strategy):
         # Stop-loss size based on ATR
         stop_size = to_float(atr_value) * self.atr_multiplier
 
-        adx_typed = adx_value
 
         # Trading logic
-        if adx_typed.MovingAverage > 25:  # Strong trend
+        if adx_value.MovingAverage > 25:  # Strong trend
             if price > upper_band and self.Position <= 0:
                 # Buy signal: price above upper Bollinger band with strong trend
                 self.BuyMarket(self.Volume + Math.Abs(self.Position))
@@ -181,7 +179,7 @@ class adx_bollinger_strategy(Strategy):
                 # Set stop-loss
                 stop_price = price + stop_size
                 self.RegisterOrder(self.CreateOrder(Sides.Buy, stop_price, max(Math.Abs(self.Position + self.Volume), self.Volume)))
-        elif adx_typed.MovingAverage < 20:
+        elif adx_value.MovingAverage < 20:
             # Trend is weakening - close any position
             if self.Position > 0:
                 self.SellMarket(self.Position)

--- a/API/0177_Ichimoku_Stochastic/ichimoku_stochastic_strategy.py
+++ b/API/0177_Ichimoku_Stochastic/ichimoku_stochastic_strategy.py
@@ -163,23 +163,22 @@ class ichimoku_stochastic_strategy(Strategy):
             return
 
         # Get additional values from Ichimoku
-        ichimoku_typed = ichimoku_value
 
-        if ichimoku_typed.Tenkan is None:
+        if ichimoku_value.Tenkan is None:
             return
-        tenkan = float(ichimoku_typed.Tenkan)
+        tenkan = float(ichimoku_value.Tenkan)
 
-        if ichimoku_typed.Kijun is None:
+        if ichimoku_value.Kijun is None:
             return
-        kijun = float(ichimoku_typed.Kijun)
+        kijun = float(ichimoku_value.Kijun)
 
-        if ichimoku_typed.SenkouA is None:
+        if ichimoku_value.SenkouA is None:
             return
-        senkou_a = float(ichimoku_typed.SenkouA)
+        senkou_a = float(ichimoku_value.SenkouA)
 
-        if ichimoku_typed.SenkouB is None:
+        if ichimoku_value.SenkouB is None:
             return
-        senkou_b = float(ichimoku_typed.SenkouB)
+        senkou_b = float(ichimoku_value.SenkouB)
 
         # Current price (close of the candle)
         price = float(candle.ClosePrice)
@@ -192,12 +191,11 @@ class ichimoku_stochastic_strategy(Strategy):
         is_bullish_cross = tenkan > kijun
         is_bearish_cross = tenkan < kijun
 
-        stoch_typed = stoch_value
 
         # Get Stochastic %K value
-        if stoch_typed.K is None:
+        if stoch_value.K is None:
             return
-        stochastic_k = float(stoch_typed.K)
+        stochastic_k = float(stoch_value.K)
 
         # Trading logic
         if is_above_kumo and is_bullish_cross and stochastic_k < 20 and self.Position <= 0:

--- a/API/0187_Donchian_MACD/donchian_macd_strategy.py
+++ b/API/0187_Donchian_MACD/donchian_macd_strategy.py
@@ -151,9 +151,8 @@ class donchian_macd_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        macdTyped = macdValue
-        signalValue = macdTyped.Signal
-        macdDec = macdTyped.Macd
+        signalValue = macdValue.Signal
+        macdDec = macdValue.Macd
 
         # Check for breakouts with MACD trend confirmation
         # Long entry: Price breaks above Donchian high and MACD > Signal
@@ -187,13 +186,12 @@ class donchian_macd_strategy(Strategy):
 
             self.LogInfo("Exit signal: MACD trend reversal. MACD: {0}, Signal: {1}".format(macdDec, signalValue))
 
-        donchianTyped = donchianValue
-        if donchianTyped.UpperBand is None or donchianTyped.LowerBand is None:
+        if donchianValue.UpperBand is None or donchianValue.LowerBand is None:
             return
 
         # Update previous values for next candle
-        self._previousHighest = float(donchianTyped.UpperBand)
-        self._previousLowest = float(donchianTyped.LowerBand)
+        self._previousHighest = float(donchianValue.UpperBand)
+        self._previousLowest = float(donchianValue.LowerBand)
         self._previousMacd = macdDec
         self._previousSignal = signalValue
 

--- a/API/0193_Supertrend_ADX/supertrend_adx_strategy.py
+++ b/API/0193_Supertrend_ADX/supertrend_adx_strategy.py
@@ -142,12 +142,10 @@ class supertrend_adx_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        adx_typed = adx_value
-        supertrend_typed = supertrend_value
 
         # Determine current position relative to Supertrend
-        is_above_supertrend = candle.ClosePrice > supertrend_typed.Value
-        is_strong_trend = adx_typed.MovingAverage > self.AdxThreshold
+        is_above_supertrend = candle.ClosePrice > supertrend_value.Value
+        is_strong_trend = adx_value.MovingAverage > self.AdxThreshold
 
         # Log current state
         self.LogInfo(f"Close: {candle.ClosePrice}, Supertrend: {supertrend_value}, ADX: {adx_value}, Above: {is_above_supertrend}, Strong Trend: {is_strong_trend}")
@@ -176,7 +174,7 @@ class supertrend_adx_strategy(Strategy):
                 self.LogInfo(f"Exit short position: Price crossed above Supertrend ({supertrend_value})")
 
         # Save current state
-        self._last_supertrend = supertrend_typed.Value
+        self._last_supertrend = supertrend_value.Value
         self._is_above_supertrend = is_above_supertrend
 
     def CreateClone(self):

--- a/API/0194_Keltner_MACD/keltner_macd_strategy.py
+++ b/API/0194_Keltner_MACD/keltner_macd_strategy.py
@@ -204,12 +204,11 @@ class keltner_macd_strategy(Strategy):
         upperBand = ema + self.Multiplier * atr
         lowerBand = ema - self.Multiplier * atr
 
-        macd_typed = macd_value
-        if macd_typed.Macd is None or macd_typed.Signal is None:
+        if macd_value.Macd is None or macd_value.Signal is None:
             return
 
-        macd = float(macd_typed.Macd)
-        signal = float(macd_typed.Signal)
+        macd = float(macd_value.Macd)
+        signal = float(macd_value.Signal)
 
         # Detect MACD crosses
         macdCrossedAboveSignal = self._prevMacd <= self._prevSignal and macd > signal

--- a/API/0198_VWAP_MACD/vwap_macd_strategy.py
+++ b/API/0198_VWAP_MACD/vwap_macd_strategy.py
@@ -134,15 +134,14 @@ class vwap_macd_strategy(Strategy):
         # Get VWAP value (calculated per day)
         vwap = to_float(process_candle(self._vwap, candle))
 
-        macd_typed = macd_value
 
         # Check if MACD and Signal values are available
-        if macd_typed.Macd is None or macd_typed.Signal is None:
+        if macd_value.Macd is None or macd_value.Signal is None:
             return
 
         # Extract MACD and Signal values
-        macd = float(macd_typed.Macd)
-        signal = float(macd_typed.Signal)
+        macd = float(macd_value.Macd)
+        signal = float(macd_value.Signal)
 
         # Detect MACD crosses
         macd_crossed_above_signal = self._prev_macd <= self._prev_signal and macd > signal

--- a/API/0202_Donchian_CCI/donchian_cci_strategy.py
+++ b/API/0202_Donchian_CCI/donchian_cci_strategy.py
@@ -112,16 +112,15 @@ class donchian_cci_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        donchian_typed = donchian_value
         if (
-            donchian_typed.UpperBand is None
-            or donchian_typed.LowerBand is None
-            or donchian_typed.Middle is None
+            donchian_value.UpperBand is None
+            or donchian_value.LowerBand is None
+            or donchian_value.Middle is None
         ):
             return
-        upper_band = float(donchian_typed.UpperBand)
-        lower_band = float(donchian_typed.LowerBand)
-        middle_band = float(donchian_typed.Middle)
+        upper_band = float(donchian_value.UpperBand)
+        lower_band = float(donchian_value.LowerBand)
+        middle_band = float(donchian_value.Middle)
 
         cci_dec = cci_value
         price = float(candle.ClosePrice)

--- a/API/0203_Keltner_Williams_R/keltner_williams_r_strategy.py
+++ b/API/0203_Keltner_Williams_R/keltner_williams_r_strategy.py
@@ -125,10 +125,9 @@ class keltner_williams_r_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        keltner_typed = keltner_value  # KeltnerChannelsValue
-        upper = keltner_typed.Upper
-        lower = keltner_typed.Lower
-        middle = keltner_typed.Middle
+        upper = keltner_value.Upper
+        lower = keltner_value.Lower
+        middle = keltner_value.Middle
 
         williams_r = to_float(williams_r_value)
 

--- a/API/0221_Bollinger_Band_Squeeze/bollinger_band_squeeze_strategy.py
+++ b/API/0221_Bollinger_Band_Squeeze/bollinger_band_squeeze_strategy.py
@@ -131,15 +131,14 @@ class bollinger_band_squeeze_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        bollingerTyped = bollingerValue
 
-        if bollingerTyped.UpBand is None:
+        if bollingerValue.UpBand is None:
             return
-        upperBand = float(bollingerTyped.UpBand)
+        upperBand = float(bollingerValue.UpBand)
 
-        if bollingerTyped.LowBand is None:
+        if bollingerValue.LowBand is None:
             return
-        lowerBand = float(bollingerTyped.LowBand)
+        lowerBand = float(bollingerValue.LowBand)
 
         atr = to_float(atrValue)
 

--- a/API/0241_ADX_Mean_Reversion/adx_mean_reversion_strategy.py
+++ b/API/0241_ADX_Mean_Reversion/adx_mean_reversion_strategy.py
@@ -145,14 +145,13 @@ class adx_mean_reversion_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        adx_typed = adx_value
-        if adx_typed.MovingAverage is None:
+        if adx_value.MovingAverage is None:
             return
-        current_adx = float(adx_typed.MovingAverage)
+        current_adx = float(adx_value.MovingAverage)
 
-        if adx_typed.Dx is None or adx_typed.Dx.Plus is None or adx_typed.Dx.Minus is None:
+        if adx_value.Dx is None or adx_value.Dx.Plus is None or adx_value.Dx.Minus is None:
             return
-        dx = adx_typed.Dx
+        dx = adx_value.Dx
         plus_di = float(dx.Plus)
         minus_di = float(dx.Minus)
 

--- a/API/0248_Stochastic_Breakout/stochastic_breakout_strategy.py
+++ b/API/0248_Stochastic_Breakout/stochastic_breakout_strategy.py
@@ -155,11 +155,10 @@ class stochastic_breakout_strategy(Strategy):
             return
 
         # Get stochastic value (K line)
-        stochTyped = stochValue
-        if stochTyped.K is None:
+        if stochValue.K is None:
             return
 
-        stochK = stochTyped.K
+        stochK = stochValue.K
 
         # Calculate average and standard deviation of stochastic
         stochAvgValue = to_float(process_float(self._stochAverage, stochK, candle.ServerTime, candle.State == CandleStates.Finished))

--- a/API/0251_MACD_Breakout/macd_breakout_strategy.py
+++ b/API/0251_MACD_Breakout/macd_breakout_strategy.py
@@ -174,13 +174,12 @@ class macd_breakout_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        macd_typed = macd_value
 
         # Extract the histogram value (MACD Line - Signal Line)
-        if macd_typed.Macd is None or macd_typed.Signal is None:
+        if macd_value.Macd is None or macd_value.Signal is None:
             return
 
-        macd = float(macd_typed.Macd)
+        macd = float(macd_value.Macd)
 
         # Process indicators for MACD histogram
         macd_hist_sma_value = to_float(process_float(self._macd_hist_sma, macd, candle.ServerTime, candle.State == CandleStates.Finished))

--- a/API/0256_Bollinger_Band_Width_Breakout/bollinger_band_width_breakout_strategy.py
+++ b/API/0256_Bollinger_Band_Width_Breakout/bollinger_band_width_breakout_strategy.py
@@ -147,13 +147,12 @@ class bollinger_band_width_breakout_strategy(Strategy):
         current_atr = to_float(atr_value)
 
         # Calculate Bollinger Band width
-        bollinger_typed = bollinger_value
-        if bollinger_typed.UpBand is None:
+        if bollinger_value.UpBand is None:
             return
-        if bollinger_typed.LowBand is None:
+        if bollinger_value.LowBand is None:
             return
-        upper_band = float(bollinger_typed.UpBand)
-        lower_band = float(bollinger_typed.LowBand)
+        upper_band = float(bollinger_value.UpBand)
+        lower_band = float(bollinger_value.LowBand)
 
         last_width = upper_band - lower_band
 

--- a/API/0259_Ichimoku_Cloud_Width_Breakout/ichimoku_width_breakout_strategy.py
+++ b/API/0259_Ichimoku_Cloud_Width_Breakout/ichimoku_width_breakout_strategy.py
@@ -169,23 +169,22 @@ class ichimoku_width_breakout_strategy(Strategy):
 
         # Get current Ichimoku values
         # The structure of values depends on the implementation, this is just an example
-        ichimoku_typed = ichimoku_value
 
-        if ichimoku_typed.Tenkan is None:
+        if ichimoku_value.Tenkan is None:
             return
-        tenkan = float(ichimoku_typed.Tenkan)
+        tenkan = float(ichimoku_value.Tenkan)
 
-        if ichimoku_typed.Kijun is None:
+        if ichimoku_value.Kijun is None:
             return
-        kijun = float(ichimoku_typed.Kijun)
+        kijun = float(ichimoku_value.Kijun)
 
-        if ichimoku_typed.SenkouA is None:
+        if ichimoku_value.SenkouA is None:
             return
-        senkou_span_a = float(ichimoku_typed.SenkouA)
+        senkou_span_a = float(ichimoku_value.SenkouA)
 
-        if ichimoku_typed.SenkouB is None:
+        if ichimoku_value.SenkouB is None:
             return
-        senkou_span_b = float(ichimoku_typed.SenkouB)
+        senkou_span_b = float(ichimoku_value.SenkouB)
 
         # Calculate Cloud width (absolute difference between Senkou lines)
         width = Math.Abs(senkou_span_a - senkou_span_b)

--- a/API/0268_Stochastic_Slope_Breakout/stochastic_slope_breakout_strategy.py
+++ b/API/0268_Stochastic_Slope_Breakout/stochastic_slope_breakout_strategy.py
@@ -174,8 +174,7 @@ class stochastic_slope_breakout_strategy(Strategy):
 
         # Extract Stochastic %K value - the main line that we'll track the slope of
         # Stochastic returns a complex value with both %K and %D values
-        stochTyped = stochValue
-        kValue = stochTyped.K
+        kValue = stochValue.K
         if kValue is None:
             return
 

--- a/API/0269_CCI_Slope_Breakout/cci_slope_breakout_strategy.py
+++ b/API/0269_CCI_Slope_Breakout/cci_slope_breakout_strategy.py
@@ -137,17 +137,17 @@ class cci_slope_breakout_strategy(Strategy):
             return
 
         # Calculate CCI slope
-        currentSlopeTyped = process_float(
+        currentSlope = process_float(
             self._cciSlope,
             cciValue,
             candle.ServerTime,
             candle.State == CandleStates.Finished,
         )
 
-        if currentSlopeTyped.LinearReg is None:
+        if currentSlope.LinearReg is None:
             return
 
-        currentSlopeValue = float(currentSlopeTyped.LinearReg)
+        currentSlopeValue = float(currentSlope.LinearReg)
 
         # Update slope stats when we have 2 values to calculate slope
         if self._prevCciSlopeValue != 0:

--- a/API/0270_Williams_R_Slope_Breakout/williams_r_slope_breakout_strategy.py
+++ b/API/0270_Williams_R_Slope_Breakout/williams_r_slope_breakout_strategy.py
@@ -140,15 +140,15 @@ class williams_r_slope_breakout_strategy(Strategy):
             return
 
         # Calculate Williams %R slope
-        current_slope_typed = process_float(
+        current_slope = process_float(
             self._williams_r_slope,
             williams_r_value,
             candle.ServerTime,
             candle.State == CandleStates.Finished,
         )
-        if current_slope_typed.LinearReg is None:
+        if current_slope.LinearReg is None:
             return  # Skip if slope is not available
-        current_slope_value = current_slope_typed.LinearReg
+        current_slope_value = current_slope.LinearReg
 
         # Update slope stats when we have 2 values to calculate slope
         if self._prev_slope_value != 0:

--- a/API/0271_MACD_Slope_Breakout/macd_slope_breakout_strategy.py
+++ b/API/0271_MACD_Slope_Breakout/macd_slope_breakout_strategy.py
@@ -168,16 +168,15 @@ class macd_slope_breakout_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        macd_typed = macd_value
-        if macd_typed.Macd is None or macd_typed.Signal is None:
+        if macd_value.Macd is None or macd_value.Signal is None:
             return
 
         # Calculate MACD histogram value (MACD - Signal)
-        macd_hist = macd_typed.Macd - macd_typed.Signal
+        macd_hist = macd_value.Macd - macd_value.Signal
 
         # Calculate MACD histogram slope
-        current_slope_typed = process_float(self._macd_hist_slope, macd_hist, candle.ServerTime, candle.State == CandleStates.Finished)
-        current_slope_value = current_slope_typed.LinearReg
+        current_slope = process_float(self._macd_hist_slope, macd_hist, candle.ServerTime, candle.State == CandleStates.Finished)
+        current_slope_value = current_slope.LinearReg
         if current_slope_value is None:
             return
 

--- a/API/0272_ADX_Slope_Breakout/adx_slope_breakout_strategy.py
+++ b/API/0272_ADX_Slope_Breakout/adx_slope_breakout_strategy.py
@@ -157,8 +157,8 @@ class adx_slope_breakout_strategy(Strategy):
             return
 
         # Calculate ADX slope
-        currentSlopeTyped = process_float(self._adxSlope, adx, candle.ServerTime, candle.State == CandleStates.Finished)
-        currentSlopeValue = currentSlopeTyped.LinearReg
+        currentSlope = process_float(self._adxSlope, adx, candle.ServerTime, candle.State == CandleStates.Finished)
+        currentSlopeValue = currentSlope.LinearReg
         if currentSlopeValue is None:
             return
 

--- a/API/0273_ATR_Slope_Breakout/atr_slope_breakout_strategy.py
+++ b/API/0273_ATR_Slope_Breakout/atr_slope_breakout_strategy.py
@@ -155,15 +155,15 @@ class atr_slope_breakout_strategy(Strategy):
         price_above_ema = candle.ClosePrice > ema_value
 
         # Calculate ATR slope
-        current_slope_typed = process_float(
+        current_slope = process_float(
             self._atr_slope,
             atr,
             candle.ServerTime,
             candle.State == CandleStates.Finished,
         )
-        if current_slope_typed.LinearReg is None:
+        if current_slope.LinearReg is None:
             return  # Skip if we can't get the slope value
-        current_slope_value = float(current_slope_typed.LinearReg)
+        current_slope_value = float(current_slope.LinearReg)
 
         # Update slope stats when we have 2 values to calculate slope
         if self._prev_slope_value != 0:

--- a/API/0274_Volume_Slope_Breakout/volume_slope_breakout_strategy.py
+++ b/API/0274_Volume_Slope_Breakout/volume_slope_breakout_strategy.py
@@ -160,11 +160,11 @@ class volume_slope_breakout_strategy(Strategy):
         volumeRatio = volumeValue / volumeSma
 
         # We use LinearRegression to calculate slope of this ratio
-        currentSlopeTyped = process_float(self._volumeSlope, volumeRatio, candle.ServerTime, candle.State == CandleStates.Finished)
+        currentSlope = process_float(self._volumeSlope, volumeRatio, candle.ServerTime, candle.State == CandleStates.Finished)
 
-        if currentSlopeTyped.LinearReg is None:
+        if currentSlope.LinearReg is None:
             return  # Skip if slope is not available
-        currentSlopeValue = currentSlopeTyped.LinearReg
+        currentSlopeValue = currentSlope.LinearReg
 
         # Update slope stats when we have 2 values to calculate slope
         if self._prevSlopeValue != 0:

--- a/API/0275_OBV_Slope_Breakout/obv_slope_breakout_strategy.py
+++ b/API/0275_OBV_Slope_Breakout/obv_slope_breakout_strategy.py
@@ -141,14 +141,14 @@ class obv_slope_breakout_strategy(Strategy):
             return
 
         # Calculate OBV slope
-        slopeTyped = process_float(self._obvSlope, obvValue, candle.ServerTime, candle.State == CandleStates.Finished)
-        if not slopeTyped.IsFinal:
+        slope = process_float(self._obvSlope, obvValue, candle.ServerTime, candle.State == CandleStates.Finished)
+        if not slope.IsFinal:
             return
 
-        if slopeTyped.LinearReg is None:
+        if slope.LinearReg is None:
             return
 
-        slopeValue = float(slopeTyped.LinearReg)
+        slopeValue = float(slope.LinearReg)
 
         self._lastObvSlope = slopeValue
 

--- a/API/0276_Bollinger_Width_Mean_Reversion/bollinger_width_mean_reversion_strategy.py
+++ b/API/0276_Bollinger_Width_Mean_Reversion/bollinger_width_mean_reversion_strategy.py
@@ -172,12 +172,11 @@ class bollinger_width_mean_reversion_strategy(Strategy):
         # Process ATR
         lastAtr = to_float(atr_value)
 
-        bollingerTyped = bollinger_value
-        if bollingerTyped.UpBand is None or bollingerTyped.LowBand is None:
+        if bollinger_value.UpBand is None or bollinger_value.LowBand is None:
             return
 
         # Calculate Bollinger width
-        lastWidth = float(bollingerTyped.UpBand) - float(bollingerTyped.LowBand)
+        lastWidth = float(bollinger_value.UpBand) - float(bollinger_value.LowBand)
 
         # Calculate width's average and standard deviation
         widthAvg = process_float(self._widthAvg, lastWidth, candle.ServerTime, candle.State == CandleStates.Finished)

--- a/API/0279_Ichimoku_Cloud_Width_Mean_Reversion/ichimoku_cloud_width_mean_reversion_strategy.py
+++ b/API/0279_Ichimoku_Cloud_Width_Mean_Reversion/ichimoku_cloud_width_mean_reversion_strategy.py
@@ -162,18 +162,17 @@ class ichimoku_cloud_width_mean_reversion_strategy(Strategy):
             return
 
         # Extract values from the Ichimoku indicator
-        ichimokuTyped = ichimokuValue
 
-        tenkan = ichimokuTyped.Tenkan
+        tenkan = ichimokuValue.Tenkan
         if tenkan is None:
             return
-        kijun = ichimokuTyped.Kijun
+        kijun = ichimokuValue.Kijun
         if kijun is None:
             return
-        senkouA = ichimokuTyped.SenkouA
+        senkouA = ichimokuValue.SenkouA
         if senkouA is None:
             return
-        senkouB = ichimokuTyped.SenkouB
+        senkouB = ichimokuValue.SenkouB
         if senkouB is None:
             return
 

--- a/API/0287_Stochastic_Slope_Mean_Reversion/stochastic_slope_mean_reversion_strategy.py
+++ b/API/0287_Stochastic_Slope_Mean_Reversion/stochastic_slope_mean_reversion_strategy.py
@@ -165,11 +165,10 @@ class stochastic_slope_mean_reversion_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        stoch_typed = stoch_value
-        if stoch_typed.K is None:
+        if stoch_value.K is None:
             return
 
-        stoch_k = float(stoch_typed.K)
+        stoch_k = float(stoch_value.K)
 
         # Calculate Stochastic %K slope only if we have previous %K value
         if self._previous_stoch_k_value != 0:

--- a/API/0291_ADX_Slope_Mean_Reversion/adx_slope_mean_reversion_strategy.py
+++ b/API/0291_ADX_Slope_Mean_Reversion/adx_slope_mean_reversion_strategy.py
@@ -164,12 +164,11 @@ class adx_slope_mean_reversion_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        adx_typed = adx_value
-        if adx_typed.MovingAverage is None:
+        if adx_value.MovingAverage is None:
             return
 
-        adx = float(adx_typed.MovingAverage)
-        dx = adx_typed.Dx
+        adx = float(adx_value.MovingAverage)
+        dx = adx_value.Dx
         if dx is None or dx.Plus is None or dx.Minus is None:
             return
 

--- a/API/0307_MACD_Adaptive_Histogram/macd_adaptive_histogram_strategy.py
+++ b/API/0307_MACD_Adaptive_Histogram/macd_adaptive_histogram_strategy.py
@@ -192,13 +192,12 @@ class macd_adaptive_histogram_strategy(Strategy):
         if candle.State != CandleStates.Finished:
             return
 
-        macd_typed = macd_value
-        if macd_typed.Macd is None or macd_typed.Signal is None:
+        if macd_value.Macd is None or macd_value.Signal is None:
             return
 
         # Extract MACD values
-        macd = macd_typed.Macd
-        signal = macd_typed.Signal
+        macd = macd_value.Macd
+        signal = macd_value.Signal
         histogram = macd - signal
 
         # Process the histogram through the statistics indicators

--- a/API/0308_Ichimoku_Volume_Cluster/ichimoku_volume_cluster_strategy.py
+++ b/API/0308_Ichimoku_Volume_Cluster/ichimoku_volume_cluster_strategy.py
@@ -165,22 +165,21 @@ class ichimoku_volume_cluster_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        ichimoku_typed = ichimoku_value
 
         # Extract Ichimoku values
-        if ichimoku_typed.Tenkan is None:
+        if ichimoku_value.Tenkan is None:
             return
-        if ichimoku_typed.Kijun is None:
+        if ichimoku_value.Kijun is None:
             return
-        if ichimoku_typed.SenkouA is None:
+        if ichimoku_value.SenkouA is None:
             return
-        if ichimoku_typed.SenkouB is None:
+        if ichimoku_value.SenkouB is None:
             return
 
-        tenkan = ichimoku_typed.Tenkan
-        kijun = ichimoku_typed.Kijun
-        senkou_a = ichimoku_typed.SenkouA
-        senkou_b = ichimoku_typed.SenkouB
+        tenkan = ichimoku_value.Tenkan
+        kijun = ichimoku_value.Kijun
+        senkou_a = ichimoku_value.SenkouA
+        senkou_b = ichimoku_value.SenkouB
 
         # Determine cloud position
         price_above_cloud = candle.ClosePrice > Math.Max(senkou_a, senkou_b)

--- a/API/0313_VWAP_ADX_Trend_Strength/vwap_adx_trend_strength_strategy.py
+++ b/API/0313_VWAP_ADX_Trend_Strength/vwap_adx_trend_strength_strategy.py
@@ -98,12 +98,11 @@ class vwap_adx_trend_strength_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        adx_typed = adx_value
 
         # Extract values from ADX composite indicator
-        adx_ma = adx_typed.MovingAverage  # ADX value
-        di_plus = adx_typed.Dx.Plus  # +DI value
-        di_minus = adx_typed.Dx.Minus  # -DI value
+        adx_ma = adx_value.MovingAverage  # ADX value
+        di_plus = adx_value.Dx.Plus  # +DI value
+        di_minus = adx_value.Dx.Minus  # -DI value
 
         # Get VWAP
         vwap_dec = to_float(vwap_value)

--- a/API/0315_Stochastic_Dynamic_Zones/stochastic_with_dynamic_zones_strategy.py
+++ b/API/0315_Stochastic_Dynamic_Zones/stochastic_with_dynamic_zones_strategy.py
@@ -148,12 +148,11 @@ class stochastic_with_dynamic_zones_strategy(Strategy):
             stopLoss=Unit(1, UnitTypes.Percent)
         )
     def ProcessStochastic(self, candle, stoch_value):
-        stoch_typed = stoch_value
-        if stoch_typed.K is None:
+        if stoch_value.K is None:
             return
 
         # Calculate dynamic zones
-        stoch_k = float(stoch_typed.K)
+        stoch_k = float(stoch_value.K)
         stoch_k_avg = to_float(process_float(self._stoch_sma, stoch_k, candle.ServerTime, candle.State == CandleStates.Finished))
         stoch_k_std_dev = to_float(process_float(self._stoch_std_dev, stoch_k, candle.ServerTime, candle.State == CandleStates.Finished))
 

--- a/API/0316_ADX_Volume_Breakout/adx_with_volume_breakout_strategy.py
+++ b/API/0316_ADX_Volume_Breakout/adx_with_volume_breakout_strategy.py
@@ -103,13 +103,12 @@ class adx_with_volume_breakout_strategy(Strategy):
         subscription = self.SubscribeCandles(self.CandleType)
 
         def process(candle, adx_value):
-            adx_typed = adx_value
-            if adx_typed.MovingAverage is None:
+            if adx_value.MovingAverage is None:
                 return
-            adx_ma = adx_typed.MovingAverage
-            if adx_typed.Dx is None or adx_typed.Dx.Plus is None or adx_typed.Dx.Minus is None:
+            adx_ma = adx_value.MovingAverage
+            if adx_value.Dx is None or adx_value.Dx.Plus is None or adx_value.Dx.Minus is None:
                 return
-            dx = adx_typed.Dx
+            dx = adx_value.Dx
             plus_di = dx.Plus
             minus_di = dx.Minus
 

--- a/API/0319_Bollinger_K-Means_Cluster/bollinger_kmeans_strategy.py
+++ b/API/0319_Bollinger_K-Means_Cluster/bollinger_kmeans_strategy.py
@@ -140,18 +140,17 @@ class bollinger_kmeans_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        bollinger_typed = bollinger_value
 
         # Extract values from indicators
         if (
-            bollinger_typed.UpBand is None
-            or bollinger_typed.LowBand is None
-            or bollinger_typed.MovingAverage is None
+            bollinger_value.UpBand is None
+            or bollinger_value.LowBand is None
+            or bollinger_value.MovingAverage is None
         ):
             return
-        bollinger_upper = float(bollinger_typed.UpBand)
-        bollinger_middle = float(bollinger_typed.MovingAverage)
-        bollinger_lower = float(bollinger_typed.LowBand)
+        bollinger_upper = float(bollinger_value.UpBand)
+        bollinger_middle = float(bollinger_value.MovingAverage)
+        bollinger_lower = float(bollinger_value.LowBand)
 
         rsi = to_float(rsi_value)
         self._atr_value = to_float(atr_value)

--- a/API/0321_Ichimoku_Hurst_Exponent/ichimoku_hurst_exponent_strategy.py
+++ b/API/0321_Ichimoku_Hurst_Exponent/ichimoku_hurst_exponent_strategy.py
@@ -138,22 +138,21 @@ class ichimoku_hurst_exponent_strategy(Strategy):
             return
 
         # Store Ichimoku values
-        ichimoku_typed = ichimoku_value
-        if ichimoku_typed.Tenkan is None:
+        if ichimoku_value.Tenkan is None:
             return
-        tenkan = float(ichimoku_typed.Tenkan)
+        tenkan = float(ichimoku_value.Tenkan)
 
-        if ichimoku_typed.Kijun is None:
+        if ichimoku_value.Kijun is None:
             return
-        kijun = float(ichimoku_typed.Kijun)
+        kijun = float(ichimoku_value.Kijun)
 
-        if ichimoku_typed.SenkouA is None:
+        if ichimoku_value.SenkouA is None:
             return
-        senkou_a = float(ichimoku_typed.SenkouA)
+        senkou_a = float(ichimoku_value.SenkouA)
 
-        if ichimoku_typed.SenkouB is None:
+        if ichimoku_value.SenkouB is None:
             return
-        senkou_b = float(ichimoku_typed.SenkouB)
+        senkou_b = float(ichimoku_value.SenkouB)
 
         # Update price data for Hurst exponent calculation
         self._prices.append(candle.ClosePrice)

--- a/API/0326_VWAP_Stochastic_Divergence/vwap_adx_trend_strategy.py
+++ b/API/0326_VWAP_Stochastic_Divergence/vwap_adx_trend_strategy.py
@@ -125,12 +125,11 @@ class vwap_adx_trend_strategy(Strategy):
         if candle.State != CandleStates.Finished:
             return
 
-        adx_typed = adx_value
-        if adx_typed.MovingAverage is None:
+        if adx_value.MovingAverage is None:
             return
-        adx = adx_typed.MovingAverage
+        adx = adx_value.MovingAverage
 
-        dx = adx_typed.Dx
+        dx = adx_value.Dx
         if dx.Plus is None or dx.Minus is None:
             return
         plus_di = dx.Plus

--- a/API/0329_MACD_Volume_Cluster/macd_volume_cluster_strategy.py
+++ b/API/0329_MACD_Volume_Cluster/macd_volume_cluster_strategy.py
@@ -198,9 +198,8 @@ class macd_volume_cluster_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        macd_typed = macd_value
-        macd_line = macd_typed.Macd
-        signal_line = macd_typed.Signal
+        macd_line = macd_value.Macd
+        signal_line = macd_value.Signal
 
         # Determine if we have a volume spike
         is_volume_spike = candle.TotalVolume > (self._avg_volume + self.volume_deviation_factor * self._volume_std_dev)

--- a/API/0330_Ichimoku_Volatility_Contraction/ichimoku_volatility_contraction_strategy.py
+++ b/API/0330_Ichimoku_Volatility_Contraction/ichimoku_volatility_contraction_strategy.py
@@ -181,23 +181,22 @@ class ichimoku_volatility_contraction_strategy(Strategy):
             return
 
         # Extract Ichimoku values
-        ichimoku_typed = ichimoku_value
 
-        if ichimoku_typed.Tenkan is None:
+        if ichimoku_value.Tenkan is None:
             return
-        tenkan = float(ichimoku_typed.Tenkan)
+        tenkan = float(ichimoku_value.Tenkan)
 
-        if ichimoku_typed.Kijun is None:
+        if ichimoku_value.Kijun is None:
             return
-        kijun = float(ichimoku_typed.Kijun)
+        kijun = float(ichimoku_value.Kijun)
 
-        if ichimoku_typed.SenkouA is None:
+        if ichimoku_value.SenkouA is None:
             return
-        senkou_a = float(ichimoku_typed.SenkouA)
+        senkou_a = float(ichimoku_value.SenkouA)
 
-        if ichimoku_typed.SenkouB is None:
+        if ichimoku_value.SenkouB is None:
             return
-        senkou_b = float(ichimoku_typed.SenkouB)
+        senkou_b = float(ichimoku_value.SenkouB)
 
         # Determine Kumo (cloud) boundaries
         upper_kumo = max(senkou_a, senkou_b)

--- a/API/0338_Adaptive_Bollinger_Breakout/adaptive_bollinger_breakout_strategy.py
+++ b/API/0338_Adaptive_Bollinger_Breakout/adaptive_bollinger_breakout_strategy.py
@@ -186,18 +186,17 @@ class adaptive_bollinger_breakout_strategy(Strategy):
             # use running average
             is_high_volatility = atr_val > (self._atr_sum / self._atr_count if self._atr_count > 0 else atr_val)
 
-            bollinger_typed = bollinger_value
 
             if (
-                bollinger_typed.UpBand is None
-                or bollinger_typed.LowBand is None
-                or bollinger_typed.MovingAverage is None
+                bollinger_value.UpBand is None
+                or bollinger_value.LowBand is None
+                or bollinger_value.MovingAverage is None
             ):
                 return  # Not enough data to calculate bands
 
-            upper_band = float(bollinger_typed.UpBand)
-            lower_band = float(bollinger_typed.LowBand)
-            middle_band = float(bollinger_typed.MovingAverage)
+            upper_band = float(bollinger_value.UpBand)
+            lower_band = float(bollinger_value.LowBand)
+            middle_band = float(bollinger_value.MovingAverage)
 
             if is_high_volatility:
                 # Breakout above upper band - Sell signal

--- a/API/0339_MACD_Sentiment_Filter/macd_with_sentiment_filter_strategy.py
+++ b/API/0339_MACD_Sentiment_Filter/macd_with_sentiment_filter_strategy.py
@@ -173,17 +173,16 @@ class macd_with_sentiment_filter_strategy(Strategy):
         # Update sentiment score (in a real system this would come from external source)
         self.UpdateSentimentScore(candle)
 
-        macd_typed = macd_value
-        if macd_typed.Macd is None or macd_typed.Signal is None:
+        if macd_value.Macd is None or macd_value.Signal is None:
             return
 
         # Store previous MACD values for state tracking
         prev_macd_over_signal = self._prev_macd > self._prev_signal
-        curr_macd_over_signal = macd_typed.Macd > macd_typed.Signal
+        curr_macd_over_signal = macd_value.Macd > macd_value.Signal
 
         # Update previous values for next candle
-        self._prev_macd = macd_typed.Macd
-        self._prev_signal = macd_typed.Signal
+        self._prev_macd = macd_value.Macd
+        self._prev_signal = macd_value.Signal
 
         # First candle, just store values
         if self.IsFirstRun():

--- a/API/0343_Keltner_Reinforcement_Learning_Signal/keltner_with_rl_signal_strategy.py
+++ b/API/0343_Keltner_Reinforcement_Learning_Signal/keltner_with_rl_signal_strategy.py
@@ -164,11 +164,10 @@ class keltner_with_rl_signal_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        keltner_typed = keltner_value  # KeltnerChannelsValue
 
-        upper_band = keltner_typed.Upper
-        lower_band = keltner_typed.Lower
-        middle_band = keltner_typed.Middle
+        upper_band = keltner_value.Upper
+        lower_band = keltner_value.Lower
+        middle_band = keltner_value.Middle
 
         if upper_band is None or lower_band is None or middle_band is None:
             return

--- a/API/0348_Stochastic_Implied_Volatility_Skew/stochastic_implied_volatility_skew_strategy.py
+++ b/API/0348_Stochastic_Implied_Volatility_Skew/stochastic_implied_volatility_skew_strategy.py
@@ -162,9 +162,8 @@ class stochastic_implied_volatility_skew_strategy(Strategy):
         if not self.IsFormedAndOnlineAndAllowTrading():
             return
 
-        stoch_typed = stoch_value
-        stoch_k = stoch_typed.K
-        stoch_d = stoch_typed.D
+        stoch_k = stoch_value.K
+        stoch_d = stoch_value.D
 
         # Entry logic
         if stoch_k < 20 and self._current_iv_skew > self._avg_iv_skew and self.Position <= 0:


### PR DESCRIPTION
## Summary
- clean up Python strategies by removing redundant temporary `*typed` variables
- replace typed references with the underlying indicator values
- update slope strategies to use regular variable names

## Testing
- `python3 -m compileall -q API`

------
https://chatgpt.com/codex/tasks/task_e_6879604e673c83238bb88e66383702d9