### PR TITLE
Move state reset to OnReseted for strategies 211-220

### DIFF
--- a/API/0211_CCI_VWAP/CS/CciVwapStrategy.cs
+++ b/API/0211_CCI_VWAP/CS/CciVwapStrategy.cs
@@ -7,7 +7,7 @@ using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies
-{
+		{
 	/// <summary>
 	/// Strategy that uses CCI and VWAP indicators to identify oversold and overbought conditions.
 	/// Enters long when CCI is below -100 and price is below VWAP.
@@ -77,11 +77,18 @@ namespace StockSharp.Samples.Strategies
 		}
 		
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_cci = null;
+			_currentVwap = default;
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
-
-			_currentVwap = default;
 
 			// Initialize CCI indicator
 			_cci = new CommodityChannelIndex
@@ -163,4 +170,4 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 	}
-}
+		}

--- a/API/0211_CCI_VWAP/PY/cci_vwap_strategy.py
+++ b/API/0211_CCI_VWAP/PY/cci_vwap_strategy.py
@@ -69,6 +69,7 @@ class cci_vwap_strategy(Strategy):
 
     def OnReseted(self):
         super(cci_vwap_strategy, self).OnReseted()
+        self._cci = None
         self._current_vwap = 0.0
 
     def OnStarted(self, time):

--- a/API/0212_Williams_R_Ichimoku/CS/WilliamsIchimokuStrategy.cs
+++ b/API/0212_Williams_R_Ichimoku/CS/WilliamsIchimokuStrategy.cs
@@ -7,7 +7,7 @@ using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies
-{
+		{
 	/// <summary>
 	/// Strategy based on Williams %R and Ichimoku indicators.
 	/// Enters long when Williams %R is below -80 (oversold) and price is above Ichimoku Cloud with Tenkan-sen > Kijun-sen.
@@ -111,11 +111,19 @@ namespace StockSharp.Samples.Strategies
 		}
 		
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_williamsR = null;
+			_ichimoku = null;
+			_lastKijun = null;
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
-
-			_lastKijun = null;
 
 			// Initialize indicators
 			_williamsR = new WilliamsR
@@ -230,4 +238,4 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 	}
-}
+		}

--- a/API/0212_Williams_R_Ichimoku/PY/williams_ichimoku_strategy.py
+++ b/API/0212_Williams_R_Ichimoku/PY/williams_ichimoku_strategy.py
@@ -106,10 +106,14 @@ class williams_ichimoku_strategy(Strategy):
         """!! REQUIRED !! Returns securities for strategy."""
         return [(self.Security, self.CandleType)]
 
+    def OnReseted(self):
+        super(williams_ichimoku_strategy, self).OnReseted()
+        self._williams_r = None
+        self._ichimoku = None
+        self._last_kijun = None
+
     def OnStarted(self, time):
         super(williams_ichimoku_strategy, self).OnStarted(time)
-
-        self._last_kijun = None
 
         # Initialize indicators
         self._williams_r = WilliamsR()

--- a/API/0213_MA_Parabolic_SAR/CS/MaParabolicSarStrategy.cs
+++ b/API/0213_MA_Parabolic_SAR/CS/MaParabolicSarStrategy.cs
@@ -7,7 +7,7 @@ using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies
-{
+		{
 	/// <summary>
 	/// Strategy based on Moving Average and Parabolic SAR indicators.
 	/// Enters long when price is above MA and above SAR.
@@ -122,11 +122,19 @@ namespace StockSharp.Samples.Strategies
 		}
 		
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_ma = null;
+			_parabolicSar = null;
+			_lastSarValue = default;
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
-
-			_lastSarValue = default;
 
 			// Initialize indicators
 			_ma = new() { Length = MaPeriod };
@@ -207,4 +215,4 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 	}
-}
+		}

--- a/API/0213_MA_Parabolic_SAR/PY/ma_parabolic_sar_strategy.py
+++ b/API/0213_MA_Parabolic_SAR/PY/ma_parabolic_sar_strategy.py
@@ -111,10 +111,14 @@ class ma_parabolic_sar_strategy(Strategy):
         """!! REQUIRED !! Returns securities for strategy."""
         return [(self.Security, self.CandleType)]
 
+    def OnReseted(self):
+        super(ma_parabolic_sar_strategy, self).OnReseted()
+        self._ma = None
+        self._parabolic_sar = None
+        self._last_sar_value = 0.0
+
     def OnStarted(self, time):
         super(ma_parabolic_sar_strategy, self).OnStarted(time)
-
-        self._last_sar_value = 0.0
 
         # Initialize indicators
         self._ma = SimpleMovingAverage()

