### PR TITLE
Move strategy state reset to OnReseted

### DIFF
--- a/API/0301_Adaptive_EMA_Breakout/CS/AdaptiveEmaBreakoutStrategy.cs
+++ b/API/0301_Adaptive_EMA_Breakout/CS/AdaptiveEmaBreakoutStrategy.cs
@@ -111,8 +111,8 @@ namespace StockSharp.Samples.Strategies
 		{
 			base.OnReseted();
 
-			_isFirstCandle = true;
 			_prevAdaptiveEmaValue = default;
+			_isFirstCandle = true;
 		}
 
 		/// <inheritdoc />

--- a/API/0301_Adaptive_EMA_Breakout/PY/adaptive_ema_breakout_strategy.py
+++ b/API/0301_Adaptive_EMA_Breakout/PY/adaptive_ema_breakout_strategy.py
@@ -98,8 +98,8 @@ class adaptive_ema_breakout_strategy(Strategy):
 
     def OnReseted(self):
         super(adaptive_ema_breakout_strategy, self).OnReseted()
-        self._isFirstCandle = True
         self._prevAdaptiveEmaValue = 0.0
+        self._isFirstCandle = True
 
     def OnStarted(self, time):
         super(adaptive_ema_breakout_strategy, self).OnStarted(time)

--- a/API/0302_Volatility_Cluster_Breakout/CS/VolatilityClusterBreakoutStrategy.cs
+++ b/API/0302_Volatility_Cluster_Breakout/CS/VolatilityClusterBreakoutStrategy.cs
@@ -104,42 +104,49 @@ namespace StockSharp.Samples.Strategies
 			return [(Security, CandleType)];
 		}
 
-		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
-		{
-			base.OnStarted(time);
+\t\t/// <inheritdoc />
+\t\tprotected override void OnReseted()
+\t\t{
+\t\t\tbase.OnReseted();
 
-			// Create indicators
-			var sma = new SimpleMovingAverage { Length = PriceAvgPeriod };
-			var stdDev = new StandardDeviation { Length = PriceAvgPeriod };
-			var atr = new AverageTrueRange { Length = AtrPeriod };
-			_atrAvg = new SimpleMovingAverage { Length = AtrPeriod };
+\t\t\t_atrAvg = new SimpleMovingAverage { Length = AtrPeriod };
+\t\t}
 
-			// Create subscription
-			var subscription = SubscribeCandles(CandleType);
-			
-			// Bind indicators to subscription
-			subscription
-				.Bind(sma, stdDev, atr, ProcessCandle)
-				.Start();
+\t\t/// <inheritdoc />
+\t\tprotected override void OnStarted(DateTimeOffset time)
+\t\t{
+\t\t\tbase.OnStarted(time);
 
-			// Enable position protection with dynamic stops
-			StartProtection(
-				takeProfit: new Unit(0), // We'll handle exits in the strategy logic
-				stopLoss: new Unit(0),   // We'll handle stops in the strategy logic  
-				useMarketOrders: true
-			);
+\t\t\t// Create indicators
+\t\t\tvar sma = new SimpleMovingAverage { Length = PriceAvgPeriod };
+\t\t\tvar stdDev = new StandardDeviation { Length = PriceAvgPeriod };
+\t\t\tvar atr = new AverageTrueRange { Length = AtrPeriod };
 
-			// Setup chart if available
-			var area = CreateChartArea();
-			if (area != null)
-			{
-				DrawCandles(area, subscription);
-				DrawIndicator(area, sma);
-				DrawIndicator(area, atr);
-				DrawOwnTrades(area);
-			}
-		}
+\t\t\t// Create subscription
+\t\t\tvar subscription = SubscribeCandles(CandleType);
+
+\t\t\t// Bind indicators to subscription
+\t\t\tsubscription
+\t\t\t\t.Bind(sma, stdDev, atr, ProcessCandle)
+\t\t\t\t.Start();
+
+\t\t\t// Enable position protection with dynamic stops
+\t\t\tStartProtection(
+\t\t\t\ttakeProfit: new Unit(0), // We'll handle exits in the strategy logic
+\t\t\t\tstopLoss: new Unit(0),   // We'll handle stops in the strategy logic
+\t\t\t\tuseMarketOrders: true
+\t\t\t);
+
+\t\t\t// Setup chart if available
+\t\t\tvar area = CreateChartArea();
+\t\t\tif (area != null)
+\t\t\t{
+\t\t\t\tDrawCandles(area, subscription);
+\t\t\t\tDrawIndicator(area, sma);
+\t\t\t\tDrawIndicator(area, atr);
+\t\t\t\tDrawOwnTrades(area);
+\t\t\t}
+\t\t}
 
 		private void ProcessCandle(ICandleMessage candle, decimal smaValue, decimal stdDevValue, decimal atrValue)
 		{

--- a/API/0302_Volatility_Cluster_Breakout/PY/volatility_cluster_breakout_strategy.py
+++ b/API/0302_Volatility_Cluster_Breakout/PY/volatility_cluster_breakout_strategy.py
@@ -103,6 +103,11 @@ class volatility_cluster_breakout_strategy(Strategy):
         """Return security and timeframe used by the strategy."""
         return [(self.Security, self.candle_type)]
 
+    def OnReseted(self):
+        super(volatility_cluster_breakout_strategy, self).OnReseted()
+        self._atr_avg = SimpleMovingAverage()
+        self._atr_avg.Length = self.atr_period
+
     def OnStarted(self, time):
         """Called when the strategy starts."""
         super(volatility_cluster_breakout_strategy, self).OnStarted(time)
@@ -114,8 +119,6 @@ class volatility_cluster_breakout_strategy(Strategy):
         std_dev.Length = self.price_avg_period
         atr = AverageTrueRange()
         atr.Length = self.atr_period
-        self._atr_avg = SimpleMovingAverage()
-        self._atr_avg.Length = self.atr_period
 
         # Create subscription
         subscription = self.SubscribeCandles(self.candle_type)

--- a/API/0303_Seasonality_Adjusted_Momentum/CS/SeasonalityAdjustedMomentumStrategy.cs
+++ b/API/0303_Seasonality_Adjusted_Momentum/CS/SeasonalityAdjustedMomentumStrategy.cs
@@ -110,6 +110,15 @@ namespace StockSharp.Samples.Strategies
 		{
 			return [(Security, CandleType)];
 		}
+		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_seasonalStrengthByMonth.Clear();
+			InitializeSeasonalityData();
+		}
+
 
 		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)

