### PR TITLE
Fix strategy state reset for initial API samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,5 @@ pub/
 .idea/
 !Net.HPSocket/HPSocket/Src/Common/debug/
 !Net.HPSocket/**/Dependent/**/x64/
+
+__pycache__/

--- a/API/0001_MA_CrossOver/CS/MaCrossoverStrategy.cs
+++ b/API/0001_MA_CrossOver/CS/MaCrossoverStrategy.cs
@@ -94,13 +94,19 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
-
+			base.OnReseted();
 			// Initialize variables
 			_entryPrice = 0;
 			_isLongPosition = false;
+
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Create indicators
 			var fastMa = new SMA { Length = FastLength };

--- a/API/0001_MA_CrossOver/PY/ma_crossover_strategy.py
+++ b/API/0001_MA_CrossOver/PY/ma_crossover_strategy.py
@@ -98,11 +98,6 @@ class ma_crossover_strategy(Strategy):
         """
         super(ma_crossover_strategy, self).OnStarted(time)
 
-        # Initialize state variables
-        self._entry_price = 0.0
-        self._is_long_position = False
-        self._is_initialized = False
-
         # Create indicators
         fast_ma = SMA()
         fast_ma.Length = self.fast_length

--- a/API/0002_NDay_Breakout/CS/NdayBreakoutStrategy.cs
+++ b/API/0002_NDay_Breakout/CS/NdayBreakoutStrategy.cs
@@ -101,14 +101,20 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
-
+			base.OnReseted();
 			// Initialize tracking variables
 			_nDayHigh = 0;
 			_nDayLow = decimal.MaxValue;
 			_isFormed = false;
+
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Create indicators
 			_highest = new Highest { Length = LookbackPeriod };

--- a/API/0002_NDay_Breakout/PY/nday_breakout_strategy.py
+++ b/API/0002_NDay_Breakout/PY/nday_breakout_strategy.py
@@ -97,11 +97,6 @@ class nday_breakout_strategy(Strategy):
         """
         super(nday_breakout_strategy, self).OnStarted(time)
 
-        # Initialize tracking variables
-        self._n_day_high = 0.0
-        self._n_day_low = float('inf')
-        self._is_formed = False
-
         # Create indicators
         self._highest = Highest()
         self._highest.Length = self.lookback_period

--- a/API/0003_ADX_Trend/CS/AdxTrendStrategy.cs
+++ b/API/0003_ADX_Trend/CS/AdxTrendStrategy.cs
@@ -106,13 +106,19 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
-
+			base.OnReseted();
 			_adxAboveThreshold = default;
 			_prevAdxValue = default;
 			_prevMaValue = default;
+
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Create indicators
 			var adx = new AverageDirectionalIndex { Length = AdxPeriod };

--- a/API/0003_ADX_Trend/PY/adx_trend_strategy.py
+++ b/API/0003_ADX_Trend/PY/adx_trend_strategy.py
@@ -104,11 +104,6 @@ class adx_trend_strategy(Strategy):
         """
         super(adx_trend_strategy, self).OnStarted(time)
 
-        # Initialize state
-        self._adx_above_threshold = False
-        self._prev_adx_value = 0.0
-        self._prev_ma_value = 0.0
-
         # Create indicators
         adx = AverageDirectionalIndex()
         adx.Length = self.adx_period

--- a/API/0004_Parabolic_SAR_Trend/CS/ParabolicSarTrendStrategy.cs
+++ b/API/0004_Parabolic_SAR_Trend/CS/ParabolicSarTrendStrategy.cs
@@ -75,12 +75,18 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+			_prevSarValue = 0;
+			_prevIsPriceAboveSar = false;
+
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
-
-			_prevSarValue = 0;
-			_prevIsPriceAboveSar = false;
 
 			// Create Parabolic SAR indicator
 			var parabolicSar = new ParabolicSar

--- a/API/0004_Parabolic_SAR_Trend/PY/parabolic_sar_trend_strategy.py
+++ b/API/0004_Parabolic_SAR_Trend/PY/parabolic_sar_trend_strategy.py
@@ -76,10 +76,6 @@ class parabolic_sar_trend_strategy(Strategy):
         """
         super(parabolic_sar_trend_strategy, self).OnStarted(time)
 
-        # Initialize state
-        self._prev_sar_value = 0.0
-        self._prev_is_price_above_sar = False
-
         # Create Parabolic SAR indicator
         parabolic_sar = ParabolicSar()
         parabolic_sar.Acceleration = self.acceleration_factor

--- a/API/0005_Donchian_Channel/CS/DonchianChannelStrategy.cs
+++ b/API/0005_Donchian_Channel/CS/DonchianChannelStrategy.cs
@@ -61,13 +61,19 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
-
+			base.OnReseted();
 			_prevClosePrice = default;
 			_prevUpperBand = default;
 			_prevLowerBand = default;
+
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Create indicators
 			var donchian = new DonchianChannels { Length = ChannelPeriod };

