### PR TITLE
Move strategy state reset to OnReseted

### DIFF
--- a/API/0301_Adaptive_EMA_Breakout/CS/AdaptiveEmaBreakoutStrategy.cs
+++ b/API/0301_Adaptive_EMA_Breakout/CS/AdaptiveEmaBreakoutStrategy.cs
@@ -73,37 +73,46 @@ namespace StockSharp.Samples.Strategies
 		public AdaptiveEmaBreakoutStrategy()
 		{
 			_fast = Param(nameof(Fast), 2)
-				.SetGreaterThanZero()
-				.SetDisplay("Fast period", "Fast (EMA) period for calculating KAMA", "KAMA Settings")
-				.SetCanOptimize(true)
-				.SetOptimize(2, 10, 1);
+			.SetGreaterThanZero()
+			.SetDisplay("Fast period", "Fast (EMA) period for calculating KAMA", "KAMA Settings")
+			.SetCanOptimize(true)
+			.SetOptimize(2, 10, 1);
 
 			_slow = Param(nameof(Slow), 30)
-				.SetGreaterThanZero()
-				.SetDisplay("Slow period", "Slow (EMA) period for calculating KAMA", "KAMA Settings")
-				.SetCanOptimize(true)
-				.SetOptimize(20, 40, 5);
+			.SetGreaterThanZero()
+			.SetDisplay("Slow period", "Slow (EMA) period for calculating KAMA", "KAMA Settings")
+			.SetCanOptimize(true)
+			.SetOptimize(20, 40, 5);
 
 			_lookback = Param(nameof(Lookback), 10)
-				.SetGreaterThanZero()
-				.SetDisplay("Lookback", "Main period for calculating KAMA", "KAMA Settings")
-				.SetCanOptimize(true)
-				.SetOptimize(5, 20, 5);
+			.SetGreaterThanZero()
+			.SetDisplay("Lookback", "Main period for calculating KAMA", "KAMA Settings")
+			.SetCanOptimize(true)
+			.SetOptimize(5, 20, 5);
 
 			_stopMultiplier = Param(nameof(StopMultiplier), 2m)
-				.SetGreaterThanZero()
-				.SetDisplay("Stop ATR multiplier", "ATR multiplier for stop-loss", "Strategy Settings")
-				.SetCanOptimize(true)
-				.SetOptimize(1.0m, 3.0m, 0.5m);
+			.SetGreaterThanZero()
+			.SetDisplay("Stop ATR multiplier", "ATR multiplier for stop-loss", "Strategy Settings")
+			.SetCanOptimize(true)
+			.SetOptimize(1.0m, 3.0m, 0.5m);
 
 			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
-				.SetDisplay("Candle type", "Type of candles for strategy", "General");
+			.SetDisplay("Candle type", "Type of candles for strategy", "General");
 		}
 
 		/// <inheritdoc />
 		public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
 		{
 			return [(Security, CandleType)];
+		}
+
+		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_isFirstCandle = true;
+			_prevAdaptiveEmaValue = default;
 		}
 
 		/// <inheritdoc />
@@ -115,23 +124,20 @@ namespace StockSharp.Samples.Strategies
 			var adaptiveEma = new KaufmanAdaptiveMovingAverage { Length = Lookback, FastSCPeriod = Fast, SlowSCPeriod = Slow };
 			var atr = new AverageTrueRange { Length = 14 };
 
-			// Reset state variables
-			_isFirstCandle = true;
-			_prevAdaptiveEmaValue = 0;
 
 			// Create subscription
 			var subscription = SubscribeCandles(CandleType);
-			
+
 			// Bind indicators to subscription
 			subscription
-				.Bind(adaptiveEma, atr, ProcessCandle)
-				.Start();
+			.Bind(adaptiveEma, atr, ProcessCandle)
+			.Start();
 
 			// Enable position protection
 			StartProtection(
-				takeProfit: new Unit(0), // We'll handle exits in the strategy logic
-				stopLoss: new Unit(0),   // We'll handle stops in the strategy logic
-				useMarketOrders: true
+			takeProfit: new Unit(0), // We'll handle exits in the strategy logic
+			stopLoss: new Unit(0),   // We'll handle stops in the strategy logic
+			useMarketOrders: true
 			);
 
 			// Setup chart if available
@@ -148,11 +154,11 @@ namespace StockSharp.Samples.Strategies
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)
-				return;
+			return;
 
 			// Check if strategy is ready to trade
 			if (!IsFormedAndOnlineAndAllowTrading())
-				return;
+			return;
 
 			// Initialize values on first candle
 			if (_isFirstCandle)
@@ -164,11 +170,11 @@ namespace StockSharp.Samples.Strategies
 
 			// Calculate trend direction
 			var adaptiveEmaTrendUp = adaptiveEmaValue > _prevAdaptiveEmaValue;
-			
+
 			// Define entry conditions
 			var longEntryCondition = candle.ClosePrice > adaptiveEmaValue && adaptiveEmaTrendUp && Position <= 0;
 			var shortEntryCondition = candle.ClosePrice < adaptiveEmaValue && !adaptiveEmaTrendUp && Position >= 0;
-			
+
 			// Define exit conditions
 			var longExitCondition = candle.ClosePrice < adaptiveEmaValue && Position > 0;
 			var shortExitCondition = candle.ClosePrice > adaptiveEmaValue && Position < 0;
@@ -178,26 +184,26 @@ namespace StockSharp.Samples.Strategies
 			{
 				// Calculate position size
 				var positionSize = Volume + Math.Abs(Position);
-				
+
 				// Calculate stop loss level
 				var stopPrice = candle.ClosePrice - atrValue * StopMultiplier;
-				
+
 				// Enter long position
 				BuyMarket(positionSize);
-				
+
 				LogInfo($"Long entry: Price={candle.ClosePrice}, KAMA={adaptiveEmaValue}, ATR={atrValue}, Stop={stopPrice}");
 			}
 			else if (shortEntryCondition)
 			{
 				// Calculate position size
 				var positionSize = Volume + Math.Abs(Position);
-				
+
 				// Calculate stop loss level
 				var stopPrice = candle.ClosePrice + atrValue * StopMultiplier;
-				
+
 				// Enter short position
 				SellMarket(positionSize);
-				
+
 				LogInfo($"Short entry: Price={candle.ClosePrice}, KAMA={adaptiveEmaValue}, ATR={atrValue}, Stop={stopPrice}");
 			}
 			else if (longExitCondition)

--- a/API/0301_Adaptive_EMA_Breakout/PY/adaptive_ema_breakout_strategy.py
+++ b/API/0301_Adaptive_EMA_Breakout/PY/adaptive_ema_breakout_strategy.py
@@ -50,8 +50,6 @@ class adaptive_ema_breakout_strategy(Strategy):
             .SetDisplay("Candle type", "Type of candles for strategy", "General")
 
         # Internal state variables
-        self._prevAdaptiveEmaValue = 0.0
-        self._isFirstCandle = True
 
     @property
     def Fast(self):
@@ -98,6 +96,11 @@ class adaptive_ema_breakout_strategy(Strategy):
     def CandleType(self, value):
         self._candleType.Value = value
 
+    def OnReseted(self):
+        super(adaptive_ema_breakout_strategy, self).OnReseted()
+        self._isFirstCandle = True
+        self._prevAdaptiveEmaValue = 0.0
+
     def OnStarted(self, time):
         super(adaptive_ema_breakout_strategy, self).OnStarted(time)
 
@@ -109,9 +112,6 @@ class adaptive_ema_breakout_strategy(Strategy):
         atr = AverageTrueRange()
         atr.Length = 14
 
-        # Reset state variables
-        self._isFirstCandle = True
-        self._prevAdaptiveEmaValue = 0.0
 
         # Create subscription
         subscription = self.SubscribeCandles(self.CandleType)

--- a/API/0319_Bollinger_K-Means_Cluster/CS/BollingerKMeansStrategy.cs
+++ b/API/0319_Bollinger_K-Means_Cluster/CS/BollingerKMeansStrategy.cs
@@ -25,10 +25,10 @@ namespace StockSharp.Samples.Strategies
 		private readonly StrategyParam<decimal> _bollingerDeviation;
 		private readonly StrategyParam<DataType> _candleType;
 		private readonly StrategyParam<int> _kMeansHistoryLength;
-		
+
 		private BollingerBands _bollinger;
 		private decimal _atrValue;
-		
+
 		// Cluster state tracking
 		private enum ClusterState
 		{
@@ -36,12 +36,12 @@ namespace StockSharp.Samples.Strategies
 			Neutral,
 			Overbought
 		}
-		
+
 		private ClusterState _currentClusterState = ClusterState.Neutral;
 		private readonly SynchronizedList<decimal> _rsiValues = [];
 		private readonly SynchronizedList<decimal> _priceValues = [];
 		private readonly SynchronizedList<decimal> _volumeValues = [];
-		
+
 		private RelativeStrengthIndex _rsi;
 		private AverageTrueRange _atr;
 
@@ -71,7 +71,7 @@ namespace StockSharp.Samples.Strategies
 			get => _candleType.Value;
 			set => _candleType.Value = value;
 		}
-		
+
 		/// <summary>
 		/// Length of history for K-Means clustering.
 		/// </summary>
@@ -87,22 +87,22 @@ namespace StockSharp.Samples.Strategies
 		public BollingerKMeansStrategy()
 		{
 			_bollingerLength = Param(nameof(BollingerLength), 20)
-				.SetDisplay("Bollinger Length", "Length of the Bollinger Bands indicator", "Indicators")
-				.SetCanOptimize(true)
-				.SetOptimize(10, 50, 5);
+			.SetDisplay("Bollinger Length", "Length of the Bollinger Bands indicator", "Indicators")
+			.SetCanOptimize(true)
+			.SetOptimize(10, 50, 5);
 
 			_bollingerDeviation = Param(nameof(BollingerDeviation), 2.0m)
-				.SetDisplay("Bollinger Deviation", "Standard deviation multiplier for Bollinger Bands", "Indicators")
-				.SetCanOptimize(true)
-				.SetOptimize(1.0m, 3.0m, 0.5m);
+			.SetDisplay("Bollinger Deviation", "Standard deviation multiplier for Bollinger Bands", "Indicators")
+			.SetCanOptimize(true)
+			.SetOptimize(1.0m, 3.0m, 0.5m);
 
 			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
-				.SetDisplay("Candle Type", "Type of candles to use", "General");
-				
+			.SetDisplay("Candle Type", "Type of candles to use", "General");
+
 			_kMeansHistoryLength = Param(nameof(KMeansHistoryLength), 50)
-				.SetDisplay("K-Means History Length", "Length of history for K-Means clustering", "Clustering")
-				.SetCanOptimize(true)
-				.SetOptimize(30, 100, 10);
+			.SetDisplay("K-Means History Length", "Length of history for K-Means clustering", "Clustering")
+			.SetCanOptimize(true)
+			.SetOptimize(30, 100, 10);
 		}
 
 		/// <inheritdoc />