--- a/API/0303_Seasonality_Adjusted_Momentum/PY/seasonality_adjusted_momentum_strategy.py
+++ b/API/0303_Seasonality_Adjusted_Momentum/PY/seasonality_adjusted_momentum_strategy.py
@@ -97,6 +97,11 @@ class seasonality_adjusted_momentum_strategy(Strategy):
         self._seasonal_strength_by_month[11] = 0.6  # November
         self._seasonal_strength_by_month[12] = 0.9  # December
 
+    def OnReseted(self):
+        super(seasonality_adjusted_momentum_strategy, self).OnReseted()
+        self._seasonal_strength_by_month.clear()
+        self.InitializeSeasonalityData()
+
     def OnStarted(self, time):
         super(seasonality_adjusted_momentum_strategy, self).OnStarted(time)
 

--- a/API/0305_RSI_Dynamic_Overbought_Oversold/CS/RsiDynamicOverboughtOversoldStrategy.cs
+++ b/API/0305_RSI_Dynamic_Overbought_Oversold/CS/RsiDynamicOverboughtOversoldStrategy.cs
@@ -105,42 +105,49 @@ namespace StockSharp.Samples.Strategies
 			return [(Security, CandleType)];
 		}
 
-		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
-		{
-			base.OnStarted(time);
+\t\t/// <inheritdoc />
+\t\tprotected override void OnReseted()
+\t\t{
+\t\t\tbase.OnReseted();
 
-			// Create indicators
-			var rsi = new RelativeStrengthIndex { Length = RsiPeriod };
-			_rsiSma = new SimpleMovingAverage { Length = MovingAvgPeriod };
-			_rsiStdDev = new StandardDeviation { Length = MovingAvgPeriod };
-			var priceSma = new SimpleMovingAverage { Length = MovingAvgPeriod };
+\t\t\t_rsiSma = new SimpleMovingAverage { Length = MovingAvgPeriod };
+\t\t\t_rsiStdDev = new StandardDeviation { Length = MovingAvgPeriod };
+\t\t}
 
-			// Create subscription
-			var subscription = SubscribeCandles(CandleType);
-			
-			// Create RSI and price SMA processing
-			subscription
-				.Bind(rsi, priceSma, ProcessCandle)
-				.Start();
-				
-			// Enable position protection with percentage stop-loss
-			StartProtection(
-				takeProfit: new Unit(0), // We'll handle exits in the strategy logic
-				stopLoss: new Unit(StopLossPercent, UnitTypes.Percent),
-				useMarketOrders: true
-			);
+\t\t/// <inheritdoc />
+\t\tprotected override void OnStarted(DateTimeOffset time)
+\t\t{
+\t\t\tbase.OnStarted(time);
 
-			// Setup chart if available
-			var area = CreateChartArea();
-			if (area != null)
-			{
-				DrawCandles(area, subscription);
-				DrawIndicator(area, rsi);
-				DrawIndicator(area, priceSma);
-				DrawOwnTrades(area);
-			}
-		}
+\t\t\t// Create indicators
+\t\t\tvar rsi = new RelativeStrengthIndex { Length = RsiPeriod };
+\t\t\tvar priceSma = new SimpleMovingAverage { Length = MovingAvgPeriod };
+
+\t\t\t// Create subscription
+\t\t\tvar subscription = SubscribeCandles(CandleType);
+
+\t\t\t// Create RSI and price SMA processing
+\t\t\tsubscription
+\t\t\t\t.Bind(rsi, priceSma, ProcessCandle)
+\t\t\t\t.Start();
+
+\t\t\t// Enable position protection with percentage stop-loss
+\t\t\tStartProtection(
+\t\t\t\ttakeProfit: new Unit(0), // We'll handle exits in the strategy logic
+\t\t\t\tstopLoss: new Unit(StopLossPercent, UnitTypes.Percent),
+\t\t\t\tuseMarketOrders: true
+\t\t\t);
+
+\t\t\t// Setup chart if available
+\t\t\tvar area = CreateChartArea();
+\t\t\tif (area != null)
+\t\t\t{
+\t\t\t\tDrawCandles(area, subscription);
+\t\t\t\tDrawIndicator(area, rsi);
+\t\t\t\tDrawIndicator(area, priceSma);
+\t\t\t\tDrawOwnTrades(area);
+\t\t\t}
+\t\t}
 
 		private void ProcessCandle(ICandleMessage candle, decimal rsiValue, decimal priceSmaValue)
 		{

--- a/API/0305_RSI_Dynamic_Overbought_Oversold/PY/rsi_dynamic_overbought_oversold_strategy.py
+++ b/API/0305_RSI_Dynamic_Overbought_Oversold/PY/rsi_dynamic_overbought_oversold_strategy.py
@@ -96,6 +96,13 @@ class rsi_dynamic_overbought_oversold_strategy(Strategy):
     def CandleType(self, value):
         self._candleType.Value = value
 
+    def OnReseted(self):
+        super(rsi_dynamic_overbought_oversold_strategy, self).OnReseted()
+        self._rsiSma = SimpleMovingAverage()
+        self._rsiSma.Length = self.MovingAvgPeriod
+        self._rsiStdDev = StandardDeviation()
+        self._rsiStdDev.Length = self.MovingAvgPeriod
+
     def OnStarted(self, time):
         """Called when the strategy starts."""
         super(rsi_dynamic_overbought_oversold_strategy, self).OnStarted(time)
@@ -103,10 +110,6 @@ class rsi_dynamic_overbought_oversold_strategy(Strategy):
         # Create indicators
         rsi = RelativeStrengthIndex()
         rsi.Length = self.RsiPeriod
-        self._rsiSma = SimpleMovingAverage()
-        self._rsiSma.Length = self.MovingAvgPeriod
-        self._rsiStdDev = StandardDeviation()
-        self._rsiStdDev.Length = self.MovingAvgPeriod
         priceSma = SimpleMovingAverage()
         priceSma.Length = self.MovingAvgPeriod
 

--- a/API/0306_Bollinger_Volatility_Breakout/CS/BollingerVolatilityBreakoutStrategy.cs
+++ b/API/0306_Bollinger_Volatility_Breakout/CS/BollingerVolatilityBreakoutStrategy.cs
@@ -121,47 +121,54 @@ namespace StockSharp.Samples.Strategies
 			return [(Security, CandleType)];
 		}
 
