### PR TITLE
Refactor strategy reset handling

### DIFF
--- a/API/0241_ADX_Mean_Reversion/CS/AdxMeanReversionStrategy.cs
+++ b/API/0241_ADX_Mean_Reversion/CS/AdxMeanReversionStrategy.cs
@@ -115,11 +115,11 @@ namespace StockSharp.Samples.Strategies
 		{
 			return [(Security, CandleType)];
 		}
-
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			// Reset variables
+			base.OnReseted();
+
 			_prevAdx = 0;
 			_avgAdx = 0;
 			_stdDevAdx = 0;
@@ -127,7 +127,12 @@ namespace StockSharp.Samples.Strategies
 			_sumSquaresAdx = 0;
 			_count = 0;
 			_adxValues.Clear();
+		}
 
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
 			// Create ADX indicator
 			var adx = new AverageDirectionalIndex { Length = AdxPeriod };
 

--- a/API/0241_ADX_Mean_Reversion/PY/adx_mean_reversion_strategy.py
+++ b/API/0241_ADX_Mean_Reversion/PY/adx_mean_reversion_strategy.py
@@ -97,14 +97,8 @@ class adx_mean_reversion_strategy(Strategy):
     def StopLossPercent(self, value):
         self._stop_loss_percent.Value = value
 
-    def OnStarted(self, time):
-        """
-        Called when the strategy starts. Resets statistics, creates indicators,
-        and sets up charting.
-        """
-        super(adx_mean_reversion_strategy, self).OnStarted(time)
-
-        # Reset variables
+    def OnReseted(self):
+        super(adx_mean_reversion_strategy, self).OnReseted()
         self._prev_adx = 0.0
         self._avg_adx = 0.0
         self._std_dev_adx = 0.0
@@ -112,6 +106,13 @@ class adx_mean_reversion_strategy(Strategy):
         self._sum_squares_adx = 0.0
         self._count = 0
         self._adx_values.clear()
+
+    def OnStarted(self, time):
+        """
+        Called when the strategy starts. Resets statistics, creates indicators,
+        and sets up charting.
+        """
+        super(adx_mean_reversion_strategy, self).OnStarted(time)
 
         # Create ADX indicator
         adx = AverageDirectionalIndex()

--- a/API/0242_Volatility_Mean_Reversion/CS/VolatilityMeanReversionStrategy.cs
+++ b/API/0242_Volatility_Mean_Reversion/CS/VolatilityMeanReversionStrategy.cs
@@ -115,11 +115,11 @@ namespace StockSharp.Samples.Strategies
 		{
 			return [(Security, CandleType)];
 		}
-
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			// Reset variables
+			base.OnReseted();
+
 			_prevAtr = 0;
 			_avgAtr = 0;
 			_stdDevAtr = 0;
@@ -127,7 +127,12 @@ namespace StockSharp.Samples.Strategies
 			_sumSquaresAtr = 0;
 			_count = 0;
 			_atrValues.Clear();
+		}
 
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
 			// Create ATR indicator
 			var atr = new AverageTrueRange { Length = AtrPeriod };
 

--- a/API/0242_Volatility_Mean_Reversion/PY/volatility_mean_reversion_strategy.py
+++ b/API/0242_Volatility_Mean_Reversion/PY/volatility_mean_reversion_strategy.py
@@ -106,11 +106,8 @@ class volatility_mean_reversion_strategy(Strategy):
         """!! REQUIRED!! Return securities and candle types used."""
         return [(self.Security, self.CandleType)]
 
-    def OnStarted(self, time):
-        """Called when the strategy starts."""
-        super(volatility_mean_reversion_strategy, self).OnStarted(time)
-
-        # Reset variables
+    def OnReseted(self):
+        super(volatility_mean_reversion_strategy, self).OnReseted()
         self._prevAtr = 0
         self._avgAtr = 0
         self._stdDevAtr = 0
