### PR TITLE
Parametrize candle type for multiple strategies

### DIFF
--- a/API/0387_Pairs_Trading_Country_ETFs/PairsTradingCountryETFsStrategy.cs
+++ b/API/0387_Pairs_Trading_Country_ETFs/PairsTradingCountryETFsStrategy.cs
@@ -32,7 +32,16 @@ namespace StockSharp.Samples.Strategies
 		private readonly StrategyParam<decimal> _entryZ;
 		private readonly StrategyParam<decimal> _exitZ;
 		private readonly StrategyParam<decimal> _minUsd;
-		private readonly DataType _tf = TimeSpan.FromDays(1).TimeFrame();
+		private readonly StrategyParam<DataType> _candleType;
+
+		/// <summary>
+		/// The type of candles to use for strategy calculation.
+		/// </summary>
+		public DataType CandleType
+		{
+			get => _candleType.Value;
+			set => _candleType.Value = value;
+		}
 
 		/// <summary>
 		/// Strategy universe containing exactly two ETFs.
@@ -100,6 +109,8 @@ namespace StockSharp.Samples.Strategies
 			_minUsd = Param(nameof(MinTradeUsd), 200m)
 			.SetGreaterThanZero()
 			.SetDisplay("Min Trade USD", "Minimum trade value in USD", "General");
+			_candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
+				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 
 		public override IEnumerable<(Security, DataType)> GetWorkingSecurities()
@@ -108,8 +119,8 @@ namespace StockSharp.Samples.Strategies
 				throw new InvalidOperationException("Universe must contain exactly two ETFs.");
 			_a = Universe.ElementAt(0);
 			_b = Universe.ElementAt(1);
-			yield return (_a, _tf);
-			yield return (_b, _tf);
+			yield return (_a, CandleType);
+			yield return (_b, CandleType);
 		}
 
 		protected override void OnStarted(DateTimeOffset t)
@@ -117,8 +128,8 @@ namespace StockSharp.Samples.Strategies
 			if (Universe == null || Universe.Count() != 2)
 				throw new InvalidOperationException("Universe must contain exactly two ETFs.");
 			base.OnStarted(t);
-			SubscribeCandles(_tf, true, _a).Bind(c => ProcessCandle(c, _a)).Start();
-			SubscribeCandles(_tf, true, _b).Bind(c => ProcessCandle(c, _b)).Start();
+			SubscribeCandles(CandleType, true, _a).Bind(c => ProcessCandle(c, _a)).Start();
+			SubscribeCandles(CandleType, true, _b).Bind(c => ProcessCandle(c, _b)).Start();
 		}
 
 		private void ProcessCandle(ICandleMessage candle, Security security)

--- a/API/0391_Residual_Momentum_Factor/ResidualMomentumFactorStrategy.cs
+++ b/API/0391_Residual_Momentum_Factor/ResidualMomentumFactorStrategy.cs
@@ -26,7 +26,16 @@ namespace StockSharp.Samples.Strategies
 		private readonly StrategyParam<IEnumerable<Security>> _univ;
 		private readonly StrategyParam<int> _decile;
 		private readonly StrategyParam<decimal> _minUsd;
-		private readonly DataType _tf = TimeSpan.FromDays(1).TimeFrame();
+		private readonly StrategyParam<DataType> _candleType;
+
+		/// <summary>
+		/// The type of candles to use for strategy calculation.
+		/// </summary>
+		public DataType CandleType
+		{
+			get => _candleType.Value;
+			set => _candleType.Value = value;
+		}
 		private readonly Dictionary<Security, decimal> _w = new();
 		private readonly Dictionary<Security, decimal> _latestPrices = new();
 		private DateTime _last = DateTime.MinValue;
@@ -71,12 +80,14 @@ namespace StockSharp.Samples.Strategies
 
 			_minUsd = Param(nameof(MinTradeUsd), 200m)
 				.SetDisplay("Min Trade USD", "Minimum dollar value per trade", "General");
+			_candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
+				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 
 		/// <inheritdoc />
 		public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
 		{
-			return Universe.Select(s => (s, _tf));
+			return Universe.Select(s => (s, CandleType));
 		}
 
 		/// <inheritdoc />