-		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
-		{
-			base.OnStarted(time);
+\t\t/// <inheritdoc />
+\t\tprotected override void OnReseted()
+\t\t{
+\t\t\tbase.OnReseted();
 
-			// Create indicators
-			var bollingerBands = new BollingerBands 
-			{ 
-				Length = BollingerPeriod,
-				Width = BollingerDeviation
-			};
-			
-			var atr = new AverageTrueRange { Length = AtrPeriod };
-			_atrSma = new SimpleMovingAverage { Length = AtrPeriod };
-			_atrStdDev = new StandardDeviation { Length = AtrPeriod };
+\t\t\t_atrSma = new SimpleMovingAverage { Length = AtrPeriod };
+\t\t\t_atrStdDev = new StandardDeviation { Length = AtrPeriod };
+\t\t}
 
-			// Create subscription
-			var subscription = SubscribeCandles(CandleType);
-			
-			// Bind main indicators to subscription
-			subscription
-				.BindEx(bollingerBands, atr, ProcessCandle)
-				.Start();
-				
-			// Enable position protection
-			StartProtection(
-				takeProfit: new Unit(0), // We'll handle exits in the strategy logic
-				stopLoss: new Unit(0),   // We'll handle stops in the strategy logic
-				useMarketOrders: true
-			);
+\t\t/// <inheritdoc />
+\t\tprotected override void OnStarted(DateTimeOffset time)
+\t\t{
+\t\t\tbase.OnStarted(time);
 
-			// Setup chart if available
-			var area = CreateChartArea();
-			if (area != null)
-			{
-				DrawCandles(area, subscription);
-				DrawIndicator(area, bollingerBands);
-				DrawIndicator(area, atr);
-				DrawOwnTrades(area);
-			}
-		}
+\t\t\t// Create indicators
+\t\t\tvar bollingerBands = new BollingerBands
+\t\t\t{
+\t\t\t\tLength = BollingerPeriod,
+\t\t\t\tWidth = BollingerDeviation
+\t\t\t};
+
+\t\t\tvar atr = new AverageTrueRange { Length = AtrPeriod };
+
+\t\t\t// Create subscription
+\t\t\tvar subscription = SubscribeCandles(CandleType);
+
+\t\t\t// Bind main indicators to subscription
+\t\t\tsubscription
+\t\t\t\t.BindEx(bollingerBands, atr, ProcessCandle)
+\t\t\t\t.Start();
+
+\t\t\t// Enable position protection
+\t\t\tStartProtection(
+\t\t\t\ttakeProfit: new Unit(0), // We'll handle exits in the strategy logic
+\t\t\t\tstopLoss: new Unit(0),   // We'll handle stops in the strategy logic
+\t\t\t\tuseMarketOrders: true
+\t\t\t);
+
+\t\t\t// Setup chart if available
+\t\t\tvar area = CreateChartArea();
+\t\t\tif (area != null)
+\t\t\t{
+\t\t\t\tDrawCandles(area, subscription);
+\t\t\t\tDrawIndicator(area, bollingerBands);
+\t\t\t\tDrawIndicator(area, atr);
+\t\t\t\tDrawOwnTrades(area);
+\t\t\t}
+\t\t}
 
 		private void ProcessCandle(ICandleMessage candle, IIndicatorValue bbValue, IIndicatorValue atrValue)
 		{

--- a/API/0306_Bollinger_Volatility_Breakout/PY/bollinger_volatility_breakout_strategy.py
+++ b/API/0306_Bollinger_Volatility_Breakout/PY/bollinger_volatility_breakout_strategy.py
@@ -108,6 +108,13 @@ class bollinger_volatility_breakout_strategy(Strategy):
         """Return security and timeframe used by the strategy."""
         return [(self.Security, self.CandleType)]
 
+    def OnReseted(self):
+        super(bollinger_volatility_breakout_strategy, self).OnReseted()
+        self._atr_sma = SimpleMovingAverage()
+        self._atr_sma.Length = self.AtrPeriod
+        self._atr_std_dev = StandardDeviation()
+        self._atr_std_dev.Length = self.AtrPeriod
+
     def OnStarted(self, time):
         super(bollinger_volatility_breakout_strategy, self).OnStarted(time)
 
@@ -118,10 +125,6 @@ class bollinger_volatility_breakout_strategy(Strategy):
 
         atr = AverageTrueRange()
         atr.Length = self.AtrPeriod
-        self._atr_sma = SimpleMovingAverage()
-        self._atr_sma.Length = self.AtrPeriod
-        self._atr_std_dev = StandardDeviation()
-        self._atr_std_dev.Length = self.AtrPeriod
 
         # Create subscription
         subscription = self.SubscribeCandles(self.CandleType)

--- a/API/0307_MACD_Adaptive_Histogram/CS/MacdAdaptiveHistogramStrategy.cs
+++ b/API/0307_MACD_Adaptive_Histogram/CS/MacdAdaptiveHistogramStrategy.cs
@@ -137,50 +137,55 @@ namespace StockSharp.Samples.Strategies
 			return [(Security, CandleType)];
 		}
 