--- a/API/0005_Donchian_Channel/PY/donchian_channel_strategy.py
+++ b/API/0005_Donchian_Channel/PY/donchian_channel_strategy.py
@@ -67,11 +67,6 @@ class donchian_channel_strategy(Strategy):
         """
         super(donchian_channel_strategy, self).OnStarted(time)
 
-        # Initialize state
-        self._prev_close_price = 0.0
-        self._prev_upper_band = 0.0
-        self._prev_lower_band = 0.0
-
         # Create indicators
         donchian = DonchianChannels()
         donchian.Length = self.channel_period

--- a/API/0006_Tripple_MA/CS/TripleMAStrategy.cs
+++ b/API/0006_Tripple_MA/CS/TripleMAStrategy.cs
@@ -104,11 +104,17 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+			_prevIsShortAboveMiddle = default;
+
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
-
-			_prevIsShortAboveMiddle = default;
 
 			// Create indicators
 			var shortMa = new SimpleMovingAverage { Length = ShortMaPeriod };

--- a/API/0006_Tripple_MA/PY/triple_ma_strategy.py
+++ b/API/0006_Tripple_MA/PY/triple_ma_strategy.py
@@ -99,9 +99,6 @@ class triple_ma_strategy(Strategy):
         """
         super(triple_ma_strategy, self).OnStarted(time)
 
-        # Initialize state
-        self._prev_is_short_above_middle = False
-
         # Create indicators
         short_ma = SimpleMovingAverage()
         short_ma.Length = self.short_ma_period

--- a/API/0007_Keltner_Channel_Breakout/CS/KeltnerChannelBreakoutStrategy.cs
+++ b/API/0007_Keltner_Channel_Breakout/CS/KeltnerChannelBreakoutStrategy.cs
@@ -92,14 +92,20 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
-
+			base.OnReseted();
 			_prevClosePrice = default;
 			_prevUpperBand = default;
 			_prevLowerBand = default;
 			_prevEma = default;
+
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Create indicators
 			var keltnerChannel = new KeltnerChannels

--- a/API/0007_Keltner_Channel_Breakout/PY/keltner_channel_breakout_strategy.py
+++ b/API/0007_Keltner_Channel_Breakout/PY/keltner_channel_breakout_strategy.py
@@ -93,12 +93,6 @@ class keltner_channel_breakout_strategy(Strategy):
         """
         super(keltner_channel_breakout_strategy, self).OnStarted(time)
 
-        # Initialize state
-        self._prev_close_price = 0.0
-        self._prev_upper_band = 0.0
-        self._prev_lower_band = 0.0
-        self._prev_ema = 0.0
-
         # Create indicators
         keltner_channel = KeltnerChannels()
         keltner_channel.Length = self.ema_period

--- a/API/0008_Hull_MA_Trend/CS/HullMaTrendStrategy.cs
+++ b/API/0008_Hull_MA_Trend/CS/HullMaTrendStrategy.cs
@@ -89,11 +89,17 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+			_prevHmaValue = default;
+
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
-
-			_prevHmaValue = default;
 
 			// Create indicators
 			var hma = new HullMovingAverage { Length = HmaPeriod };

--- a/API/0008_Hull_MA_Trend/PY/hull_ma_trend_strategy.py
+++ b/API/0008_Hull_MA_Trend/PY/hull_ma_trend_strategy.py
@@ -87,9 +87,6 @@ class hull_ma_trend_strategy(Strategy):
         """
         super(hull_ma_trend_strategy, self).OnStarted(time)
 
-        # Initialize state
-        self._prev_hma_value = 0.0
-
         # Create indicators
         hma = HullMovingAverage()
         hma.Length = self.hma_period

--- a/API/0009_MACD_Trend/CS/MacdTrendStrategy.cs
+++ b/API/0009_MACD_Trend/CS/MacdTrendStrategy.cs
@@ -104,11 +104,17 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+			_prevIsMacdAboveSignal = false;
+
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
-
-			_prevIsMacdAboveSignal = false;
 
 			// Create MACD indicator with signal line
 

--- a/API/0009_MACD_Trend/PY/macd_trend_strategy.py
+++ b/API/0009_MACD_Trend/PY/macd_trend_strategy.py
@@ -99,9 +99,6 @@ class macd_trend_strategy(Strategy):
         """
         super(macd_trend_strategy, self).OnStarted(time)
 
-        # Initialize state
-        self._prev_is_macd_above_signal = False
-
         # Create MACD indicator with signal line
         macd = MovingAverageConvergenceDivergenceSignal()
         # Configure MACD parameters

--- a/API/0010_Super_Trend/CS/SupertrendStrategy.cs
+++ b/API/0010_Super_Trend/CS/SupertrendStrategy.cs
@@ -75,12 +75,18 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+			_prevIsPriceAboveSupertrend = false;
+			_prevSupertrendValue = 0;
+
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
-
-			_prevIsPriceAboveSupertrend = false;
-			_prevSupertrendValue = 0;
 
 			// Create custom supertrend indicator
 			// Since StockSharp doesn't have a built-in Supertrend indicator,

--- a/API/0010_Super_Trend/PY/supertrend_strategy.py
+++ b/API/0010_Super_Trend/PY/supertrend_strategy.py
@@ -77,10 +77,6 @@ class supertrend_strategy(Strategy):
         """
         super(supertrend_strategy, self).OnStarted(time)
 
