### PR TITLE
Refactor strategy state reset to OnReseted

### DIFF
--- a/API/0352_Asset_Class_Trend_Following/AssetClassTrendFollowingStrategy.cs
+++ b/API/0352_Asset_Class_Trend_Following/AssetClassTrendFollowingStrategy.cs
@@ -88,6 +88,17 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_sma.Clear();
+			_latestPrices.Clear();
+			_held.Clear();
+			_lastDay = default;
+		}
+
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);

--- a/API/0354_Betting_Against_Beta_Stocks/BettingAgainstBetaStocksStrategy.cs
+++ b/API/0354_Betting_Against_Beta_Stocks/BettingAgainstBetaStocksStrategy.cs
@@ -109,6 +109,17 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_wins.Clear();
+			_weights.Clear();
+			_latestPrices.Clear();
+			_lastDay = default;
+		}
+
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			if (Universe == null || !Universe.Any())

--- a/API/0355_Betting_Against_Beta/BettingAgainstBetaStrategy.cs
+++ b/API/0355_Betting_Against_Beta/BettingAgainstBetaStrategy.cs
@@ -109,6 +109,17 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_wins.Clear();
+			_weights.Clear();
+			_latestPrices.Clear();
+			_lastDay = default;
+		}
+
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			if (Security == null)

--- a/API/0356_Bitcoin_Intraday_Seasonality/BitcoinIntradaySeasonalityStrategy.cs
+++ b/API/0356_Bitcoin_Intraday_Seasonality/BitcoinIntradaySeasonalityStrategy.cs
@@ -74,6 +74,14 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_latestPrices.Clear();
+		}
+
 		protected override void OnStarted(DateTimeOffset t)
 		{
 			base.OnStarted(t);

--- a/API/0357_Book_To_Market_Value/BookToMarketValueStrategy.cs
+++ b/API/0357_Book_To_Market_Value/BookToMarketValueStrategy.cs
@@ -76,6 +76,12 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+		}
+
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);

--- a/API/0358_Commodity_Momentum/CommodityMomentumStrategy.cs
+++ b/API/0358_Commodity_Momentum/CommodityMomentumStrategy.cs
@@ -85,6 +85,16 @@ namespace StockSharp.Samples.Strategies
 			Universe.Select(s => (s, CandleType));
 
 		/// <inheritdoc />
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_px.Clear();
+			_latestPrices.Clear();
+			_lastDay = default;
+		}
+
 		protected override void OnStarted(DateTimeOffset t)
 		{
 			base.OnStarted(t);

--- a/API/0359_Consistent_Momentum/ConsistentMomentumStrategy.cs
+++ b/API/0359_Consistent_Momentum/ConsistentMomentumStrategy.cs
@@ -103,6 +103,17 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_prices.Clear();
+			_latestPrices.Clear();
+			_tranches.Clear();
+			_lastDay = default;
+		}
+
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			if (Universe == null || !Universe.Any())

--- a/API/0360_Country_Value_Factor/CountryValueFactorStrategy.cs
+++ b/API/0360_Country_Value_Factor/CountryValueFactorStrategy.cs
@@ -66,6 +66,12 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+		}
+
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);

--- a/API/0361_Crude_Oil_Predicts_Equity/CrudeOilPredictsEquityStrategy.cs
+++ b/API/0361_Crude_Oil_Predicts_Equity/CrudeOilPredictsEquityStrategy.cs
@@ -101,6 +101,16 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_wins.Clear();
+			_latestPrices.Clear();
+			_lastDay = default;
+		}
+
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);

--- a/API/0362_Crypto_Rebalancing_Premium/CryptoRebalancingPremiumStrategy.cs
+++ b/API/0362_Crypto_Rebalancing_Premium/CryptoRebalancingPremiumStrategy.cs
@@ -87,6 +87,15 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_latestPrices.Clear();
+			_last = default;
+		}
+
 		protected override void OnStarted(DateTimeOffset t)
 		{
 			base.OnStarted(t);

--- a/API/0363_Currency_Momentum_Factor/CurrencyMomentumFactorStrategy.cs
+++ b/API/0363_Currency_Momentum_Factor/CurrencyMomentumFactorStrategy.cs
@@ -101,6 +101,17 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_wins.Clear();
+			_w.Clear();
+			_latestPrices.Clear();
+			_lastDay = default;
+		}
+
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);