@@ -88,7 +99,7 @@ namespace StockSharp.Samples.Strategies
 				throw new InvalidOperationException("Universe cannot be empty.");
 
 			var trig = Universe.First();
-			SubscribeCandles(_tf, true, trig)
+			SubscribeCandles(CandleType, true, trig)
 				.Bind(c => ProcessCandle(c, trig))
 				.Start();
 		}

--- a/API/0392_Return_Asymmetry_Commodity/ReturnAsymmetryCommodityStrategy.cs
+++ b/API/0392_Return_Asymmetry_Commodity/ReturnAsymmetryCommodityStrategy.cs
@@ -31,7 +31,7 @@ namespace StockSharp.Samples.Strategies
 		private readonly StrategyParam<int> _window;
 		private readonly StrategyParam<int> _top;
 		private readonly StrategyParam<decimal> _minUsd;
-		private readonly DataType _tf = TimeSpan.FromDays(1).TimeFrame();
+		private readonly StrategyParam<DataType> _candleType;
 
 		/// <summary>
 		/// Commodity futures to trade.
@@ -69,6 +69,15 @@ namespace StockSharp.Samples.Strategies
 			set => _minUsd.Value = value;
 		}
 
+
+		/// <summary>
+		/// The type of candles to use for strategy calculation.
+		/// </summary>
+		public DataType CandleType
+		{
+			get => _candleType.Value;
+			set => _candleType.Value = value;
+		}
 		#endregion
 
 		private class Win
@@ -97,12 +106,14 @@ namespace StockSharp.Samples.Strategies
 
 			_minUsd = Param(nameof(MinTradeUsd), 200m)
 				.SetDisplay("Min Trade USD", "Minimum dollar value per trade", "General");
+			_candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
+				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 
 		/// <inheritdoc />
 		public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
 		{
-			return Futures.Select(s => (s, _tf));
+			return Futures.Select(s => (s, CandleType));
 		}
 
 		/// <inheritdoc />

--- a/API/0393_ROAEffect_Stocks/ROAEffectStocksStrategy.cs
+++ b/API/0393_ROAEffect_Stocks/ROAEffectStocksStrategy.cs
@@ -24,7 +24,16 @@ namespace StockSharp.Samples.Strategies
 		private readonly StrategyParam<IEnumerable<Security>> _univ;
 		private readonly StrategyParam<int> _decile;
 		private readonly StrategyParam<decimal> _minUsd;
-		private readonly DataType _tf = TimeSpan.FromDays(1).TimeFrame();
+		private readonly StrategyParam<DataType> _candleType;
+
+		/// <summary>
+		/// The type of candles to use for strategy calculation.
+		/// </summary>
+		public DataType CandleType
+		{
+			get => _candleType.Value;
+			set => _candleType.Value = value;
+		}
 		private readonly Dictionary<Security, decimal> _w = new();
 		private readonly Dictionary<Security, decimal> _latestPrices = new();
 		private DateTime _last = DateTime.MinValue;
@@ -69,12 +78,14 @@ namespace StockSharp.Samples.Strategies
 
 			_minUsd = Param(nameof(MinTradeUsd), 200m)
 				.SetDisplay("Min Trade USD", "Minimum dollar value per trade", "General");
+			_candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
+				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 
 		/// <inheritdoc />
 		public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
 		{
-			return Universe.Select(s => (s, _tf));
+			return Universe.Select(s => (s, CandleType));
 		}
 
 		/// <inheritdoc />
@@ -86,7 +97,7 @@ namespace StockSharp.Samples.Strategies
 				throw new InvalidOperationException("Universe cannot be empty.");
 
 			var trig = Universe.First();
-			SubscribeCandles(_tf, true, trig)
+			SubscribeCandles(CandleType, true, trig)
 				.Bind(c => ProcessCandle(c, trig))
 				.Start();
 		}

--- a/API/0394_Sector_Momentum_Rotation/SectorMomentumRotationStrategy.cs
+++ b/API/0394_Sector_Momentum_Rotation/SectorMomentumRotationStrategy.cs
@@ -25,7 +25,16 @@ namespace StockSharp.Samples.Strategies
 		private readonly StrategyParam<IEnumerable<Security>> _sects;
 		private readonly StrategyParam<int> _look;
 		private readonly StrategyParam<decimal> _minUsd;