-        # Initialize state
-        self._prev_is_price_above_supertrend = False
-        self._prev_supertrend_value = 0.0
-
         # Create ATR indicator for Supertrend calculation
         # Since StockSharp doesn't have built-in Supertrend, we calculate it manually
         atr = AverageTrueRange()

--- a/API/0011_Ichimoku_Kumo_Breakout/CS/IchimokuKumoBreakoutStrategy.cs
+++ b/API/0011_Ichimoku_Kumo_Breakout/CS/IchimokuKumoBreakoutStrategy.cs
@@ -93,14 +93,20 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
-
+			base.OnReseted();
 			_prevTenkanValue = default;
 			_prevKijunValue = default;
 			_prevIsTenkanAboveKijun = default;
 			_prevIsPriceAboveCloud = default;
+
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Create Ichimoku indicator
 			var ichimoku = new Ichimoku

--- a/API/0011_Ichimoku_Kumo_Breakout/PY/ichimoku_kumo_breakout_strategy.py
+++ b/API/0011_Ichimoku_Kumo_Breakout/PY/ichimoku_kumo_breakout_strategy.py
@@ -93,12 +93,6 @@ class ichimoku_kumo_breakout_strategy(Strategy):
         """
         super(ichimoku_kumo_breakout_strategy, self).OnStarted(time)
 
-        # Initialize state
-        self._prev_tenkan_value = 0.0
-        self._prev_kijun_value = 0.0
-        self._prev_is_tenkan_above_kijun = False
-        self._prev_is_price_above_cloud = False
-
         # Create Ichimoku indicator
         ichimoku = Ichimoku()
         ichimoku.Tenkan.Length = self.tenkan_period

--- a/API/0012_Heikin_Ashi_Consecutive/CS/HeikinAshiConsecutiveStrategy.cs
+++ b/API/0012_Heikin_Ashi_Consecutive/CS/HeikinAshiConsecutiveStrategy.cs
@@ -80,16 +80,22 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
-
+			base.OnReseted();
 			_bullishCount = default;
 			_bearishCount = default;
 			_prevHaOpen = default;
 			_prevHaClose = default;
 			_prevHaHigh = default;
 			_prevHaLow = default;
+
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Create subscription
 			var subscription = SubscribeCandles(CandleType);

--- a/API/0012_Heikin_Ashi_Consecutive/PY/heikin_ashi_consecutive_strategy.py
+++ b/API/0012_Heikin_Ashi_Consecutive/PY/heikin_ashi_consecutive_strategy.py
@@ -84,14 +84,6 @@ class heikin_ashi_consecutive_strategy(Strategy):
         """
         super(heikin_ashi_consecutive_strategy, self).OnStarted(time)
 
-        # Initialize state
-        self._bullish_count = 0
-        self._bearish_count = 0
-        self._prev_ha_open = 0.0
-        self._prev_ha_close = 0.0
-        self._prev_ha_high = 0.0
-        self._prev_ha_low = 0.0
-
         # Create subscription
         subscription = self.SubscribeCandles(self.candle_type)
         

--- a/API/0014_TradingView_Supertrend_Flip/CS/TradingViewSupertrendFlipStrategy.cs
+++ b/API/0014_TradingView_Supertrend_Flip/CS/TradingViewSupertrendFlipStrategy.cs
@@ -94,15 +94,21 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
-
+			base.OnReseted();
 			_prevSupertrendValue = 0;
 			_prevIsPriceAboveSupertrend = false;
 			_avgVolume = 0;
 			_supertrendValue = 0;
 			_volumeQueue.Clear();
+
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Create custom indicators
 			// Since StockSharp doesn't have a built-in Supertrend indicator,

--- a/API/0014_TradingView_Supertrend_Flip/PY/tradingview_supertrend_flip_strategy.py
+++ b/API/0014_TradingView_Supertrend_Flip/PY/tradingview_supertrend_flip_strategy.py
@@ -96,13 +96,6 @@ class tradingview_supertrend_flip_strategy(Strategy):
         """
         super(tradingview_supertrend_flip_strategy, self).OnStarted(time)
 
-        # Initialize state
-        self._prev_supertrend_value = 0.0
-        self._prev_is_price_above_supertrend = False
-        self._avg_volume = 0.0
-        self._supertrend_value = 0.0
-        self._volume_queue = []
-
         # Create custom indicators
         # Since StockSharp doesn't have built-in Supertrend, we use ATR and customize calculation
         atr = AverageTrueRange()

--- a/API/0015_Gann_Swing_Breakout/CS/GannSwingBreakoutStrategy.cs
+++ b/API/0015_Gann_Swing_Breakout/CS/GannSwingBreakoutStrategy.cs
@@ -83,10 +83,9 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
-
+			base.OnReseted();
 			_lastSwingHigh = default;
 			_lastSwingLow = default;
 			_highBarIndex = default;
@@ -96,6 +95,13 @@ namespace StockSharp.Samples.Strategies
 			_recentHighs.Clear();
 			_recentLows.Clear();
 			_recentCandles.Clear();
+
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Create indicators
 			var ma = new SimpleMovingAverage { Length = MaPeriod };

--- a/API/0015_Gann_Swing_Breakout/PY/gann_swing_breakout_strategy.py
+++ b/API/0015_Gann_Swing_Breakout/PY/gann_swing_breakout_strategy.py
@@ -91,17 +91,6 @@ class gann_swing_breakout_strategy(Strategy):
         """
         super(gann_swing_breakout_strategy, self).OnStarted(time)
 