@@ -112,15 +112,21 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
+			base.OnReseted();
 
 			_atrValue = default;
 			_currentClusterState = ClusterState.Neutral;
 			_rsiValues.Clear();
 			_priceValues.Clear();
 			_volumeValues.Clear();
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Create indicators
 			_bollinger = new BollingerBands
@@ -128,12 +134,12 @@ namespace StockSharp.Samples.Strategies
 				Length = BollingerLength,
 				Width = BollingerDeviation
 			};
-			
+
 			_rsi = new RelativeStrengthIndex
 			{
 				Length = 14
 			};
-			
+
 			_atr = new AverageTrueRange
 			{
 				Length = 14
@@ -141,14 +147,14 @@ namespace StockSharp.Samples.Strategies
 
 			// Create and initialize subscription
 			var subscription = SubscribeCandles(CandleType);
-			
+
 			subscription
-				.BindEx(
-					_bollinger, 
-					_rsi,
-					_atr,
-					ProcessCandle)
-				.Start();
+			.BindEx(
+			_bollinger, 
+			_rsi,
+			_atr,
+			ProcessCandle)
+			.Start();
 
 			// Setup chart visualization if available
 			var area = CreateChartArea();
@@ -158,23 +164,23 @@ namespace StockSharp.Samples.Strategies
 				DrawIndicator(area, _bollinger);
 				DrawOwnTrades(area);
 			}
-			
+
 			// Setup position protection
 			StartProtection(
-				new Unit(2, UnitTypes.Percent), 
-				new Unit(2, UnitTypes.Percent)
+			new Unit(2, UnitTypes.Percent), 
+			new Unit(2, UnitTypes.Percent)
 			);
 		}
-		
+
 		private void ProcessCandle(ICandleMessage candle, IIndicatorValue bollingerValue, IIndicatorValue rsiValue, IIndicatorValue atrValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)
-				return;
+			return;
 
 			// Check if strategy is ready to trade
 			if (!IsFormedAndOnlineAndAllowTrading())
-				return;
+			return;
 
 			var bollingerTyped = (BollingerBandsValue)bollingerValue;
 
@@ -185,13 +191,13 @@ namespace StockSharp.Samples.Strategies
 
 			var rsi = rsiValue.ToDecimal();
 			_atrValue = atrValue.ToDecimal();
-			
+
 			// Update data for clustering
 			UpdateClusterData(candle, rsi);
-			
+
 			// Calculate K-Means clusters and determine market state
 			CalculateClusters();
-			
+
 			// Trading logic
 			if (candle.ClosePrice < bollingerLower && _currentClusterState == ClusterState.Oversold && Position <= 0)
 			{
@@ -218,14 +224,14 @@ namespace StockSharp.Samples.Strategies
 				LogInfo($"Exit Short: Price returned to middle band ({bollingerMiddle:F2})");
 			}
 		}
-		
+
 		private void UpdateClusterData(ICandleMessage candle, decimal rsi)
 		{
 			// Add current values to the data series
 			_priceValues.Add(candle.ClosePrice);
 			_rsiValues.Add(rsi);
 			_volumeValues.Add(candle.TotalVolume);
-			
+
 			// Maintain the desired history length
 			while (_priceValues.Count > KMeansHistoryLength)
 			{
@@ -234,28 +240,28 @@ namespace StockSharp.Samples.Strategies
 				_volumeValues.RemoveAt(0);
 			}
 		}
-		
+
 		private void CalculateClusters()
 		{
 			// Only perform clustering when we have enough data
 			if (_priceValues.Count < KMeansHistoryLength)
-				return;
-				
+			return;
+
 			// Normalize the data (simple min-max normalization)
 			var normalizedRsi = _rsiValues.Last() / 100m;  // RSI is already 0-100
-			
+
 			// Find min/max for price normalization
 			decimal? minPrice = null;
 			decimal? maxPrice = null;
-			
+
 			foreach (var price in _priceValues)
 			{
 				if (minPrice == null || price < minPrice.Value)
-					minPrice = price;
+				minPrice = price;
 				if (maxPrice == null || price > maxPrice.Value)
-					maxPrice = price;
+				maxPrice = price;
 			}
-			
+
 			// Normalize the last price
 			decimal normalizedPrice = 0.5m;
 			if (minPrice.HasValue && maxPrice.HasValue && maxPrice.Value != minPrice.Value)
@@ -263,12 +269,12 @@ namespace StockSharp.Samples.Strategies
 				var priceRange = maxPrice.Value - minPrice.Value;
 				normalizedPrice = (_priceValues.Last() - minPrice.Value) / priceRange;
 			}
-			
+
 			// Simple rules-based clustering (simplified K-means approximation)
 			// Oversold: Low RSI (< 30) and price near bottom of range
 			// Overbought: High RSI (> 70) and price near top of range
 			// Neutral: Everything else
-			
+
 			if (normalizedRsi < 0.3m && normalizedPrice < 0.3m)
 			{
 				_currentClusterState = ClusterState.Oversold;
@@ -281,7 +287,7 @@ namespace StockSharp.Samples.Strategies
 			{
 				_currentClusterState = ClusterState.Neutral;
 			}
-			
+
 			LogInfo($"Cluster State: {_currentClusterState}, Normalized RSI: {normalizedRsi:F2}, Normalized Price: {normalizedPrice:F2}");
 		}
 	}

--- a/API/0319_Bollinger_K-Means_Cluster/PY/bollinger_kmeans_strategy.py
+++ b/API/0319_Bollinger_K-Means_Cluster/PY/bollinger_kmeans_strategy.py
@@ -101,15 +101,17 @@ class bollinger_kmeans_strategy(Strategy):
     def KMeansHistoryLength(self, value):
         self._kmeans_history_length.Value = value
 
-    def OnStarted(self, time):
-        """Initialize indicators, subscription and charting."""
-        super(bollinger_kmeans_strategy, self).OnStarted(time)
-
+    def OnReseted(self):
+        super(bollinger_kmeans_strategy, self).OnReseted()
         self._atr_value = 0.0
         self._current_cluster_state = ClusterState.Neutral
         self._rsi_values.clear()
         self._price_values.clear()
         self._volume_values.clear()
+
+    def OnStarted(self, time):
+        """Initialize indicators, subscription and charting."""
+        super(bollinger_kmeans_strategy, self).OnStarted(time)
 
         # Create indicators
         self._bollinger = BollingerBands()

--- a/API/0320_MACD_Hidden_Markov_Model/PY/macd_hidden_markov_model_strategy.py
+++ b/API/0320_MACD_Hidden_Markov_Model/PY/macd_hidden_markov_model_strategy.py
@@ -103,13 +103,15 @@ class macd_hidden_markov_model_strategy(Strategy):
     def GetWorkingSecurities(self):
         return [(self.Security, self.CandleType)]
 
-    def OnStarted(self, time):
-        super(macd_hidden_markov_model_strategy, self).OnStarted(time)
-
+    def OnReseted(self):
+        super(macd_hidden_markov_model_strategy, self).OnReseted()
         self._current_state = self.MarketState.Neutral
         self._prev_price = 0
         self._price_changes = []
         self._volumes = []
+
+    def OnStarted(self, time):
+        super(macd_hidden_markov_model_strategy, self).OnStarted(time)
 
         # Create MACD indicator
         self._macd = MovingAverageConvergenceDivergenceSignal()

--- a/API/0321_Ichimoku_Hurst_Exponent/CS/IchimokuHurstStrategy.cs
+++ b/API/0321_Ichimoku_Hurst_Exponent/CS/IchimokuHurstStrategy.cs
@@ -24,9 +24,9 @@ namespace StockSharp.Samples.Strategies
 		private readonly StrategyParam<int> _hurstPeriod;
 		private readonly StrategyParam<decimal> _hurstThreshold;
 		private readonly StrategyParam<DataType> _candleType;
-		
+
 		private Ichimoku _ichimoku;
-		
+
 		// Data for Hurst exponent calculations
 		private readonly SynchronizedList<decimal> _prices = [];
 		private decimal _hurstExponent;