-		private readonly DataType _tf = TimeSpan.FromDays(1).TimeFrame();
+		private readonly StrategyParam<DataType> _candleType;
+
+		/// <summary>
+		/// The type of candles to use for strategy calculation.
+		/// </summary>
+		public DataType CandleType
+		{
+			get => _candleType.Value;
+			set => _candleType.Value = value;
+		}
 		private readonly Dictionary<Security, RollingWin> _px = new();
 		private readonly Dictionary<Security, decimal> _latestPrices = new();
 		private DateTime _last = DateTime.MinValue;
@@ -70,12 +79,14 @@ namespace StockSharp.Samples.Strategies
 
 			_minUsd = Param(nameof(MinTradeUsd), 200m)
 				.SetDisplay("Min Trade USD", "Minimum dollar value per trade", "General");
+			_candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
+				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 
 		/// <inheritdoc />
 		public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
 		{
-			return SectorETFs.Select(s => (s, _tf));
+			return SectorETFs.Select(s => (s, CandleType));
 		}
 
 		/// <inheritdoc />
@@ -87,7 +98,7 @@ namespace StockSharp.Samples.Strategies
 				throw new InvalidOperationException("Sectors cannot be empty.");
 
 			var trig = SectorETFs.First();
-			SubscribeCandles(_tf, true, trig)
+			SubscribeCandles(CandleType, true, trig)
 				.Bind(c => ProcessCandle(c, trig))
 				.Start();
 

--- a/API/0395_Short_Interest_Effect/ShortInterestEffectStrategy.cs
+++ b/API/0395_Short_Interest_Effect/ShortInterestEffectStrategy.cs
@@ -25,7 +25,16 @@ namespace StockSharp.Samples.Strategies
 		private readonly StrategyParam<IEnumerable<Security>> _univ;
 		private readonly StrategyParam<int> _decile;
 		private readonly StrategyParam<decimal> _minUsd;
-		private readonly DataType _tf = TimeSpan.FromDays(1).TimeFrame();
+		private readonly StrategyParam<DataType> _candleType;
+
+		/// <summary>
+		/// The type of candles to use for strategy calculation.
+		/// </summary>
+		public DataType CandleType
+		{
+			get => _candleType.Value;
+			set => _candleType.Value = value;
+		}
 		private readonly Dictionary<Security, decimal> _w = new();
 		private readonly Dictionary<Security, decimal> _latestPrices = new();
 		private DateTime _last = DateTime.MinValue;
@@ -70,12 +79,14 @@ namespace StockSharp.Samples.Strategies
 
 			_minUsd = Param(nameof(MinTradeUsd), 200m)
 				.SetDisplay("Min Trade USD", "Minimum dollar value per trade", "General");
+			_candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
+				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 
 		/// <inheritdoc />
 		public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
 		{
-			return Universe.Select(s => (s, _tf));
+			return Universe.Select(s => (s, CandleType));
 		}
 
 		/// <inheritdoc />
@@ -87,7 +98,7 @@ namespace StockSharp.Samples.Strategies
 				throw new InvalidOperationException("Universe cannot be empty.");
 
 			var trig = Universe.First();
-			SubscribeCandles(_tf, true, trig)
+			SubscribeCandles(CandleType, true, trig)
 				.Bind(c => ProcessCandle(c, trig))
 				.Start();
 		}

--- a/API/0396_Short_Term_Reversal_Futures/ShortTermReversalFuturesStrategy.cs
+++ b/API/0396_Short_Term_Reversal_Futures/ShortTermReversalFuturesStrategy.cs
@@ -23,7 +23,16 @@ namespace StockSharp.Samples.Strategies
 		private readonly StrategyParam<IEnumerable<Security>> _univ;
 		private readonly StrategyParam<int> _look;
 		private readonly StrategyParam<decimal> _min;
-		private readonly DataType _tf = TimeSpan.FromDays(1).TimeFrame();
+		private readonly StrategyParam<DataType> _candleType;
+
+		/// <summary>
+		/// The type of candles to use for strategy calculation.
+		/// </summary>
+		public DataType CandleType
+		{
+			get => _candleType.Value;
+			set => _candleType.Value = value;
+		}
 		private readonly Dictionary<Security, Queue<decimal>> _px = new();
 		private readonly Dictionary<Security, decimal> _w = new();
 		private readonly Dictionary<Security, decimal> _latestPrices = new();
