### PR TITLE
Move strategy state reset to OnReseted

### DIFF
--- a/API/0193_Supertrend_ADX/CS/SupertrendAdxStrategy.cs
+++ b/API/0193_Supertrend_ADX/CS/SupertrendAdxStrategy.cs
@@ -115,12 +115,18 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
+			base.OnReseted();
 
 			_lastSupertrend = 0;
 			_isAboveSupertrend = false;
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Create indicators
 			var atr = new AverageTrueRange { Length = SupertrendPeriod };

--- a/API/0193_Supertrend_ADX/PY/supertrend_adx_strategy.py
+++ b/API/0193_Supertrend_ADX/PY/supertrend_adx_strategy.py
@@ -104,11 +104,14 @@ class supertrend_adx_strategy(Strategy):
     def GetWorkingSecurities(self):
         return [(self.Security, self.CandleType)]
 
-    def OnStarted(self, time):
-        super(supertrend_adx_strategy, self).OnStarted(time)
+    def OnReseted(self):
+        super(supertrend_adx_strategy, self).OnReseted()
 
         self._last_supertrend = 0
         self._is_above_supertrend = False
+
+    def OnStarted(self, time):
+        super(supertrend_adx_strategy, self).OnStarted(time)
 
         # Create indicators
         atr = AverageTrueRange()

--- a/API/0194_Keltner_MACD/CS/KeltnerMacdStrategy.cs
+++ b/API/0194_Keltner_MACD/CS/KeltnerMacdStrategy.cs
@@ -165,6 +165,20 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_ema?.Reset();
+			_atr?.Reset();
+			_macd?.Reset();
+
+			_prevMacd = 0;
+			_prevSignal = 0;
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
@@ -183,9 +197,6 @@ namespace StockSharp.Samples.Strategies
 				SignalMa = { Length = MacdSignalPeriod }
 			};
 			// Initialize variables
-			_prevMacd = 0;
-			_prevSignal = 0;
-
 			// Create subscription
 			var subscription = SubscribeCandles(CandleType);
 

--- a/API/0194_Keltner_MACD/PY/keltner_macd_strategy.py
+++ b/API/0194_Keltner_MACD/PY/keltner_macd_strategy.py
@@ -153,6 +153,19 @@ class keltner_macd_strategy(Strategy):
     def GetWorkingSecurities(self):
         return [(self.Security, self.CandleType)]
 
+    def OnReseted(self):
+        super(keltner_macd_strategy, self).OnReseted()
+
+        if self._ema is not None:
+            self._ema.Reset()
+        if self._atr is not None:
+            self._atr.Reset()
+        if self._macd is not None:
+            self._macd.Reset()
+
+        self._prevMacd = 0.0
+        self._prevSignal = 0.0
+
     def OnStarted(self, time):
         """Called when the strategy starts."""
         super(keltner_macd_strategy, self).OnStarted(time)
@@ -168,10 +181,6 @@ class keltner_macd_strategy(Strategy):
         self._macd.Macd.ShortMa.Length = self.MacdFastPeriod
         self._macd.Macd.LongMa.Length = self.MacdSlowPeriod
         self._macd.SignalMa.Length = self.MacdSignalPeriod
-
-        # Reset previous values
-        self._prevMacd = 0.0
-        self._prevSignal = 0.0
 
         # Subscribe to candles and bind indicators
         subscription = self.SubscribeCandles(self.CandleType)

--- a/API/0197_Hull_MA_ADX/CS/HullMaAdxStrategy.cs
+++ b/API/0197_Hull_MA_ADX/CS/HullMaAdxStrategy.cs
@@ -111,6 +111,19 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_hma?.Reset();
+			_adx?.Reset();
+			_atr?.Reset();
+
+			_prevHmaValue = 0;
+			_prevAdxValue = 0;
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
@@ -119,10 +132,6 @@ namespace StockSharp.Samples.Strategies
 			_hma = new() { Length = HmaPeriod };
 			_adx = new() { Length = AdxPeriod };
 			_atr = new() { Length = 14 };
-
-			// Initialize variables
-			_prevHmaValue = 0;
-			_prevAdxValue = 0;
 
 			// Create subscription
 			var subscription = SubscribeCandles(CandleType);

--- a/API/0197_Hull_MA_ADX/PY/hull_ma_adx_strategy.py
+++ b/API/0197_Hull_MA_ADX/PY/hull_ma_adx_strategy.py
@@ -106,6 +106,13 @@ class hull_ma_adx_strategy(Strategy):
     def OnReseted(self):
         """Resets internal state when strategy is reset."""
         super(hull_ma_adx_strategy, self).OnReseted()
