### PR TITLE
feat: add candle type parameters

### DIFF
--- a/API/0356_Bitcoin_Intraday_Seasonality/BitcoinIntradaySeasonalityStrategy.cs
+++ b/API/0356_Bitcoin_Intraday_Seasonality/BitcoinIntradaySeasonalityStrategy.cs
@@ -15,7 +15,7 @@ namespace StockSharp.Samples.Strategies
 	{
 		private readonly StrategyParam<int[]> _hoursLong;
 		private readonly StrategyParam<decimal> _minUsd;
-		private readonly DataType _tf = TimeSpan.FromHours(1).TimeFrame();
+		private readonly StrategyParam<DataType> _candleType;
 
 		/// <summary>
 		/// UTC hours when the strategy holds a long position.
@@ -35,6 +35,15 @@ namespace StockSharp.Samples.Strategies
 			set => _minUsd.Value = value;
 		}
 
+		/// <summary>
+		/// The type of candles to use for strategy calculation.
+		/// </summary>
+		public DataType CandleType
+		{
+			get => _candleType.Value;
+			set => _candleType.Value = value;
+		}
+
 		private readonly Dictionary<Security, decimal> _latestPrices = new();
 
 		/// <summary>
@@ -50,6 +59,9 @@ namespace StockSharp.Samples.Strategies
 			_minUsd = Param(nameof(MinTradeUsd), 200m)
 				.SetGreaterThanZero()
 				.SetDisplay("Min Trade USD", "Minimum order value in USD", "Trading");
+
+			_candleType = Param(nameof(CandleType), TimeSpan.FromHours(1).TimeFrame())
+				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 
 		/// <inheritdoc />
@@ -58,7 +70,7 @@ namespace StockSharp.Samples.Strategies
 			if (Security == null)
 				throw new InvalidOperationException("BTC security not set.");
 
-			return new[] { (Security, _tf) };
+			return new[] { (Security, CandleType) };
 		}
 
 		/// <inheritdoc />
@@ -72,7 +84,7 @@ namespace StockSharp.Samples.Strategies
 			if (Security == null)
 				throw new InvalidOperationException("BTC security not set.");
 
-			SubscribeCandles(_tf, true, Security)
+			SubscribeCandles(CandleType, true, Security)
 				.Bind(c => ProcessCandle(c, Security))
 				.Start();
 		}

--- a/API/0357_Book_To_Market_Value/BookToMarketValueStrategy.cs
+++ b/API/0357_Book_To_Market_Value/BookToMarketValueStrategy.cs
@@ -24,7 +24,7 @@ namespace StockSharp.Samples.Strategies
 		// Parameters
 		private readonly StrategyParam<IEnumerable<Security>> _univ;
 		private readonly StrategyParam<decimal> _min;
-		private readonly DataType _tf = TimeSpan.FromDays(1).TimeFrame();
+		private readonly StrategyParam<DataType> _candleType;
 
 		/// <summary>
 		/// Securities universe to analyze.
@@ -45,6 +45,15 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <summary>
+		/// The type of candles to use for strategy calculation.
+		/// </summary>
+		public DataType CandleType
+		{
+			get => _candleType.Value;
+			set => _candleType.Value = value;
+		}
+
+		/// <summary>
 		/// Initializes a new instance of the <see cref="BookToMarketValueStrategy"/> class.
 		/// </summary>
 		public BookToMarketValueStrategy()
@@ -55,12 +64,15 @@ namespace StockSharp.Samples.Strategies
 			_min = Param(nameof(MinTradeUsd), 200m)
 				.SetGreaterThanZero()
 				.SetDisplay("Min Trade USD", "Minimum trade value in USD", "General");
+
+			_candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
+				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 
 		/// <inheritdoc />
 		public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
 		{
-			return Universe.Select(sec => (sec, _tf));
+			return Universe.Select(sec => (sec, CandleType));
 		}
 
 		/// <inheritdoc />
@@ -73,7 +85,7 @@ namespace StockSharp.Samples.Strategies
 
 			var trigger = Universe.First();
 
-			SubscribeCandles(_tf, true, trigger)
+			SubscribeCandles(CandleType, true, trigger)
 				.Bind(candle => OnDay(candle.OpenTime.Date))
 				.Start();
 		}

