### PR TITLE
refactor: move state reset to OnReseted

### DIFF
--- a/API/0061_MACD_Divergence/CS/MacdDivergenceStrategy.cs
+++ b/API/0061_MACD_Divergence/CS/MacdDivergenceStrategy.cs
@@ -124,11 +124,10 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
+			base.OnReseted();
 
-			// Reset variables
 			_previousPrice = null;
 			_previousMacd = null;
 			_currentPrice = null;
@@ -136,6 +135,12 @@ namespace StockSharp.Samples.Strategies
 			_barsSinceDivergence = 0;
 			_bullishDivergence = false;
 			_bearishDivergence = false;
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Create MACD indicator
 

--- a/API/0061_MACD_Divergence/PY/macd_divergence_strategy.py
+++ b/API/0061_MACD_Divergence/PY/macd_divergence_strategy.py
@@ -117,15 +117,6 @@ class macd_divergence_strategy(Strategy):
         """
         super(macd_divergence_strategy, self).OnStarted(time)
 
-        # Reset variables
-        self._previousPrice = None
-        self._previousMacd = None
-        self._currentPrice = None
-        self._currentMacd = None
-        self._barsSinceDivergence = 0
-        self._bullishDivergence = False
-        self._bearishDivergence = False
-
         # Create MACD indicator
         macd = MovingAverageConvergenceDivergenceSignal()
         macd.Macd.ShortMa.Length = self.FastMacdPeriod

--- a/API/0063_Engulfing_Bullish/CS/EngulfingBullishStrategy.cs
+++ b/API/0063_Engulfing_Bullish/CS/EngulfingBullishStrategy.cs
@@ -88,12 +88,18 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
+			base.OnReseted();
 
 			_previousCandle = null;
 			_consecutiveDownBars = 0;
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Subscribe to candles
 			var subscription = SubscribeCandles(CandleType);

--- a/API/0063_Engulfing_Bullish/PY/engulfing_bullish_strategy.py
+++ b/API/0063_Engulfing_Bullish/PY/engulfing_bullish_strategy.py
@@ -85,9 +85,6 @@ class engulfing_bullish_strategy(Strategy):
         """
         super(engulfing_bullish_strategy, self).OnStarted(time)
 
-        self._previousCandle = None
-        self._consecutiveDownBars = 0
-
         # Subscribe to candles
         subscription = self.SubscribeCandles(self.CandleType)
 

--- a/API/0064_Engulfing_Bearish/CS/EngulfingBearishStrategy.cs
+++ b/API/0064_Engulfing_Bearish/CS/EngulfingBearishStrategy.cs
@@ -88,12 +88,18 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
+			base.OnReseted();
 
 			_previousCandle = null;
 			_consecutiveUpBars = 0;
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Subscribe to candles
 			var subscription = SubscribeCandles(CandleType);

--- a/API/0064_Engulfing_Bearish/PY/engulfing_bearish_strategy.py
+++ b/API/0064_Engulfing_Bearish/PY/engulfing_bearish_strategy.py
@@ -85,9 +85,6 @@ class engulfing_bearish_strategy(Strategy):
         """
         super(engulfing_bearish_strategy, self).OnStarted(time)
 
-        self._previousCandle = None
-        self._consecutiveUpBars = 0
-
         # Subscribe to candles
         subscription = self.SubscribeCandles(self.CandleType)
 

--- a/API/0066_Three_Bar_Reversal_Up/CS/ThreeBarReversalUpStrategy.cs
+++ b/API/0066_Three_Bar_Reversal_Up/CS/ThreeBarReversalUpStrategy.cs
@@ -92,15 +92,21 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_lastThreeCandles.Clear();
+			_lowestIndicator = null;
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
 
-			// Clear candle queue
-			_lastThreeCandles.Clear();
-
-			// Create lowest indicator for downtrend identification
-			_lowestIndicator = new Lowest { Length = DowntrendLength };
+// Create lowest indicator for downtrend identification
+_lowestIndicator = new Lowest { Length = DowntrendLength };
 
 			// Subscribe to candles
 			var subscription = SubscribeCandles(CandleType);

--- a/API/0066_Three_Bar_Reversal_Up/PY/three_bar_reversal_up_strategy.py
+++ b/API/0066_Three_Bar_Reversal_Up/PY/three_bar_reversal_up_strategy.py
@@ -80,6 +80,7 @@ class three_bar_reversal_up_strategy(Strategy):
         """
         super(three_bar_reversal_up_strategy, self).OnReseted()
         self._lastThreeCandles.Clear()
+        self._lowestIndicator = None
 
     def OnStarted(self, time):
         """
@@ -88,9 +89,6 @@ class three_bar_reversal_up_strategy(Strategy):
         :param time: The time when the strategy started.
         """
         super(three_bar_reversal_up_strategy, self).OnStarted(time)
