### PR TITLE
style: unify strategies 401-410

### DIFF
--- a/API/0402_Synthetic_Lending_Rates/SyntheticLendingRatesStrategy.cs
+++ b/API/0402_Synthetic_Lending_Rates/SyntheticLendingRatesStrategy.cs
@@ -18,29 +18,47 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies
 {
+	/// <summary>
+	/// Trades based on changes in synthetic lending-rate intensity.
+	/// </summary>
 	public class SyntheticLendingRatesStrategy : Strategy
 	{
 		private readonly StrategyParam<decimal> _minUsd;
 		private readonly DataType _tf = TimeSpan.FromMinutes(1).TimeFrame();
 		private readonly Dictionary<Security, decimal> _latestPrices = new();
 
-		public decimal MinTradeUsd => _minUsd.Value;
+		/// <summary>
+		/// Minimum trade value in USD.
+		/// </summary>
+		public decimal MinTradeUsd
+		{
+			get => _minUsd.Value;
+			set => _minUsd.Value = value;
+		}
+
 		private decimal? _intensityT0;
 
 		public SyntheticLendingRatesStrategy()
 		{
-			_minUsd = Param(nameof(MinTradeUsd), 200m);
+			_minUsd = Param(nameof(MinTradeUsd), 200m)
+				.SetDisplay("Min Trade USD", "Minimum notional value for orders", "Risk Management");
 		}
 
+		/// <inheritdoc />
 		public override IEnumerable<(Security, DataType)> GetWorkingSecurities()
 		{
 			if (Security == null)
 				throw new InvalidOperationException("Security not set");
+
 			yield return (Security, _tf);
 		}
 
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset t)
 		{
+			if (Security == null)
+				throw new InvalidOperationException("Security not set");
+
 			base.OnStarted(t);
 			SubscribeCandles(_tf, true, Security).Bind(c => ProcessCandle(c, Security)).Start();
 		}

--- a/API/0406_Turn_Of_Month/TurnOfMonthStrategy.cs
+++ b/API/0406_Turn_Of_Month/TurnOfMonthStrategy.cs
@@ -16,6 +16,9 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies
 {
+	/// <summary>
+	/// Turn-of-the-month effect strategy for index ETFs.
+	/// </summary>
 	public class TurnOfMonthStrategy : Strategy
 	{
 		private readonly StrategyParam<Security> _etf;
@@ -28,28 +31,72 @@ namespace StockSharp.Samples.Strategies
 		private int _tdMonthEnd = int.MaxValue;
 		private int _tdMonthStart = 0;
 
-		public Security ETF { get => _etf.Value; set => _etf.Value = value; }
-		public int DaysPrior => _prior.Value;  // enter N days before month-end
-		public int DaysAfter => _after.Value;  // exit D days into new month
-		public decimal MinTradeUsd => _minUsd.Value;
+		/// <summary>
+		/// ETF used for trading.
+		/// </summary>
+		public Security ETF
+		{
+			get => _etf.Value;
+			set => _etf.Value = value;
+		}
+
+		/// <summary>
+		/// Number of trading days before month-end to enter.
+		/// </summary>
+		public int DaysPrior
+		{
+			get => _prior.Value;
+			set => _prior.Value = value;
+		}
+
+		/// <summary>
+		/// Number of trading days into new month to exit.
+		/// </summary>
+		public int DaysAfter
+		{
+			get => _after.Value;
+			set => _after.Value = value;
+		}
+
+		/// <summary>
+		/// Minimum trade value in USD.
+		/// </summary>
+		public decimal MinTradeUsd
+		{
+			get => _minUsd.Value;
+			set => _minUsd.Value = value;
+		}
 
 		public TurnOfMonthStrategy()
 		{
-			_etf = Param<Security>(nameof(ETF), null);
-			_prior = Param(nameof(DaysPrior), 1);
-			_after = Param(nameof(DaysAfter), 3);
-			_minUsd = Param(nameof(MinTradeUsd), 200m);
+			_etf = Param<Security>(nameof(ETF), null)
+				.SetDisplay("ETF", "Security to trade", "Universe");
+
+			_prior = Param(nameof(DaysPrior), 1)
+				.SetDisplay("Days Prior", "Trading days before month end", "Parameters");
+
+			_after = Param(nameof(DaysAfter), 3)
+				.SetDisplay("Days After", "Trading days into new month", "Parameters");
+
+			_minUsd = Param(nameof(MinTradeUsd), 200m)
+				.SetDisplay("Min Trade USD", "Minimum notional value for orders", "Risk Management");
 		}
 
+		/// <inheritdoc />
 		public override IEnumerable<(Security, DataType)> GetWorkingSecurities()
 		{
 			if (ETF == null)
 				throw new InvalidOperationException("Set ETF");
+
 			yield return (ETF, _tf);
 		}
 
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
+			if (ETF == null)
+				throw new InvalidOperationException("ETF must be set.");
+
 			base.OnStarted(time);
 
 			SubscribeCandles(_tf, true, ETF)

--- a/API/0408_Volatility_Risk_Premium/VolatilityRiskPremiumStrategy.cs
+++ b/API/0408_Volatility_Risk_Premium/VolatilityRiskPremiumStrategy.cs
@@ -14,6 +14,9 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies
 {
+	/// <summary>
+	/// Placeholder strategy for volatility risk premium across assets.
+	/// </summary>
 	public class VolatilityRiskPremiumStrategy : Strategy
 	{
 		// Parameters
@@ -21,24 +24,47 @@ namespace StockSharp.Samples.Strategies
 		private readonly StrategyParam<decimal> _min;
 		private readonly DataType _tf = TimeSpan.FromDays(1).TimeFrame();
 
-		public IEnumerable<Security> Universe { get => _univ.Value; set => _univ.Value = value; }
-		public decimal MinTradeUsd => _min.Value;
+		/// <summary>
+		/// List of securities to trade.
+		/// </summary>
+		public IEnumerable<Security> Universe
+		{
+			get => _univ.Value;
+			set => _univ.Value = value;
+		}
+
+		/// <summary>
+		/// Minimum trade value in USD.
+		/// </summary>
+		public decimal MinTradeUsd
+		{
+			get => _min.Value;
+			set => _min.Value = value;
+		}
 
 		public VolatilityRiskPremiumStrategy()
 		{
-			_univ = Param<IEnumerable<Security>>(nameof(Universe), Array.Empty<Security>());
-			_min = Param(nameof(MinTradeUsd), 200m);
+			_univ = Param<IEnumerable<Security>>(nameof(Universe), Array.Empty<Security>())
+				.SetDisplay("Universe", "List of securities to trade", "Universe");
+
+			_min = Param(nameof(MinTradeUsd), 200m)
+				.SetDisplay("Min Trade USD", "Minimum notional value for orders", "Risk Management");
 		}
 
-		public override IEnumerable<(Security, DataType)> GetWorkingSecurities() =>
-			Universe.Select(s => (s, _tf));
+		/// <inheritdoc />
+		public override IEnumerable<(Security, DataType)> GetWorkingSecurities()
+		{
+			return Universe.Select(s => (s, _tf));
+		}
 
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset t)
 		{
-			base.OnStarted(t);
-			var trig = Universe.FirstOrDefault();
-			if (trig == null)
+			if (Universe == null || !Universe.Any())
 				throw new InvalidOperationException("Universe empty");
+
+			base.OnStarted(t);
+			var trig = Universe.First();
 			SubscribeCandles(_tf, true, trig).Bind(c => OnDay(c.OpenTime.Date)).Start();
 		}
 

--- a/API/0409_Weeks52High/Weeks52HighStrategy.cs
+++ b/API/0409_Weeks52High/Weeks52HighStrategy.cs
@@ -19,6 +19,9 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies
 {
+	/// <summary>
+	/// Implements the 52-week high effect across industry groups.
+	/// </summary>
 	public class Weeks52HighStrategy : Strategy
 	{
 		#region Parameters
@@ -28,10 +31,41 @@ namespace StockSharp.Samples.Strategies
 		private readonly StrategyParam<int> _holdingMonths; // tranche holding period months
 		private readonly StrategyParam<int> _windowDays;    // 52‑week lookback (trading days)
 
-		public IEnumerable<Security> Universe { get => _universe.Value; set => _universe.Value = value; }
-		public int IndustriesCount => _industries.Value;
-		public int HoldingPeriodMonths => _holdingMonths.Value;
-		public int LookbackDays => _windowDays.Value;
+		/// <summary>
+		/// List of securities used by the strategy.
+		/// </summary>
+		public IEnumerable<Security> Universe
+		{
+			get => _universe.Value;
+			set => _universe.Value = value;
+		}
+
+		/// <summary>
+		/// Number of winner and loser industries.
+		/// </summary>
+		public int IndustriesCount
+		{
+			get => _industries.Value;
+			set => _industries.Value = value;
+		}
+
+		/// <summary>
+		/// Tranche holding period in months.
+		/// </summary>
+		public int HoldingPeriodMonths
+		{
+			get => _holdingMonths.Value;
+			set => _holdingMonths.Value = value;
+		}
+
+		/// <summary>
+		/// Lookback window in trading days.
+		/// </summary>
+		public int LookbackDays
+		{
+			get => _windowDays.Value;
+			set => _windowDays.Value = value;
+		}
 
 		#endregion
 
@@ -59,6 +93,7 @@ namespace StockSharp.Samples.Strategies
 
 		#region Universe & candles
 
+		/// <inheritdoc />
 		public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
 		{
 			if (Universe == null || !Universe.Any())
@@ -68,8 +103,12 @@ namespace StockSharp.Samples.Strategies
 			return Universe.Select(s => (s, dt));
 		}
 
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
+			if (Universe == null || !Universe.Any())
+				throw new InvalidOperationException("Universe cannot be empty — populate Universe before start.");
+
 			base.OnStarted(time);
 
 			foreach (var (sec, dt) in GetWorkingSecurities())


### PR DESCRIPTION
## Summary
- harmonize strategies 0401-0410 to the same style as earlier samples
- document parameters, expose setters, and add runtime validation

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689205d062708323a2f762785e6e89dd