-		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
-		{
-			base.OnStarted(time);
+\t\t/// <inheritdoc />
+\t\tprotected override void OnReseted()
+\t\t{
+\t\t\tbase.OnReseted();
 
-			// Create MACD indicator with custom settings
-			var macdLine = new MovingAverageConvergenceDivergenceSignal
-			{
-				Macd =
-				{
-					ShortMa = { Length = FastPeriod },
-					LongMa = { Length = SlowPeriod },
-				},
-				SignalMa = { Length = SignalPeriod }
-			};
-			
-			// Create indicators for the histogram statistics
-			_histAvg = new SimpleMovingAverage { Length = HistogramAvgPeriod };
-			_histStdDev = new StandardDeviation { Length = HistogramAvgPeriod };
+\t\t\t_histAvg = new SimpleMovingAverage { Length = HistogramAvgPeriod };
+\t\t\t_histStdDev = new StandardDeviation { Length = HistogramAvgPeriod };
+\t\t}
 
-			// Create subscription
-			var subscription = SubscribeCandles(CandleType);
-			
-			// Bind MACD to subscription
-			subscription
-				.BindEx(macdLine, ProcessCandle)
-				.Start();
+\t\t/// <inheritdoc />
+\t\tprotected override void OnStarted(DateTimeOffset time)
+\t\t{
+\t\t\tbase.OnStarted(time);
 
-			// Enable position protection with percentage stop-loss
-			StartProtection(
-				takeProfit: new Unit(0), // We'll handle exits in the strategy logic
-				stopLoss: new Unit(StopLossPercent, UnitTypes.Percent),
-				useMarketOrders: true
-			);
+\t\t\t// Create MACD indicator with custom settings
+\t\t\tvar macdLine = new MovingAverageConvergenceDivergenceSignal
+\t\t\t{
+\t\t\t\tMacd =
+\t\t\t\t{
+\t\t\t\t\tShortMa = { Length = FastPeriod },
+\t\t\t\t\tLongMa = { Length = SlowPeriod },
+\t\t\t\t},
+\t\t\t\tSignalMa = { Length = SignalPeriod }
+\t\t\t};
 
-			// Setup chart if available
-			var area = CreateChartArea();
-			if (area != null)
-			{
-				DrawCandles(area, subscription);
-				DrawIndicator(area, macdLine);
-				DrawOwnTrades(area);
-			}
-		}
+\t\t\t// Create subscription
+\t\t\tvar subscription = SubscribeCandles(CandleType);
+
+\t\t\t// Bind MACD to subscription
+\t\t\tsubscription
+\t\t\t\t.BindEx(macdLine, ProcessCandle)
+\t\t\t\t.Start();
+
+\t\t\t// Enable position protection with percentage stop-loss
+\t\t\tStartProtection(
+\t\t\t\ttakeProfit: new Unit(0), // We'll handle exits in the strategy logic
+\t\t\t\tstopLoss: new Unit(StopLossPercent, UnitTypes.Percent),
+\t\t\t\tuseMarketOrders: true
+\t\t\t);
+
+\t\t\t// Setup chart if available
+\t\t\tvar area = CreateChartArea();
+\t\t\tif (area != null)
+\t\t\t{
+\t\t\t\tDrawCandles(area, subscription);
+\t\t\t\tDrawIndicator(area, macdLine);
+\t\t\t\tDrawOwnTrades(area);
+\t\t\t}
+\t\t}
 
 		private void ProcessCandle(ICandleMessage candle, IIndicatorValue macdValue)
 		{

--- a/API/0307_MACD_Adaptive_Histogram/PY/macd_adaptive_histogram_strategy.py
+++ b/API/0307_MACD_Adaptive_Histogram/PY/macd_adaptive_histogram_strategy.py
@@ -151,6 +151,13 @@ class macd_adaptive_histogram_strategy(Strategy):
     def CandleType(self, value):
         self._candle_type.Value = value
 
+    def OnReseted(self):
+        super(macd_adaptive_histogram_strategy, self).OnReseted()
+        self._hist_avg = SimpleMovingAverage()
+        self._hist_avg.Length = self.HistogramAvgPeriod
+        self._hist_std_dev = StandardDeviation()
+        self._hist_std_dev.Length = self.HistogramAvgPeriod
+
     def OnStarted(self, time):
         """Called when the strategy starts."""
         super(macd_adaptive_histogram_strategy, self).OnStarted(time)
@@ -160,12 +167,6 @@ class macd_adaptive_histogram_strategy(Strategy):
         macd_line.Macd.ShortMa.Length = self.FastPeriod
         macd_line.Macd.LongMa.Length = self.SlowPeriod
         macd_line.SignalMa.Length = self.SignalPeriod
-
-        # Create indicators for the histogram statistics
-        self._hist_avg = SimpleMovingAverage()
-        self._hist_avg.Length = self.HistogramAvgPeriod
-        self._hist_std_dev = StandardDeviation()
-        self._hist_std_dev.Length = self.HistogramAvgPeriod
 
         # Create subscription
         subscription = self.SubscribeCandles(self.CandleType)

--- a/API/0308_Ichimoku_Volume_Cluster/CS/IchimokuVolumeClusterStrategy.cs
+++ b/API/0308_Ichimoku_Volume_Cluster/CS/IchimokuVolumeClusterStrategy.cs
@@ -121,54 +121,59 @@ namespace StockSharp.Samples.Strategies
 			return [(Security, CandleType)];
 		}
 