@@ -91,32 +91,32 @@ namespace StockSharp.Samples.Strategies
 		public IchimokuHurstStrategy()
 		{
 			_tenkanPeriod = Param(nameof(TenkanPeriod), 9)
-				.SetDisplay("Tenkan Period", "Tenkan-sen (conversion line) period", "Ichimoku")
-				.SetCanOptimize(true)
-				.SetOptimize(5, 15, 1);
+			.SetDisplay("Tenkan Period", "Tenkan-sen (conversion line) period", "Ichimoku")
+			.SetCanOptimize(true)
+			.SetOptimize(5, 15, 1);
 
 			_kijunPeriod = Param(nameof(KijunPeriod), 26)
-				.SetDisplay("Kijun Period", "Kijun-sen (base line) period", "Ichimoku")
-				.SetCanOptimize(true)
-				.SetOptimize(20, 40, 2);
+			.SetDisplay("Kijun Period", "Kijun-sen (base line) period", "Ichimoku")
+			.SetCanOptimize(true)
+			.SetOptimize(20, 40, 2);
 
 			_senkouSpanBPeriod = Param(nameof(SenkouSpanBPeriod), 52)
-				.SetDisplay("Senkou Span B Period", "Senkou Span B (leading span B) period", "Ichimoku")
-				.SetCanOptimize(true)
-				.SetOptimize(40, 70, 5);
-				
+			.SetDisplay("Senkou Span B Period", "Senkou Span B (leading span B) period", "Ichimoku")
+			.SetCanOptimize(true)
+			.SetOptimize(40, 70, 5);
+
 			_hurstPeriod = Param(nameof(HurstPeriod), 100)
-				.SetDisplay("Hurst Period", "Hurst exponent calculation period", "Hurst Exponent")
-				.SetCanOptimize(true)
-				.SetOptimize(50, 200, 10);
-				
+			.SetDisplay("Hurst Period", "Hurst exponent calculation period", "Hurst Exponent")
+			.SetCanOptimize(true)
+			.SetOptimize(50, 200, 10);
+
 			_hurstThreshold = Param(nameof(HurstThreshold), 0.5m)
-				.SetDisplay("Hurst Threshold", "Hurst exponent threshold for trend strength", "Hurst Exponent")
-				.SetCanOptimize(true)
-				.SetOptimize(0.45m, 0.6m, 0.05m);
+			.SetDisplay("Hurst Threshold", "Hurst exponent threshold for trend strength", "Hurst Exponent")
+			.SetCanOptimize(true)
+			.SetOptimize(0.45m, 0.6m, 0.05m);
 
 			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
-				.SetDisplay("Candle Type", "Type of candles to use", "General");
+			.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 
 		/// <inheritdoc />
@@ -126,12 +126,18 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
+			base.OnReseted();
 
 			_prices.Clear();
 			_hurstExponent = 0.5m; // Default Hurst exponent value
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Create Ichimoku indicator
 			_ichimoku = new Ichimoku
@@ -143,10 +149,10 @@ namespace StockSharp.Samples.Strategies
 
 			// Create subscription and bind indicator
 			var subscription = SubscribeCandles(CandleType);
-			
+
 			subscription
-				.BindEx(_ichimoku, ProcessCandle)
-				.Start();
+			.BindEx(_ichimoku, ProcessCandle)
+			.Start();
 
 			// Setup chart visualization if available
 			var area = CreateChartArea();
@@ -157,47 +163,47 @@ namespace StockSharp.Samples.Strategies
 				DrawOwnTrades(area);
 			}
 		}
-		
+
 		private void ProcessCandle(ICandleMessage candle, IIndicatorValue ichimokuValue)
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)
-				return;
+			return;
 
 			// Store Ichimoku values
 			var ichimokuTyped = (IchimokuValue)ichimokuValue;
 
 			if (ichimokuTyped.Tenkan is not decimal tenkan)
-				return;
+			return;
 
 			if (ichimokuTyped.Kijun is not decimal kijun)
-				return;
+			return;
 
 			if (ichimokuTyped.SenkouA is not decimal senkouA)
-				return;
+			return;
 
 			if (ichimokuTyped.SenkouB is not decimal senkouB)
-				return;
+			return;
 
 			// Update price data for Hurst exponent calculation
 			_prices.Add(candle.ClosePrice);
-			
+
 			// Keep only the number of prices needed for Hurst calculation
 			while (_prices.Count > HurstPeriod)
-				_prices.RemoveAt(0);
-			
+			_prices.RemoveAt(0);
+
 			// Calculate Hurst exponent when we have enough data
 			if (_prices.Count >= HurstPeriod)
-				CalculateHurstExponent();
-			
+			CalculateHurstExponent();
+
 			// Continue with position checks
 			if (!IsFormedAndOnlineAndAllowTrading())
-				return;
-			
+			return;
+
 			// Check if price is above/below Kumo (cloud)
 			bool isPriceAboveKumo = candle.ClosePrice > Math.Max(senkouA, senkouB);
 			bool isPriceBelowKumo = candle.ClosePrice < Math.Min(senkouA, senkouB);
-			
+
 			// Trading logic
 			// Buy when price is above the cloud, Tenkan > Kijun, and Hurst > threshold (trending market)
 			if (isPriceAboveKumo && tenkan > kijun && _hurstExponent > HurstThreshold && Position <= 0)
@@ -224,54 +230,54 @@ namespace StockSharp.Samples.Strategies
 				LogInfo($"Exit Short: Price {candle.ClosePrice:F2} rose above Kumo");
 			}
 		}
-		
+
 		private void CalculateHurstExponent()
 		{
 			// This is a simplified Hurst exponent calculation using R/S analysis
 			// Note: A full implementation would use multiple time scales
-			
+
 			// Calculate log returns
 			List<decimal> logReturns = [];
 			for (int i = 1; i < _prices.Count; i++)
 			{
 				if (_prices[i-1] != 0)
-					logReturns.Add((decimal)Math.Log((double)(_prices[i] / _prices[i-1])));
+				logReturns.Add((decimal)Math.Log((double)(_prices[i] / _prices[i-1])));
 			}
-			
+
 			if (logReturns.Count < 10)
-				return;
-			
+			return;
+
 			// Calculate mean
 			decimal mean = logReturns.Sum() / logReturns.Count;
-			
+
 			// Calculate cumulative deviation series
 			List<decimal> cumulativeDeviation = [];
 			decimal sum = 0;
-			
+
 			foreach (var logReturn in logReturns)
 			{
 				sum += (logReturn - mean);
 				cumulativeDeviation.Add(sum);
 			}
-			
+
 			// Calculate range (max - min of cumulative deviation)
 			decimal range = cumulativeDeviation.Max() - cumulativeDeviation.Min();
-			
+
 			// Calculate standard deviation
 			decimal sumSquares = logReturns.Sum(x => (x - mean) * (x - mean));
 			decimal stdDev = (decimal)Math.Sqrt((double)(sumSquares / logReturns.Count));
-			
+
 			if (stdDev == 0)
-				return;
-			
+			return;
+
 			// Calculate R/S statistic
 			decimal rs = range / stdDev;
-			
+
 			// Hurst = log(R/S) / log(N)
 			decimal logN = (decimal)Math.Log((double)logReturns.Count);
 			if (logN != 0)
-				_hurstExponent = (decimal)Math.Log((double)rs) / logN;
-				
+			_hurstExponent = (decimal)Math.Log((double)rs) / logN;
+
 			LogInfo($"Calculated Hurst Exponent: {_hurstExponent:F3} (R/S: {rs:F3}, N: {logReturns.Count})");
 		}
 	}

--- a/API/0321_Ichimoku_Hurst_Exponent/PY/ichimoku_hurst_exponent_strategy.py
+++ b/API/0321_Ichimoku_Hurst_Exponent/PY/ichimoku_hurst_exponent_strategy.py
@@ -109,11 +109,13 @@ class ichimoku_hurst_exponent_strategy(Strategy):
         """!! REQUIRED !! Return securities used by the strategy."""
         return [(self.Security, self.CandleType)]
 
-    def OnStarted(self, time):
-        super(ichimoku_hurst_exponent_strategy, self).OnStarted(time)
-
+    def OnReseted(self):
+        super(ichimoku_hurst_exponent_strategy, self).OnReseted()
         self._prices.clear()
         self._hurst_exponent = 0.5  # Default Hurst exponent value
+
+    def OnStarted(self, time):
+        super(ichimoku_hurst_exponent_strategy, self).OnStarted(time)
 
         # Create Ichimoku indicator
         self._ichimoku = Ichimoku()

--- a/API/0322_Supertrend_RSI_Divergence/PY/supertrend_rsi_divergence_strategy.py
+++ b/API/0322_Supertrend_RSI_Divergence/PY/supertrend_rsi_divergence_strategy.py
@@ -90,15 +90,17 @@ class supertrend_rsi_divergence_strategy(Strategy):
     def GetWorkingSecurities(self):
         return [(self.Security, self.CandleType)]
 
-    def OnStarted(self, time):
-        super(supertrend_rsi_divergence_strategy, self).OnStarted(time)
-
+    def OnReseted(self):
+        super(supertrend_rsi_divergence_strategy, self).OnReseted()
         self._prices = []
         self._rsi_values = []
         self._is_long_position = False
         self._is_short_position = False
         self._trend_direction = None
         self._supertrend_value = 0
+
+    def OnStarted(self, time):
+        super(supertrend_rsi_divergence_strategy, self).OnStarted(time)
 
         # Create indicators
         self._supertrend = SuperTrend()

--- a/API/0324_Keltner_Kalman_Filter/CS/KeltnerKalmanStrategy.cs
+++ b/API/0324_Keltner_Kalman_Filter/CS/KeltnerKalmanStrategy.cs
@@ -101,32 +101,32 @@ namespace StockSharp.Samples.Strategies
 		public KeltnerKalmanStrategy()
 		{
 			_emaPeriod = Param(nameof(EmaPeriod), 20)
-				.SetDisplay("EMA Period", "EMA period for Keltner Channel", "Keltner Channel")
-				.SetCanOptimize(true)
-				.SetOptimize(10, 30, 5);
+			.SetDisplay("EMA Period", "EMA period for Keltner Channel", "Keltner Channel")
+			.SetCanOptimize(true)
+			.SetOptimize(10, 30, 5);
 
 			_atrPeriod = Param(nameof(AtrPeriod), 14)
-				.SetDisplay("ATR Period", "ATR period for Keltner Channel", "Keltner Channel")
-				.SetCanOptimize(true)
-				.SetOptimize(10, 20, 2);
+			.SetDisplay("ATR Period", "ATR period for Keltner Channel", "Keltner Channel")
+			.SetCanOptimize(true)
+			.SetOptimize(10, 20, 2);
 
 			_atrMultiplier = Param(nameof(AtrMultiplier), 2.0m)
-				.SetDisplay("ATR Multiplier", "ATR multiplier for Keltner Channel", "Keltner Channel")
-				.SetCanOptimize(true)
-				.SetOptimize(1.5m, 3.0m, 0.5m);
+			.SetDisplay("ATR Multiplier", "ATR multiplier for Keltner Channel", "Keltner Channel")
+			.SetCanOptimize(true)
+			.SetOptimize(1.5m, 3.0m, 0.5m);
 
 			_kalmanProcessNoise = Param(nameof(KalmanProcessNoise), 0.01m)
-				.SetDisplay("Kalman Process Noise (Q)", "Kalman filter process noise parameter", "Kalman Filter")
-				.SetCanOptimize(true)
-				.SetOptimize(0.001m, 0.1m, 0.005m);
+			.SetDisplay("Kalman Process Noise (Q)", "Kalman filter process noise parameter", "Kalman Filter")
+			.SetCanOptimize(true)
+			.SetOptimize(0.001m, 0.1m, 0.005m);
 
 			_kalmanMeasurementNoise = Param(nameof(KalmanMeasurementNoise), 0.1m)
-				.SetDisplay("Kalman Measurement Noise (R)", "Kalman filter measurement noise parameter", "Kalman Filter")
-				.SetCanOptimize(true)
-				.SetOptimize(0.01m, 1.0m, 0.05m);
+			.SetDisplay("Kalman Measurement Noise (R)", "Kalman filter measurement noise parameter", "Kalman Filter")
+			.SetCanOptimize(true)
+			.SetOptimize(0.01m, 1.0m, 0.05m);
 
 			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
-				.SetDisplay("Candle Type", "Type of candles to use", "General");
+			.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 
 		/// <inheritdoc />
@@ -136,11 +136,10 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
+			base.OnReseted();
 
-			// Initialize Kalman filter
 			_kalmanEstimate = 0;
 			_kalmanError = 1;
 			_prices.Clear();
@@ -150,6 +149,11 @@ namespace StockSharp.Samples.Strategies
 			_atrValue = 0;
 			_upperBand = 0;
 			_lowerBand = 0;
+		}
+
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Create indicators
 			_ema = new ExponentialMovingAverage