--- a/API/0364_Currency_PPPValue/CurrencyPPPValueStrategy.cs
+++ b/API/0364_Currency_PPPValue/CurrencyPPPValueStrategy.cs
@@ -89,6 +89,16 @@ namespace StockSharp.Samples.Strategies
 
 
 		/// <inheritdoc />
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_w.Clear();
+			_latestPrices.Clear();
+			_lastDay = default;
+		}
+
 		protected override void OnStarted(DateTimeOffset t)
 		{
 			base.OnStarted(t);

--- a/API/0365_Dispersion_Trading/DispersionTradingStrategy.cs
+++ b/API/0365_Dispersion_Trading/DispersionTradingStrategy.cs
@@ -99,6 +99,17 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_windows.Clear();
+			_latestPrices.Clear();
+			_lastDay = default;
+			_open = default;
+		}
+
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);

--- a/API/0366_Dollar_Carry_Trade/DollarCarryTradeStrategy.cs
+++ b/API/0366_Dollar_Carry_Trade/DollarCarryTradeStrategy.cs
@@ -107,6 +107,17 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_carry.Clear();
+			_weights.Clear();
+			_latestPrices.Clear();
+			_lastRebalanceDate = default;
+		}
+
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);

--- a/API/0367_Earnings_Announcement_Premium/EarningsAnnouncementPremiumStrategy.cs
+++ b/API/0367_Earnings_Announcement_Premium/EarningsAnnouncementPremiumStrategy.cs
@@ -119,6 +119,16 @@ namespace StockSharp.Samples.Strategies
 			Universe.Select(s => (s, CandleType));
 
 		/// <inheritdoc />
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_exitSchedule.Clear();
+			_latestPrices.Clear();
+			_lastProcessed = default;
+		}
+
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);

--- a/API/0368_Earnings_Announcement_Reversal/EarningsAnnouncementReversalStrategy.cs
+++ b/API/0368_Earnings_Announcement_Reversal/EarningsAnnouncementReversalStrategy.cs
@@ -106,6 +106,15 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_map.Clear();
+			_latestPrices.Clear();
+		}
+
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);

--- a/API/0369_Earnings_Announcements_With_Buybacks/EarningsAnnouncementsWithBuybacksStrategy.cs
+++ b/API/0369_Earnings_Announcements_With_Buybacks/EarningsAnnouncementsWithBuybacksStrategy.cs
@@ -115,6 +115,16 @@ namespace StockSharp.Samples.Strategies
 		}
 		
 		/// <inheritdoc />
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_exit.Clear();
+			_latestPrices.Clear();
+			_lastProcessed = default;
+		}
+
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);

--- a/API/0370_Earnings_Quality_Factor/EarningsQualityFactorStrategy.cs
+++ b/API/0370_Earnings_Quality_Factor/EarningsQualityFactorStrategy.cs
@@ -79,6 +79,16 @@ namespace StockSharp.Samples.Strategies
 		}
 		
 		/// <inheritdoc />
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_weights.Clear();
+			_latestPrices.Clear();
+			_lastProcessed = default;
+		}
+
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);

--- a/API/0371_ESGFactor_Momentum/ESGFactorMomentumStrategy.cs
+++ b/API/0371_ESGFactor_Momentum/ESGFactorMomentumStrategy.cs
@@ -95,6 +95,17 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_windows.Clear();
+			_latestPrices.Clear();
+			_held.Clear();
+			_lastProc = default;
+		}
+
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);