-		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
-		{
-			base.OnStarted(time);
+\t\t/// <inheritdoc />
+\t\tprotected override void OnReseted()
+\t\t{
+\t\t\tbase.OnReseted();
 
-			// Create Ichimoku indicator
-			var ichimoku = new Ichimoku
-			{
-				Tenkan = { Length = TenkanPeriod },
-				Kijun = { Length = KijunPeriod },
-				SenkouB = { Length = SenkouSpanBPeriod },
-			};
-			
-			// Create volume indicators
-			_volumeAvg = new SimpleMovingAverage { Length = VolumeAvgPeriod };
-			_volumeStdDev = new StandardDeviation { Length = VolumeAvgPeriod };
+\t\t\t_volumeAvg = new SimpleMovingAverage { Length = VolumeAvgPeriod };
+\t\t\t_volumeStdDev = new StandardDeviation { Length = VolumeAvgPeriod };
+\t\t}
 
-			// Create subscription
-			var subscription = SubscribeCandles(CandleType);
-			
-			// Bind Ichimoku to subscription
-			subscription
-				.BindEx(ichimoku, ProcessCandle)
-				.Start();
-				
-			// Setup stop-loss at Kijun-sen level
-			StartProtection(
-				takeProfit: new Unit(0), // We'll handle exits in the strategy logic
-				stopLoss: new Unit(0),   // Using Kijun-sen as dynamic stop-loss
-				useMarketOrders: true
-			);
+\t\t/// <inheritdoc />
+\t\tprotected override void OnStarted(DateTimeOffset time)
+\t\t{
+\t\t\tbase.OnStarted(time);
 
-			// Setup chart if available
-			var area = CreateChartArea();
-			if (area != null)
-			{
-				DrawCandles(area, subscription);
-				DrawIndicator(area, ichimoku);
-				DrawOwnTrades(area);
-				
-				// Create second area for volume
-				var volumeArea = CreateChartArea();
-				if (volumeArea != null)
-				{
-					DrawIndicator(volumeArea, _volumeAvg);
-				}
-			}
-		}
+\t\t\t// Create Ichimoku indicator
+\t\t\tvar ichimoku = new Ichimoku
+\t\t\t{
+\t\t\t\tTenkan = { Length = TenkanPeriod },
+\t\t\t\tKijun = { Length = KijunPeriod },
+\t\t\t\tSenkouB = { Length = SenkouSpanBPeriod },
+\t\t\t};
+
+\t\t\t// Create subscription
+\t\t\tvar subscription = SubscribeCandles(CandleType);
+
+\t\t\t// Bind Ichimoku to subscription
+\t\t\tsubscription
+\t\t\t\t.BindEx(ichimoku, ProcessCandle)
+\t\t\t\t.Start();
+
+\t\t\t// Setup stop-loss at Kijun-sen level
+\t\t\tStartProtection(
+\t\t\t\ttakeProfit: new Unit(0), // We'll handle exits in the strategy logic
+\t\t\t\tstopLoss: new Unit(0),   // Using Kijun-sen as dynamic stop-loss
+\t\t\t\tuseMarketOrders: true
+\t\t\t);
+
+\t\t\t// Setup chart if available
+\t\t\tvar area = CreateChartArea();
+\t\t\tif (area != null)
+\t\t\t{
+\t\t\t\tDrawCandles(area, subscription);
+\t\t\t\tDrawIndicator(area, ichimoku);
+\t\t\t\tDrawOwnTrades(area);
+
+\t\t\t\t// Create second area for volume
+\t\t\t\tvar volumeArea = CreateChartArea();
+\t\t\t\tif (volumeArea != null)
+\t\t\t\t{
+\t\t\t\t\tDrawIndicator(volumeArea, _volumeAvg);
+\t\t\t\t}
+\t\t\t}
+\t\t}
 
 		private void ProcessCandle(ICandleMessage candle, IIndicatorValue v)
 		{

--- a/API/0308_Ichimoku_Volume_Cluster/PY/ichimoku_volume_cluster_strategy.py
+++ b/API/0308_Ichimoku_Volume_Cluster/PY/ichimoku_volume_cluster_strategy.py
@@ -110,6 +110,13 @@ class ichimoku_volume_cluster_strategy(Strategy):
     def CandleType(self, value):
         self._candle_type.Value = value
 
+    def OnReseted(self):
+        super(ichimoku_volume_cluster_strategy, self).OnReseted()
+        self._volume_avg = SimpleMovingAverage()
+        self._volume_avg.Length = self.VolumeAvgPeriod
+        self._volume_std_dev = StandardDeviation()
+        self._volume_std_dev.Length = self.VolumeAvgPeriod
+
     def OnStarted(self, time):
         """Called when the strategy starts."""
         super(ichimoku_volume_cluster_strategy, self).OnStarted(time)
@@ -119,12 +126,6 @@ class ichimoku_volume_cluster_strategy(Strategy):
         ichimoku.Tenkan.Length = self.TenkanPeriod
         ichimoku.Kijun.Length = self.KijunPeriod
         ichimoku.SenkouB.Length = self.SenkouSpanBPeriod
-
-        # Create volume indicators
-        self._volume_avg = SimpleMovingAverage()
-        self._volume_avg.Length = self.VolumeAvgPeriod
-        self._volume_std_dev = StandardDeviation()
-        self._volume_std_dev.Length = self.VolumeAvgPeriod
 
         # Create subscription
         subscription = self.SubscribeCandles(self.CandleType)

--- a/API/0309_Supertrend_Momentum_Filter/CS/SupertrendWithMomentumStrategy.cs
+++ b/API/0309_Supertrend_Momentum_Filter/CS/SupertrendWithMomentumStrategy.cs
@@ -90,49 +90,54 @@ namespace StockSharp.Samples.Strategies
 			return [(Security, CandleType)];
 		}
 