@@ -118,6 +115,10 @@ class volatility_mean_reversion_strategy(Strategy):
         self._sumSquaresAtr = 0
         self._count = 0
         self._atrValues.Clear()
+
+    def OnStarted(self, time):
+        """Called when the strategy starts."""
+        super(volatility_mean_reversion_strategy, self).OnStarted(time)
 
         # Create ATR indicator
         atr = AverageTrueRange()

--- a/API/0243_Volume_Mean_Reversion/CS/VolumeMeanReversionStrategy.cs
+++ b/API/0243_Volume_Mean_Reversion/CS/VolumeMeanReversionStrategy.cs
@@ -98,18 +98,23 @@ namespace StockSharp.Samples.Strategies
 		{
 			return [(Security, CandleType)];
 		}
-
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			// Reset variables
+			base.OnReseted();
+
 			_avgVolume = 0;
 			_stdDevVolume = 0;
 			_sumVolume = 0;
 			_sumSquaresVolume = 0;
 			_count = 0;
 			_volumeValues.Clear();
+		}
 
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
 			// Create Volume indicator (for visualization)
 			var volume = new VolumeIndicator();
 

--- a/API/0243_Volume_Mean_Reversion/PY/volume_mean_reversion_strategy.py
+++ b/API/0243_Volume_Mean_Reversion/PY/volume_mean_reversion_strategy.py
@@ -88,19 +88,20 @@ class volume_mean_reversion_strategy(Strategy):
         """Return security and timeframe used by the strategy."""
         return [(self.Security, self.CandleType)]
 
-    def OnStarted(self, time):
-        """
-        Reset variables and initialize indicators, subscriptions and charting.
-        """
-        super(volume_mean_reversion_strategy, self).OnStarted(time)
-
-        # Reset variables
+    def OnReseted(self):
+        super(volume_mean_reversion_strategy, self).OnReseted()
         self._avg_volume = 0.0
         self._std_dev_volume = 0.0
         self._sum_volume = 0.0
         self._sum_squares_volume = 0.0
         self._count = 0
         self._volume_values = []
+
+    def OnStarted(self, time):
+        """
+        Initialize indicators, subscriptions and charting.
+        """
+        super(volume_mean_reversion_strategy, self).OnStarted(time)
 
         # Create Volume indicator (for visualization)
         volume = VolumeIndicator()

--- a/API/0244_OBV_Mean_Reversion/CS/ObvMeanReversionStrategy.cs
+++ b/API/0244_OBV_Mean_Reversion/CS/ObvMeanReversionStrategy.cs
@@ -80,15 +80,21 @@ namespace StockSharp.Samples.Strategies
 		{
 			return [(Security, CandleType)];
 		}
+		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_currentObv = default;
+			_obvAvgValue = default;
+			_obvStdDevValue = default;
+		}
+
 
 		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
-
-			_currentObv = default;
-			_obvAvgValue = default;
-			_obvStdDevValue = default;
 
 			// Create indicators
 			_obv = new OnBalanceVolume();

--- a/API/0244_OBV_Mean_Reversion/PY/obv_mean_reversion_strategy.py
+++ b/API/0244_OBV_Mean_Reversion/PY/obv_mean_reversion_strategy.py
@@ -73,12 +73,14 @@ class obv_mean_reversion_strategy(Strategy):
     def CandleType(self, value):
         self._candle_type.Value = value
 
-    def OnStarted(self, time):
-        super(obv_mean_reversion_strategy, self).OnStarted(time)
-
+    def OnReseted(self):
+        super(obv_mean_reversion_strategy, self).OnReseted()
         self._current_obv = None
         self._obv_avg_value = None
         self._obv_std_dev_value = None
+
+    def OnStarted(self, time):
+        super(obv_mean_reversion_strategy, self).OnStarted(time)
 
         # Create indicators
         self._obv = OnBalanceVolume()