@@ -166,8 +170,8 @@ namespace StockSharp.Samples.Strategies
 			var subscription = SubscribeCandles(CandleType);
 
 			subscription
-				.Bind(_ema, _atr, ProcessCandle)
-				.Start();
+			.Bind(_ema, _atr, ProcessCandle)
+			.Start();
 
 			// Setup chart visualization if available
 			var area = CreateChartArea();
@@ -180,8 +184,8 @@ namespace StockSharp.Samples.Strategies
 
 			// Setup position protection
 			StartProtection(
-				new Unit(2, UnitTypes.Percent),
-				new Unit(2, UnitTypes.Percent)
+			new Unit(2, UnitTypes.Percent),
+			new Unit(2, UnitTypes.Percent)
 			);
 		}
 
@@ -189,7 +193,7 @@ namespace StockSharp.Samples.Strategies
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)
-				return;
+			return;
 
 			// Save indicator values
 			_emaValue = emaValue;
@@ -205,13 +209,13 @@ namespace StockSharp.Samples.Strategies
 			// Store prices for slope calculation
 			_prices.Add(candle.ClosePrice);
 			if (_prices.Count > 10)
-				_prices.RemoveAt(0);
+			_prices.RemoveAt(0);
 
 			// Calculate Kalman slope (trend direction)
 			decimal kalmanSlope = CalculateKalmanSlope();
 
 			if (!IsFormedAndOnlineAndAllowTrading())
-				return;
+			return;
 
 			// Trading logic
 			// Buy when price is above EMA+k*ATR (upper band) and Kalman filter shows uptrend
@@ -265,7 +269,7 @@ namespace StockSharp.Samples.Strategies
 		{
 			// Need at least a few points to calculate a slope
 			if (_prices.Count < 3)
-				return 0;
+			return 0;
 
 			// Simple linear regression slope calculation
 			int n = _prices.Count;
@@ -288,7 +292,7 @@ namespace StockSharp.Samples.Strategies
 			decimal denominator = n * sumX2 - sumX * sumX;
 
 			if (denominator == 0)
-				return 0;
+			return 0;
 
 			decimal slope = (n * sumXY - sumX * sumY) / denominator;
 			return slope;

--- a/API/0324_Keltner_Kalman_Filter/PY/keltner_kalman_strategy.py
+++ b/API/0324_Keltner_Kalman_Filter/PY/keltner_kalman_strategy.py
@@ -119,10 +119,8 @@ class keltner_kalman_strategy(Strategy):
     def GetWorkingSecurities(self):
         return [(self.Security, self.CandleType)]
 
-    def OnStarted(self, time):
-        super(keltner_kalman_strategy, self).OnStarted(time)
-
-        # Initialize Kalman filter
+    def OnReseted(self):
+        super(keltner_kalman_strategy, self).OnReseted()
         self._kalman_estimate = 0
         self._kalman_error = 1
         self._prices.clear()
@@ -132,6 +130,9 @@ class keltner_kalman_strategy(Strategy):
         self._atr_value = 0
         self._upper_band = 0
         self._lower_band = 0
+
+    def OnStarted(self, time):
+        super(keltner_kalman_strategy, self).OnStarted(time)
 
         # Create indicators
         self._ema = ExponentialMovingAverage()

--- a/API/0325_Hull_MA_Volatility_Contraction/PY/hull_ma_volatility_contraction_strategy.py
+++ b/API/0325_Hull_MA_Volatility_Contraction/PY/hull_ma_volatility_contraction_strategy.py
@@ -87,14 +87,16 @@ class hull_ma_volatility_contraction_strategy(Strategy):
         """Return security and candle type used by the strategy."""
         return [(self.Security, self.CandleType)]
 
-    def OnStarted(self, time):
-        super(hull_ma_volatility_contraction_strategy, self).OnStarted(time)
-
+    def OnReseted(self):
+        super(hull_ma_volatility_contraction_strategy, self).OnReseted()
         self._prev_hma_value = 0.0
         self._current_hma_value = 0.0
         self._is_long_position = False
         self._is_short_position = False
         self._atr_values = []
+
+    def OnStarted(self, time):
+        super(hull_ma_volatility_contraction_strategy, self).OnStarted(time)
 
         # Create indicators
         self._hma = HullMovingAverage()

--- a/API/0326_VWAP_Stochastic_Divergence/PY/vwap_adx_trend_strategy.py
+++ b/API/0326_VWAP_Stochastic_Divergence/PY/vwap_adx_trend_strategy.py
@@ -85,17 +85,19 @@ class vwap_adx_trend_strategy(Strategy):
     def GetWorkingSecurities(self):
         return [(self.Security, self.candle_type)]
 
-    def OnStarted(self, time):
-        super(vwap_adx_trend_strategy, self).OnStarted(time)
-
+    def OnReseted(self):
+        super(vwap_adx_trend_strategy, self).OnReseted()
         self._vwap_value = 0.0
         self._adx_value = 0.0
         self._plus_di_value = 0.0
         self._minus_di_value = 0.0
 
+    def OnStarted(self, time):
+        super(vwap_adx_trend_strategy, self).OnStarted(time)
+
         # Create indicators
         self._vwap = VolumeWeightedMovingAverage()
-
+        
         self._adx = AverageDirectionalIndex()
         self._adx.Length = self.adx_period
 

--- a/API/0329_MACD_Volume_Cluster/PY/macd_volume_cluster_strategy.py
+++ b/API/0329_MACD_Volume_Cluster/PY/macd_volume_cluster_strategy.py
@@ -127,6 +127,12 @@ class macd_volume_cluster_strategy(Strategy):
         self._volume_std_dev = 0
         self._processed_candles = 0
 
+    def OnReseted(self):
+        super(macd_volume_cluster_strategy, self).OnReseted()
+        self._avg_volume = 0
+        self._volume_std_dev = 0
+        self._processed_candles = 0
+
     def OnStarted(self, time):
         """
         Called when the strategy starts. Sets up indicators, subscriptions, and charting.
@@ -134,11 +140,6 @@ class macd_volume_cluster_strategy(Strategy):
         :param time: The time when the strategy started.
         """
         super(macd_volume_cluster_strategy, self).OnStarted(time)
-
-        # Initialize values
-        self._avg_volume = 0
-        self._volume_std_dev = 0
-        self._processed_candles = 0
 
         # Create MACD indicator
         macd = MovingAverageConvergenceDivergenceSignal()

--- a/API/0334_Hull_MA_K-Means_Cluster/PY/hull_kmeans_cluster_strategy.py
+++ b/API/0334_Hull_MA_K-Means_Cluster/PY/hull_kmeans_cluster_strategy.py
@@ -48,7 +48,6 @@ class hull_kmeans_cluster_strategy(Strategy):
         self._volume_ratio_data = Queue[float]()
 
         self._prev_hull_value = 0.0
-        self._current_market_state = self._MarketState.Neutral
         self._last_price = 0.0
         self._avg_volume = 0.0
 
@@ -87,18 +86,20 @@ class hull_kmeans_cluster_strategy(Strategy):
     def GetWorkingSecurities(self):
         return [(self.Security, self.CandleType)]
 
-    def OnStarted(self, time):
-        super(hull_kmeans_cluster_strategy, self).OnStarted(time)
-
-        # Reset state variables
+    def OnReseted(self):
+        super(hull_kmeans_cluster_strategy, self).OnReseted()
         self._prev_hull_value = 0
         self._current_market_state = self._MarketState.Neutral
         self._last_price = 0
         self._avg_volume = 0
-
         self._price_change_data.Clear()
         self._rsi_data.Clear()
         self._volume_ratio_data.Clear()
+
+    def OnStarted(self, time):
+        super(hull_kmeans_cluster_strategy, self).OnStarted(time)
+
+
 
         # Create Hull Moving Average indicator
         hull_ma = HullMovingAverage()

--- a/API/0335_VWAP_Hidden_Markov_Model/CS/VwapHiddenMarkovModelStrategy.cs
+++ b/API/0335_VWAP_Hidden_Markov_Model/CS/VwapHiddenMarkovModelStrategy.cs
@@ -26,11 +26,11 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		private MarketState _currentMarketState = MarketState.Neutral;
-		
+
 		// Feature data for HMM
 		private readonly Queue<decimal> _priceData = [];
 		private readonly Queue<decimal> _volumeData = [];
-		
+
 		// Transition probabilities
 		private readonly decimal[,] _transitionMatrix = new decimal[3, 3]
 		{
@@ -72,15 +72,15 @@ namespace StockSharp.Samples.Strategies
 		public VwapHiddenMarkovModelStrategy()
 		{
 			_hmmDataLength = Param(nameof(HmmDataLength), 100)
-				.SetGreaterThanZero()
-				.SetDisplay("HMM Data Length", "Number of periods to use for HMM", "HMM Settings");
+			.SetGreaterThanZero()
+			.SetDisplay("HMM Data Length", "Number of periods to use for HMM", "HMM Settings");
 
 			_stopLossPercent = Param(nameof(StopLossPercent), 2m)
-				.SetGreaterThanZero()
-				.SetDisplay("Stop Loss %", "Stop Loss percentage from entry price", "Risk Management");
+			.SetGreaterThanZero()
+			.SetDisplay("Stop Loss %", "Stop Loss percentage from entry price", "Risk Management");
 
 			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
-				.SetDisplay("Candle Type", "Type of candles to use", "General");
+			.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 
 		/// <inheritdoc />
@@ -90,14 +90,18 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
+			base.OnReseted();
 
-			// Reset state variables
 			_currentMarketState = MarketState.Neutral;
 			_priceData.Clear();
 			_volumeData.Clear();
+		}
+
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Create Vwap indicator
 			var vwap = new VolumeWeightedMovingAverage();
@@ -107,8 +111,8 @@ namespace StockSharp.Samples.Strategies
 
 			// Bind VWAP indicator to subscription and start
 			subscription
-				.Bind(vwap, ProcessVwap)
-				.Start();
+			.Bind(vwap, ProcessVwap)
+			.Start();
 
 			// Add chart visualization
 			var area = CreateChartArea();
@@ -121,8 +125,8 @@ namespace StockSharp.Samples.Strategies
 
 			// Start position protection with percentage-based stop-loss
 			StartProtection(
-				takeProfit: new Unit(0), // No fixed take profit
-				stopLoss: new Unit(StopLossPercent, UnitTypes.Percent)
+			takeProfit: new Unit(0), // No fixed take profit
+			stopLoss: new Unit(StopLossPercent, UnitTypes.Percent)
 			);
 		}
 
@@ -130,11 +134,11 @@ namespace StockSharp.Samples.Strategies
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)
-				return;
+			return;
 
 			// Check if strategy is ready to trade
 			if (!IsFormedAndOnlineAndAllowTrading())