--- a/API/0214_Bollinger_Supertrend/CS/BollingerSupertrendStrategy.cs
+++ b/API/0214_Bollinger_Supertrend/CS/BollingerSupertrendStrategy.cs
@@ -7,7 +7,7 @@ using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies
-{
+		{
 	/// <summary>
 	/// Strategy based on Bollinger Bands and Supertrend indicators.
 	/// Enters long when price breaks above upper Bollinger Band and is above Supertrend.
@@ -114,21 +114,28 @@ namespace StockSharp.Samples.Strategies
 		}
 		
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_bollinger = null;
+			_atr = null;
+			_isLongTrend = default;
+			_supertrendValue = default;
+			_lastClose = default;
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
 
-			_isLongTrend = default;
-			_supertrendValue = default;
-			_lastClose = default;
-
-
-			// Initialize indicators
+// Initialize indicators
 			_bollinger = new BollingerBands
-			{
-				Length = BollingerPeriod,
-				Width = BollingerDeviation
-			};
+		{
+Length = BollingerPeriod,
+Width = BollingerDeviation
+		};
 			
 			_atr = new AverageTrueRange
 			{
@@ -260,4 +267,4 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 	}
-}
+		}

--- a/API/0214_Bollinger_Supertrend/PY/bollinger_supertrend_strategy.py
+++ b/API/0214_Bollinger_Supertrend/PY/bollinger_supertrend_strategy.py
@@ -114,11 +114,6 @@ class bollinger_supertrend_strategy(Strategy):
         """Called when the strategy starts."""
         super(bollinger_supertrend_strategy, self).OnStarted(time)
 
-        # Reset state
-        self._is_long_trend = False
-        self._supertrend_value = 0.0
-        self._last_close = 0.0
-
         # Initialize indicators
         bollinger = BollingerBands()
         bollinger.Length = self.BollingerPeriod

--- a/API/0215_RSI_Donchian/CS/RsiDonchianStrategy.cs
+++ b/API/0215_RSI_Donchian/CS/RsiDonchianStrategy.cs
@@ -7,7 +7,7 @@ using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies
-{
+		{
 	/// <summary>
 	/// Strategy based on RSI and Donchian Channel indicators.
 	/// Enters long when RSI is below 30 (oversold) and price breaks above Donchian high.
@@ -101,21 +101,30 @@ namespace StockSharp.Samples.Strategies
 		}
 		
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
+			base.OnReseted();
 
+			_rsi = null;
+			_highestHigh = null;
+			_lowestLow = null;
 			_previousRsi = 0;
 			_donchianHigh = 0;
 			_donchianLow = 0;
 			_donchianMiddle = 0;
 			_currentRsi = 0;
+		}
 
-			// Initialize indicators
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
+
+// Initialize indicators
 			_rsi = new RelativeStrengthIndex
-			{
-				Length = RsiPeriod
-			};
+		{
+Length = RsiPeriod
+		};
 			
 			_highestHigh = new Highest
 			{
@@ -227,4 +236,4 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 	}
-}
+		}

--- a/API/0215_RSI_Donchian/PY/rsi_donchian_strategy.py
+++ b/API/0215_RSI_Donchian/PY/rsi_donchian_strategy.py
@@ -93,15 +93,20 @@ class rsi_donchian_strategy(Strategy):
         """Return the security and candle type this strategy works with."""
         return [(self.Security, self.CandleType)]
 
-    def OnStarted(self, time):
-        """Called when the strategy starts."""
-        super(rsi_donchian_strategy, self).OnStarted(time)
-
+    def OnReseted(self):
+        super(rsi_donchian_strategy, self).OnReseted()
+        self._rsi = None
+        self._highest_high = None
+        self._lowest_low = None
         self._previous_rsi = 0
         self._donchian_high = 0
         self._donchian_low = 0
         self._donchian_middle = 0
         self._current_rsi = 0
+
+    def OnStarted(self, time):
+        """Called when the strategy starts."""
+        super(rsi_donchian_strategy, self).OnStarted(time)
 
         # Initialize indicators
         self._rsi = RelativeStrengthIndex()

--- a/API/0216_Mean_Reversion/CS/MeanReversionStrategy.cs
+++ b/API/0216_Mean_Reversion/CS/MeanReversionStrategy.cs
@@ -7,7 +7,7 @@ using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies
-{
+		{
 	/// <summary>
 	/// Statistical Mean Reversion strategy.
 	/// Enters long when price falls below the mean by a specified number of standard deviations.
@@ -94,11 +94,20 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_ma = null;
+			_stdDev = null;
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
 
-			// Initialize indicators
+// Initialize indicators
 			_ma = new() { Length = MovingAveragePeriod };
 			_stdDev = new() { Length = MovingAveragePeriod };
 
@@ -176,4 +185,4 @@ namespace StockSharp.Samples.Strategies
 			}
 		}
 	}
