### PR TITLE
Refactor strategy reset handling for 221-230

### DIFF
--- a/API/0221_Bollinger_Band_Squeeze/CS/BollingerBandSqueezeStrategy.cs
+++ b/API/0221_Bollinger_Band_Squeeze/CS/BollingerBandSqueezeStrategy.cs
@@ -96,6 +96,17 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_prevBollingerWidth = 0;
+			_avgBollingerWidth = 0;
+			_bollingerWidthSum = 0;
+			_bollingerWidths.Clear();
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
@@ -108,13 +119,6 @@ namespace StockSharp.Samples.Strategies
 			};
 
 			_atr = new AverageTrueRange { Length = BollingerPeriod };
-
-			// Reset state
-			_prevBollingerWidth = 0;
-			_avgBollingerWidth = 0;
-			_bollingerWidthSum = 0;
-			_bollingerWidths.Clear();
-
 			// Create subscription and bind indicator
 			var subscription = SubscribeCandles(CandleType);
 			subscription

--- a/API/0221_Bollinger_Band_Squeeze/PY/bollinger_band_squeeze_strategy.py
+++ b/API/0221_Bollinger_Band_Squeeze/PY/bollinger_band_squeeze_strategy.py
@@ -91,6 +91,14 @@ class bollinger_band_squeeze_strategy(Strategy):
     def GetWorkingSecurities(self):
         return [(self.Security, self.CandleType)]
 
+    def OnReseted(self):
+        super(bollinger_band_squeeze_strategy, self).OnReseted()
+
+        self._prevBollingerWidth = 0.0
+        self._avgBollingerWidth = 0.0
+        self._bollingerWidthSum = 0.0
+        self._bollingerWidths = []
+
     def OnStarted(self, time):
         super(bollinger_band_squeeze_strategy, self).OnStarted(time)
 
@@ -102,11 +110,6 @@ class bollinger_band_squeeze_strategy(Strategy):
         self._atr = AverageTrueRange()
         self._atr.Length = self.BollingerPeriod
 
-        # Reset state
-        self._prevBollingerWidth = 0.0
-        self._avgBollingerWidth = 0.0
-        self._bollingerWidthSum = 0.0
-        self._bollingerWidths = []
 
         # Create subscription and bind indicator
         subscription = self.SubscribeCandles(self.CandleType)

--- a/API/0222_Cointegration_Pairs/CS/CointegrationPairsStrategy.cs
+++ b/API/0222_Cointegration_Pairs/CS/CointegrationPairsStrategy.cs
@@ -133,6 +133,20 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_residualMean = 0;
+			_residualStdDev = 0;
+			_residualSum = 0;
+			_squaredResidualSum = 0;
+			_residuals.Clear();
+			_asset1Price = 0;
+			_asset2Price = 0;
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
@@ -143,14 +157,6 @@ namespace StockSharp.Samples.Strategies
 			// Use the same portfolio for second asset or find another portfolio
 			_asset2Portfolio = Portfolio;
 
-			// Reset state
-			_residualMean = 0;
-			_residualStdDev = 0;
-			_residualSum = 0;
-			_squaredResidualSum = 0;
-			_residuals.Clear();
-			_asset1Price = 0;
-			_asset2Price = 0;
 
 			// Subscribe to Asset1 candles
 			var asset1Subscription = SubscribeCandles(CandleType)

--- a/API/0222_Cointegration_Pairs/PY/cointegration_pairs_strategy.py
+++ b/API/0222_Cointegration_Pairs/PY/cointegration_pairs_strategy.py
@@ -117,6 +117,17 @@ class cointegration_pairs_strategy(Strategy):
     def GetWorkingSecurities(self):
         return [(self.Security, self.CandleType), (self.Asset2, self.CandleType)]
 
+    def OnReseted(self):
+        super(cointegration_pairs_strategy, self).OnReseted()
+
+        self._residualMean = 0
+        self._residualStdDev = 0
+        self._residualSum = 0
+        self._squaredResidualSum = 0
+        self._residuals.Clear()
+        self._asset1Price = 0
+        self._asset2Price = 0
+
     def OnStarted(self, time):
         super(cointegration_pairs_strategy, self).OnStarted(time)
 
@@ -126,14 +137,6 @@ class cointegration_pairs_strategy(Strategy):
         # Use the same portfolio for second asset or find another portfolio
         self._asset2Portfolio = self.Portfolio
 
-        # Reset state
-        self._residualMean = 0
-        self._residualStdDev = 0
-        self._residualSum = 0
-        self._squaredResidualSum = 0
-        self._residuals.Clear()
-        self._asset1Price = 0
-        self._asset2Price = 0
 
         # Create subscriptions for both assets
         asset1Subscription = self.SubscribeCandles(self.CandleType)