-				return;
+			return;
 
 			// Update data for HMM
 			UpdateHmmData(candle);
@@ -144,7 +148,7 @@ namespace StockSharp.Samples.Strategies
 			{
 				// Update current market state using HMM
 				_currentMarketState = RunHmm();
-				
+
 				// Log market state updates periodically
 				if (candle.OpenTime.Second == 0 && candle.OpenTime.Minute % 15 == 0)
 				{
@@ -172,25 +176,25 @@ namespace StockSharp.Samples.Strategies
 			// Add price data to queue
 			_priceData.Enqueue(candle.ClosePrice);
 			if (_priceData.Count > HmmDataLength)
-				_priceData.Dequeue();
+			_priceData.Dequeue();
 
 			// Add volume data to queue
 			_volumeData.Enqueue(candle.TotalVolume);
 			if (_volumeData.Count > HmmDataLength)
-				_volumeData.Dequeue();
+			_volumeData.Dequeue();
 		}
 
 		private MarketState RunHmm()
 		{
 			// This is a simplified implementation of Hidden Markov Model
 			// A full implementation would use Baum-Welch algorithm for training and Viterbi algorithm for decoding
-			
+
 			// Convert data to observations
 			var observations = GenerateObservations();
-			
+
 			// Decode the most likely state sequence (simplified Viterbi)
 			var states = SimplifiedViterbi(observations);
-			
+
 			// Return the most recent state
 			return states.Last();
 		}
@@ -200,31 +204,31 @@ namespace StockSharp.Samples.Strategies
 			// Generate observation sequence from price and volume data
 			// This is a simplified approach - in a real implementation, we would
 			// use more sophisticated techniques to generate observations
-			
+
 			var result = new List<int>();
 			var prices = _priceData.ToArray();
 			var volumes = _volumeData.ToArray();
-			
+
 			for (int i = 1; i < prices.Length; i++)
 			{
 				decimal priceChange = (prices[i] - prices[i - 1]) / prices[i - 1];
 				decimal volumeRatio = volumes[i] / Math.Max(1, volumes[i - 1]);
-				
+
 				// Classify observation:
 				// 0: Price down, low volume
 				// 1: Price down, high volume
 				// 2: Price up, low volume
 				// 3: Price up, high volume
-				
+
 				int observation;
 				if (priceChange < 0)
-					observation = volumeRatio > 1.1m ? 1 : 0;
+				observation = volumeRatio > 1.1m ? 1 : 0;
 				else
-					observation = volumeRatio > 1.1m ? 3 : 2;
-				
+				observation = volumeRatio > 1.1m ? 3 : 2;
+
 				result.Add(observation);
 			}
-			
+
 			return result;
 		}
 
@@ -232,7 +236,7 @@ namespace StockSharp.Samples.Strategies
 		{
 			// This is a very simplified version of the Viterbi algorithm
 			// For a real implementation, proper HMM libraries should be used
-			
+
 			// Emission probabilities: P(observation | state)
 			var emissionMatrix = new decimal[3, 4]
 			{
@@ -240,54 +244,54 @@ namespace StockSharp.Samples.Strategies
 				{ 0.1m, 0.1m, 0.3m, 0.5m }, // Bullish -> obs0, obs1, obs2, obs3
 				{ 0.5m, 0.3m, 0.1m, 0.1m }  // Bearish -> obs0, obs1, obs2, obs3
 			};
-			
+
 			// Initialize with equal probabilities for each state
 			var currentStateProbabilities = new decimal[3] { 1m / 3, 1m / 3, 1m / 3 };
 			var stateSequence = new List<MarketState>();
-			
+
 			// Process each observation
 			foreach (var obs in observations)
 			{
 				var newProbabilities = new decimal[3];
-				
+
 				// Calculate new state probabilities based on observation and transition matrix
 				for (int newState = 0; newState < 3; newState++)
 				{
 					decimal totalProb = 0;
-					
+
 					for (int oldState = 0; oldState < 3; oldState++)
 					{
 						totalProb += currentStateProbabilities[oldState] * 
-							_transitionMatrix[oldState, newState] * 
-							emissionMatrix[newState, obs];
+						_transitionMatrix[oldState, newState] * 
+						emissionMatrix[newState, obs];
 					}
-					
+
 					newProbabilities[newState] = totalProb;
 				}
-				
+
 				// Normalize probabilities
 				decimal sum = newProbabilities.Sum();
 				if (sum > 0)
 				{
 					for (int i = 0; i < 3; i++)
-						newProbabilities[i] /= sum;
+					newProbabilities[i] /= sum;
 				}
-				
+
 				// Find most likely state
 				int maxIndex = 0;
 				for (int i = 1; i < 3; i++)
 				{
 					if (newProbabilities[i] > newProbabilities[maxIndex])
-						maxIndex = i;
+					maxIndex = i;
 				}
-				
+
 				// Add state to sequence
 				stateSequence.Add((MarketState)maxIndex);
-				
+
 				// Update current probabilities
 				currentStateProbabilities = newProbabilities;
 			}
-			
+
 			return stateSequence;
 		}
 	}

--- a/API/0335_VWAP_Hidden_Markov_Model/PY/vwap_hidden_markov_model_strategy.py
+++ b/API/0335_VWAP_Hidden_Markov_Model/PY/vwap_hidden_markov_model_strategy.py
@@ -76,17 +76,18 @@ class vwap_hidden_markov_model_strategy(Strategy):
     def GetWorkingSecurities(self):
         return [(self.Security, self.CandleType)]
 
-    def OnStarted(self, time):
-        super(vwap_hidden_markov_model_strategy, self).OnStarted(time)
-
-        # Reset state variables
+    def OnReseted(self):
+        super(vwap_hidden_markov_model_strategy, self).OnReseted()
         self._current_market_state = MarketState.Neutral
         self._price_data.clear()
         self._volume_data.clear()
 
+    def OnStarted(self, time):
+        super(vwap_hidden_markov_model_strategy, self).OnStarted(time)
+
         # Create Vwap indicator
         vwap = VolumeWeightedMovingAverage()
-
+        
         # Create subscription for candles
         subscription = self.SubscribeCandles(self.CandleType)
 

--- a/API/0338_Adaptive_Bollinger_Breakout/CS/AdaptiveBollingerBreakoutStrategy.cs
+++ b/API/0338_Adaptive_Bollinger_Breakout/CS/AdaptiveBollingerBreakoutStrategy.cs
@@ -89,27 +89,27 @@ namespace StockSharp.Samples.Strategies
 		public AdaptiveBollingerBreakoutStrategy()
 		{
 			_minBollingerPeriod = Param(nameof(MinBollingerPeriod), 10)
-				.SetGreaterThanZero()
-				.SetDisplay("Min Bollinger Period", "Minimum period for adaptive Bollinger Bands", "Indicator Settings");
+			.SetGreaterThanZero()
+			.SetDisplay("Min Bollinger Period", "Minimum period for adaptive Bollinger Bands", "Indicator Settings");
 
 			_maxBollingerPeriod = Param(nameof(MaxBollingerPeriod), 30)
-				.SetGreaterThanZero()
-				.SetDisplay("Max Bollinger Period", "Maximum period for adaptive Bollinger Bands", "Indicator Settings");
+			.SetGreaterThanZero()
+			.SetDisplay("Max Bollinger Period", "Maximum period for adaptive Bollinger Bands", "Indicator Settings");
 
 			_minBollingerDeviation = Param(nameof(MinBollingerDeviation), 1.5m)
-				.SetGreaterThanZero()
-				.SetDisplay("Min Bollinger Deviation", "Minimum standard deviation multiplier", "Indicator Settings");
+			.SetGreaterThanZero()
+			.SetDisplay("Min Bollinger Deviation", "Minimum standard deviation multiplier", "Indicator Settings");
 
 			_maxBollingerDeviation = Param(nameof(MaxBollingerDeviation), 2.5m)
-				.SetGreaterThanZero()
-				.SetDisplay("Max Bollinger Deviation", "Maximum standard deviation multiplier", "Indicator Settings");
+			.SetGreaterThanZero()
+			.SetDisplay("Max Bollinger Deviation", "Maximum standard deviation multiplier", "Indicator Settings");
 
 			_atrPeriod = Param(nameof(AtrPeriod), 14)
-				.SetGreaterThanZero()
-				.SetDisplay("ATR Period", "Period for ATR volatility calculation", "Indicator Settings");
+			.SetGreaterThanZero()
+			.SetDisplay("ATR Period", "Period for ATR volatility calculation", "Indicator Settings");
 
 			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
-				.SetDisplay("Candle Type", "Type of candles to use", "General");
+			.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
 
 		/// <inheritdoc />
@@ -119,18 +119,21 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
+			base.OnReseted();
 
-			// Initialize adaptive parameters
 			_currentBollingerPeriod = MaxBollingerPeriod; // Start with maximum period
 			_currentBollingerDeviation = MinBollingerDeviation; // Start with minimum deviation
-
 			_atr = default;
 			_bollinger = default;
 			_atrSum = default;
 			_atrCount = default;
+		}
+
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Create ATR indicator for volatility measurement
 			_atr = new AverageTrueRange