--- a/API/0360_Country_Value_Factor/CountryValueFactorStrategy.cs
+++ b/API/0360_Country_Value_Factor/CountryValueFactorStrategy.cs
@@ -15,8 +15,7 @@ namespace StockSharp.Samples.Strategies
 	{
 		private readonly StrategyParam<IEnumerable<Security>> _universe;
 		private readonly StrategyParam<decimal> _minTradeUsd;
-
-		private readonly DataType _timeFrame = TimeSpan.FromDays(1).TimeFrame();
+		private readonly StrategyParam<DataType> _candleType;
 
 		/// <summary>
 		/// Securities to trade.
@@ -37,6 +36,15 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <summary>
+		/// The type of candles to use for strategy calculation.
+		/// </summary>
+		public DataType CandleType
+		{
+			get => _candleType.Value;
+			set => _candleType.Value = value;
+		}
+
+		/// <summary>
 		/// Initializes a new instance of <see cref="CountryValueFactorStrategy"/>.
 		/// </summary>
 		public CountryValueFactorStrategy()
@@ -46,12 +54,15 @@ namespace StockSharp.Samples.Strategies
 
 			_minTradeUsd = Param(nameof(MinTradeUsd), 200m)
 				.SetDisplay("Min Trade USD", "Minimal trade size in USD", "General");
+
+			_candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
+				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 
 		/// <inheritdoc />
 		public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
 		{
-			return Universe?.Select(s => (s, _timeFrame)) ?? Array.Empty<(Security, DataType)>();
+			return Universe?.Select(s => (s, CandleType)) ?? Array.Empty<(Security, DataType)>();
 		}
 
 		/// <inheritdoc />
@@ -64,7 +75,7 @@ namespace StockSharp.Samples.Strategies
 
 			var trigger = Universe.First();
 
-			SubscribeCandles(_timeFrame, true, trigger)
+			SubscribeCandles(CandleType, true, trigger)
 				.Bind(c => OnDay(c.OpenTime.Date))
 				.Start();
 		}

--- a/API/0362_Crypto_Rebalancing_Premium/CryptoRebalancingPremiumStrategy.cs
+++ b/API/0362_Crypto_Rebalancing_Premium/CryptoRebalancingPremiumStrategy.cs
@@ -18,7 +18,7 @@ namespace StockSharp.Samples.Strategies
 		private readonly StrategyParam<Security> _btc;
 		private readonly StrategyParam<Security> _eth;
 		private readonly StrategyParam<decimal> _minUsd;
-		private readonly DataType _tf = TimeSpan.FromHours(1).TimeFrame();
+		private readonly StrategyParam<DataType> _candleType;
 		private readonly Dictionary<Security, decimal> _latestPrices = new();
 		private DateTime _last = DateTime.MinValue;
 
@@ -50,6 +50,15 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <summary>
+		/// The type of candles to use for strategy calculation.
+		/// </summary>
+		public DataType CandleType
+		{
+			get => _candleType.Value;
+			set => _candleType.Value = value;
+		}
+
+		/// <summary>
 		/// Initializes a new instance of <see cref="CryptoRebalancingPremiumStrategy"/>.
 		/// </summary>
 		public CryptoRebalancingPremiumStrategy()
@@ -66,12 +75,15 @@ namespace StockSharp.Samples.Strategies
 			_minUsd = Param(nameof(MinTradeUsd), 200m)
 				.SetGreaterThanZero()
 				.SetDisplay("Min Trade USD", "Minimum dollar amount per trade", "Trading");
+
+			_candleType = Param(nameof(CandleType), TimeSpan.FromHours(1).TimeFrame())
+				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 
 		/// <inheritdoc />
 		public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
 		{
-			return [(BTC, _tf), (ETH, _tf)];
+			return [(BTC, CandleType), (ETH, CandleType)];
 		}
 
 		/// <inheritdoc />

--- a/API/0373_FScore_Reversal/FScoreReversalStrategy.cs
+++ b/API/0373_FScore_Reversal/FScoreReversalStrategy.cs
@@ -28,6 +28,7 @@ namespace StockSharp.Samples.Strategies
 		private readonly StrategyParam<int> _hi;
 		private readonly StrategyParam<int> _lo;
 		private readonly StrategyParam<decimal> _minUsd;
+		private readonly StrategyParam<DataType> _candleType;
 		
 		/// <summary>
 		/// Securities universe to trade.
@@ -53,6 +54,11 @@ namespace StockSharp.Samples.Strategies
 		/// Minimum trade value in USD.
 		/// </summary>
 		public decimal MinTradeUsd { get => _minUsd.Value; set => _minUsd.Value = value; }
+
+		/// <summary>
+		/// The type of candles to use for strategy calculation.
+		/// </summary>
+		public DataType CandleType { get => _candleType.Value; set => _candleType.Value = value; }
 		#endregion
 
 		private readonly Dictionary<Security, FScoreRollingWindow> _prices = new();
