### PR TITLE
Move strategy state reset to OnReseted for strategies 231-240

### DIFF
--- a/API/0231_Volatility_Skew_Arbitrage/CS/VolatilitySkewArbitrageStrategy.cs
+++ b/API/0231_Volatility_Skew_Arbitrage/CS/VolatilitySkewArbitrageStrategy.cs
@@ -100,13 +100,20 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+			_volSkewStdDev.Reset();
+			_barCount = 0;
+			_avgVolSkew = 0;
+			_currentVolSkew = 0;
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
 
-			_barCount = 0;
-			_avgVolSkew = 0;
-			_currentVolSkew = 0;
 
 			// Subscribe to implied volatility for both options
 			if (OptionWithLowVol != null && OptionWithHighVol != null)

--- a/API/0231_Volatility_Skew_Arbitrage/PY/volatility_skew_arbitrage_strategy.py
+++ b/API/0231_Volatility_Skew_Arbitrage/PY/volatility_skew_arbitrage_strategy.py
@@ -102,10 +102,6 @@ class volatility_skew_arbitrage_strategy(Strategy):
     def OnStarted(self, time):
         super(volatility_skew_arbitrage_strategy, self).OnStarted(time)
 
-        self._bar_count = 0
-        self._avg_vol_skew = 0
-        self._current_vol_skew = 0
-
         # Subscribe to implied volatility for both options
         if self.option_with_low_vol is not None and self.option_with_high_vol is not None:
             self.SubscribeLevel1(self.option_with_low_vol) \
@@ -123,6 +119,13 @@ class volatility_skew_arbitrage_strategy(Strategy):
             takeProfit=None,
             stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
         )
+
+    def OnReseted(self):
+        super(volatility_skew_arbitrage_strategy, self).OnReseted()
+        self._vol_skew_std_dev.Reset()
+        self._bar_count = 0
+        self._avg_vol_skew = 0
+        self._current_vol_skew = 0
     def ProcessLowOptionImpliedVolatility(self, data):
         low_iv = data.TryGetDecimal(Level1Fields.ImpliedVolatility) or 0
         high_iv = self._current_vol_skew + low_iv

--- a/API/0232_Correlation_Breakout/CS/CorrelationBreakoutStrategy.cs
+++ b/API/0232_Correlation_Breakout/CS/CorrelationBreakoutStrategy.cs
@@ -134,6 +134,17 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+			_corrStdDev.Reset();
+			_currentIndex = 0;
+			_avgCorrelation = 0;
+			_lastCorrelation = 0;
+			_isInitialized = false;
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
@@ -141,10 +152,6 @@ namespace StockSharp.Samples.Strategies
 			// Initialize arrays
 			_asset1Prices = new decimal[LookbackPeriod];
 			_asset2Prices = new decimal[LookbackPeriod];
-			_currentIndex = 0;
-			_avgCorrelation = 0;
-			_lastCorrelation = 0;
-			_isInitialized = false;
 
 			// Subscribe to candles for both assets
 			if (Asset1 != null && Asset2 != null && CandleType != null)

--- a/API/0232_Correlation_Breakout/PY/correlation_breakout_strategy.py
+++ b/API/0232_Correlation_Breakout/PY/correlation_breakout_strategy.py
@@ -127,10 +127,6 @@ class correlation_breakout_strategy(Strategy):
         # Initialize arrays
         self._asset1_prices = [0.0] * self.LookbackPeriod
         self._asset2_prices = [0.0] * self.LookbackPeriod
-        self._current_index = 0
-        self._avg_correlation = 0.0
-        self._last_correlation = 0.0
-        self._is_initialized = False
 
         # Subscribe to candles for both assets
         if self.Asset1 is not None and self.Asset2 is not None and self.CandleType is not None:
@@ -154,6 +150,14 @@ class correlation_breakout_strategy(Strategy):
             takeProfit=None,
             stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
+
+    def OnReseted(self):
+        super(correlation_breakout_strategy, self).OnReseted()
+        self._corr_std_dev.Reset()
+        self._current_index = 0
+        self._avg_correlation = 0.0
+        self._last_correlation = 0.0
+        self._is_initialized = False
     def ProcessAsset1Candle(self, candle):
         if candle.State != CandleStates.Finished:
             return

--- a/API/0233_Beta_Neutral_Arbitrage/CS/BetaNeutralArbitrageStrategy.cs
+++ b/API/0233_Beta_Neutral_Arbitrage/CS/BetaNeutralArbitrageStrategy.cs
@@ -130,17 +130,25 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
-
+			base.OnReseted();
+			_spreadSma.Reset();
+			_spreadStdDev.Reset();
 			_barCount = 0;