@@ -150,8 +153,8 @@ namespace StockSharp.Samples.Strategies
 
 			// Bind indicators to subscription and start
 			subscription
-				.BindEx(_atr, _bollinger, ProcessIndicators)
-				.Start();
+			.BindEx(_atr, _bollinger, ProcessIndicators)
+			.Start();
 
 			// Add chart visualization
 			var area = CreateChartArea();
@@ -164,8 +167,8 @@ namespace StockSharp.Samples.Strategies
 
 			// Start position protection with ATR-based stop-loss
 			StartProtection(
-				takeProfit: new Unit(0), // No fixed take profit
-				stopLoss: new Unit(2, UnitTypes.Absolute) // 2 ATR stop-loss
+			takeProfit: new Unit(0), // No fixed take profit
+			stopLoss: new Unit(2, UnitTypes.Absolute) // 2 ATR stop-loss
 			);
 		}
 
@@ -173,7 +176,7 @@ namespace StockSharp.Samples.Strategies
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)
-				return;
+			return;
 
 			// --- ATR logic (was ProcessAtr) ---
 			if (atrValue.IsFinal)
@@ -208,7 +211,7 @@ namespace StockSharp.Samples.Strategies
 
 			// --- Bollinger logic (was ProcessBollinger) ---
 			if (!IsFormedAndOnlineAndAllowTrading())
-				return;
+			return;
 
 			if (bollingerValue.IsFinal && _atr.IsFormed)
 			{
@@ -217,10 +220,10 @@ namespace StockSharp.Samples.Strategies
 				bool isHighVolatility = atrVal > (_atrCount > 0 ? _atrSum / _atrCount : atrVal);
 
 				var bollingerTyped = (BollingerBandsValue)bollingerValue;
-				
+
 				if (bollingerTyped.UpBand is not decimal upperBand ||
-					bollingerTyped.LowBand is not decimal lowerBand ||
-					bollingerTyped.MovingAverage is not decimal middleBand)
+				bollingerTyped.LowBand is not decimal lowerBand ||
+				bollingerTyped.MovingAverage is not decimal middleBand)
 				{
 					return; // Not enough data to calculate bands
 				}
@@ -243,7 +246,7 @@ namespace StockSharp.Samples.Strategies
 
 				// Exit logic based on middle band reversion
 				if ((Position > 0 && candle.ClosePrice > middleBand) || 
-					(Position < 0 && candle.ClosePrice < middleBand))
+				(Position < 0 && candle.ClosePrice < middleBand))
 				{
 					LogInfo($"Exit signal: Price ({candle.ClosePrice}) reverted to middle band ({middleBand})");
 					ClosePosition();

--- a/API/0338_Adaptive_Bollinger_Breakout/PY/adaptive_bollinger_breakout_strategy.py
+++ b/API/0338_Adaptive_Bollinger_Breakout/PY/adaptive_bollinger_breakout_strategy.py
@@ -105,17 +105,18 @@ class adaptive_bollinger_breakout_strategy(Strategy):
     def GetWorkingSecurities(self):
         return [(self.Security, self.candle_type)]
 
-    def OnStarted(self, time):
-        super(adaptive_bollinger_breakout_strategy, self).OnStarted(time)
-
+    def OnReseted(self):
+        super(adaptive_bollinger_breakout_strategy, self).OnReseted()
         # Initialize adaptive parameters
         self._current_bollinger_period = self.max_bollinger_period  # Start with maximum period
         self._current_bollinger_deviation = self.min_bollinger_deviation  # Start with minimum deviation
-
         self._atr = None
         self._bollinger = None
         self._atr_sum = 0.0
         self._atr_count = 0
+
+    def OnStarted(self, time):
+        super(adaptive_bollinger_breakout_strategy, self).OnStarted(time)
 
         # Create ATR indicator for volatility measurement
         self._atr = AverageTrueRange()

--- a/API/0339_MACD_Sentiment_Filter/PY/macd_with_sentiment_filter_strategy.py
+++ b/API/0339_MACD_Sentiment_Filter/PY/macd_with_sentiment_filter_strategy.py
@@ -129,20 +129,20 @@ class macd_with_sentiment_filter_strategy(Strategy):
     def candle_type(self, value):
         self._candle_type.Value = value
 
-    def OnStarted(self, time):
-        super(macd_with_sentiment_filter_strategy, self).OnStarted(time)
-
+    def OnReseted(self):
+        super(macd_with_sentiment_filter_strategy, self).OnReseted()
         self._prev_macd = 0.0
         self._prev_signal = 0.0
         self._sentiment_score = 0.0
+
+    def OnStarted(self, time):
+        super(macd_with_sentiment_filter_strategy, self).OnStarted(time)
 
         # Create MACD indicator
         macd = MovingAverageConvergenceDivergenceSignal()
         macd.Macd.ShortMa.Length = self.macd_fast
         macd.Macd.LongMa.Length = self.macd_slow
         macd.SignalMa.Length = self.macd_signal
-        # Initialize sentiment score
-        self._sentiment_score = 0.0
 
         # Subscribe to candles and bind indicator
         subscription = self.SubscribeCandles(self.candle_type)

--- a/API/0340_Ichimoku_Implied_Volatility/PY/ichimoku_implied_volatility_strategy.py
+++ b/API/0340_Ichimoku_Implied_Volatility/PY/ichimoku_implied_volatility_strategy.py
@@ -114,14 +114,16 @@ class ichimoku_implied_volatility_strategy(Strategy):
         """Return the security and candle type this strategy works with."""
         return [(self.Security, self.CandleType)]
 
-    def OnStarted(self, time):
-        super(ichimoku_implied_volatility_strategy, self).OnStarted(time)
-
+    def OnReseted(self):
+        super(ichimoku_implied_volatility_strategy, self).OnReseted()
         self._prev_above_kumo = False
         self._prev_tenkan_above_kijun = False
         self._prev_price = 0.0
         self._avg_implied_volatility = 0.0
         self._implied_volatility_history.clear()
+
+    def OnStarted(self, time):
+        super(ichimoku_implied_volatility_strategy, self).OnStarted(time)
 
         # Create Ichimoku indicator
         ichimoku = Ichimoku()

--- a/API/0341_Supertrend_Put_Call_Ratio/PY/supertrend_put_call_ratio_strategy.py
+++ b/API/0341_Supertrend_Put_Call_Ratio/PY/supertrend_put_call_ratio_strategy.py
@@ -111,16 +111,17 @@ class supertrend_put_call_ratio_strategy(Strategy):
         """!! REQUIRED !! Returns securities for strategy."""
         return [(self.Security, self.CandleType)]
 
-    def OnStarted(self, time):
-        super(supertrend_put_call_ratio_strategy, self).OnStarted(time)
-
-        # Initialize flags
+    def OnReseted(self):
+        super(supertrend_put_call_ratio_strategy, self).OnReseted()
         self._pcrHistory.clear()
         self._isLong = False
         self._isShort = False
         self._currentPcr = 0.0
         self._pcrAverage = 0.0
         self._pcrStdDev = 0.0
+
+    def OnStarted(self, time):
+        super(supertrend_put_call_ratio_strategy, self).OnStarted(time)
 
         # Create Supertrend indicator
         self._supertrend = SuperTrend()

--- a/API/0342_Donchian_Sentiment_Spike/PY/donchian_with_sentiment_spike_strategy.py
+++ b/API/0342_Donchian_Sentiment_Spike/PY/donchian_with_sentiment_spike_strategy.py
@@ -104,9 +104,8 @@ class donchian_with_sentiment_spike_strategy(Strategy):
     def candle_type(self, value):
         self._candle_type.Value = value
 
-    def OnStarted(self, time):
-        super(donchian_with_sentiment_spike_strategy, self).OnStarted(time)
-
+    def OnReseted(self):
+        super(donchian_with_sentiment_spike_strategy, self).OnReseted()
         # Initialize flags
         self._is_long = False
         self._is_short = False
@@ -115,6 +114,9 @@ class donchian_with_sentiment_spike_strategy(Strategy):
         self._sentiment_average = 0.0
         self._sentiment_std_dev = 0.0
         self._current_sentiment = 0.0
+
+    def OnStarted(self, time):
+        super(donchian_with_sentiment_spike_strategy, self).OnStarted(time)
 
         # Create Donchian Channel indicator
         donchian = DonchianChannels()

--- a/API/0343_Keltner_Reinforcement_Learning_Signal/PY/keltner_with_rl_signal_strategy.py
+++ b/API/0343_Keltner_Reinforcement_Learning_Signal/PY/keltner_with_rl_signal_strategy.py
@@ -122,9 +122,8 @@ class keltner_with_rl_signal_strategy(Strategy):
         """!! REQUIRED!! override to return securities used by the strategy."""
         return [(self.Security, self.CandleType)]
 
-    def OnStarted(self, time):
-        super(keltner_with_rl_signal_strategy, self).OnStarted(time)
-
+    def OnReseted(self):
+        super(keltner_with_rl_signal_strategy, self).OnReseted()
         # Initialize RL state variables
         self._current_signal = self._RLSignal.None_
         self._consecutive_wins = 0
@@ -134,6 +133,9 @@ class keltner_with_rl_signal_strategy(Strategy):
         self._previous_atr = 0
         self._previous_price = 0
         self._previous_signal_price = 0
+
+    def OnStarted(self, time):
+        super(keltner_with_rl_signal_strategy, self).OnStarted(time)
 
         # Create Keltner Channels using EMA and ATR
         keltner = KeltnerChannels()

--- a/API/0344_Hull_MA_Implied_Volatility_Breakout/PY/hull_ma_implied_volatility_breakout_strategy.py
+++ b/API/0344_Hull_MA_Implied_Volatility_Breakout/PY/hull_ma_implied_volatility_breakout_strategy.py
@@ -114,9 +114,8 @@ class hull_ma_implied_volatility_breakout_strategy(Strategy):
     def GetWorkingSecurities(self):
         return [(self.Security, self.CandleType)]
 
-    def OnStarted(self, time):
-        super(hull_ma_implied_volatility_breakout_strategy, self).OnStarted(time)
-
+    def OnReseted(self):
+        super(hull_ma_implied_volatility_breakout_strategy, self).OnReseted()
         # Initialize flags
         self._isLong = False
         self._isShort = False
@@ -126,6 +125,9 @@ class hull_ma_implied_volatility_breakout_strategy(Strategy):
         self._ivAverage = 0.0
         self._ivStdDev = 0.0
         self._impliedVolatilityHistory[:] = []
+
+    def OnStarted(self, time):
+        super(hull_ma_implied_volatility_breakout_strategy, self).OnStarted(time)
 
         # Create indicators
         hma = HullMovingAverage()

--- a/API/0345_VWAP_Behavioral_Bias_Filter/CS/VwapWithBehavioralBiasFilterStrategy.cs
+++ b/API/0345_VWAP_Behavioral_Bias_Filter/CS/VwapWithBehavioralBiasFilterStrategy.cs
@@ -25,17 +25,17 @@ namespace StockSharp.Samples.Strategies
 		private readonly StrategyParam<int> _biasWindowSize;
 		private readonly StrategyParam<decimal> _stopLoss;
 		private readonly StrategyParam<DataType> _candleType;
-		
+
 		private VolumeWeightedMovingAverage _vwap;
 		private decimal _currentBiasScore;
-		
+
 		// Tracks recent price movements for bias calculation
 		private readonly Queue<decimal> _recentPriceMovements = [];
-		
+
 		// Flags to track positions
 		private bool _isLong;
 		private bool _isShort;
-		
+
 		/// <summary>
 		/// Behavioral bias threshold for entry signal.
 		/// </summary>
@@ -44,7 +44,7 @@ namespace StockSharp.Samples.Strategies
 			get => _biasThreshold.Value;
 			set => _biasThreshold.Value = value;
 		}