-}
+		}

--- a/API/0216_Mean_Reversion/PY/mean_reversion_strategy.py
+++ b/API/0216_Mean_Reversion/PY/mean_reversion_strategy.py
@@ -86,6 +86,11 @@ class mean_reversion_strategy(Strategy):
         """See base class for details."""
         return [(self.Security, self.CandleType)]
 
+    def OnReseted(self):
+        super(mean_reversion_strategy, self).OnReseted()
+        self._ma = None
+        self._stdDev = None
+
     def OnStarted(self, time):
         super(mean_reversion_strategy, self).OnStarted(time)
 

--- a/API/0217_Pairs_Trading/CS/PairsTradingStrategy.cs
+++ b/API/0217_Pairs_Trading/CS/PairsTradingStrategy.cs
@@ -7,7 +7,7 @@ using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies
-{
+		{
 	/// <summary>
 	/// Statistical Pairs Trading strategy.
 	/// Trades the spread between two correlated assets, entering positions when
@@ -114,12 +114,20 @@ namespace StockSharp.Samples.Strategies
 		}
 		
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_spreadMA = null;
+			_spreadStdDev = null;
+			_spread = 0;
+			_lastSecondPrice = 0;
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
-
-			_spread = 0;
-			_lastSecondPrice = 0;
 
 			if (SecondSecurity == null)
 				throw new InvalidOperationException("Second security is not specified.");
@@ -237,4 +245,4 @@ namespace StockSharp.Samples.Strategies
 			_lastSecondPrice = candle.ClosePrice;
 		}
 	}
-}
+		}

--- a/API/0217_Pairs_Trading/PY/pairs_trading_strategy.py
+++ b/API/0217_Pairs_Trading/PY/pairs_trading_strategy.py
@@ -108,14 +108,13 @@ class pairs_trading_strategy(Strategy):
 
     def OnReseted(self):
         super(pairs_trading_strategy, self).OnReseted()
+        self._spread_ma = None
+        self._spread_std_dev = None
         self._spread = 0
         self._last_second_price = 0
 
     def OnStarted(self, time):
         super(pairs_trading_strategy, self).OnStarted(time)
-
-        self._spread = 0
-        self._last_second_price = 0
 
         if self.second_security is None:
             raise Exception("Second security is not specified.")

--- a/API/0218_ZScore_Reversal/CS/ZScoreReversalStrategy.cs
+++ b/API/0218_ZScore_Reversal/CS/ZScoreReversalStrategy.cs
@@ -7,7 +7,7 @@ using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies
-{
+		{
 	/// <summary>
 	/// Strategy that trades based on Z-Score (normalized price deviation from the mean).
 	/// Enters long when Z-Score is below a negative threshold (price significantly below mean).
@@ -96,13 +96,21 @@ namespace StockSharp.Samples.Strategies
 		}
 		
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_ma = null;
+			_stdDev = null;
+			_lastZScore = default;
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
 
-			_lastZScore = default;
-
-			// Initialize indicators
+// Initialize indicators
 			_ma = new() { Length = LookbackPeriod };
 			_stdDev = new() { Length = LookbackPeriod };
 			
@@ -187,4 +195,4 @@ namespace StockSharp.Samples.Strategies
 			_lastZScore = zScore;
 		}
 	}
-}
+		}

--- a/API/0218_ZScore_Reversal/PY/z_score_reversal_strategy.py
+++ b/API/0218_ZScore_Reversal/PY/z_score_reversal_strategy.py
@@ -86,10 +86,14 @@ class z_score_reversal_strategy(Strategy):
     def GetWorkingSecurities(self):
         return [(self.Security, self.candle_type)]
 
+    def OnReseted(self):
+        super(z_score_reversal_strategy, self).OnReseted()
+        self._ma = None
+        self._std_dev = None
+        self._last_z_score = 0.0
+
     def OnStarted(self, time):
         super(z_score_reversal_strategy, self).OnStarted(time)
-
-        self._last_z_score = 0.0
 
         # Initialize indicators
         self._ma = SimpleMovingAverage()

--- a/API/0219_Statistical_Arbitrage/CS/StatisticalArbitrageStrategy.cs
+++ b/API/0219_Statistical_Arbitrage/CS/StatisticalArbitrageStrategy.cs
@@ -7,7 +7,7 @@ using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies
-{
+		{
 	/// <summary>
 	/// Statistical Arbitrage strategy that trades pairs of securities based on their relative mean reversion.
 	/// Enters when one asset is below its mean while the other is above its mean.
@@ -99,14 +99,22 @@ namespace StockSharp.Samples.Strategies
 		}
 		
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
+			base.OnReseted();
 
+			_firstMA = null;
+			_secondMA = null;
 			_lastFirstPrice = 0;
 			_lastSecondPrice = 0;
 			_entrySpread = 0;
 			_secondMAValue = 0;
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			if (SecondSecurity == null)
 				throw new InvalidOperationException("Second security is not specified.");
@@ -234,4 +242,4 @@ namespace StockSharp.Samples.Strategies
 			_secondMAValue = maValue.ToDecimal();
 		}
 	}