--- a/API/0245_Momentum_Breakout/CS/MomentumBreakoutStrategy.cs
+++ b/API/0245_Momentum_Breakout/CS/MomentumBreakoutStrategy.cs
@@ -96,15 +96,21 @@ namespace StockSharp.Samples.Strategies
 		{
 			return [(Security, CandleType)];
 		}
+		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_currentMomentum = default;
+			_momentumAvgValue = default;
+			_momentumStdDevValue = default;
+		}
+
 
 		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
-
-			_currentMomentum = default;
-			_momentumAvgValue = default;
-			_momentumStdDevValue = default;
 
 			// Create indicators
 			_momentum = new Momentum { Length = MomentumPeriod };

--- a/API/0245_Momentum_Breakout/PY/momentum_breakout_strategy.py
+++ b/API/0245_Momentum_Breakout/PY/momentum_breakout_strategy.py
@@ -87,13 +87,15 @@ class momentum_breakout_strategy(Strategy):
     def candle_type(self, value):
         self._candle_type.Value = value
 
-    def OnStarted(self, time):
-        """Called when the strategy starts."""
-        super(momentum_breakout_strategy, self).OnStarted(time)
-
+    def OnReseted(self):
+        super(momentum_breakout_strategy, self).OnReseted()
         self._current_momentum = None
         self._momentum_avg_value = None
         self._momentum_stddev_value = None
+
+    def OnStarted(self, time):
+        """Called when the strategy starts."""
+        super(momentum_breakout_strategy, self).OnStarted(time)
 
         # Create indicators
         self._momentum = Momentum()

--- a/API/0247_RSI_Breakout/CS/RsiBreakoutStrategy.cs
+++ b/API/0247_RSI_Breakout/CS/RsiBreakoutStrategy.cs
@@ -97,16 +97,22 @@ namespace StockSharp.Samples.Strategies
 		{
 			return [(Security, CandleType)];
 		}
-
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
+			base.OnReseted();
 
 			_prevRsiValue = default;
 			_currentRsiValue = default;
 			_currentRsiAvg = default;
 			_currentRsiStdDev = default;
+		}
+
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Create indicators
 			_rsi = new RelativeStrengthIndex { Length = RsiPeriod };

--- a/API/0247_RSI_Breakout/PY/rsi_breakout_strategy.py
+++ b/API/0247_RSI_Breakout/PY/rsi_breakout_strategy.py
@@ -106,11 +106,6 @@ class rsi_breakout_strategy(Strategy):
         """Called when the strategy starts."""
         super(rsi_breakout_strategy, self).OnStarted(time)
 
-        self._prevRsiValue = 0.0
-        self._currentRsiValue = 0.0
-        self._currentRsiAvg = 0.0
-        self._currentRsiStdDev = 0.0
-
         # Create indicators
         self._rsi = RelativeStrengthIndex()
         self._rsi.Length = self.RsiPeriod

--- a/API/0248_Stochastic_Breakout/CS/StochasticBreakoutStrategy.cs
+++ b/API/0248_Stochastic_Breakout/CS/StochasticBreakoutStrategy.cs
@@ -122,15 +122,21 @@ namespace StockSharp.Samples.Strategies
 		{
 			return [(Security, CandleType)];
 		}
+		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_prevStochValue = 0;
+			_prevStochAverage = 0;
+			_prevStochStdDev = 0;
+		}
+
 
 		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
-
-			_prevStochAverage = default;
-			_prevStochStdDev = default;
-			_prevStochValue = default;
 
 			// Initialize indicators
 			_stochastic = new StochasticOscillator
@@ -142,11 +148,6 @@ namespace StockSharp.Samples.Strategies
 			_stochAverage = new SimpleMovingAverage { Length = LookbackPeriod };
 			_stochStdDev = new StandardDeviation { Length = LookbackPeriod };
 			
-			// Reset stored values
-			_prevStochValue = 0;
-			_prevStochAverage = 0;
-			_prevStochStdDev = 0;
-
 			// Create subscription and bind indicators
 			var subscription = SubscribeCandles(CandleType);
 			subscription