@@ -71,9 +80,11 @@ namespace StockSharp.Samples.Strategies
 			_min = Param(nameof(MinTradeUsd), 200m)
 				.SetGreaterThanZero()
 				.SetDisplay("Min Trade USD", "Minimum trade value in USD", "Parameters");
+			_candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
+				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 
-		public override IEnumerable<(Security, DataType)> GetWorkingSecurities() => Universe.Select(s => (s, _tf));
+		public override IEnumerable<(Security, DataType)> GetWorkingSecurities() => Universe.Select(s => (s, CandleType));
 
 		protected override void OnStarted(DateTimeOffset t)
 		{

--- a/API/0397_Short_Term_Reversal_Stocks/ShortTermReversalStocksStrategy.cs
+++ b/API/0397_Short_Term_Reversal_Stocks/ShortTermReversalStocksStrategy.cs
@@ -23,7 +23,16 @@ namespace StockSharp.Samples.Strategies
 		private readonly StrategyParam<IEnumerable<Security>> _univ;
 		private readonly StrategyParam<int> _look;
 		private readonly StrategyParam<decimal> _min;
-		private readonly DataType _tf = TimeSpan.FromDays(1).TimeFrame();
+		private readonly StrategyParam<DataType> _candleType;
+
+		/// <summary>
+		/// The type of candles to use for strategy calculation.
+		/// </summary>
+		public DataType CandleType
+		{
+			get => _candleType.Value;
+			set => _candleType.Value = value;
+		}
 		private readonly Dictionary<Security, Queue<decimal>> _px = new();
 		private readonly Dictionary<Security, decimal> _w = new();
 		private readonly Dictionary<Security, decimal> _latestPrices = new();
@@ -71,9 +80,11 @@ namespace StockSharp.Samples.Strategies
 			_min = Param(nameof(MinTradeUsd), 200m)
 				.SetGreaterThanZero()
 				.SetDisplay("Min Trade USD", "Minimum trade value in USD", "Parameters");
+			_candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
+				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 
-		public override IEnumerable<(Security, DataType)> GetWorkingSecurities() => Universe.Select(s => (s, _tf));
+		public override IEnumerable<(Security, DataType)> GetWorkingSecurities() => Universe.Select(s => (s, CandleType));
 
 		protected override void OnStarted(DateTimeOffset t)
 		{

--- a/API/0398_Skewness_Commodity/SkewnessCommodityStrategy.cs
+++ b/API/0398_Skewness_Commodity/SkewnessCommodityStrategy.cs
@@ -30,7 +30,7 @@ namespace StockSharp.Samples.Strategies
 		private readonly StrategyParam<int> _window;
 		private readonly StrategyParam<int> _topN;
 		private readonly StrategyParam<decimal> _minUsd;
-		private readonly DataType _tf = TimeSpan.FromDays(1).TimeFrame();
+		private readonly StrategyParam<DataType> _candleType;
 
 		/// <summary>
 		/// Futures contracts to evaluate.
@@ -67,6 +67,15 @@ namespace StockSharp.Samples.Strategies
 			get => _minUsd.Value;
 			set => _minUsd.Value = value;
 		}
+
+		/// <summary>
+		/// The type of candles to use for strategy calculation.
+		/// </summary>
+		public DataType CandleType
+		{
+			get => _candleType.Value;
+			set => _candleType.Value = value;
+		}
 		#endregion
 
 		// rolling windows of prices
@@ -94,10 +103,12 @@ namespace StockSharp.Samples.Strategies
 			_minUsd = Param(nameof(MinTradeUsd), 200m)
 				.SetGreaterThanZero()
 				.SetDisplay("Min Trade USD", "Minimum trade value in USD", "Parameters");
+			_candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
+				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 
 		public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities() =>
-			Futures.Select(f => (f, _tf));
+			Futures.Select(f => (f, CandleType));
 
 		protected override void OnStarted(DateTimeOffset time)
 		{

--- a/API/0399_Small_Cap_Premium/SmallCapPremiumStrategy.cs
+++ b/API/0399_Small_Cap_Premium/SmallCapPremiumStrategy.cs
@@ -26,7 +26,7 @@ namespace StockSharp.Samples.Strategies
 		private readonly StrategyParam<IEnumerable<Security>> _universe;
 		private readonly StrategyParam<int> _quint;
 		private readonly StrategyParam<decimal> _minUsd;
-		private readonly DataType _tf = TimeSpan.FromDays(1).TimeFrame();
+		private readonly StrategyParam<DataType> _candleType;
 
 		/// <summary>
 		/// Universe of stocks to rank by market capitalization.
@@ -54,6 +54,15 @@ namespace StockSharp.Samples.Strategies
 			get => _minUsd.Value;
 			set => _minUsd.Value = value;
 		}
+
+		/// <summary>
+		/// The type of candles to use for strategy calculation.
+		/// </summary>
+		public DataType CandleType
+		{
+			get => _candleType.Value;
+			set => _candleType.Value = value;
+		}
 		#endregion
 
 		private readonly Dictionary<Security, decimal> _weights = new();
@@ -75,10 +84,12 @@ namespace StockSharp.Samples.Strategies
 			_minUsd = Param(nameof(MinTradeUsd), 200m)
 				.SetGreaterThanZero()
 				.SetDisplay("Min Trade USD", "Minimum trade value in USD", "Parameters");
+			_candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
+				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 
 		public override IEnumerable<(Security, DataType)> GetWorkingSecurities() =>
-			Universe.Select(s => (s, _tf));
+			Universe.Select(s => (s, CandleType));
 
 		protected override void OnStarted(DateTimeOffset t)
 		{
@@ -89,7 +100,7 @@ namespace StockSharp.Samples.Strategies
 
 			var trigger = Universe.First();
 
-			SubscribeCandles(_tf, true, trigger)
+			SubscribeCandles(CandleType, true, trigger)
 				.Bind(c => ProcessCandle(c, trigger))
 				.Start();
 		}

--- a/API/0401_Soccer_Clubs_Arbitrage/SoccerClubsArbitrageStrategy.cs
+++ b/API/0401_Soccer_Clubs_Arbitrage/SoccerClubsArbitrageStrategy.cs
@@ -27,7 +27,7 @@ namespace StockSharp.Samples.Strategies
 		private readonly StrategyParam<decimal> _entry;
 		private readonly StrategyParam<decimal> _exit;
 		private readonly StrategyParam<decimal> _minUsd;
-		private readonly DataType _tf = TimeSpan.FromDays(1).TimeFrame();
+		private readonly StrategyParam<DataType> _candleType;
 
 		/// <summary>
 		/// Securities pair used for arbitrage.
@@ -64,6 +64,15 @@ namespace StockSharp.Samples.Strategies
 			get => _minUsd.Value;
 			set => _minUsd.Value = value;
 		}