-		
+
 		/// <summary>
 		/// Window size for behavioral bias calculation.
 		/// </summary>
@@ -53,7 +53,7 @@ namespace StockSharp.Samples.Strategies
 			get => _biasWindowSize.Value;
 			set => _biasWindowSize.Value = value;
 		}
-		
+
 		/// <summary>
 		/// Stop loss percentage.
 		/// </summary>
@@ -62,7 +62,7 @@ namespace StockSharp.Samples.Strategies
 			get => _stopLoss.Value;
 			set => _stopLoss.Value = value;
 		}
-		
+
 		/// <summary>
 		/// Type of candles to use.
 		/// </summary>
@@ -71,61 +71,66 @@ namespace StockSharp.Samples.Strategies
 			get => _candleType.Value;
 			set => _candleType.Value = value;
 		}
-		
+
 		/// <summary>
 		/// Constructor with default parameters.
 		/// </summary>
 		public VwapWithBehavioralBiasFilterStrategy()
 		{
 			_biasThreshold = Param(nameof(BiasThreshold), 0.5m)
-				.SetGreaterThanZero()
-				.SetDisplay("Bias Threshold", "Threshold for behavioral bias", "Behavioral Settings")
-				.SetCanOptimize(true)
-				.SetOptimize(0.3m, 0.7m, 0.1m);
-				
+			.SetGreaterThanZero()
+			.SetDisplay("Bias Threshold", "Threshold for behavioral bias", "Behavioral Settings")
+			.SetCanOptimize(true)
+			.SetOptimize(0.3m, 0.7m, 0.1m);
+
 			_biasWindowSize = Param(nameof(BiasWindowSize), 20)
-				.SetGreaterThanZero()
-				.SetDisplay("Bias Window Size", "Window size for behavioral bias calculation", "Behavioral Settings")
-				.SetCanOptimize(true)
-				.SetOptimize(10, 30, 5);
-				
+			.SetGreaterThanZero()
+			.SetDisplay("Bias Window Size", "Window size for behavioral bias calculation", "Behavioral Settings")
+			.SetCanOptimize(true)
+			.SetOptimize(10, 30, 5);
+
 			_stopLoss = Param(nameof(StopLoss), 2m)
-				.SetGreaterThanZero()
-				.SetDisplay("Stop Loss (%)", "Stop Loss percentage from entry price", "Risk Management")
-				.SetCanOptimize(true)
-				.SetOptimize(1m, 3m, 0.5m);
-				
+			.SetGreaterThanZero()
+			.SetDisplay("Stop Loss (%)", "Stop Loss percentage from entry price", "Risk Management")
+			.SetCanOptimize(true)
+			.SetOptimize(1m, 3m, 0.5m);
+
 			_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
-				.SetDisplay("Candle Type", "Type of candles to use", "General");
+			.SetDisplay("Candle Type", "Type of candles to use", "General");
 		}
-		
+
 		/// <inheritdoc />
 		public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
 		{
 			return [(Security, CandleType)];
 		}
-		
+
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
-			
-			// Initialize flags
+			base.OnReseted();
+
 			_isLong = false;
 			_isShort = false;
 			_currentBiasScore = 0;
 			_recentPriceMovements.Clear();
+			_vwap = default;
+		}
+
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Initialize VWAP indicator
 			_vwap = new();
-			
+
 			// Subscribe to candles and bind indicator
 			var subscription = SubscribeCandles(CandleType);
-			
+
 			subscription
-				.Bind(_vwap, ProcessCandle)
-				.Start();
-			
+			.Bind(_vwap, ProcessCandle)
+			.Start();
+
 			// Create chart visualization if available
 			var area = CreateChartArea();
 			if (area != null)
@@ -134,14 +139,14 @@ namespace StockSharp.Samples.Strategies
 				DrawIndicator(area, _vwap);
 				DrawOwnTrades(area);
 			}
-			
+
 			// Enable position protection with stop-loss
 			StartProtection(
-				new Unit(0),  // No take profit
-				new Unit(StopLoss, UnitTypes.Percent) // Stop-loss as percentage
+			new Unit(0),  // No take profit
+			new Unit(StopLoss, UnitTypes.Percent) // Stop-loss as percentage
 			);
 		}
-		
+
 		/// <summary>
 		/// Process each candle and VWAP value.
 		/// </summary>
@@ -149,23 +154,23 @@ namespace StockSharp.Samples.Strategies
 		{
 			// Skip unfinished candles
 			if (candle.State != CandleStates.Finished)
-				return;
-			
+			return;
+
 			// Check if strategy is ready to trade
 			if (!IsFormedAndOnlineAndAllowTrading())
-				return;
-			
+			return;
+
 			// Update behavioral bias score
 			UpdateBehavioralBias(candle);
-			
+
 			var price = candle.ClosePrice;
 			var priceBelowVwap = price < vwapValue;
 			var priceAboveVwap = price > vwapValue;
-			
+
 			// Trading logic
-			
+
 			// Entry conditions
-			
+
 			// Long entry: Price below VWAP and negative bias score (panic)
 			if (priceBelowVwap && _currentBiasScore < -BiasThreshold && !_isLong && Position <= 0)
 			{
@@ -182,9 +187,9 @@ namespace StockSharp.Samples.Strategies
 				_isShort = true;
 				_isLong = false;
 			}
-			
+
 			// Exit conditions
-			
+
 			// Exit long: Price rises above VWAP
 			if (_isLong && priceAboveVwap && Position > 0)
 			{
@@ -200,7 +205,7 @@ namespace StockSharp.Samples.Strategies
 				_isShort = false;
 			}
 		}
-		
+
 		/// <summary>
 		/// Update behavioral bias score based on recent price movements.
 		/// This is a simplified model of behavioral biases in markets.
@@ -213,25 +218,25 @@ namespace StockSharp.Samples.Strategies
 			{
 				priceChange = (candle.ClosePrice - candle.OpenPrice) / candle.OpenPrice * 100;
 			}
-			
+
 			// Add to queue
 			_recentPriceMovements.Enqueue(priceChange);
-			
+
 			// Maintain window size
 			while (_recentPriceMovements.Count > BiasWindowSize)
 			{
 				_recentPriceMovements.Dequeue();
 			}
-			
+
 			// Not enough data yet
 			if (_recentPriceMovements.Count < 5)
 			{
 				_currentBiasScore = 0;
 				return;
 			}
-			
+
 			// Calculate various components of bias score
-			
+
 			// 1. Recent momentum (last 5 candles)
 			decimal recentMovement = 0;
 			int count = 0;
@@ -243,27 +248,27 @@ namespace StockSharp.Samples.Strategies
 				}
 				count++;
 			}
-			
+
 			// 2. Overreaction to recent news (volatility of recent moves)
 			decimal volatility = 0;
 			decimal sum = 0;
 			decimal sumSquared = 0;
-			
+
 			foreach (var movement in _recentPriceMovements)
 			{
 				sum += movement;
 				sumSquared += movement * movement;
 			}
-			
+
 			decimal avg = sum / _recentPriceMovements.Count;
 			decimal variance = (sumSquared / _recentPriceMovements.Count) - (avg * avg);
 			volatility = (decimal)Math.Sqrt((double)Math.Max(0, variance));
-			
+
 			// 3. Herding behavior (consecutive moves in same direction)
 			decimal previousMove = 0;
 			int consecutiveSameDirection = 0;
 			int maxConsecutive = 0;
-			
+
 			foreach (var movement in _recentPriceMovements)
 			{
 				if (previousMove != 0 && Math.Sign(movement) == Math.Sign(previousMove))
@@ -277,25 +282,25 @@ namespace StockSharp.Samples.Strategies
 				}
 				previousMove = movement;
 			}
-			
+
 			// 4. Current candle characteristics
 			decimal bodySize = Math.Abs(candle.ClosePrice - candle.OpenPrice);
 			decimal totalSize = candle.HighPrice - candle.LowPrice;
 			decimal bodyRatio = totalSize > 0 ? bodySize / totalSize : 0;
-			
+
 			// Combined bias score calculation
 			_currentBiasScore = 0;
-			
+
 			// Recent momentum component (range -0.5 to 0.5)
 			_currentBiasScore += Math.Min(0.5m, Math.Max(-0.5m, recentMovement / 2));