+        if getattr(self, '_hma', None) is not None:
+            self._hma.Reset()
+        if getattr(self, '_adx', None) is not None:
+            self._adx.Reset()
+        if getattr(self, '_atr', None) is not None:
+            self._atr.Reset()
+
         self._prev_hma_value = 0.0
         self._prev_adx_value = 0.0
 
@@ -119,10 +126,6 @@ class hull_ma_adx_strategy(Strategy):
         self._adx.Length = self.adx_period
         self._atr = AverageTrueRange()
         self._atr.Length = 14
-
-        # Initialize variables
-        self._prev_hma_value = 0.0
-        self._prev_adx_value = 0.0
 
         # Create subscription
         subscription = self.SubscribeCandles(self.candle_type)

--- a/API/0198_VWAP_MACD/CS/VwapMacdStrategy.cs
+++ b/API/0198_VWAP_MACD/CS/VwapMacdStrategy.cs
@@ -106,6 +106,18 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_macd?.Reset();
+			_vwap?.Reset();
+
+			_prevMacd = 0;
+			_prevSignal = 0;
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
@@ -122,10 +134,6 @@ namespace StockSharp.Samples.Strategies
 				SignalMa = { Length = MacdSignalPeriod }
 			};
 			_vwap = new() { Length = MacdSignalPeriod };
-			// Initialize variables
-			_prevMacd = 0;
-			_prevSignal = 0;
-
 			// Enable position protection
 			StartProtection(new Unit(StopLossPercent, UnitTypes.Percent), new Unit(StopLossPercent, UnitTypes.Percent));
 

--- a/API/0198_VWAP_MACD/PY/vwap_macd_strategy.py
+++ b/API/0198_VWAP_MACD/PY/vwap_macd_strategy.py
@@ -89,6 +89,17 @@ class vwap_macd_strategy(Strategy):
     def candle_type(self, value):
         self._candle_type.Value = value
 
+    def OnReseted(self):
+        super(vwap_macd_strategy, self).OnReseted()
+
+        if self._macd is not None:
+            self._macd.Reset()
+        if self._vwap is not None:
+            self._vwap.Reset()
+
+        self._prev_macd = 0
+        self._prev_signal = 0
+
     def OnStarted(self, time):
         super(vwap_macd_strategy, self).OnStarted(time)
 
@@ -99,10 +110,6 @@ class vwap_macd_strategy(Strategy):
         self._macd.SignalMa.Length = self.macd_signal_period
         self._vwap = VolumeWeightedMovingAverage()
         self._vwap.Length = self.macd_signal_period
-
-        # Initialize variables
-        self._prev_macd = 0
-        self._prev_signal = 0
 
         # Enable position protection
         self.StartProtection(

--- a/API/0200_Ichimoku_ADX/CS/IchimokuAdxStrategy.cs
+++ b/API/0200_Ichimoku_ADX/CS/IchimokuAdxStrategy.cs
@@ -133,14 +133,19 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
+			base.OnReseted();
 
-			// Reset state tracking variables
 			_isPriceAboveCloud = default;
 			_isTenkanAboveKijun = default;
 			_lastAdxValue = default;
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Create indicators
 			var ichimoku = new Ichimoku

--- a/API/0200_Ichimoku_ADX/PY/ichimoku_adx_strategy.py
+++ b/API/0200_Ichimoku_ADX/PY/ichimoku_adx_strategy.py
@@ -127,13 +127,15 @@ class ichimoku_adx_strategy(Strategy):
     def GetWorkingSecurities(self):
         return [(self.Security, self.CandleType)]
 
-    def OnStarted(self, time):
-        super(ichimoku_adx_strategy, self).OnStarted(time)
+    def OnReseted(self):
+        super(ichimoku_adx_strategy, self).OnReseted()
 
-        # Reset state tracking variables
         self._is_price_above_cloud = False
         self._is_tenkan_above_kijun = False
         self._last_adx_value = 0.0
+
+    def OnStarted(self, time):
+        super(ichimoku_adx_strategy, self).OnStarted(time)
 
         # Create indicators
         ichimoku = Ichimoku()


### PR DESCRIPTION
## Summary
- move state reset logic from `OnStarted` to new `OnReseted` overrides in strategies 0193, 0194, 0197, 0198 and 0200 for both C# and Python
- ensure indicator instances are reset alongside state variables

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_6893161ffa088323aa345cf147f0c23b