-			_asset1Beta = 1;  // Default beta until calculated
-			_asset2Beta = 1;  // Default beta until calculated
+			_asset1Beta = 1;
+			_asset2Beta = 1;
 			_avgSpread = 0;
 			_lastSpread = 0;
 			_asset1LastPrice = 0;
 			_asset2LastPrice = 0;
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
+
 
 			// Subscribe to candles for assets and market index
 			if (Asset1 != null && Asset2 != null && MarketIndex != null && CandleType != null)

--- a/API/0233_Beta_Neutral_Arbitrage/PY/beta_neutral_arbitrage_strategy.py
+++ b/API/0233_Beta_Neutral_Arbitrage/PY/beta_neutral_arbitrage_strategy.py
@@ -117,14 +117,6 @@ class beta_neutral_arbitrage_strategy(Strategy):
         """Called when the strategy starts. Sets up subscriptions and charting."""
         super(beta_neutral_arbitrage_strategy, self).OnStarted(time)
 
-        self._bar_count = 0
-        self._asset1_beta = 1
-        self._asset2_beta = 1
-        self._avg_spread = 0
-        self._last_spread = 0
-        self._asset1_last_price = 0
-        self._asset2_last_price = 0
-
         self._spread_sma.Length = self.lookback_period
         self._spread_std_dev.Length = self.lookback_period
 
@@ -161,6 +153,18 @@ class beta_neutral_arbitrage_strategy(Strategy):
             takeProfit=None,
             stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
         )
+
+    def OnReseted(self):
+        super(beta_neutral_arbitrage_strategy, self).OnReseted()
+        self._spread_sma.Reset()
+        self._spread_std_dev.Reset()
+        self._bar_count = 0
+        self._asset1_beta = 1
+        self._asset2_beta = 1
+        self._avg_spread = 0
+        self._last_spread = 0
+        self._asset1_last_price = 0
+        self._asset2_last_price = 0
     def ProcessAsset1Candle(self, candle):
         if candle.State != CandleStates.Finished:
             return

--- a/API/0235_VWAP_Mean_Reversion/CS/VwapMeanReversionStrategy.cs
+++ b/API/0235_VWAP_Mean_Reversion/CS/VwapMeanReversionStrategy.cs
@@ -79,12 +79,18 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+			_currentAtr = default;
+			_currentVwap = default;
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
 
-			_currentAtr = default;
-			_currentVwap = default;
 
 			// Create indicators
 			_atr = new AverageTrueRange { Length = AtrPeriod };

--- a/API/0235_VWAP_Mean_Reversion/PY/vwap_mean_reversion_strategy.py
+++ b/API/0235_VWAP_Mean_Reversion/PY/vwap_mean_reversion_strategy.py
@@ -77,9 +77,6 @@ class vwap_mean_reversion_strategy(Strategy):
         """Set up indicators, subscriptions and protection."""
         super(vwap_mean_reversion_strategy, self).OnStarted(time)
 
-        self._current_atr = 0
-        self._current_vwap = 0
-
         # Create indicators
         self._atr = AverageTrueRange()
         self._atr.Length = self.AtrPeriod
@@ -104,6 +101,11 @@ class vwap_mean_reversion_strategy(Strategy):
             takeProfit=Unit(5, UnitTypes.Percent),
             stopLoss=Unit(2, UnitTypes.Percent)
         )
+
+    def OnReseted(self):
+        super(vwap_mean_reversion_strategy, self).OnReseted()
+        self._current_atr = 0
+        self._current_vwap = 0
     def ProcessATR(self, candle, atr_value):
         if candle.State != CandleStates.Finished:
             return

--- a/API/0236_RSI_Mean_Reversion/CS/RsiMeanReversionStrategy.cs
+++ b/API/0236_RSI_Mean_Reversion/CS/RsiMeanReversionStrategy.cs
@@ -96,11 +96,17 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+			_prevRsiValue = 0;
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
 
-			_prevRsiValue = 0;
 
 			// Create indicators
 			_rsi = new RelativeStrengthIndex { Length = RsiPeriod };

--- a/API/0236_RSI_Mean_Reversion/PY/rsi_mean_reversion_strategy.py
+++ b/API/0236_RSI_Mean_Reversion/PY/rsi_mean_reversion_strategy.py
@@ -85,8 +85,6 @@ class rsi_mean_reversion_strategy(Strategy):
         """Called when the strategy starts."""
         super(rsi_mean_reversion_strategy, self).OnStarted(time)
 