-        # Initialize state
-        self._last_swing_high = None
-        self._last_swing_low = None
-        self._high_bar_index = 0
-        self._low_bar_index = 0
-        self._current_bar_index = 0
-        self._recent_highs = []
-        self._recent_lows = []
-        self._recent_candles = []
-        self._prev_ma_value = 0.0
-
         # Create indicators
         ma = SimpleMovingAverage()
         ma.Length = self.ma_period

--- a/API/0016_RSI_Divergence/CS/RsiDivergenceStrategy.cs
+++ b/API/0016_RSI_Divergence/CS/RsiDivergenceStrategy.cs
@@ -74,14 +74,20 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
-
+			base.OnReseted();
 			// Reset state variables
 			_prevPrice = 0;
 			_prevRsi = 0;
 			_isFirstCandle = true;
+
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Create RSI indicator
 			var rsi = new RelativeStrengthIndex { Length = RsiPeriod };

--- a/API/0016_RSI_Divergence/PY/rsi_divergence_strategy.py
+++ b/API/0016_RSI_Divergence/PY/rsi_divergence_strategy.py
@@ -80,11 +80,6 @@ class rsi_divergence_strategy(Strategy):
         """
         super(rsi_divergence_strategy, self).OnStarted(time)
 
-        # Reset state variables
-        self._prev_price = 0.0
-        self._prev_rsi = 0.0
-        self._is_first_candle = True
-
         # Create RSI indicator
         rsi = RelativeStrengthIndex()
         rsi.Length = self.rsi_period

--- a/API/0018_ROC_Impulce/CS/RocImpulseStrategy.cs
+++ b/API/0018_ROC_Impulce/CS/RocImpulseStrategy.cs
@@ -73,13 +73,19 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
-
+			base.OnReseted();
 			// Reset state variables
 			_previousRoc = 0;
 			_isFirstCandle = true;
+
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Create indicators
 			var roc = new RateOfChange { Length = RocPeriod };

--- a/API/0018_ROC_Impulce/PY/roc_impulse_strategy.py
+++ b/API/0018_ROC_Impulce/PY/roc_impulse_strategy.py
@@ -77,10 +77,6 @@ class roc_impulse_strategy(Strategy):
         """
         super(roc_impulse_strategy, self).OnStarted(time)
 
-        # Reset state variables
-        self._previous_roc = 0.0
-        self._is_first_candle = True
-
         # Create indicators
         roc = RateOfChange()
         roc.Length = self.roc_period

--- a/API/0021_Bollinger_Squeeze/CS/BollingerSqueezeStrategy.cs
+++ b/API/0021_Bollinger_Squeeze/CS/BollingerSqueezeStrategy.cs
@@ -89,14 +89,20 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
-
+			base.OnReseted();
 			// Reset state variables
 			_previousBandWidth = 0;
 			_isFirstValue = true;
 			_isInSqueeze = false;
+
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Create Bollinger Bands indicator
 			var bollingerBands = new BollingerBands

--- a/API/0021_Bollinger_Squeeze/PY/bollinger_squeeze_strategy.py
+++ b/API/0021_Bollinger_Squeeze/PY/bollinger_squeeze_strategy.py
@@ -91,11 +91,6 @@ class bollinger_squeeze_strategy(Strategy):
         """
         super(bollinger_squeeze_strategy, self).OnStarted(time)
 
-        # Reset state variables
-        self._previous_band_width = 0.0
-        self._is_first_value = True
-        self._is_in_squeeze = False
-
         # Create Bollinger Bands indicator
         bollinger_bands = BollingerBands()
         bollinger_bands.Length = self.bollinger_period

--- a/API/0023_Elder_Impulse/CS/ElderImpulseStrategy.cs
+++ b/API/0023_Elder_Impulse/CS/ElderImpulseStrategy.cs
@@ -119,13 +119,19 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
-
+			base.OnReseted();
 			// Reset state variables
 			_previousEma = 0;
 			_isFirstCandle = true;
+
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Create indicators
 			var ema = new ExponentialMovingAverage { Length = EmaPeriod };

--- a/API/0023_Elder_Impulse/PY/elder_impulse_strategy.py
+++ b/API/0023_Elder_Impulse/PY/elder_impulse_strategy.py
@@ -115,10 +115,6 @@ class elder_impulse_strategy(Strategy):
         """
         super(elder_impulse_strategy, self).OnStarted(time)
 