+
+		/// <summary>
+		/// The type of candles to use for strategy calculation.
+		/// </summary>
+		public DataType CandleType
+		{
+			get => _candleType.Value;
+			set => _candleType.Value = value;
+		}
 		#endregion
 
 		private Security _a, _b;
@@ -82,6 +91,8 @@ namespace StockSharp.Samples.Strategies
 
 			_minUsd = Param(nameof(MinTradeUsd), 200m)
 				.SetDisplay("Min Trade USD", "Minimum notional value for orders", "Risk Management");
+			_candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
+				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 
 		/// <inheritdoc />
@@ -92,8 +103,8 @@ namespace StockSharp.Samples.Strategies
 
 			_a = Pair.ElementAt(0);
 			_b = Pair.ElementAt(1);
-			yield return (_a, _tf);
-			yield return (_b, _tf);
+			yield return (_a, CandleType);
+			yield return (_b, CandleType);
 		}
 
 		/// <inheritdoc />
@@ -113,7 +124,7 @@ namespace StockSharp.Samples.Strategies
 			}
 
 			// Use first ticker's candle as daily trigger
-			SubscribeCandles(_tf, true, _a)
+			SubscribeCandles(CandleType, true, _a)
 				.Bind(c => TriggerDaily())
 				.Start();
 		}