-		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
-		{
-			base.OnStarted(time);
+\t\t/// <inheritdoc />
+\t\tprotected override void OnReseted()
+\t\t{
+\t\t\tbase.OnReseted();
 
-			// Initialize previous values
-			_prevMomentum = 0;
+\t\t\t_prevMomentum = default;
+\t\t}
 
-			// Create indicators
-			var supertrend = new SuperTrend
-			{
-				Length = SupertrendPeriod,
-				Multiplier = SupertrendMultiplier
-			};
+\t\t/// <inheritdoc />
+\t\tprotected override void OnStarted(DateTimeOffset time)
+\t\t{
+\t\t\tbase.OnStarted(time);
 
-			var momentum = new Momentum
-			{
-				Length = MomentumPeriod
-			};
+\t\t\t// Create indicators
+\t\t\tvar supertrend = new SuperTrend
+\t\t\t{
+\t\t\t\tLength = SupertrendPeriod,
+\t\t\t\tMultiplier = SupertrendMultiplier
+\t\t\t};
 
-			// Subscribe to candles and bind indicators
-			var subscription = SubscribeCandles(CandleType);
-			
-			subscription
-				.Bind(supertrend, momentum, ProcessCandle)
-				.Start();
+\t\t\tvar momentum = new Momentum
+\t\t\t{
+\t\t\t\tLength = MomentumPeriod
+\t\t\t};
 
-			// Setup chart if available
-			var area = CreateChartArea();
-			if (area != null)
-			{
-				DrawCandles(area, subscription);
-				DrawIndicator(area, supertrend);
-				DrawIndicator(area, momentum);
-				DrawOwnTrades(area);
-			}
+\t\t\t// Subscribe to candles and bind indicators
+\t\t\tvar subscription = SubscribeCandles(CandleType);
 
-			// Setup position protection
-			StartProtection(
-				takeProfit: new Unit(2, UnitTypes.Percent),
-				stopLoss: new Unit(1, UnitTypes.Percent)
-			);
-		}
+\t\t\tsubscription
+\t\t\t\t.Bind(supertrend, momentum, ProcessCandle)
+\t\t\t\t.Start();
+
+\t\t\t// Setup chart if available
+\t\t\tvar area = CreateChartArea();
+\t\t\tif (area != null)
+\t\t\t{
+\t\t\t\tDrawCandles(area, subscription);
+\t\t\t\tDrawIndicator(area, supertrend);
+\t\t\t\tDrawIndicator(area, momentum);
+\t\t\t\tDrawOwnTrades(area);
+\t\t\t}
+
+\t\t\t// Setup position protection
+\t\t\tStartProtection(
+\t\t\t\ttakeProfit: new Unit(2, UnitTypes.Percent),
+\t\t\t\tstopLoss: new Unit(1, UnitTypes.Percent)
+\t\t\t);
+\t\t}
 
 		private void ProcessCandle(ICandleMessage candle, decimal supertrendValue, decimal momentumValue)
 		{

--- a/API/0309_Supertrend_Momentum_Filter/PY/supertrend_momentum_filter_strategy.py
+++ b/API/0309_Supertrend_Momentum_Filter/PY/supertrend_momentum_filter_strategy.py
@@ -84,11 +84,12 @@ class supertrend_momentum_filter_strategy(Strategy):
     def GetWorkingSecurities(self):
         return [(self.Security, self.CandleType)]
 
+    def OnReseted(self):
+        super(supertrend_momentum_filter_strategy, self).OnReseted()
+        self._prev_momentum = 0.0
+
     def OnStarted(self, time):
         super(supertrend_momentum_filter_strategy, self).OnStarted(time)
-
-        # Initialize previous values
-        self._prev_momentum = 0
 
         # Create indicators
         supertrend = SuperTrend()

--- a/API/0310_Donchian_Volatility_Contraction/PY/donchian_volatility_contraction_strategy.py
+++ b/API/0310_Donchian_Volatility_Contraction/PY/donchian_volatility_contraction_strategy.py
@@ -105,13 +105,14 @@ class donchian_volatility_contraction_strategy(Strategy):
     def GetWorkingSecurities(self):
         return [(self.Security, self.CandleType)]
 
-    def OnStarted(self, time):
-        super(donchian_volatility_contraction_strategy, self).OnStarted(time)
-
-        # Initialize values
+    def OnReseted(self):
+        super(donchian_volatility_contraction_strategy, self).OnReseted()
         self._avg_dc_width = 0
         self._std_dev_dc_width = 0
         self._current_dc_width = 0
+
+    def OnStarted(self, time):
+        super(donchian_volatility_contraction_strategy, self).OnStarted(time)
 
         # Create indicators
         donchian_high = Highest()


### PR DESCRIPTION
## Summary
- reset strategy fields in OnReseted instead of OnStarted for API strategies 301-310
- reinitialize Seasonality Adjusted Momentum state from OnReseted
- fix tab-based indentation in C# strategy resets

## Testing
- `dotnet test` *(command not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689315ecbb3883238e9de8a21a21b91b