--- a/API/0372_Fed_Model/FedModelStrategy.cs
+++ b/API/0372_Fed_Model/FedModelStrategy.cs
@@ -123,7 +123,19 @@ namespace StockSharp.Samples.Strategies
 				yield return (EarningsYieldSym, CandleType);
 		}
 
-                protected override void OnStarted(DateTimeOffset time)
+                
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_eq.Clear();
+			_gap.Clear();
+			_rf.Clear();
+			_latestPrices.Clear();
+			_lastMonth = default;
+		}
+
+		protected override void OnStarted(DateTimeOffset time)
                 {
                         if (Universe == null || !Universe.Any())
                         {

--- a/API/0373_FScore_Reversal/FScoreReversalStrategy.cs
+++ b/API/0373_FScore_Reversal/FScoreReversalStrategy.cs
@@ -98,6 +98,20 @@ namespace StockSharp.Samples.Strategies
 			return Universe.Select(s => (s, CandleType));
 		}
 
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_prices.Clear();
+			_ret.Clear();
+			_fscore.Clear();
+			_w.Clear();
+			_latestPrices.Clear();
+			_lastRebalance = default;
+			_q.Clear();
+		}
+
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			if (Universe == null || !Universe.Any())

--- a/API/0374_FXCarry_Trade/FXCarryTradeStrategy.cs
+++ b/API/0374_FXCarry_Trade/FXCarryTradeStrategy.cs
@@ -67,6 +67,16 @@ namespace StockSharp.Samples.Strategies
 		public override IEnumerable<(Security, DataType)> GetWorkingSecurities() =>
 			Universe.Select(s => (s, CandleType));
 
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_weights.Clear();
+			_latestPrices.Clear();
+			_lastDay = default;
+		}
+
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			if (Universe == null || !Universe.Any())

--- a/API/0375_January_Barometer/JanuaryBarometerStrategy.cs
+++ b/API/0375_January_Barometer/JanuaryBarometerStrategy.cs
@@ -76,6 +76,15 @@ namespace StockSharp.Samples.Strategies
 			return new[] { (EquityETF, CandleType) };
 		}
 
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_latestPrices.Clear();
+			_janOpenPrice = default;
+		}
+
 		protected override void OnStarted(DateTimeOffset t)
 		{
 			if (EquityETF == null || CashETF == null)

--- a/API/0376_Lexical_Density_Filings/LexicalDensityFilingsStrategy.cs
+++ b/API/0376_Lexical_Density_Filings/LexicalDensityFilingsStrategy.cs
@@ -87,6 +87,16 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_weights.Clear();
+			_latestPrices.Clear();
+			_lastDay = default;
+		}
+
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);

--- a/API/0377_Low_Volatility_Stocks/LowVolatilityStocksStrategy.cs
+++ b/API/0377_Low_Volatility_Stocks/LowVolatilityStocksStrategy.cs
@@ -105,7 +105,18 @@ namespace StockSharp.Samples.Strategies
 				}
 
 				/// <inheritdoc />
-				protected override void OnStarted(DateTimeOffset t)
+				
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_ret.Clear();
+			_w.Clear();
+			_latestPrices.Clear();
+			_lastDay = default;
+		}
+
+		protected override void OnStarted(DateTimeOffset t)
 				{
 						base.OnStarted(t);
 

--- a/API/0378_Momentum_Asset_Growth/MomentumAssetGrowthStrategy.cs
+++ b/API/0378_Momentum_Asset_Growth/MomentumAssetGrowthStrategy.cs
@@ -133,7 +133,18 @@ namespace StockSharp.Samples.Strategies
 				}
 
 				/// <inheritdoc />
-				protected override void OnStarted(DateTimeOffset t)
+				
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_px.Clear();
+			_w.Clear();
+			_latestPrices.Clear();
+			_last = default;
+		}
+
+		protected override void OnStarted(DateTimeOffset t)
 				{
 						base.OnStarted(t);
 

--- a/API/0379_Momentum_Factor_Stocks/MomentumFactorStocksStrategy.cs
+++ b/API/0379_Momentum_Factor_Stocks/MomentumFactorStocksStrategy.cs
@@ -118,7 +118,18 @@ namespace StockSharp.Samples.Strategies
 				}
 
 				/// <inheritdoc />