-        # Reset state variables
-        self._previous_ema = 0.0
-        self._is_first_candle = True
-
         # Create indicators
         ema = ExponentialMovingAverage()
         ema.Length = self.ema_period

--- a/API/0025_Stochastic_RSI_Cross/CS/StochasticRsiCrossStrategy.cs
+++ b/API/0025_Stochastic_RSI_Cross/CS/StochasticRsiCrossStrategy.cs
@@ -120,14 +120,20 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
-
+			base.OnReseted();
 			// Reset state variables
 			_prevK = 0;
 			_prevD = 0;
 			_isFirstCandle = true;
+
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Create a StochRsi indicator
 			var rsi = new RelativeStrengthIndex { Length = RsiPeriod };

--- a/API/0025_Stochastic_RSI_Cross/PY/stochastic_rsi_cross_strategy.py
+++ b/API/0025_Stochastic_RSI_Cross/PY/stochastic_rsi_cross_strategy.py
@@ -115,11 +115,6 @@ class stochastic_rsi_cross_strategy(Strategy):
         """
         super(stochastic_rsi_cross_strategy, self).OnStarted(time)
 
-        # Reset state variables
-        self._prev_k = 0.0
-        self._prev_d = 0.0
-        self._is_first_candle = True
-
         # Create a StochRsi indicator (simulated using regular Stochastic)
         rsi = RelativeStrengthIndex()
         rsi.Length = self.rsi_period

--- a/API/0028_ZScore/CS/ZScoreStrategy.cs
+++ b/API/0028_ZScore/CS/ZScoreStrategy.cs
@@ -118,12 +118,18 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+			// Reset state variables
+			_prevZScore = 0;
+
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
-
-			// Reset state variables
-			_prevZScore = 0;
 
 			// Create indicators
 			var sma = new SimpleMovingAverage { Length = MAPeriod };

--- a/API/0028_ZScore/PY/z_score_strategy.py
+++ b/API/0028_ZScore/PY/z_score_strategy.py
@@ -110,9 +110,6 @@ class z_score_strategy(Strategy):
         """
         super(z_score_strategy, self).OnStarted(time)
 
-        # Reset state variables
-        self._prev_z_score = 0.0
-
         # Create indicators
         sma = SimpleMovingAverage()
         sma.Length = self.ma_period

--- a/API/0032_ATR_Reversion/CS/AtrReversionStrategy.cs
+++ b/API/0032_ATR_Reversion/CS/AtrReversionStrategy.cs
@@ -104,12 +104,18 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+			// Reset state variables
+			_prevClose = 0;
+
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
-
-			// Reset state variables
-			_prevClose = 0;
 
 			// Create indicators
 			var atr = new AverageTrueRange { Length = AtrPeriod };

--- a/API/0032_ATR_Reversion/PY/atr_reversion_strategy.py
+++ b/API/0032_ATR_Reversion/PY/atr_reversion_strategy.py
@@ -99,9 +99,6 @@ class atr_reversion_strategy(Strategy):
         """
         super(atr_reversion_strategy, self).OnStarted(time)
 
-        # Reset state variables
-        self._prev_close = 0.0
-
         # Create indicators
         atr = AverageTrueRange()
         atr.Length = self.atr_period

--- a/API/0033_MACD_Zero/CS/MacdZeroStrategy.cs
+++ b/API/0033_MACD_Zero/CS/MacdZeroStrategy.cs
@@ -104,12 +104,18 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+			// Reset state variables
+			_prevMacd = 0;
+
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
-
-			// Reset state variables
-			_prevMacd = 0;
 
 			// Create MACD indicator with signal line
 

--- a/API/0033_MACD_Zero/PY/macd_zero_strategy.py
+++ b/API/0033_MACD_Zero/PY/macd_zero_strategy.py
@@ -99,9 +99,6 @@ class macd_zero_strategy(Strategy):
         """
         super(macd_zero_strategy, self).OnStarted(time)
 
-        # Reset state variables
-        self._prev_macd = 0.0
-
         # Create MACD indicator with signal line
         macd = MovingAverageConvergenceDivergenceSignal()
         macd.Macd.ShortMa.Length = self.fast_period

--- a/API/0034_Low_Vol_Reversion/CS/LowVolReversionStrategy.cs
+++ b/API/0034_Low_Vol_Reversion/CS/LowVolReversionStrategy.cs
@@ -120,13 +120,19 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
-
+			base.OnReseted();
 			// Reset state variables
 			_avgAtr = 0;
 			_lookbackCounter = 0;
+
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Create indicators
 			var sma = new SimpleMovingAverage { Length = MAPeriod };

