### PR TITLE
refactor: unify strategies 391-395 style

### DIFF
--- a/API/0391_Residual_Momentum_Factor/ResidualMomentumFactorStrategy.cs
+++ b/API/0391_Residual_Momentum_Factor/ResidualMomentumFactorStrategy.cs
@@ -4,11 +4,12 @@
 // Monthly rebalance on first trading day via trigger candle.
 // Long top decile, short bottom decile.
 // -----------------------------------------------------------------------------
-// Date: 2 Aug 2025  
+// Date: 2 Aug 2025	 
 // -----------------------------------------------------------------------------
 using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using StockSharp.Algo;
 using StockSharp.Algo.Candles;
 using StockSharp.BusinessEntities;
@@ -16,6 +17,10 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies
 {
+	/// <summary>
+	/// Residual momentum factor strategy that goes long securities with the highest
+	/// residual momentum and short those with the lowest.
+	/// </summary>
 	public class ResidualMomentumFactorStrategy : Strategy
 	{
 		private readonly StrategyParam<IEnumerable<Security>> _univ;
@@ -26,24 +31,66 @@ namespace StockSharp.Samples.Strategies
 		private readonly Dictionary<Security, decimal> _latestPrices = new();
 		private DateTime _last = DateTime.MinValue;
 
-		public IEnumerable<Security> Universe { get => _univ.Value; set => _univ.Value = value; }
-		public int Decile => _decile.Value;
-		public decimal MinTradeUsd => _minUsd.Value;
-
-		public ResidualMomentumFactorStrategy()
+		/// <summary>
+		/// Universe of securities to trade.
+		/// </summary>
+		public IEnumerable<Security> Universe
 		{
-			_univ = Param<IEnumerable<Security>>(nameof(Universe), Array.Empty<Security>());
-			_decile = Param(nameof(Decile), 10);
-			_minUsd = Param(nameof(MinTradeUsd), 200m);
+			get => _univ.Value;
+			set => _univ.Value = value;
 		}
 
-		public override IEnumerable<(Security, DataType)> GetWorkingSecurities() => Universe.Select(s => (s, _tf));
-
-		protected override void OnStarted(DateTimeOffset t)
+		/// <summary>
+		/// Number of deciles used to rank securities.
+		/// </summary>
+		public int Decile
 		{
-			base.OnStarted(t);
-			var trig = Universe.FirstOrDefault() ?? throw new InvalidOperationException("Universe empty");
-			SubscribeCandles(_tf, true, trig).Bind(c => ProcessCandle(c, trig)).Start();
+			get => _decile.Value;
+			set => _decile.Value = value;
+		}
+
+		/// <summary>
+		/// Minimum dollar value per trade.
+		/// </summary>
+		public decimal MinTradeUsd
+		{
+			get => _minUsd.Value;
+			set => _minUsd.Value = value;
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ResidualMomentumFactorStrategy"/> class.
+		/// </summary>
+		public ResidualMomentumFactorStrategy()
+		{
+			_univ = Param<IEnumerable<Security>>(nameof(Universe), Array.Empty<Security>())
+				.SetDisplay("Universe", "Securities to trade", "General");
+
+			_decile = Param(nameof(Decile), 10)
+				.SetDisplay("Decile", "Number of deciles for ranking", "General");
+
+			_minUsd = Param(nameof(MinTradeUsd), 200m)
+				.SetDisplay("Min Trade USD", "Minimum dollar value per trade", "General");
+		}
+
+		/// <inheritdoc />
+		public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
+		{
+			return Universe.Select(s => (s, _tf));
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
+
+			if (Universe == null || !Universe.Any())
+				throw new InvalidOperationException("Universe cannot be empty.");
+
+			var trig = Universe.First();
+			SubscribeCandles(_tf, true, trig)
+				.Bind(c => ProcessCandle(c, trig))
+				.Start();
 		}
 
 		private void ProcessCandle(ICandleMessage candle, Security security)
@@ -62,9 +109,12 @@ namespace StockSharp.Samples.Strategies
 		{
 			if (d == _last)
 				return;
+
 			_last = d;
+
 			if (d.Day != 1)
 				return;
+
 			Rebalance();
 		}
 
@@ -72,23 +122,36 @@ namespace StockSharp.Samples.Strategies
 		{
 			var score = new Dictionary<Security, decimal>();
 			foreach (var s in Universe)
+			{
 				if (TryGetResidualMomentum(s, out var sc))
 					score[s] = sc;
+			}
+
 			if (score.Count < Decile * 2)
 				return;
+
 			int bucket = score.Count / Decile;
 			var longs = score.OrderByDescending(kv => kv.Value).Take(bucket).Select(kv => kv.Key).ToList();
 			var shorts = score.OrderBy(kv => kv.Value).Take(bucket).Select(kv => kv.Key).ToList();
 			_w.Clear();
-			decimal wl = 1m / longs.Count, ws = -1m / shorts.Count;
+
+			decimal wl = 1m / longs.Count;
+			decimal ws = -1m / shorts.Count;
+
 			foreach (var s in longs)
 				_w[s] = wl;
+
 			foreach (var s in shorts)
 				_w[s] = ws;
+
 			foreach (var position in Positions)
+			{
 				if (!_w.ContainsKey(position.Security))
 					Move(position.Security, 0);
+			}
+
 			var portfolioValue = Portfolio.CurrentValue ?? 0m;
+
 			foreach (var kv in _w)
 			{
 				var price = GetLatestPrice(kv.Key);
@@ -102,16 +165,30 @@ namespace StockSharp.Samples.Strategies
 			return _latestPrices.TryGetValue(security, out var price) ? price : 0m;
 		}
 
-		private void Move(Security s, decimal tgt) 
-		{ 
-			var diff = tgt - Pos(s); 
+		private void Move(Security s, decimal tgt)
+		{
+			var diff = tgt - Pos(s);
 			var price = GetLatestPrice(s);
-			if (price <= 0 || Math.Abs(diff) * price < MinTradeUsd) 
-				return; 
-			RegisterOrder(new Order { Security = s, Portfolio = Portfolio, Side = diff > 0 ? Sides.Buy : Sides.Sell, Volume = Math.Abs(diff), Type = OrderTypes.Market, Comment = "ResMom" }); 
+			if (price <= 0 || Math.Abs(diff) * price < MinTradeUsd)
+				return;
+
+			RegisterOrder(new Order
+			{
+				Security = s,
+				Portfolio = Portfolio,
+				Side = diff > 0 ? Sides.Buy : Sides.Sell,
+				Volume = Math.Abs(diff),
+				Type = OrderTypes.Market,
+				Comment = "ResMom",
+			});
 		}
 
 		private decimal Pos(Security s) => GetPositionValue(s, Portfolio) ?? 0;
-		private bool TryGetResidualMomentum(Security s, out decimal sc) { sc = 0; return false; }
+
+		private bool TryGetResidualMomentum(Security s, out decimal sc)
+		{
+			sc = 0;
+			return false;
+		}
 	}
 }

--- a/API/0395_Short_Interest_Effect/ShortInterestEffectStrategy.cs
+++ b/API/0395_Short_Interest_Effect/ShortInterestEffectStrategy.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using StockSharp.Algo;
 using StockSharp.Algo.Candles;
 using StockSharp.BusinessEntities;
@@ -16,6 +17,9 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies
 {
+	/// <summary>
+	/// Strategy that trades based on short-interest levels.
+	/// </summary>
 	public class ShortInterestEffectStrategy : Strategy
 	{
 		private readonly StrategyParam<IEnumerable<Security>> _univ;
@@ -26,24 +30,66 @@ namespace StockSharp.Samples.Strategies
 		private readonly Dictionary<Security, decimal> _latestPrices = new();
 		private DateTime _last = DateTime.MinValue;
 
-		public IEnumerable<Security> Universe { get => _univ.Value; set => _univ.Value = value; }
-		public int Decile => _decile.Value;
-		public decimal MinTradeUsd => _minUsd.Value;
-
-		public ShortInterestEffectStrategy()
+		/// <summary>
+		/// Universe of stocks to trade.
+		/// </summary>
+		public IEnumerable<Security> Universe
 		{
-			_univ = Param<IEnumerable<Security>>(nameof(Universe), Array.Empty<Security>());
-			_decile = Param(nameof(Decile), 10);
-			_minUsd = Param(nameof(MinTradeUsd), 200m);
+			get => _univ.Value;
+			set => _univ.Value = value;
 		}
 
-		public override IEnumerable<(Security, DataType)> GetWorkingSecurities() => Universe.Select(s => (s, _tf));
-
-		protected override void OnStarted(DateTimeOffset t)
+		/// <summary>
+		/// Number of deciles used for ranking.
+		/// </summary>
+		public int Decile
 		{
-			base.OnStarted(t);
-			var trig = Universe.FirstOrDefault() ?? throw new InvalidOperationException("Universe empty");
-			SubscribeCandles(_tf, true, trig).Bind(c => ProcessCandle(c, trig)).Start();
+			get => _decile.Value;
+			set => _decile.Value = value;
+		}
+
+		/// <summary>
+		/// Minimum dollar value per trade.
+		/// </summary>
+		public decimal MinTradeUsd
+		{
+			get => _minUsd.Value;
+			set => _minUsd.Value = value;
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ShortInterestEffectStrategy"/> class.
+		/// </summary>
+		public ShortInterestEffectStrategy()
+		{
+			_univ = Param<IEnumerable<Security>>(nameof(Universe), Array.Empty<Security>())
+				.SetDisplay("Universe", "Stocks to trade", "General");
+
+			_decile = Param(nameof(Decile), 10)
+				.SetDisplay("Decile", "Number of deciles for ranking", "General");
+
+			_minUsd = Param(nameof(MinTradeUsd), 200m)
+				.SetDisplay("Min Trade USD", "Minimum dollar value per trade", "General");
+		}
+
+		/// <inheritdoc />
+		public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
+		{
+			return Universe.Select(s => (s, _tf));
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
+
+			if (Universe == null || !Universe.Any())
+				throw new InvalidOperationException("Universe cannot be empty.");
+
+			var trig = Universe.First();
+			SubscribeCandles(_tf, true, trig)
+				.Bind(c => ProcessCandle(c, trig))
+				.Start();
 		}
 
 		private void ProcessCandle(ICandleMessage candle, Security security)
@@ -62,9 +108,12 @@ namespace StockSharp.Samples.Strategies
 		{
 			if (d == _last)
 				return;
+
 			_last = d;
+
 			if (d.Day != 1)
 				return;
+
 			Rebalance();
 		}
 
@@ -72,23 +121,36 @@ namespace StockSharp.Samples.Strategies
 		{
 			var si = new Dictionary<Security, decimal>();
 			foreach (var s in Universe)
+			{
 				if (TryGetShortInterest(s, out var v))
 					si[s] = v;
+			}
+
 			if (si.Count < Decile * 2)
 				return;
+
 			int bucket = si.Count / Decile;
-			var longs = si.OrderBy(kv => kv.Value).Take(bucket).Select(kv => kv.Key).ToList();   // lowest SI
+			var longs = si.OrderBy(kv => kv.Value).Take(bucket).Select(kv => kv.Key).ToList();
 			var shorts = si.OrderByDescending(kv => kv.Value).Take(bucket).Select(kv => kv.Key).ToList();
+
 			_w.Clear();
-			decimal wl = 1m / longs.Count, ws = -1m / shorts.Count;
+			decimal wl = 1m / longs.Count;
+			decimal ws = -1m / shorts.Count;
+
 			foreach (var s in longs)
 				_w[s] = wl;
+
 			foreach (var s in shorts)
 				_w[s] = ws;
+
 			foreach (var position in Positions)
+			{
 				if (!_w.ContainsKey(position.Security))
 					Move(position.Security, 0);
+			}
+
 			var portfolioValue = Portfolio.CurrentValue ?? 0m;
+
 			foreach (var kv in _w)
 			{
 				var price = GetLatestPrice(kv.Key);
@@ -102,16 +164,30 @@ namespace StockSharp.Samples.Strategies
 			return _latestPrices.TryGetValue(security, out var price) ? price : 0m;
 		}
 
-		private void Move(Security s, decimal tgt) 
-		{ 
-			var diff = tgt - Pos(s); 
+		private void Move(Security s, decimal tgt)
+		{
+			var diff = tgt - Pos(s);
 			var price = GetLatestPrice(s);
-			if (price <= 0 || Math.Abs(diff) * price < MinTradeUsd) 
-				return; 
-			RegisterOrder(new Order { Security = s, Portfolio = Portfolio, Side = diff > 0 ? Sides.Buy : Sides.Sell, Volume = Math.Abs(diff), Type = OrderTypes.Market, Comment = "ShortInt" }); 
+			if (price <= 0 || Math.Abs(diff) * price < MinTradeUsd)
+				return;
+
+			RegisterOrder(new Order
+			{
+				Security = s,
+				Portfolio = Portfolio,
+				Side = diff > 0 ? Sides.Buy : Sides.Sell,
+				Volume = Math.Abs(diff),
+				Type = OrderTypes.Market,
+				Comment = "ShortInt",
+			});
 		}
 
 		private decimal Pos(Security s) => GetPositionValue(s, Portfolio) ?? 0;
-		private bool TryGetShortInterest(Security s, out decimal v) { v = 0; return false; }
+
+		private bool TryGetShortInterest(Security s, out decimal v)
+		{
+			v = 0;
+			return false;
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- refactor residual momentum strategy with comments, setters, and universe validation
- apply consistent style and validation to return asymmetry strategy
- bring remaining 0393-0395 strategies to shared style with tabs and property setters

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689205bf242c8323b801cf9fdf4d16ce