-				protected override void OnStarted(DateTimeOffset t)
+				
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_px.Clear();
+			_latestPrices.Clear();
+			_last = default;
+			_w.Clear();
+		}
+
+		protected override void OnStarted(DateTimeOffset t)
 				{
 						base.OnStarted(t);
 

--- a/API/0380_Momentum_Rev_Vol/MomentumRevVolStrategy.cs
+++ b/API/0380_Momentum_Rev_Vol/MomentumRevVolStrategy.cs
@@ -143,6 +143,17 @@ namespace StockSharp.Samples.Strategies
 		public override IEnumerable<(Security, DataType)> GetWorkingSecurities() =>
 			Universe.Select(s => (s, CandleType));
 
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_map.Clear();
+			_latestPrices.Clear();
+			_lastDay = default;
+			_w.Clear();
+		}
+
 		protected override void OnStarted(DateTimeOffset t)
 		{
 			base.OnStarted(t);

--- a/API/0381_Momentum_Style_Rotation/MomentumStyleRotationStrategy.cs
+++ b/API/0381_Momentum_Style_Rotation/MomentumStyleRotationStrategy.cs
@@ -86,6 +86,16 @@ namespace StockSharp.Samples.Strategies
 				yield return (Security, CandleType);
 		}
 
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_px.Clear();
+			_latestPrices.Clear();
+			_lastDay = default;
+		}
+
 		protected override void OnStarted(DateTimeOffset t)
 		{
 			base.OnStarted(t);

--- a/API/0382_Month12Cycle/Month12CycleStrategy.cs
+++ b/API/0382_Month12Cycle/Month12CycleStrategy.cs
@@ -109,6 +109,18 @@ namespace StockSharp.Samples.Strategies
 			return Universe.Select(s => (s, CandleType));
 		}
 
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_monthCloses.Clear();
+			_cap.Clear();
+			_latestPrices.Clear();
+			_targetWeights.Clear();
+			_data.Clear();
+		}
+
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);