--- a/API/0034_Low_Vol_Reversion/PY/low_vol_reversion_strategy.py
+++ b/API/0034_Low_Vol_Reversion/PY/low_vol_reversion_strategy.py
@@ -113,10 +113,6 @@ class low_vol_reversion_strategy(Strategy):
         """
         super(low_vol_reversion_strategy, self).OnStarted(time)
 
-        # Reset state variables
-        self._avg_atr = 0.0
-        self._lookback_counter = 0
-
         # Create indicators
         sma = SimpleMovingAverage()
         sma.Length = self.ma_period

--- a/API/0036_ATR_Expansion/CS/AtrExpansionStrategy.cs
+++ b/API/0036_ATR_Expansion/CS/AtrExpansionStrategy.cs
@@ -89,12 +89,18 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+			// Reset state variables
+			_prevAtr = 0;
+
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
-
-			// Reset state variables
-			_prevAtr = 0;
 
 			// Create indicators
 			var atr = new AverageTrueRange { Length = AtrPeriod };

--- a/API/0036_ATR_Expansion/PY/atr_expansion_strategy.py
+++ b/API/0036_ATR_Expansion/PY/atr_expansion_strategy.py
@@ -87,9 +87,6 @@ class atr_expansion_strategy(Strategy):
         """
         super(atr_expansion_strategy, self).OnStarted(time)
 
-        # Reset state variables
-        self._prev_atr = 0.0
-
         # Create indicators
         atr = AverageTrueRange()
         atr.Length = self.atr_period

--- a/API/0037_VIX_Trigger/CS/VixTriggerStrategy.cs
+++ b/API/0037_VIX_Trigger/CS/VixTriggerStrategy.cs
@@ -97,14 +97,20 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
-
+			base.OnReseted();
 			// Reset state variables
 			_prevVix = 0;
 			_latestVix = 0;
 			_isVixRising = false;
+
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Create indicator
 			var sma = new SimpleMovingAverage { Length = MAPeriod };

--- a/API/0037_VIX_Trigger/PY/vix_trigger_strategy.py
+++ b/API/0037_VIX_Trigger/PY/vix_trigger_strategy.py
@@ -90,11 +90,6 @@ class vix_trigger_strategy(Strategy):
         """
         super(vix_trigger_strategy, self).OnStarted(time)
 
-        # Reset state variables
-        self._prevVix = 0
-        self._latestVix = 0
-        self._isVixRising = False
-
         # Create indicator
         sma = SimpleMovingAverage()
         sma.Length = self.MAPeriod

--- a/API/0038_BB_Width/CS/BollingerBandWidthStrategy.cs
+++ b/API/0038_BB_Width/CS/BollingerBandWidthStrategy.cs
@@ -89,12 +89,18 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+			// Reset state variables
+			_prevWidth = 0;
+
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
-
-			// Reset state variables
-			_prevWidth = 0;
 
 			// Create indicators
 			var bollinger = new BollingerBands

--- a/API/0038_BB_Width/PY/bollinger_band_width_strategy.py
+++ b/API/0038_BB_Width/PY/bollinger_band_width_strategy.py
@@ -85,9 +85,6 @@ class bollinger_band_width_strategy(Strategy):
         """
         super(bollinger_band_width_strategy, self).OnStarted(time)
 
-        # Reset state variables
-        self._prevWidth = 0
-
         # Create indicators
         bollinger = BollingerBands()
         bollinger.Length = self.BollingerPeriod

--- a/API/0039_HV_Breakout/CS/HvBreakoutStrategy.cs
+++ b/API/0039_HV_Breakout/CS/HvBreakoutStrategy.cs
@@ -91,14 +91,20 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
-
+			base.OnReseted();
 			// Reset state variables
 			_referencePrice = 0;
 			_historicalVolatility = 0;
 			_isReferenceSet = false;
+
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Create indicators
 			var standardDeviation = new StandardDeviation { Length = HvPeriod };

--- a/API/0039_HV_Breakout/PY/hv_breakout_strategy.py
+++ b/API/0039_HV_Breakout/PY/hv_breakout_strategy.py
@@ -88,11 +88,6 @@ class hv_breakout_strategy(Strategy):
         """
         super(hv_breakout_strategy, self).OnStarted(time)
 
-        # Reset state variables
-        self._referencePrice = 0
-        self._historicalVolatility = 0
-        self._isReferenceSet = False
-
         # Create indicators
         standardDeviation = StandardDeviation()
         standardDeviation.Length = self.HvPeriod

--- a/API/0040_ATR_Trailing/CS/AtrTrailingStrategy.cs
+++ b/API/0040_ATR_Trailing/CS/AtrTrailingStrategy.cs
@@ -90,13 +90,19 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
-
+			base.OnReseted();
 			// Reset state variables
 			_entryPrice = 0;
 			_trailingStopLevel = 0;
+
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Create indicators
 			var atr = new AverageTrueRange { Length = AtrPeriod };

--- a/API/0040_ATR_Trailing/PY/atr_trailing_strategy.py
+++ b/API/0040_ATR_Trailing/PY/atr_trailing_strategy.py
@@ -86,10 +86,6 @@ class atr_trailing_strategy(Strategy):
         """
         super(atr_trailing_strategy, self).OnStarted(time)
 