--- a/API/0402_Synthetic_Lending_Rates/SyntheticLendingRatesStrategy.cs
+++ b/API/0402_Synthetic_Lending_Rates/SyntheticLendingRatesStrategy.cs
@@ -24,7 +24,16 @@ namespace StockSharp.Samples.Strategies
 	public class SyntheticLendingRatesStrategy : Strategy
 	{
 		private readonly StrategyParam<decimal> _minUsd;
-		private readonly DataType _tf = TimeSpan.FromMinutes(1).TimeFrame();
+		private readonly StrategyParam<DataType> _candleType;
+
+		/// <summary>
+		/// The type of candles to use for strategy calculation.
+		/// </summary>
+		public DataType CandleType
+		{
+			get => _candleType.Value;
+			set => _candleType.Value = value;
+		}
 		private readonly Dictionary<Security, decimal> _latestPrices = new();
 
 		/// <summary>
@@ -42,6 +51,8 @@ namespace StockSharp.Samples.Strategies
 		{
 			_minUsd = Param(nameof(MinTradeUsd), 200m)
 				.SetDisplay("Min Trade USD", "Minimum notional value for orders", "Risk Management");
+			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(1).TimeFrame())
+				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 
 		/// <inheritdoc />
@@ -50,7 +61,7 @@ namespace StockSharp.Samples.Strategies
 			if (Security == null)
 				throw new InvalidOperationException("Security not set");
 
-			yield return (Security, _tf);
+			yield return (Security, CandleType);
 		}
 
 		/// <inheritdoc />
@@ -60,7 +71,7 @@ namespace StockSharp.Samples.Strategies
 				throw new InvalidOperationException("Security not set");
 
 			base.OnStarted(t);
-			SubscribeCandles(_tf, true, Security).Bind(c => ProcessCandle(c, Security)).Start();
+			SubscribeCandles(CandleType, true, Security).Bind(c => ProcessCandle(c, Security)).Start();
 		}
 
 		private void ProcessCandle(ICandleMessage candle, Security security)

--- a/API/0403_Term_Structure_Commodities/TermStructureCommoditiesStrategy.cs
+++ b/API/0403_Term_Structure_Commodities/TermStructureCommoditiesStrategy.cs
@@ -23,7 +23,16 @@ namespace StockSharp.Samples.Strategies
 		private readonly StrategyParam<IEnumerable<Security>> _univ;
 		private readonly StrategyParam<int> _quint;
 		private readonly StrategyParam<decimal> _minUsd;
-		private readonly DataType _tf = TimeSpan.FromDays(1).TimeFrame();
+		private readonly StrategyParam<DataType> _candleType;
+
+		/// <summary>
+		/// The type of candles to use for strategy calculation.
+		/// </summary>
+		public DataType CandleType
+		{
+			get => _candleType.Value;
+			set => _candleType.Value = value;
+		}
 		private readonly Dictionary<Security, decimal> _w = new();
 		private readonly Dictionary<Security, decimal> _latestPrices = new();
 		private DateTime _last = DateTime.MinValue;
@@ -65,12 +74,14 @@ namespace StockSharp.Samples.Strategies
 
 			_minUsd = Param(nameof(MinTradeUsd), 200m)
 				.SetDisplay("Min Trade USD", "Minimum notional value for orders", "Risk Management");
+			_candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
+				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 
 		/// <inheritdoc />
 		public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
 		{
-			return Universe.Select(s => (s, _tf));
+			return Universe.Select(s => (s, CandleType));
 		}
 
 		/// <inheritdoc />
@@ -82,7 +93,7 @@ namespace StockSharp.Samples.Strategies
 			base.OnStarted(t);
 
 			var trig = Universe.First();
-			SubscribeCandles(_tf, true, trig).Bind(c => ProcessCandle(c, trig)).Start();
+			SubscribeCandles(CandleType, true, trig).Bind(c => ProcessCandle(c, trig)).Start();
 		}
 
 		private void ProcessCandle(ICandleMessage candle, Security security)

--- a/API/0404_Time_Series_Momentum/TimeSeriesMomentumStrategy.cs
+++ b/API/0404_Time_Series_Momentum/TimeSeriesMomentumStrategy.cs
@@ -23,7 +23,16 @@ namespace StockSharp.Samples.Strategies
 		private readonly StrategyParam<int> _look;
 		private readonly StrategyParam<int> _vol;
 		private readonly StrategyParam<decimal> _minUsd;