-}
+		}

--- a/API/0219_Statistical_Arbitrage/PY/statistical_arbitrage_strategy.py
+++ b/API/0219_Statistical_Arbitrage/PY/statistical_arbitrage_strategy.py
@@ -91,6 +91,8 @@ class statistical_arbitrage_strategy(Strategy):
     def OnReseted(self):
         """Resets internal state when strategy is reset."""
         super(statistical_arbitrage_strategy, self).OnReseted()
+        self._first_ma = None
+        self._second_ma = None
         self._last_first_price = 0
         self._last_second_price = 0
         self._entry_spread = 0
@@ -103,11 +105,6 @@ class statistical_arbitrage_strategy(Strategy):
         :param time: The time when the strategy started.
         """
         super(statistical_arbitrage_strategy, self).OnStarted(time)
-
-        self._last_first_price = 0
-        self._last_second_price = 0
-        self._entry_spread = 0
-        self._second_ma_value = 0
 
         if self.SecondSecurity is None:
             raise Exception("Second security is not specified.")

--- a/API/0220_Volatility_Breakout/CS/VolatilityBreakoutStrategy.cs
+++ b/API/0220_Volatility_Breakout/CS/VolatilityBreakoutStrategy.cs
@@ -7,7 +7,7 @@ using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies
-{
+		{
 	/// <summary>
 	/// Volatility Breakout strategy. Enters trades when price breaks out from average price with volatility threshold.
 	/// </summary>
@@ -78,17 +78,24 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_sma = null;
+			_atr = null;
+			_prevSma = 0;
+			_prevAtr = 0;
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
 
-			// Create indicators
+// Create indicators
 			_sma = new SimpleMovingAverage { Length = Period };
 			_atr = new AverageTrueRange { Length = Period };
-			
-			// Reset state
-			_prevSma = 0;
-			_prevAtr = 0;
 
 			// Create subscription and bind indicators
 			var subscription = SubscribeCandles(CandleType);
@@ -153,4 +160,4 @@ namespace StockSharp.Samples.Strategies
 			_prevAtr = currentAtr;
 		}
 	}
-}
+		}

--- a/API/0220_Volatility_Breakout/PY/volatility_breakout_strategy.py
+++ b/API/0220_Volatility_Breakout/PY/volatility_breakout_strategy.py
@@ -72,6 +72,13 @@ class volatility_breakout_strategy(Strategy):
         """See base class for details."""
         return [(self.Security, self.CandleType)]
 
+    def OnReseted(self):
+        super(volatility_breakout_strategy, self).OnReseted()
+        self._sma = None
+        self._atr = None
+        self._prev_sma = 0.0
+        self._prev_atr = 0.0
+
     def OnStarted(self, time):
         """Called when the strategy starts."""
         super(volatility_breakout_strategy, self).OnStarted(time)
@@ -81,10 +88,6 @@ class volatility_breakout_strategy(Strategy):
         self._sma.Length = self.Period
         self._atr = AverageTrueRange()
         self._atr.Length = self.Period
-
-        # Reset state
-        self._prev_sma = 0.0
-        self._prev_atr = 0.0
 
         # Create subscription and bind indicators
         subscription = self.SubscribeCandles(self.CandleType)


### PR DESCRIPTION
## Summary
- Reset internal state in `OnReseted` rather than `OnStarted` for strategies 211-220
- Mirror changes in Python strategy implementations

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*
- `python -m py_compile API/0211_CCI_VWAP/PY/cci_vwap_strategy.py API/0212_Williams_R_Ichimoku/PY/williams_ichimoku_strategy.py API/0213_MA_Parabolic_SAR/PY/ma_parabolic_sar_strategy.py API/0214_Bollinger_Supertrend/PY/bollinger_supertrend_strategy.py API/0215_RSI_Donchian/PY/rsi_donchian_strategy.py API/0216_Mean_Reversion/PY/mean_reversion_strategy.py API/0217_Pairs_Trading/PY/pairs_trading_strategy.py API/0218_ZScore_Reversal/PY/z_score_reversal_strategy.py API/0219_Statistical_Arbitrage/PY/statistical_arbitrage_strategy.py API/0220_Volatility_Breakout/PY/volatility_breakout_strategy.py`


------
https://chatgpt.com/codex/tasks/task_e_689315af6828832380a39231f2fc13db