--- a/API/0383_Mutual_Fund_Momentum/MutualFundMomentumStrategy.cs
+++ b/API/0383_Mutual_Fund_Momentum/MutualFundMomentumStrategy.cs
@@ -62,6 +62,15 @@ namespace StockSharp.Samples.Strategies
 		public override IEnumerable<(Security, DataType)> GetWorkingSecurities() =>
 			Funds.Select(f => (f, CandleType));
 
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_latestPrices.Clear();
+			_lastDay = default;
+		}
+
 		protected override void OnStarted(DateTimeOffset t)
 		{
 			base.OnStarted(t);

--- a/API/0384_Option_Expiration_Week/OptionExpirationWeekStrategy.cs
+++ b/API/0384_Option_Expiration_Week/OptionExpirationWeekStrategy.cs
@@ -55,6 +55,14 @@ namespace StockSharp.Samples.Strategies
 			return new[] { (Security, CandleType) };
 		}
 
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_latestPrices.Clear();
+		}
+
 		protected override void OnStarted(DateTimeOffset t)
 		{
 			base.OnStarted(t);

--- a/API/0385_Overnight_Sentiment_Anomaly/OvernightSentimentAnomalyStrategy.cs
+++ b/API/0385_Overnight_Sentiment_Anomaly/OvernightSentimentAnomalyStrategy.cs
@@ -96,6 +96,14 @@ namespace StockSharp.Samples.Strategies
 			yield return (EquityETF, CandleType);
 		}
 
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_latestPrices.Clear();
+		}
+
 		protected override void OnStarted(DateTimeOffset t)
 		{
 			base.OnStarted(t);

--- a/API/0386_Paired_Switching/PairedSwitchingStrategy.cs
+++ b/API/0386_Paired_Switching/PairedSwitchingStrategy.cs
@@ -86,6 +86,17 @@ namespace StockSharp.Samples.Strategies
 		public override IEnumerable<(Security, DataType)> GetWorkingSecurities() =>
 			new[] { (FirstETF, CandleType), (SecondETF, CandleType) };
 
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_p1.Clear();
+			_p2.Clear();
+			_latestPrices.Clear();
+			_last = default;
+		}
+
 		protected override void OnStarted(DateTimeOffset t)
 		{
 			if (FirstETF == null || SecondETF == null)

--- a/API/0387_Pairs_Trading_Country_ETFs/PairsTradingCountryETFsStrategy.cs
+++ b/API/0387_Pairs_Trading_Country_ETFs/PairsTradingCountryETFsStrategy.cs
@@ -123,6 +123,17 @@ namespace StockSharp.Samples.Strategies
 			yield return (_b, CandleType);
 		}
 
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_a = _b = null;
+			_ratio.Clear();
+			_latestPrices.Clear();
+			_last = default;
+		}
+
 		protected override void OnStarted(DateTimeOffset t)
 		{
 			if (Universe == null || Universe.Count() != 2)

--- a/API/0388_Pairs_Trading_Stocks/PairsTradingStocksStrategy.cs
+++ b/API/0388_Pairs_Trading_Stocks/PairsTradingStocksStrategy.cs
@@ -113,6 +113,15 @@ namespace StockSharp.Samples.Strategies
 			{ yield return (a, CandleType); yield return (b, CandleType); }
 		}
 
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_hist.Clear();
+			_latestPrices.Clear();
+		}
+
 		protected override void OnStarted(DateTimeOffset t)
 		{
 			if (Pairs == null || !Pairs.Any())

--- a/API/0389_Payday_Anomaly/PaydayAnomalyStrategy.cs
+++ b/API/0389_Payday_Anomaly/PaydayAnomalyStrategy.cs
@@ -61,6 +61,15 @@ namespace StockSharp.Samples.Strategies
 			yield return (Security, CandleType);
 		}
 
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_latestPrices.Clear();
+			_last = default;
+		}
+
 		protected override void OnStarted(DateTimeOffset t)
 		{
 			if (Security == null)

--- a/API/0390_RDExpenditures/RDExpendituresStrategy.cs
+++ b/API/0390_RDExpenditures/RDExpendituresStrategy.cs
@@ -82,6 +82,16 @@ namespace StockSharp.Samples.Strategies
 
 		public override IEnumerable<(Security, DataType)> GetWorkingSecurities() => Universe.Select(s => (s, CandleType));
 
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_w.Clear();
+			_latestPrices.Clear();
+			_last = default;
+		}
+
 		protected override void OnStarted(DateTimeOffset t)
 		{
 			if (Universe == null || !Universe.Any())

--- a/API/0391_Residual_Momentum_Factor/ResidualMomentumFactorStrategy.cs
+++ b/API/0391_Residual_Momentum_Factor/ResidualMomentumFactorStrategy.cs
@@ -91,6 +91,16 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_w.Clear();
+			_latestPrices.Clear();
+			_last = default;
+		}
+
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);

--- a/API/0392_Return_Asymmetry_Commodity/ReturnAsymmetryCommodityStrategy.cs
+++ b/API/0392_Return_Asymmetry_Commodity/ReturnAsymmetryCommodityStrategy.cs
@@ -117,6 +117,17 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_map.Clear();
+			_latestPrices.Clear();
+			_lastDay = default;
+			_w.Clear();
+		}
+
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);

--- a/API/0393_ROAEffect_Stocks/ROAEffectStocksStrategy.cs
+++ b/API/0393_ROAEffect_Stocks/ROAEffectStocksStrategy.cs
@@ -89,6 +89,16 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_w.Clear();
+			_latestPrices.Clear();
+			_last = default;
+		}
+
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);