-        self._prev_rsi_value = 0
-
         # Create indicators
         self._rsi = RelativeStrengthIndex()
         self._rsi.Length = self.RsiPeriod
@@ -113,6 +111,10 @@ class rsi_mean_reversion_strategy(Strategy):
             takeProfit=Unit(5, UnitTypes.Percent),
             stopLoss=Unit(2, UnitTypes.Percent)
         )
+
+    def OnReseted(self):
+        super(rsi_mean_reversion_strategy, self).OnReseted()
+        self._prev_rsi_value = 0
     def ProcessRsi(self, candle, rsi_value):
         if candle.State != CandleStates.Finished:
             return

--- a/API/0237_Stochastic_Mean_Reversion/CS/StochasticMeanReversionStrategy.cs
+++ b/API/0237_Stochastic_Mean_Reversion/CS/StochasticMeanReversionStrategy.cs
@@ -128,11 +128,17 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+			_prevStochKValue = default;
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
 
-			_prevStochKValue = default;
 
 			// Create indicators
 			_stochastic = new() 

--- a/API/0237_Stochastic_Mean_Reversion/PY/stochastic_mean_reversion_strategy.py
+++ b/API/0237_Stochastic_Mean_Reversion/PY/stochastic_mean_reversion_strategy.py
@@ -105,8 +105,6 @@ class stochastic_mean_reversion_strategy(Strategy):
         """Called when the strategy starts."""
         super(stochastic_mean_reversion_strategy, self).OnStarted(time)
 
-        self._prev_stoch_k_value = 0.0
-
         # Create indicators
         self._stochastic = StochasticOscillator()
         self._stochastic.K.Length = self.k_period
@@ -135,6 +133,10 @@ class stochastic_mean_reversion_strategy(Strategy):
             takeProfit=Unit(5, UnitTypes.Percent),
             stopLoss=Unit(2, UnitTypes.Percent)
         )
+
+    def OnReseted(self):
+        super(stochastic_mean_reversion_strategy, self).OnReseted()
+        self._prev_stoch_k_value = 0.0
     def ProcessStochastic(self, candle, stoch_value):
         if candle.State != CandleStates.Finished:
             return

--- a/API/0238_CCI_Mean_Reversion/CS/CciMeanReversionStrategy.cs
+++ b/API/0238_CCI_Mean_Reversion/CS/CciMeanReversionStrategy.cs
@@ -117,9 +117,9 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			// Reset variables
+			base.OnReseted();
 			_prevCci = 0;
 			_avgCci = 0;
 			_stdDevCci = 0;
@@ -127,6 +127,12 @@ namespace StockSharp.Samples.Strategies
 			_sumSquaresCci = 0;
 			_count = 0;
 			_cciValues.Clear();
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			// Reset variables
 
 			// Create CCI indicator
 			var cci = new CommodityChannelIndex { Length = CciPeriod };

--- a/API/0238_CCI_Mean_Reversion/PY/cci_mean_reversion_strategy.py
+++ b/API/0238_CCI_Mean_Reversion/PY/cci_mean_reversion_strategy.py
@@ -106,15 +106,6 @@ class cci_mean_reversion_strategy(Strategy):
 
     def OnStarted(self, time):
         """Called when the strategy starts."""
-        # Reset variables
-        self._prev_cci = 0.0
-        self._avg_cci = 0.0
-        self._std_dev_cci = 0.0
-        self._sum_cci = 0.0
-        self._sum_squares_cci = 0.0
-        self._count = 0
-        self._cci_values = []
-
         # Create CCI indicator
         cci = CommodityChannelIndex()
         cci.Length = self.CciPeriod
@@ -136,6 +127,16 @@ class cci_mean_reversion_strategy(Strategy):
             stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
         super(cci_mean_reversion_strategy, self).OnStarted(time)
+
+    def OnReseted(self):
+        super(cci_mean_reversion_strategy, self).OnReseted()
+        self._prev_cci = 0.0
+        self._avg_cci = 0.0
+        self._std_dev_cci = 0.0
+        self._sum_cci = 0.0
+        self._sum_squares_cci = 0.0
+        self._count = 0
+        self._cci_values = []
 
     def ProcessCandle(self, candle, cci_value):
         # Skip unfinished candles

--- a/API/0239_Williams_R_Mean_Reversion/CS/WilliamsRMeanReversionStrategy.cs
+++ b/API/0239_Williams_R_Mean_Reversion/CS/WilliamsRMeanReversionStrategy.cs
@@ -117,9 +117,9 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			// Reset variables
+			base.OnReseted();
 			_prevWilliamsR = 0;
 			_avgWilliamsR = 0;
 			_stdDevWilliamsR = 0;