--- a/API/0223_Momentum_Divergence/CS/MomentumDivergenceStrategy.cs
+++ b/API/0223_Momentum_Divergence/CS/MomentumDivergenceStrategy.cs
@@ -81,6 +81,17 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_prevPrice = 0;
+			_prevMomentum = 0;
+			_currentPrice = 0;
+			_currentMomentum = 0;
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
@@ -89,12 +100,6 @@ namespace StockSharp.Samples.Strategies
 			_momentum = new Momentum { Length = MomentumPeriod };
 			_sma = new SimpleMovingAverage { Length = MaPeriod };
 			
-			// Reset state
-			_prevPrice = 0;
-			_prevMomentum = 0;
-			_currentPrice = 0;
-			_currentMomentum = 0;
-
 			// Create subscription and bind indicators
 			var subscription = SubscribeCandles(CandleType);
 			subscription

--- a/API/0223_Momentum_Divergence/PY/momentum_divergence_strategy.py
+++ b/API/0223_Momentum_Divergence/PY/momentum_divergence_strategy.py
@@ -70,6 +70,14 @@ class momentum_divergence_strategy(Strategy):
     def CandleType(self, value):
         self._candleType.Value = value
 
+    def OnReseted(self):
+        super(momentum_divergence_strategy, self).OnReseted()
+
+        self._prevPrice = 0
+        self._prevMomentum = 0
+        self._currentPrice = 0
+        self._currentMomentum = 0
+
     def OnStarted(self, time):
         """
         Called when the strategy starts. Initializes indicators and subscriptions.
@@ -82,11 +90,6 @@ class momentum_divergence_strategy(Strategy):
         self._sma = SimpleMovingAverage()
         self._sma.Length = self.MaPeriod
 
-        # Reset state
-        self._prevPrice = 0
-        self._prevMomentum = 0
-        self._currentPrice = 0
-        self._currentMomentum = 0
 
         # Create subscription and bind indicators
         subscription = self.SubscribeCandles(self.CandleType)

--- a/API/0224_ATR_Mean_Reversion/CS/AtrMeanReversionStrategy.cs
+++ b/API/0224_ATR_Mean_Reversion/CS/AtrMeanReversionStrategy.cs
@@ -92,6 +92,15 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_sma = null;
+			_atr = null;
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);

--- a/API/0224_ATR_Mean_Reversion/PY/atr_mean_reversion_strategy.py
+++ b/API/0224_ATR_Mean_Reversion/PY/atr_mean_reversion_strategy.py
@@ -78,6 +78,11 @@ class atr_mean_reversion_strategy(Strategy):
     def CandleType(self, value):
         self._candleType.Value = value
 
+    def OnReseted(self):
+        super(atr_mean_reversion_strategy, self).OnReseted()
+        self._sma = None
+        self._atr = None
+
     def OnStarted(self, time):
         super(atr_mean_reversion_strategy, self).OnStarted(time)
 

--- a/API/0225_Kalman_Filter_Trend/CS/KalmanFilterTrendStrategy.cs
+++ b/API/0225_Kalman_Filter_Trend/CS/KalmanFilterTrendStrategy.cs
@@ -76,6 +76,15 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_kalmanFilter = null;
+			_atr = null;
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);

--- a/API/0225_Kalman_Filter_Trend/PY/kalman_filter_trend_strategy.py
+++ b/API/0225_Kalman_Filter_Trend/PY/kalman_filter_trend_strategy.py
@@ -64,6 +64,11 @@ class kalman_filter_trend_strategy(Strategy):
     def GetWorkingSecurities(self):
         return [(self.Security, self.CandleType)]
 
+    def OnReseted(self):
+        super(kalman_filter_trend_strategy, self).OnReseted()
+        self._kalman_filter = None
+        self._atr = None
+
     def OnStarted(self, time):
         super(kalman_filter_trend_strategy, self).OnStarted(time)
 

--- a/API/0226_Volatility_Adjusted_Mean_Reversion/CS/VolatilityAdjustedMeanReversionStrategy.cs
+++ b/API/0226_Volatility_Adjusted_Mean_Reversion/CS/VolatilityAdjustedMeanReversionStrategy.cs
@@ -77,6 +77,16 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_sma = null;
+			_atr = null;
+			_stdDev = null;
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);

--- a/API/0227_Hurst_Exponent_Trend/CS/HurstExponentTrendStrategy.cs
+++ b/API/0227_Hurst_Exponent_Trend/CS/HurstExponentTrendStrategy.cs
@@ -93,6 +93,15 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_hurst = null;
+			_sma = null;
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);

--- a/API/0227_Hurst_Exponent_Trend/PY/hurst_exponent_trend_strategy.py
+++ b/API/0227_Hurst_Exponent_Trend/PY/hurst_exponent_trend_strategy.py
@@ -87,6 +87,11 @@ class hurst_exponent_trend_strategy(Strategy):
         """Return securities and candle types used by the strategy."""
         return [(self.Security, self.CandleType)]
 
+    def OnReseted(self):
+        super(hurst_exponent_trend_strategy, self).OnReseted()
+        self._hurst = None
+        self._sma = None
+
     def OnStarted(self, time):
         super(hurst_exponent_trend_strategy, self).OnStarted(time)
 

--- a/API/0228_Hurst_Exponent_Reversion/CS/HurstExponentReversionStrategy.cs
+++ b/API/0228_Hurst_Exponent_Reversion/CS/HurstExponentReversionStrategy.cs
@@ -91,12 +91,18 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
+			base.OnReseted();
 
 			_previousHurstValue = default;
 			_currentPrice = default;
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Initialize the SMA indicator
 			_sma = new SimpleMovingAverage { Length = AveragePeriod };

--- a/API/0228_Hurst_Exponent_Reversion/PY/hurst_exponent_reversion_strategy.py
+++ b/API/0228_Hurst_Exponent_Reversion/PY/hurst_exponent_reversion_strategy.py
@@ -84,12 +84,16 @@ class hurst_exponent_reversion_strategy(Strategy):
         """Return security and timeframe used by the strategy."""
         return [(self.Security, self.CandleType)]
 
+    def OnReseted(self):
+        super(hurst_exponent_reversion_strategy, self).OnReseted()
+
+        self._previous_hurst_value = 0.0
+        self._current_price = 0.0
+
     def OnStarted(self, time):
         """Called when the strategy starts."""
         super(hurst_exponent_reversion_strategy, self).OnStarted(time)
 
-        self._previous_hurst_value = 0.0
-        self._current_price = 0.0
 
         # Initialize the SMA indicator
         self._sma = SimpleMovingAverage()

--- a/API/0229_Autocorrelation_Reversal/CS/AutocorrelationReversionStrategy.cs
+++ b/API/0229_Autocorrelation_Reversal/CS/AutocorrelationReversionStrategy.cs
@@ -93,13 +93,19 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
+			base.OnReseted();
 
 			_priceHistory.Clear();
 			_latestAutocorrelation = default;
 			_currentPrice = default;
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Initialize the SMA indicator (using same period as autocorrelation for simplicity)
 			_sma = new SimpleMovingAverage { Length = AutoCorrPeriod };

--- a/API/0229_Autocorrelation_Reversal/PY/autocorrelation_reversion_strategy.py
+++ b/API/0229_Autocorrelation_Reversal/PY/autocorrelation_reversion_strategy.py
@@ -85,12 +85,16 @@ class autocorrelation_reversion_strategy(Strategy):
     def GetWorkingSecurities(self):
         return [(self.Security, self.CandleType)]
 
-    def OnStarted(self, time):
-        super(autocorrelation_reversion_strategy, self).OnStarted(time)
+    def OnReseted(self):
+        super(autocorrelation_reversion_strategy, self).OnReseted()
 
         self._price_history = []
         self._latest_autocorrelation = 0.0
         self._current_price = 0.0
+
+    def OnStarted(self, time):
+        super(autocorrelation_reversion_strategy, self).OnStarted(time)
+
 
         # Initialize the SMA indicator (using same period as autocorrelation for simplicity)
         self._sma = SimpleMovingAverage()

--- a/API/0230_Delta_Neutral_Arbitrage/CS/DeltaNeutralArbitrageStrategy.cs
+++ b/API/0230_Delta_Neutral_Arbitrage/CS/DeltaNeutralArbitrageStrategy.cs
@@ -124,15 +124,21 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
+			base.OnReseted();
 
 			_currentSpread = default;
 			_lastAsset1Price = default;
 			_lastAsset2Price = default;
 			_asset1Volume = default;
 			_asset2Volume = default;
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			if (Asset2Security == null)
 				throw new InvalidOperationException("Asset2Security is not specified.");

--- a/API/0230_Delta_Neutral_Arbitrage/PY/delta_neutral_arbitrage_strategy.py
+++ b/API/0230_Delta_Neutral_Arbitrage/PY/delta_neutral_arbitrage_strategy.py
@@ -130,12 +130,6 @@ class delta_neutral_arbitrage_strategy(Strategy):
     def OnStarted(self, time):
         super(delta_neutral_arbitrage_strategy, self).OnStarted(time)
 
-        self._current_spread = 0.0
-        self._last_asset1_price = 0.0
-        self._last_asset2_price = 0.0
-        self._asset1_volume = 0.0
-        self._asset2_volume = 0.0
-
         if self.asset2_security is None:
             raise Exception("Asset2Security is not specified.")
 


### PR DESCRIPTION
## Summary
- Move state clearing from `OnStarted` to `OnReseted` across remaining strategies 224–227 for both C# and Python implementations
- Ensure per-strategy collections and indicators are reinitialized in `OnReseted`

## Testing
- `pytest`
- `dotnet build` *(fails: command not found; `apt-get update` reported unsigned repositories, `apt-get install -y dotnet-sdk-7.0` unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689315b47f4483239c591f797a4b7aaf