-			
+
 			// Volatility component (range -0.3 to 0.3)
 			// Higher volatility often indicates panic or euphoria
 			_currentBiasScore += Math.Sign(recentMovement) * Math.Min(0.3m, volatility / 10);
-			
+
 			// Herding component (range -0.2 to 0.2)
 			_currentBiasScore += Math.Sign(recentMovement) * Math.Min(0.2m, maxConsecutive / 10.0m);
-			
+
 			// Current candle strength component (range -0.2 to 0.2)
 			if (candle.ClosePrice > candle.OpenPrice)
 			{
@@ -305,10 +310,10 @@ namespace StockSharp.Samples.Strategies
 			{
 				_currentBiasScore -= bodyRatio * 0.2m; // Bearish bias
 			}
-			
+
 			// Ensure score is between -1 and 1
 			_currentBiasScore = Math.Max(-1.0m, Math.Min(1.0m, _currentBiasScore));
-			
+
 			LogInfo($"Behavioral Bias: {_currentBiasScore}, Components: Momentum={recentMovement/2}, Volatility={volatility/10}, Herding={maxConsecutive/10.0m}, Candle={bodyRatio*0.2m}");
 		}
 	}

--- a/API/0345_VWAP_Behavioral_Bias_Filter/PY/vwap_with_behavioral_bias_filter_strategy.py
+++ b/API/0345_VWAP_Behavioral_Bias_Filter/PY/vwap_with_behavioral_bias_filter_strategy.py
@@ -94,18 +94,20 @@ class vwap_with_behavioral_bias_filter_strategy(Strategy):
             (self.Security, self.CandleType)
         ]
 
-    def OnStarted(self, time):
-        super(vwap_with_behavioral_bias_filter_strategy, self).OnStarted(time)
-
-        # Initialize flags
+    def OnReseted(self):
+        super(vwap_with_behavioral_bias_filter_strategy, self).OnReseted()
         self._isLong = False
         self._isShort = False
         self._currentBiasScore = 0
         self._recentPriceMovements = []
+        self._vwap = None
+
+    def OnStarted(self, time):
+        super(vwap_with_behavioral_bias_filter_strategy, self).OnStarted(time)
 
         # Initialize VWAP indicator
         self._vwap = VolumeWeightedMovingAverage()
-
+        
         # Subscribe to candles and bind indicator
         subscription = self.SubscribeCandles(self.CandleType)
         subscription.Bind(self._vwap, self.ProcessCandle).Start()

--- a/API/0346_Parabolic_SAR_Sentiment_Divergence/PY/parabolic_sar_sentiment_divergence_strategy.py
+++ b/API/0346_Parabolic_SAR_Sentiment_Divergence/PY/parabolic_sar_sentiment_divergence_strategy.py
@@ -35,9 +35,6 @@ class parabolic_sar_sentiment_divergence_strategy(Strategy):
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
         self._parabolic_sar = None
-        self._prev_sentiment = 0
-        self._prev_price = 0
-        self._is_first_candle = True
 
     @property
     def StartAf(self):
@@ -66,6 +63,13 @@ class parabolic_sar_sentiment_divergence_strategy(Strategy):
     def GetWorkingSecurities(self):
         return [(self.Security, self.CandleType)]
 
+    def OnReseted(self):
+        super(parabolic_sar_sentiment_divergence_strategy, self).OnReseted()
+        self._parabolic_sar = None
+        self._prev_sentiment = 0
+        self._prev_price = 0
+        self._is_first_candle = True
+
     def OnStarted(self, time):
         super(parabolic_sar_sentiment_divergence_strategy, self).OnStarted(time)
 
@@ -74,10 +78,6 @@ class parabolic_sar_sentiment_divergence_strategy(Strategy):
         self._parabolic_sar.Acceleration = self.StartAf
         self._parabolic_sar.AccelerationMax = self.MaxAf
 
-        # Reset variables
-        self._is_first_candle = True
-        self._prev_sentiment = 0
-        self._prev_price = 0
 
         # Create subscription
         subscription = self.SubscribeCandles(self.CandleType)

--- a/API/0347_RSI_Option_Open_Interest/PY/rsi_with_option_open_interest_strategy.py
+++ b/API/0347_RSI_Option_Open_Interest/PY/rsi_with_option_open_interest_strategy.py
@@ -111,6 +111,25 @@ class rsi_with_option_open_interest_strategy(Strategy):
     def GetWorkingSecurities(self):
         return [(self.Security, self.CandleType)]
 
+    def OnReseted(self):
+        super(rsi_with_option_open_interest_strategy, self).OnReseted()
+        if self._rsi:
+            self._rsi.Reset()
+        if self._call_oi_sma:
+            self._call_oi_sma.Reset()
+        if self._put_oi_sma:
+            self._put_oi_sma.Reset()
+        if self._call_oi_stddev:
+            self._call_oi_stddev.Reset()
+        if self._put_oi_stddev:
+            self._put_oi_stddev.Reset()
+        self._current_call_oi = 0
+        self._current_put_oi = 0
+        self._avg_call_oi = 0
+        self._avg_put_oi = 0
+        self._stddev_call_oi = 0
+        self._stddev_put_oi = 0
+
     def OnStarted(self, time):
         super(rsi_with_option_open_interest_strategy, self).OnStarted(time)
 
@@ -131,14 +150,6 @@ class rsi_with_option_open_interest_strategy(Strategy):
 
         self._put_oi_stddev = StandardDeviation()
         self._put_oi_stddev.Length = self.OiPeriod
-
-        # Reset state variables
-        self._current_call_oi = 0
-        self._current_put_oi = 0
-        self._avg_call_oi = 0
-        self._avg_put_oi = 0
-        self._stddev_call_oi = 0
-        self._stddev_put_oi = 0
 
         # Create candle subscription and bind RSI
         subscription = self.SubscribeCandles(self.CandleType)

--- a/API/0348_Stochastic_Implied_Volatility_Skew/PY/stochastic_implied_volatility_skew_strategy.py
+++ b/API/0348_Stochastic_Implied_Volatility_Skew/PY/stochastic_implied_volatility_skew_strategy.py
@@ -116,6 +116,15 @@ class stochastic_implied_volatility_skew_strategy(Strategy):
         """!! REQUIRED !! Returns securities for strategy."""
         return [(self.Security, self.CandleType)]
 
+    def OnReseted(self):
+        super(stochastic_implied_volatility_skew_strategy, self).OnReseted()
+        if self._stochastic:
+            self._stochastic.Reset()
+        if self._iv_skew_sma:
+            self._iv_skew_sma.Reset()
+        self._current_iv_skew = 0
+        self._avg_iv_skew = 0
+
     def OnStarted(self, time):
         super(stochastic_implied_volatility_skew_strategy, self).OnStarted(time)
 
@@ -127,10 +136,6 @@ class stochastic_implied_volatility_skew_strategy(Strategy):
         # Create IV Skew SMA
         self._iv_skew_sma = SimpleMovingAverage()
         self._iv_skew_sma.Length = self.IvPeriod
-
-        # Reset state variables
-        self._current_iv_skew = 0
-        self._avg_iv_skew = 0
 
         # Create subscription and bind indicators
         subscription = self.SubscribeCandles(self.CandleType)

--- a/API/0349_ADX_Sentiment_Momentum/PY/adx_sentiment_momentum_strategy.py
+++ b/API/0349_ADX_Sentiment_Momentum/PY/adx_sentiment_momentum_strategy.py
@@ -99,17 +99,20 @@ class adx_sentiment_momentum_strategy(Strategy):
     def GetWorkingSecurities(self):
         return [(self.Security, self.CandleType)]
 
+    def OnReseted(self):
+        super(adx_sentiment_momentum_strategy, self).OnReseted()
+        if self._adx:
+            self._adx.Reset()
+        self._prev_sentiment = 0
+        self._current_sentiment = 0
+        self._sentiment_momentum = 0
+
     def OnStarted(self, time):
         super(adx_sentiment_momentum_strategy, self).OnStarted(time)
 
         # Create ADX Indicator
         self._adx = AverageDirectionalIndex()
         self._adx.Length = self.AdxPeriod
-
-        # Initialize sentiment values
-        self._prev_sentiment = 0
-        self._current_sentiment = 0
-        self._sentiment_momentum = 0
 
         # Create subscription and bind indicators
         subscription = self.SubscribeCandles(self.CandleType)

--- a/API/0350_CCI_Put_Call_Ratio_Divergence/PY/cci_put_call_ratio_divergence_strategy.py
+++ b/API/0350_CCI_Put_Call_Ratio_Divergence/PY/cci_put_call_ratio_divergence_strategy.py
@@ -72,6 +72,16 @@ class cci_put_call_ratio_divergence_strategy(Strategy):
     def GetWorkingSecurities(self):
         return [(self.Security, self.CandleType)]
 
+    def OnReseted(self):
+        super(cci_put_call_ratio_divergence_strategy, self).OnReseted()
+        if self._cci:
+            self._cci.Reset()
+        if self._atr:
+            self._atr.Reset()
+        self._prev_pcr = 0.0
+        self._current_pcr = 0.0
+        self._prev_price = 0.0
+
     def OnStarted(self, time):
         super(cci_put_call_ratio_divergence_strategy, self).OnStarted(time)
 
@@ -81,11 +91,6 @@ class cci_put_call_ratio_divergence_strategy(Strategy):
 
         self._atr = AverageTrueRange()
         self._atr.Length = 14  # Standard ATR period
-
-        # Initialize state variables
-        self._prev_pcr = 0.0
-        self._current_pcr = 0.0
-        self._prev_price = 0.0
 
         # Create candle subscription
         subscription = self.SubscribeCandles(self.CandleType)


### PR DESCRIPTION
## Summary
- ensure Adaptive EMA Breakout strategy resets internal state in `OnReseted`
- shift Hull MA K-Means Cluster state clearing to `OnReseted`
- handle Parabolic SAR Sentiment Divergence resets via `OnReseted`
- relocate remaining strategy state resets (0319–0345) to `OnReseted`
- convert C# strategy files to tab-based indentation and move reset logic for strategies 0347–0350 into `OnReseted`

## Testing
- `dotnet test` *(fails: command not found)*
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689267fd2c5083239b9bc0476c5180cb