-        # Reset state variables
-        self._entryPrice = 0
-        self._trailingStopLevel = 0
-
         # Create indicators
         atr = AverageTrueRange()
         atr.Length = self.AtrPeriod

--- a/API/0041_Vol_Adjusted_MA/CS/VolAdjustedMaStrategy.cs
+++ b/API/0041_Vol_Adjusted_MA/CS/VolAdjustedMaStrategy.cs
@@ -92,12 +92,18 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+			_prevAdjustedUpperBand = 0;
+			_prevAdjustedLowerBand = 0;
+
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
-
-			_prevAdjustedUpperBand = 0;
-			_prevAdjustedLowerBand = 0;
 
 			// Create indicators
 			var ma = new SimpleMovingAverage() { Length = MAPeriod };

--- a/API/0041_Vol_Adjusted_MA/PY/vol_adjusted_ma_strategy.py
+++ b/API/0041_Vol_Adjusted_MA/PY/vol_adjusted_ma_strategy.py
@@ -85,9 +85,6 @@ class vol_adjusted_ma_strategy(Strategy):
         """
         super(vol_adjusted_ma_strategy, self).OnStarted(time)
 
-        self._prevAdjustedUpperBand = 0
-        self._prevAdjustedLowerBand = 0
-
         # Create indicators
         ma = SimpleMovingAverage()
         ma.Length = self.MAPeriod

--- a/API/0042_IV_Spike/CS/IvSpikeStrategy.cs
+++ b/API/0042_IV_Spike/CS/IvSpikeStrategy.cs
@@ -92,11 +92,17 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+			_previousIV = default;
+
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
-
-			_previousIV = default;
 
 			// Create indicators
 			var ma = new SimpleMovingAverage { Length = MAPeriod };

--- a/API/0042_IV_Spike/PY/iv_spike_strategy.py
+++ b/API/0042_IV_Spike/PY/iv_spike_strategy.py
@@ -84,8 +84,6 @@ class iv_spike_strategy(Strategy):
         """
         super(iv_spike_strategy, self).OnStarted(time)
 
-        self._previousIV = 0
-
         # Create indicators
         ma = SimpleMovingAverage()
         ma.Length = self.MAPeriod

--- a/API/0043_VCP/CS/VcpStrategy.cs
+++ b/API/0043_VCP/CS/VcpStrategy.cs
@@ -77,11 +77,17 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+			_prevCandleRange = 0;
+
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
-
-			_prevCandleRange = 0;
 
 			// Create indicators
 			var ma = new SimpleMovingAverage { Length = MAPeriod };

--- a/API/0043_VCP/PY/vcp_strategy.py
+++ b/API/0043_VCP/PY/vcp_strategy.py
@@ -74,8 +74,6 @@ class vcp_strategy(Strategy):
         """
         super(vcp_strategy, self).OnStarted(time)
 
-        self._prevCandleRange = 0
-
         # Create indicators
         ma = SimpleMovingAverage()
         ma.Length = self.MAPeriod

--- a/API/0044_ATR_Range/CS/AtrRangeStrategy.cs
+++ b/API/0044_ATR_Range/CS/AtrRangeStrategy.cs
@@ -93,12 +93,18 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+			_nBarsAgoPrice = default;
+			_barCounter = default;
+
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
-
-			_nBarsAgoPrice = default;
-			_barCounter = default;
 
 			// Create indicators
 			var ma = new SimpleMovingAverage { Length = MAPeriod };

--- a/API/0044_ATR_Range/PY/atr_range_strategy.py
+++ b/API/0044_ATR_Range/PY/atr_range_strategy.py
@@ -86,9 +86,6 @@ class atr_range_strategy(Strategy):
         """
         super(atr_range_strategy, self).OnStarted(time)
 
-        self._nBarsAgoPrice = 0
-        self._barCounter = 0
-
         # Create indicators
         ma = SimpleMovingAverage()
         ma.Length = self.MAPeriod

--- a/API/0045_Choppiness_Index_Breakout/CS/ChoppinessIndexBreakoutStrategy.cs
+++ b/API/0045_Choppiness_Index_Breakout/CS/ChoppinessIndexBreakoutStrategy.cs
@@ -109,11 +109,17 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+			_prevChoppiness = 100m; // Initialize to high value
+
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
-
-			_prevChoppiness = 100m; // Initialize to high value
 
 			// Create indicators
 			var ma = new SimpleMovingAverage { Length = MAPeriod };