-		private readonly DataType _tf = TimeSpan.FromDays(1).TimeFrame();
+		private readonly StrategyParam<DataType> _candleType;
+
+		/// <summary>
+		/// The type of candles to use for strategy calculation.
+		/// </summary>
+		public DataType CandleType
+		{
+			get => _candleType.Value;
+			set => _candleType.Value = value;
+		}
 		private class Win { public Queue<decimal> Px = new(); }
 		private readonly Dictionary<Security, Win> _map = new();
 		private readonly Dictionary<Security, decimal> _w = new();
@@ -79,12 +88,14 @@ namespace StockSharp.Samples.Strategies
 
 			_minUsd = Param(nameof(MinTradeUsd), 200m)
 				.SetDisplay("Min Trade USD", "Minimum notional value for orders", "Risk Management");
+			_candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
+				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 
 		/// <inheritdoc />
 		public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
 		{
-			return Universe.Select(s => (s, _tf));
+			return Universe.Select(s => (s, CandleType));
 		}
 
 		/// <inheritdoc />

--- a/API/0405_Trend_Following_Stocks/TrendFollowingStocksStrategy.cs
+++ b/API/0405_Trend_Following_Stocks/TrendFollowingStocksStrategy.cs
@@ -23,7 +23,16 @@ namespace StockSharp.Samples.Strategies
 		private readonly StrategyParam<IEnumerable<Security>> _universe;
 		private readonly StrategyParam<int> _atrLen;
 		private readonly StrategyParam<decimal> _minUsd;
-		private readonly DataType _tf = TimeSpan.FromDays(1).TimeFrame();
+		private readonly StrategyParam<DataType> _candleType;
+
+		/// <summary>
+		/// The type of candles to use for strategy calculation.
+		/// </summary>
+		public DataType CandleType
+		{
+			get => _candleType.Value;
+			set => _candleType.Value = value;
+		}
 
 		private class StockInfo
 		{
@@ -70,12 +79,14 @@ namespace StockSharp.Samples.Strategies
 
 			_minUsd = Param(nameof(MinTradeUsd), 200m)
 				.SetDisplay("Min Trade USD", "Minimum notional value for orders", "Risk Management");
+			_candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
+				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 
 		/// <inheritdoc />
 		public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
 		{
-			return Universe.Select(s => (s, _tf));
+			return Universe.Select(s => (s, CandleType));
 		}
 
 		/// <inheritdoc />

--- a/API/0406_Turn_Of_Month/TurnOfMonthStrategy.cs
+++ b/API/0406_Turn_Of_Month/TurnOfMonthStrategy.cs
@@ -24,7 +24,16 @@ namespace StockSharp.Samples.Strategies
 		private readonly StrategyParam<int> _prior;
 		private readonly StrategyParam<int> _after;
 		private readonly StrategyParam<decimal> _minUsd;
-		private readonly DataType _tf = TimeSpan.FromDays(1).TimeFrame();
+		private readonly StrategyParam<DataType> _candleType;
+
+		/// <summary>
+		/// The type of candles to use for strategy calculation.
+		/// </summary>
+		public DataType CandleType
+		{
+			get => _candleType.Value;
+			set => _candleType.Value = value;
+		}
 
 		private readonly Dictionary<Security, decimal> _latestPrices = new();
 		private int _tdMonthEnd = int.MaxValue;
@@ -67,6 +76,8 @@ namespace StockSharp.Samples.Strategies
 
 			_minUsd = Param(nameof(MinTradeUsd), 200m)
 				.SetDisplay("Min Trade USD", "Minimum notional value for orders", "Risk Management");
+			_candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
+				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 
 		/// <inheritdoc />
@@ -75,7 +86,7 @@ namespace StockSharp.Samples.Strategies
 			if (Security == null)
 				throw new InvalidOperationException("Set ETF");
 
-			yield return (Security, _tf);
+			yield return (Security, CandleType);
 		}
 
 		/// <inheritdoc />
@@ -86,7 +97,7 @@ namespace StockSharp.Samples.Strategies
 
 			base.OnStarted(time);
 