@@ -127,6 +127,12 @@ namespace StockSharp.Samples.Strategies
 			_sumSquaresWilliamsR = 0;
 			_count = 0;
 			_williamsRValues.Clear();
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			// Reset variables
 
 			// Create Williams %R indicator
 			var williamsR = new WilliamsR { Length = WilliamsRPeriod };

--- a/API/0239_Williams_R_Mean_Reversion/PY/williams_r_mean_reversion_strategy.py
+++ b/API/0239_Williams_R_Mean_Reversion/PY/williams_r_mean_reversion_strategy.py
@@ -104,15 +104,6 @@ class williams_r_mean_reversion_strategy(Strategy):
     def OnStarted(self, time):
         super(williams_r_mean_reversion_strategy, self).OnStarted(time)
 
-        # Reset variables
-        self._prev_williams_r = 0.0
-        self._avg_williams_r = 0.0
-        self._std_dev_williams_r = 0.0
-        self._sum_williams_r = 0.0
-        self._sum_squares_williams_r = 0.0
-        self._count = 0
-        self._williams_r_values.Clear()
-
         # Create Williams %R indicator
         williams_r = WilliamsR()
         williams_r.Length = self.WilliamsRPeriod
@@ -133,6 +124,16 @@ class williams_r_mean_reversion_strategy(Strategy):
             takeProfit=Unit(0),
             stopLoss=Unit(self.StopLossPercent, UnitTypes.Percent)
         )
+
+    def OnReseted(self):
+        super(williams_r_mean_reversion_strategy, self).OnReseted()
+        self._prev_williams_r = 0.0
+        self._avg_williams_r = 0.0
+        self._std_dev_williams_r = 0.0
+        self._sum_williams_r = 0.0
+        self._sum_squares_williams_r = 0.0
+        self._count = 0
+        self._williams_r_values.Clear()
     def ProcessCandle(self, candle, williams_r_value):
         # Skip unfinished candles
         if candle.State != CandleStates.Finished:

--- a/API/0240_MACD_Mean_Reversion/CS/MacdMeanReversionStrategy.cs
+++ b/API/0240_MACD_Mean_Reversion/CS/MacdMeanReversionStrategy.cs
@@ -149,9 +149,9 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			// Reset variables
+			base.OnReseted();
 			_prevMacdHist = 0;
 			_avgMacdHist = 0;
 			_stdDevMacdHist = 0;
@@ -159,6 +159,12 @@ namespace StockSharp.Samples.Strategies
 			_sumSquaresMacdHist = 0;
 			_count = 0;
 			_macdHistValues.Clear();
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			// Reset variables
 
 			// Create MACD indicator
 			var macd = new MovingAverageConvergenceDivergenceHistogram

--- a/API/0240_MACD_Mean_Reversion/PY/macd_mean_reversion_strategy.py
+++ b/API/0240_MACD_Mean_Reversion/PY/macd_mean_reversion_strategy.py
@@ -136,15 +136,6 @@ class macd_mean_reversion_strategy(Strategy):
 
     def OnStarted(self, time):
         """Called when the strategy starts."""
-        # Reset variables
-        self._prev_macd_hist = 0.0
-        self._avg_macd_hist = 0.0
-        self._std_dev_macd_hist = 0.0
-        self._sum_macd_hist = 0.0
-        self._sum_squares_macd_hist = 0.0
-        self._count = 0
-        self._macd_hist_values = []
-
         # Create MACD indicator
         macd = MovingAverageConvergenceDivergenceHistogram()
         macd.Macd.ShortMa.Length = self.fast_macd_period
@@ -171,6 +162,16 @@ class macd_mean_reversion_strategy(Strategy):
             stopLoss=Unit(self.stop_loss_percent, UnitTypes.Percent)
         )
         super(macd_mean_reversion_strategy, self).OnStarted(time)
+
+    def OnReseted(self):
+        super(macd_mean_reversion_strategy, self).OnReseted()
+        self._prev_macd_hist = 0.0
+        self._avg_macd_hist = 0.0
+        self._std_dev_macd_hist = 0.0
+        self._sum_macd_hist = 0.0
+        self._sum_squares_macd_hist = 0.0
+        self._count = 0
+        self._macd_hist_values = []
 
     def ProcessCandle(self, candle, macd_value):
         # Skip unfinished candles


### PR DESCRIPTION
## Summary
- relocate state clearing to `OnReseted` for strategies 231-240 in both C# and Python
- reset indicators and tracking fields instead of doing so in `OnStarted`

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository unsigned)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689315b9597883238bdfd3a2069c2ee1