-
-        # Clear candle queue
-        self._lastThreeCandles.Clear()
 
         # Create lowest indicator for downtrend identification
         self._lowestIndicator = Lowest()

--- a/API/0067_Three_Bar_Reversal_Down/CS/ThreeBarReversalDownStrategy.cs
+++ b/API/0067_Three_Bar_Reversal_Down/CS/ThreeBarReversalDownStrategy.cs
@@ -92,15 +92,21 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_lastThreeCandles.Clear();
+			_highestIndicator = null;
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
 
-			// Clear candle queue
-			_lastThreeCandles.Clear();
-
-			// Create highest indicator for uptrend identification
-			_highestIndicator = new Highest { Length = UptrendLength };
+// Create highest indicator for uptrend identification
+_highestIndicator = new Highest { Length = UptrendLength };
 
 			// Subscribe to candles
 			var subscription = SubscribeCandles(CandleType);

--- a/API/0067_Three_Bar_Reversal_Down/PY/three_bar_reversal_down_strategy.py
+++ b/API/0067_Three_Bar_Reversal_Down/PY/three_bar_reversal_down_strategy.py
@@ -80,6 +80,7 @@ class three_bar_reversal_down_strategy(Strategy):
         """
         super(three_bar_reversal_down_strategy, self).OnReseted()
         self._lastThreeCandles.Clear()
+        self._highestIndicator = None
 
     def OnStarted(self, time):
         """
@@ -88,9 +89,6 @@ class three_bar_reversal_down_strategy(Strategy):
         :param time: The time when the strategy started.
         """
         super(three_bar_reversal_down_strategy, self).OnStarted(time)
-
-        # Clear candle queue
-        self._lastThreeCandles.Clear()
 
         # Create highest indicator for uptrend identification
         self._highestIndicator = Highest()

--- a/API/0068_CCI_Divergence/CS/CciDivergenceStrategy.cs
+++ b/API/0068_CCI_Divergence/CS/CciDivergenceStrategy.cs
@@ -124,11 +124,10 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
+			base.OnReseted();
 
-			// Reset variables
 			_previousPrice = null;
 			_previousCci = null;
 			_currentPrice = null;
@@ -136,8 +135,14 @@ namespace StockSharp.Samples.Strategies
 			_barsSinceDivergence = 0;
 			_bullishDivergence = false;
 			_bearishDivergence = false;
+		}
 
-			// Create CCI indicator
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
+
+// Create CCI indicator
 			var cci = new CommodityChannelIndex
 			{
 				Length = CciPeriod

--- a/API/0068_CCI_Divergence/PY/cci_divergence_strategy.py
+++ b/API/0068_CCI_Divergence/PY/cci_divergence_strategy.py
@@ -117,15 +117,6 @@ class cci_divergence_strategy(Strategy):
         """
         super(cci_divergence_strategy, self).OnStarted(time)
 
-        # Reset variables
-        self._previousPrice = None
-        self._previousCci = None
-        self._currentPrice = None
-        self._currentCci = None
-        self._barsSinceDivergence = 0
-        self._bullishDivergence = False
-        self._bearishDivergence = False
-
         # Create CCI indicator
         cci = CommodityChannelIndex()
         cci.Length = self.CciPeriod

--- a/API/0070_Morning_Star/CS/MorningStarStrategy.cs
+++ b/API/0070_Morning_Star/CS/MorningStarStrategy.cs
@@ -59,15 +59,20 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_firstCandle = null;
+			_secondCandle = null;
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
 
-			// Reset candle storage
-			_firstCandle = null;
-			_secondCandle = null;
-
-			// Create subscription
+// Create subscription
 			var subscription = SubscribeCandles(CandleType);
 			
 			subscription

--- a/API/0070_Morning_Star/PY/morning_star_strategy.py
+++ b/API/0070_Morning_Star/PY/morning_star_strategy.py
@@ -62,10 +62,6 @@ class morning_star_strategy(Strategy):
         """
         super(morning_star_strategy, self).OnStarted(time)
 
-        # Reset candle storage
-        self._firstCandle = None
-        self._secondCandle = None
-
         # Create subscription
         subscription = self.SubscribeCandles(self.CandleType)
         subscription.Bind(self.ProcessCandle).Start()


### PR DESCRIPTION
## Summary
- move state clearing for MACD, Engulfing, Three Bar Reversal, CCI Divergence and Morning Star strategies into `OnReseted`
- drop redundant resets from `OnStarted` across Python strategy versions

## Testing
- `dotnet test` *(fails: bash: command not found: dotnet)*
- `apt-get update` *(fails: repository ... InRelease is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68930bb1736083238ff63755d20cd238