--- a/API/0394_Sector_Momentum_Rotation/SectorMomentumRotationStrategy.cs
+++ b/API/0394_Sector_Momentum_Rotation/SectorMomentumRotationStrategy.cs
@@ -90,6 +90,16 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_px.Clear();
+			_latestPrices.Clear();
+			_last = default;
+		}
+
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);

--- a/API/0395_Short_Interest_Effect/ShortInterestEffectStrategy.cs
+++ b/API/0395_Short_Interest_Effect/ShortInterestEffectStrategy.cs
@@ -90,6 +90,16 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_w.Clear();
+			_latestPrices.Clear();
+			_last = default;
+		}
+
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);

--- a/API/0396_Short_Term_Reversal_Futures/ShortTermReversalFuturesStrategy.cs
+++ b/API/0396_Short_Term_Reversal_Futures/ShortTermReversalFuturesStrategy.cs
@@ -86,6 +86,17 @@ namespace StockSharp.Samples.Strategies
 
 		public override IEnumerable<(Security, DataType)> GetWorkingSecurities() => Universe.Select(s => (s, CandleType));
 
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_px.Clear();
+			_w.Clear();
+			_latestPrices.Clear();
+			_last = default;
+		}
+
 		protected override void OnStarted(DateTimeOffset t)
 		{
 			base.OnStarted(t);

--- a/API/0397_Short_Term_Reversal_Stocks/ShortTermReversalStocksStrategy.cs
+++ b/API/0397_Short_Term_Reversal_Stocks/ShortTermReversalStocksStrategy.cs
@@ -86,6 +86,17 @@ namespace StockSharp.Samples.Strategies
 
 		public override IEnumerable<(Security, DataType)> GetWorkingSecurities() => Universe.Select(s => (s, CandleType));
 
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_px.Clear();
+			_w.Clear();
+			_latestPrices.Clear();
+			_last = default;
+		}
+
 		protected override void OnStarted(DateTimeOffset t)
 		{
 			base.OnStarted(t);

--- a/API/0398_Skewness_Commodity/SkewnessCommodityStrategy.cs
+++ b/API/0398_Skewness_Commodity/SkewnessCommodityStrategy.cs
@@ -110,6 +110,17 @@ namespace StockSharp.Samples.Strategies
 		public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities() =>
 			Futures.Select(f => (f, CandleType));
 
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_px.Clear();
+			_latestPrices.Clear();
+			_lastProcessed = default;
+			_weight.Clear();
+		}
+
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);

--- a/API/0399_Small_Cap_Premium/SmallCapPremiumStrategy.cs
+++ b/API/0399_Small_Cap_Premium/SmallCapPremiumStrategy.cs
@@ -91,6 +91,16 @@ namespace StockSharp.Samples.Strategies
 		public override IEnumerable<(Security, DataType)> GetWorkingSecurities() =>
 			Universe.Select(s => (s, CandleType));
 
+		
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_weights.Clear();
+			_latestPrices.Clear();
+			_lastDay = default;
+		}
+
 		protected override void OnStarted(DateTimeOffset t)
 		{
 			base.OnStarted(t);

--- a/API/0400_Smart_Factors_Momentum_Market/SmartFactorsMomentumMarketStrategy.cs
+++ b/API/0400_Smart_Factors_Momentum_Market/SmartFactorsMomentumMarketStrategy.cs
@@ -128,6 +128,19 @@ namespace StockSharp.Samples.Strategies
 			return Factors.Values.Append(Security).Select(s => (s, CandleType));
 		}
 
+		
+		protected override void OnReseted()
+			{
+			base.OnReseted();
+				
+				_p.Clear();
+				_latestPrices.Clear();
+				_smartRet.Clear();
+				_mktRet.Clear();
+				_lastRebalanceDate = default;
+				_q.Clear();
+		}
+
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);


### PR DESCRIPTION
## Summary
- move state cleanup from `OnStarted` to `OnReseted` for strategies 351-400 in API

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689253c340c08323a36dad8b4c3883e6