### PR TITLE
Refactor Python strategies 59 and 343

### DIFF
--- a/API/0059_Hammer_Candle/hammer_candle_strategy.py
+++ b/API/0059_Hammer_Candle/hammer_candle_strategy.py
@@ -65,15 +65,7 @@ class hammer_candle_strategy(Strategy):
             self.DrawCandles(area, subscription)
             self.DrawOwnTrades(area)
 
-        # Monitor position changes
-        self.WhenPositionChanged().Do(self.OnPositionChanged).Apply(self)
-
-    def OnPositionChanged(self):
-        """
-        Called when position changes.
-        """
-        if self.Position == 0:
-            self._isPositionOpen = False
+        # Position events will be handled in OnPositionReceived
 
     def ProcessCandle(self, candle):
         """
@@ -113,6 +105,12 @@ class hammer_candle_strategy(Strategy):
 
             self.LogInfo("Hammer pattern detected. Low: {0}, Body size: {1}, Lower shadow: {2}".format(
                 candle.LowPrice, bodySize, lowerShadow))
+
+    def OnPositionReceived(self, position):
+        """Handle position information when strategy is started."""
+        super(hammer_candle_strategy, self).OnPositionReceived(position)
+        if self.Position == 0:
+            self._isPositionOpen = False
 
     def CreateClone(self):
         """

--- a/API/0343_Keltner_Reinforcement_Learning_Signal/keltner_with_rl_signal_strategy.py
+++ b/API/0343_Keltner_Reinforcement_Learning_Signal/keltner_with_rl_signal_strategy.py
@@ -144,8 +144,7 @@ class keltner_with_rl_signal_strategy(Strategy):
         subscription = self.SubscribeCandles(self.CandleType)
         subscription.BindEx(keltner, self.ProcessCandle).Start()
 
-        # Subscribe to own trades for reinforcement learning feedback
-        self.WhenOwnTradeReceived().Do(self.ProcessOwnTrade).Apply(self)
+        # Reinforcement learning feedback handled in OnOwnTradeReceived
 
         # Create chart visualization if available
         area = self.CreateChartArea()
@@ -254,8 +253,8 @@ class keltner_with_rl_signal_strategy(Strategy):
                 self.LogInfo("RL Signal: None (high volatility)")
             # Otherwise keep current signal
 
-    def ProcessOwnTrade(self, trade):
-        """Process own trades for reinforcement learning feedback."""
+    def OnOwnTradeReceived(self, trade):
+        """Handle own trades for reinforcement learning feedback."""
         # Skip if we don't have a previous signal price (first trade)
         if self._previous_signal_price == 0:
             return


### PR DESCRIPTION
## Summary
- update Hammer Candle strategy to override `OnPositionReceived`
- update Keltner RL Signal strategy to override `OnOwnTradeReceived`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879e2e638308323898262ddf3f5e4b6