-			SubscribeCandles(_tf, true, Security)
+			SubscribeCandles(CandleType, true, Security)
 				.Bind(c => ProcessCandle(c, Security))
 				.Start();
 		}

--- a/API/0407_Value_Momentum_Across_Assets/ValueMomentumAcrossAssetsStrategy.cs
+++ b/API/0407_Value_Momentum_Across_Assets/ValueMomentumAcrossAssetsStrategy.cs
@@ -22,7 +22,16 @@ namespace StockSharp.Samples.Strategies
 		// Parameters
 		private readonly StrategyParam<IEnumerable<Security>> _univ;
 		private readonly StrategyParam<decimal> _min;
-		private readonly DataType _tf = TimeSpan.FromDays(1).TimeFrame();
+		private readonly StrategyParam<DataType> _candleType;
+
+		/// <summary>
+		/// The type of candles to use for strategy calculation.
+		/// </summary>
+		public DataType CandleType
+		{
+			get => _candleType.Value;
+			set => _candleType.Value = value;
+		}
 
 		/// <summary>
 		/// List of securities to trade.
@@ -49,12 +58,14 @@ namespace StockSharp.Samples.Strategies
 
 			_min = Param(nameof(MinTradeUsd), 200m)
 				.SetDisplay("Min Trade USD", "Minimum notional value for orders", "Risk Management");
+			_candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
+				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 
 		/// <inheritdoc />
 		public override IEnumerable<(Security, DataType)> GetWorkingSecurities()
 		{
-			return Universe.Select(s => (s, _tf));
+			return Universe.Select(s => (s, CandleType));
 		}
 
 		/// <inheritdoc />
@@ -67,7 +78,7 @@ namespace StockSharp.Samples.Strategies
 
 			var trig = Universe.First();
 
-			SubscribeCandles(_tf, true, trig).Bind(c => OnDay(c.OpenTime.Date)).Start();
+			SubscribeCandles(CandleType, true, trig).Bind(c => OnDay(c.OpenTime.Date)).Start();
 		}
 
 		private void OnDay(DateTime d)

--- a/API/0408_Volatility_Risk_Premium/VolatilityRiskPremiumStrategy.cs
+++ b/API/0408_Volatility_Risk_Premium/VolatilityRiskPremiumStrategy.cs
@@ -22,7 +22,16 @@ namespace StockSharp.Samples.Strategies
 		// Parameters
 		private readonly StrategyParam<IEnumerable<Security>> _univ;
 		private readonly StrategyParam<decimal> _min;
-		private readonly DataType _tf = TimeSpan.FromDays(1).TimeFrame();
+		private readonly StrategyParam<DataType> _candleType;
+
+		/// <summary>
+		/// The type of candles to use for strategy calculation.
+		/// </summary>
+		public DataType CandleType
+		{
+			get => _candleType.Value;
+			set => _candleType.Value = value;
+		}
 
 		/// <summary>
 		/// List of securities to trade.
@@ -49,12 +58,14 @@ namespace StockSharp.Samples.Strategies
 
 			_min = Param(nameof(MinTradeUsd), 200m)
 				.SetDisplay("Min Trade USD", "Minimum notional value for orders", "Risk Management");
+			_candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
+				.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 
 		/// <inheritdoc />
 		public override IEnumerable<(Security, DataType)> GetWorkingSecurities()
 		{
-			return Universe.Select(s => (s, _tf));
+			return Universe.Select(s => (s, CandleType));
 		}
 
 		/// <inheritdoc />
@@ -65,7 +76,7 @@ namespace StockSharp.Samples.Strategies
 
 			base.OnStarted(t);
 			var trig = Universe.First();
-			SubscribeCandles(_tf, true, trig).Bind(c => OnDay(c.OpenTime.Date)).Start();
+			SubscribeCandles(CandleType, true, trig).Bind(c => OnDay(c.OpenTime.Date)).Start();
 		}
 
 		private void OnDay(DateTime d)


### PR DESCRIPTION
## Summary
- expose `CandleType` parameter across various strategies instead of hard-coded `_tf`
- default the parameter to appropriate daily or minute timeframes

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(403 errors: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689241837e588323999d4cce59d520c8