--- a/API/0045_Choppiness_Index_Breakout/PY/choppiness_index_breakout_strategy.py
+++ b/API/0045_Choppiness_Index_Breakout/PY/choppiness_index_breakout_strategy.py
@@ -96,8 +96,6 @@ class choppiness_index_breakout_strategy(Strategy):
         """
         super(choppiness_index_breakout_strategy, self).OnStarted(time)
 
-        self._prevChoppiness = 100  # Initialize to high value
-
         # Create indicators
         ma = SimpleMovingAverage()
         ma.Length = self.MAPeriod

--- a/API/0046_Volume_Spike/CS/VolumeSpikeStrategy.cs
+++ b/API/0046_Volume_Spike/CS/VolumeSpikeStrategy.cs
@@ -93,11 +93,17 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+			_previousVolume = 0;
+
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
-
-			_previousVolume = 0;
 
 			// Create indicators
 			var ma = new SimpleMovingAverage { Length = MAPeriod };

--- a/API/0046_Volume_Spike/PY/volume_spike_strategy.py
+++ b/API/0046_Volume_Spike/PY/volume_spike_strategy.py
@@ -85,8 +85,6 @@ class volume_spike_strategy(Strategy):
         """
         super(volume_spike_strategy, self).OnStarted(time)
 
-        self._previousVolume = 0
-
         # Create indicators
         ma = SimpleMovingAverage()
         ma.Length = self.MAPeriod

--- a/API/0047_OBV_Breakout/CS/ObvBreakoutStrategy.cs
+++ b/API/0047_OBV_Breakout/CS/ObvBreakoutStrategy.cs
@@ -79,13 +79,19 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
-
+			base.OnReseted();
 			_highestOBV = null;
 			_lowestOBV = null;
 			_isFirstCandle = true;
+
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Create indicators
 			var obv = new OnBalanceVolume();

--- a/API/0047_OBV_Breakout/PY/obv_breakout_strategy.py
+++ b/API/0047_OBV_Breakout/PY/obv_breakout_strategy.py
@@ -79,10 +79,6 @@ class obv_breakout_strategy(Strategy):
         """
         super(obv_breakout_strategy, self).OnStarted(time)
 
-        self._highestOBV = None
-        self._lowestOBV = None
-        self._isFirstCandle = True
-
         # Create indicators
         obv = OnBalanceVolume()
         

--- a/API/0048_VWAP_Breakout/CS/VWAPBreakoutStrategy.cs
+++ b/API/0048_VWAP_Breakout/CS/VWAPBreakoutStrategy.cs
@@ -46,13 +46,19 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
-
+			base.OnReseted();
 			_previousClosePrice = 0;
 			_previousVWAP = 0;
 			_isFirstCandle = true;
+
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Create VWAP indicator
 			var vwap = new VolumeWeightedMovingAverage();

--- a/API/0048_VWAP_Breakout/PY/vwap_breakout_strategy.py
+++ b/API/0048_VWAP_Breakout/PY/vwap_breakout_strategy.py
@@ -57,10 +57,6 @@ class vwap_breakout_strategy(Strategy):
         """
         super(vwap_breakout_strategy, self).OnStarted(time)
 
-        self._previousClosePrice = 0
-        self._previousVWAP = 0
-        self._isFirstCandle = True
-
         # Create VWAP indicator
         vwap = VolumeWeightedMovingAverage()
 

--- a/API/0049_VWMA/CS/VWMAStrategy.cs
+++ b/API/0049_VWMA/CS/VWMAStrategy.cs
@@ -63,13 +63,19 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
-
+			base.OnReseted();
 			_previousClosePrice = 0;
 			_previousVWMA = 0;
 			_isFirstCandle = true;
+
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Create VWMA indicator
 			var vwma = new VolumeWeightedMovingAverage { Length = VWMAPeriod };

--- a/API/0049_VWMA/PY/vwma_strategy.py
+++ b/API/0049_VWMA/PY/vwma_strategy.py
@@ -68,10 +68,6 @@ class vwma_strategy(Strategy):
         """
         super(vwma_strategy, self).OnStarted(time)
 
-        self._previousClosePrice = 0
-        self._previousVWMA = 0
-        self._isFirstCandle = True
-
         # Create VWMA indicator
         vwma = VolumeWeightedMovingAverage()
         vwma.Length = self.VWMAPeriod

--- a/API/0050_AD/CS/ADStrategy.cs
+++ b/API/0050_AD/CS/ADStrategy.cs
@@ -62,12 +62,18 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+			_previousADValue = 0;
+			_isFirstCandle = true;
+
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
-
-			_previousADValue = 0;
-			_isFirstCandle = true;
 
 			// Create indicators
 			var ma = new SimpleMovingAverage { Length = MAPeriod };

--- a/API/0050_AD/PY/ad_strategy.py
+++ b/API/0050_AD/PY/ad_strategy.py
@@ -65,9 +65,6 @@ class ad_strategy(Strategy):
         """
         super(ad_strategy, self).OnStarted(time)
 
-        self._previousADValue = 0
-        self._isFirstCandle = True
-
         # Create indicators
         ma = SimpleMovingAverage()
         ma.Length = self.MAPeriod


### PR DESCRIPTION
## Summary
- Move strategy state initialization from `OnStarted` to `OnReseted` for the first set of sample strategies
- Drop redundant state resets in Python samples to ensure resetting occurs only in `OnReseted`
- Ignore Python `__pycache__` directories in git

## Testing
- `python -m py_compile $(glob)` *(compiled 326 python files)*
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68924fb5b4308323bed5a45539be2167