@@ -80,14 +86,16 @@ namespace StockSharp.Samples.Strategies
 			_minUsd = Param(nameof(MinTradeUsd), 50m)
 				.SetGreaterThanZero()
 				.SetDisplay("Min trade USD", "Minimum order value", "Risk");
+
+			_candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
+				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 
 		public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
 		{
 			if (!Universe.Any())
 				throw new InvalidOperationException("Universe empty");
-			var tf = TimeSpan.FromDays(1).TimeFrame();
-			return Universe.Select(s => (s, tf));
+			return Universe.Select(s => (s, CandleType));
 		}
 
 		protected override void OnStarted(DateTimeOffset time)

--- a/API/0382_Month12Cycle/Month12CycleStrategy.cs
+++ b/API/0382_Month12Cycle/Month12CycleStrategy.cs
@@ -35,6 +35,7 @@ namespace StockSharp.Samples.Strategies
 		private readonly StrategyParam<int> _decileSize;
 		private readonly StrategyParam<decimal> _leverage;
 		private readonly StrategyParam<int> _yearsBack;
+		private readonly StrategyParam<DataType> _candleType;
 
 		/// <summary>Investment universe (must be non‑empty).</summary>
 		public IEnumerable<Security> Universe
@@ -63,6 +64,15 @@ namespace StockSharp.Samples.Strategies
 				get => _yearsBack.Value;
 				set => _yearsBack.Value = value;
 		}
+
+		/// <summary>
+		/// The type of candles to use for strategy calculation.
+		/// </summary>
+		public DataType CandleType
+		{
+			get => _candleType.Value;
+			set => _candleType.Value = value;
+		}
 		
 		#endregion
 
@@ -84,6 +94,9 @@ namespace StockSharp.Samples.Strategies
 
 			_yearsBack = Param(nameof(YearsBack), 1)
 				.SetDisplay("Years Back", "Lag in years (12 months)", "Ranking");
+
+			_candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
+				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 
 		#region Universe & candles
@@ -93,8 +106,7 @@ namespace StockSharp.Samples.Strategies
 			if (Universe == null || !Universe.Any())
 				throw new InvalidOperationException("Universe cannot be empty — populate the Universe property before starting the strategy.");
 
-			var dt = TimeSpan.FromDays(1).TimeFrame();
-			return Universe.Select(s => (s, dt));
+			return Universe.Select(s => (s, CandleType));
 		}
 
 		protected override void OnStarted(DateTimeOffset time)

--- a/API/0383_Mutual_Fund_Momentum/MutualFundMomentumStrategy.cs
+++ b/API/0383_Mutual_Fund_Momentum/MutualFundMomentumStrategy.cs
@@ -19,7 +19,7 @@ namespace StockSharp.Samples.Strategies
 	{
 		private readonly StrategyParam<IEnumerable<Security>> _funds;
 		private readonly StrategyParam<decimal> _minUsd;
-		private readonly DataType _tf = TimeSpan.FromDays(1).TimeFrame();
+		private readonly StrategyParam<DataType> _candleType;
 
 		/// <summary>List of funds.</summary>
 		public IEnumerable<Security> Funds
@@ -35,6 +35,15 @@ namespace StockSharp.Samples.Strategies
 			set => _minUsd.Value = value;
 		}
 
+		/// <summary>
+		/// The type of candles to use for strategy calculation.
+		/// </summary>
+		public DataType CandleType
+		{
+			get => _candleType.Value;
+			set => _candleType.Value = value;
+		}
+
 		private readonly Dictionary<Security, decimal> _latestPrices = new();
 		private DateTime _lastDay = DateTime.MinValue;
 
@@ -45,10 +54,13 @@ namespace StockSharp.Samples.Strategies
 
 			_minUsd = Param(nameof(MinTradeUsd), 200m)
 				.SetDisplay("Min USD", "Minimum trade value", "Risk");
+
+			_candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
+				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 
 		public override IEnumerable<(Security, DataType)> GetWorkingSecurities() =>
-			Funds.Select(f => (f, _tf));
+			Funds.Select(f => (f, CandleType));
 
 		protected override void OnStarted(DateTimeOffset t)
 		{
@@ -59,7 +71,7 @@ namespace StockSharp.Samples.Strategies
 
 			var trigger = Funds.First();
 
-			SubscribeCandles(_tf, true, trigger)
+			SubscribeCandles(CandleType, true, trigger)
 				.Bind(c => ProcessCandle(c, trigger))
 				.Start();
 		}