--- a/API/0248_Stochastic_Breakout/PY/stochastic_breakout_strategy.py
+++ b/API/0248_Stochastic_Breakout/PY/stochastic_breakout_strategy.py
@@ -106,13 +106,15 @@ class stochastic_breakout_strategy(Strategy):
         """!! REQUIRED!! Return securities and candle types used."""
         return [(self.Security, self.CandleType)]
 
+    def OnReseted(self):
+        super(stochastic_breakout_strategy, self).OnReseted()
+        self._prevStochValue = 0
+        self._prevStochAverage = 0
+        self._prevStochStdDev = 0
+
     def OnStarted(self, time):
         """Called when the strategy starts."""
         super(stochastic_breakout_strategy, self).OnStarted(time)
-
-        self._prevStochAverage = 0
-        self._prevStochStdDev = 0
-        self._prevStochValue = 0
 
         # Initialize indicators
         self._stochastic = StochasticOscillator()
@@ -123,11 +125,6 @@ class stochastic_breakout_strategy(Strategy):
         self._stochAverage.Length = self.LookbackPeriod
         self._stochStdDev = StandardDeviation()
         self._stochStdDev.Length = self.LookbackPeriod
-
-        # Reset stored values
-        self._prevStochValue = 0
-        self._prevStochAverage = 0
-        self._prevStochStdDev = 0
 
         # Create subscription and bind indicators
         subscription = self.SubscribeCandles(self.CandleType)

--- a/API/0250_Williams_R_Breakout/CS/WilliamsRBreakoutStrategy.cs
+++ b/API/0250_Williams_R_Breakout/CS/WilliamsRBreakoutStrategy.cs
@@ -109,14 +109,20 @@ namespace StockSharp.Samples.Strategies
 		{
 			return [(Security, CandleType)];
 		}
+		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_prevWilliamsRValue = 0;
+			_prevWilliamsRAvgValue = 0;
+		}
+
 		
 		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
-			
-			_prevWilliamsRValue = 0;
-			_prevWilliamsRAvgValue = 0;
 			
 			// Create indicators
 			_williamsR = new WilliamsR { Length = WilliamsRPeriod };

--- a/API/0250_Williams_R_Breakout/PY/williams_r_breakout_strategy.py
+++ b/API/0250_Williams_R_Breakout/PY/williams_r_breakout_strategy.py
@@ -102,11 +102,13 @@ class williams_r_breakout_strategy(Strategy):
     def GetWorkingSecurities(self):
         return [(self.Security, self.CandleType)]
 
-    def OnStarted(self, time):
-        super(williams_r_breakout_strategy, self).OnStarted(time)
-
+    def OnReseted(self):
+        super(williams_r_breakout_strategy, self).OnReseted()
         self._prevWilliamsRValue = 0
         self._prevWilliamsRAvgValue = 0
+
+    def OnStarted(self, time):
+        super(williams_r_breakout_strategy, self).OnStarted(time)
 
         # Create indicators
         self._williamsR = WilliamsR()


### PR DESCRIPTION
## Summary
- Move state reset logic from `OnStarted` to new `OnReseted` overrides for strategies 0241–0250.
- Update C# and Python implementations to clear indicator values and collections in `OnReseted`.

## Testing
- `python -m py_compile API/0241_ADX_Mean_Reversion/PY/adx_mean_reversion_strategy.py API/0242_Volatility_Mean_Reversion/PY/volatility_mean_reversion_strategy.py API/0243_Volume_Mean_Reversion/PY/volume_mean_reversion_strategy.py API/0244_OBV_Mean_Reversion/PY/obv_mean_reversion_strategy.py API/0245_Momentum_Breakout/PY/momentum_breakout_strategy.py API/0247_RSI_Breakout/PY/rsi_breakout_strategy.py API/0248_Stochastic_Breakout/PY/stochastic_breakout_strategy.py API/0250_Williams_R_Breakout/PY/williams_r_breakout_strategy.py`
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689315bee5588323a311adaf19c91a56