--- a/API/0384_Option_Expiration_Week/OptionExpirationWeekStrategy.cs
+++ b/API/0384_Option_Expiration_Week/OptionExpirationWeekStrategy.cs
@@ -18,7 +18,7 @@ namespace StockSharp.Samples.Strategies
 	public class OptionExpirationWeekStrategy : Strategy
 	{
 		private readonly StrategyParam<decimal> _minUsd;
-		private readonly DataType _tf = TimeSpan.FromDays(1).TimeFrame();
+		private readonly StrategyParam<DataType> _candleType;
 
 		/// <summary>Minimum trade amount in USD.</summary>
 		public decimal MinTradeUsd
@@ -27,12 +27,24 @@ namespace StockSharp.Samples.Strategies
 			set => _minUsd.Value = value;
 		}
 
+		/// <summary>
+		/// The type of candles to use for strategy calculation.
+		/// </summary>
+		public DataType CandleType
+		{
+			get => _candleType.Value;
+			set => _candleType.Value = value;
+		}
+
 		private readonly Dictionary<Security, decimal> _latestPrices = new();
 
 		public OptionExpirationWeekStrategy()
 		{
 			_minUsd = Param(nameof(MinTradeUsd), 200m)
 				.SetDisplay("Min USD", "Minimum trade value", "Risk");
+
+			_candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
+				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 
 		public override IEnumerable<(Security, DataType)> GetWorkingSecurities()
@@ -40,7 +52,7 @@ namespace StockSharp.Samples.Strategies
 			if (Security == null)
 				throw new InvalidOperationException("ETF not set.");
 
-			return new[] { (Security, _tf) };
+			return new[] { (Security, CandleType) };
 		}
 
 		protected override void OnStarted(DateTimeOffset t)
@@ -50,7 +62,7 @@ namespace StockSharp.Samples.Strategies
 			if (Security == null)
 				throw new InvalidOperationException("ETF cannot be null.");
 
-			SubscribeCandles(_tf, true, Security)
+			SubscribeCandles(CandleType, true, Security)
 				.Bind(c => ProcessCandle(c, Security))
 				.Start();
 		}

--- a/API/0400_Smart_Factors_Momentum_Market/SmartFactorsMomentumMarketStrategy.cs
+++ b/API/0400_Smart_Factors_Momentum_Market/SmartFactorsMomentumMarketStrategy.cs
@@ -25,6 +25,7 @@ namespace StockSharp.Samples.Strategies
 		private readonly StrategyParam<int> _slowM;
 		private readonly StrategyParam<int> _maM;
 		private readonly StrategyParam<decimal> _minUsd;
+		private readonly StrategyParam<DataType> _candleType;
 
 		/// <summary>
 		/// Dictionary of smart factor ETFs.
@@ -71,6 +72,15 @@ namespace StockSharp.Samples.Strategies
 			set => _minUsd.Value = value;
 		}
 
+		/// <summary>
+		/// The type of candles to use for strategy calculation.
+		/// </summary>
+		public DataType CandleType
+		{
+			get => _candleType.Value;
+			set => _candleType.Value = value;
+		}
+
 		private readonly Dictionary<Security, RollingWindow<decimal>> _p = new();
 		private readonly Dictionary<Security, decimal> _latestPrices = new();
 		private readonly RollingWindow<decimal> _smartRet;
@@ -101,6 +111,9 @@ namespace StockSharp.Samples.Strategies
 				.SetGreaterThanZero()
 				.SetDisplay("Min Trade USD", "Minimum trade value in USD", "Parameters");
 
+			_candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
+				.SetDisplay("Candle Type", "Type of candles to use", "General");
+
 			_smartRet = new RollingWindow<decimal>(_maM.Value);
 			_mktRet = new RollingWindow<decimal>(_maM.Value);
 		}
@@ -112,8 +125,7 @@ namespace StockSharp.Samples.Strategies
 			if (!Factors.Any())
 				throw new InvalidOperationException("No factors");
 
-			var tf = TimeSpan.FromDays(1).TimeFrame();
-			return Factors.Values.Append(Security).Select(s => (s, tf));
+			return Factors.Values.Append(Security).Select(s => (s, CandleType));
 		}
 
 		protected override void OnStarted(DateTimeOffset time)


### PR DESCRIPTION
## Summary
- expose CandleType parameter across multiple strategies
- update subscriptions to use the configured candle type
- reformat strategy files to use tab-based indentation

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689236f433c0832381865e44a8e24b31