### PR TITLE
Move indicator cleanup to OnReseted for strategies 341-350

### DIFF
--- a/API/0341_Supertrend_Put_Call_Ratio/PY/supertrend_put_call_ratio_strategy.py
+++ b/API/0341_Supertrend_Put_Call_Ratio/PY/supertrend_put_call_ratio_strategy.py
@@ -119,6 +119,7 @@ class supertrend_put_call_ratio_strategy(Strategy):
         self._currentPcr = 0.0
         self._pcrAverage = 0.0
         self._pcrStdDev = 0.0
+        self._supertrend = None
 
     def OnStarted(self, time):
         super(supertrend_put_call_ratio_strategy, self).OnStarted(time)

--- a/API/0342_Donchian_Sentiment_Spike/CS/DonchianWithSentimentSpikeStrategy.cs
+++ b/API/0342_Donchian_Sentiment_Spike/CS/DonchianWithSentimentSpikeStrategy.cs
@@ -127,13 +127,9 @@ namespace StockSharp.Samples.Strategies
 		{
 			base.OnReseted();
 
-			_isLong = false;
-			_isShort = false;
-			_midChannel = 0;
+			_isLong = _isShort = default;
+			_midChannel = _sentimentAverage = _sentimentStdDev = _currentSentiment = default;
 			_sentimentHistory.Clear();
-			_sentimentAverage = 0;
-			_sentimentStdDev = 0;
-			_currentSentiment = 0;
 		}
 
 		protected override void OnStarted(DateTimeOffset time)

--- a/API/0342_Donchian_Sentiment_Spike/PY/donchian_with_sentiment_spike_strategy.py
+++ b/API/0342_Donchian_Sentiment_Spike/PY/donchian_with_sentiment_spike_strategy.py
@@ -106,14 +106,9 @@ class donchian_with_sentiment_spike_strategy(Strategy):
 
     def OnReseted(self):
         super(donchian_with_sentiment_spike_strategy, self).OnReseted()
-        # Initialize flags
-        self._is_long = False
-        self._is_short = False
-        self._mid_channel = 0.0
+        self._is_long = self._is_short = False
+        self._mid_channel = self._sentiment_average = self._sentiment_std_dev = self._current_sentiment = 0.0
         self._sentiment_history.clear()
-        self._sentiment_average = 0.0
-        self._sentiment_std_dev = 0.0
-        self._current_sentiment = 0.0
 
     def OnStarted(self, time):
         super(donchian_with_sentiment_spike_strategy, self).OnStarted(time)

--- a/API/0343_Keltner_Reinforcement_Learning_Signal/CS/KeltnerWithRLSignalStrategy.cs
+++ b/API/0343_Keltner_Reinforcement_Learning_Signal/CS/KeltnerWithRLSignalStrategy.cs
@@ -134,14 +134,9 @@ namespace StockSharp.Samples.Strategies
 		{
 			base.OnReseted();
 
-			_currentSignal = RLSignal.None;
-			_consecutiveWins = default;
-			_consecutiveLosses = default;
-			_lastPrice = default;
-			_previousEma = default;
-			_previousAtr = default;
-			_previousPrice = default;
-			_previousSignalPrice = default;
+			_currentSignal = default;
+			_consecutiveWins = _consecutiveLosses = default;
+			_lastPrice = _previousEma = _previousAtr = _previousPrice = _previousSignalPrice = default;
 		}
 
 		protected override void OnStarted(DateTimeOffset time)

--- a/API/0343_Keltner_Reinforcement_Learning_Signal/PY/keltner_with_rl_signal_strategy.py
+++ b/API/0343_Keltner_Reinforcement_Learning_Signal/PY/keltner_with_rl_signal_strategy.py
@@ -126,13 +126,8 @@ class keltner_with_rl_signal_strategy(Strategy):
         super(keltner_with_rl_signal_strategy, self).OnReseted()
         # Initialize RL state variables
         self._current_signal = self._RLSignal.None_
-        self._consecutive_wins = 0
-        self._consecutive_losses = 0
-        self._last_price = 0
-        self._previous_ema = 0
-        self._previous_atr = 0
-        self._previous_price = 0
-        self._previous_signal_price = 0
+        self._consecutive_wins = self._consecutive_losses = 0
+        self._last_price = self._previous_ema = self._previous_atr = self._previous_price = self._previous_signal_price = 0
 
     def OnStarted(self, time):
         super(keltner_with_rl_signal_strategy, self).OnStarted(time)

--- a/API/0344_Hull_MA_Implied_Volatility_Breakout/CS/HullMAWithImpliedVolatilityBreakoutStrategy.cs
+++ b/API/0344_Hull_MA_Implied_Volatility_Breakout/CS/HullMAWithImpliedVolatilityBreakoutStrategy.cs
@@ -128,13 +128,8 @@ namespace StockSharp.Samples.Strategies
 		{
 			base.OnReseted();
 
-			_isLong = default;
-			_isShort = default;
-			_prevHmaValue = default;
-			_currentAtr = default;
-			_currentIv = default;
-			_ivAverage = default;
-			_ivStdDev = default;
+			_isLong = _isShort = default;
+			_prevHmaValue = _currentAtr = _currentIv = _ivAverage = _ivStdDev = default;
 			_impliedVolatilityHistory.Clear();
 		}
 

--- a/API/0344_Hull_MA_Implied_Volatility_Breakout/PY/hull_ma_implied_volatility_breakout_strategy.py
+++ b/API/0344_Hull_MA_Implied_Volatility_Breakout/PY/hull_ma_implied_volatility_breakout_strategy.py
@@ -117,14 +117,9 @@ class hull_ma_implied_volatility_breakout_strategy(Strategy):
     def OnReseted(self):
         super(hull_ma_implied_volatility_breakout_strategy, self).OnReseted()
         # Initialize flags
-        self._isLong = False
-        self._isShort = False
-        self._prevHmaValue = 0.0
-        self._currentAtr = 0.0
-        self._currentIv = 0.0
-        self._ivAverage = 0.0
-        self._ivStdDev = 0.0
-        self._impliedVolatilityHistory[:] = []
+        self._isLong = self._isShort = False
+        self._prevHmaValue = self._currentAtr = self._currentIv = self._ivAverage = self._ivStdDev = 0.0
+        self._impliedVolatilityHistory.clear()
 
     def OnStarted(self, time):
         super(hull_ma_implied_volatility_breakout_strategy, self).OnStarted(time)

--- a/API/0345_VWAP_Behavioral_Bias_Filter/PY/vwap_with_behavioral_bias_filter_strategy.py
+++ b/API/0345_VWAP_Behavioral_Bias_Filter/PY/vwap_with_behavioral_bias_filter_strategy.py
@@ -99,7 +99,7 @@ class vwap_with_behavioral_bias_filter_strategy(Strategy):
         self._isLong = False
         self._isShort = False
         self._currentBiasScore = 0
-        self._recentPriceMovements = []
+        self._recentPriceMovements.clear()
         self._vwap = None
 
     def OnStarted(self, time):

--- a/API/0347_RSI_Option_Open_Interest/CS/RsiWithOptionOpenInterestStrategy.cs
+++ b/API/0347_RSI_Option_Open_Interest/CS/RsiWithOptionOpenInterestStrategy.cs
@@ -119,17 +119,22 @@ namespace StockSharp.Samples.Strategies
 			base.OnReseted();
 
 			_rsi?.Reset();
+			_rsi = null;
 			_callOiSma?.Reset();
+			_callOiSma = null;
 			_putOiSma?.Reset();
+			_putOiSma = null;
 			_callOiStdDev?.Reset();
+			_callOiStdDev = null;
 			_putOiStdDev?.Reset();
+			_putOiStdDev = null;
 
-			_currentCallOi = 0;
-			_currentPutOi = 0;
-			_avgCallOi = 0;
-			_avgPutOi = 0;
-			_stdDevCallOi = 0;
-			_stdDevPutOi = 0;
+			_currentCallOi = default;
+			_currentPutOi = default;
+			_avgCallOi = default;
+			_avgPutOi = default;
+			_stdDevCallOi = default;
+			_stdDevPutOi = default;
 		}
 
 		/// <inheritdoc />

--- a/API/0347_RSI_Option_Open_Interest/PY/rsi_with_option_open_interest_strategy.py
+++ b/API/0347_RSI_Option_Open_Interest/PY/rsi_with_option_open_interest_strategy.py
@@ -115,14 +115,19 @@ class rsi_with_option_open_interest_strategy(Strategy):
         super(rsi_with_option_open_interest_strategy, self).OnReseted()
         if self._rsi:
             self._rsi.Reset()
+            self._rsi = None
         if self._call_oi_sma:
             self._call_oi_sma.Reset()
+            self._call_oi_sma = None
         if self._put_oi_sma:
             self._put_oi_sma.Reset()
+            self._put_oi_sma = None
         if self._call_oi_stddev:
             self._call_oi_stddev.Reset()
+            self._call_oi_stddev = None
         if self._put_oi_stddev:
             self._put_oi_stddev.Reset()
+            self._put_oi_stddev = None
         self._current_call_oi = 0
         self._current_put_oi = 0
         self._avg_call_oi = 0

--- a/API/0348_Stochastic_Implied_Volatility_Skew/CS/StochasticImpliedVolatilitySkewStrategy.cs
+++ b/API/0348_Stochastic_Implied_Volatility_Skew/CS/StochasticImpliedVolatilitySkewStrategy.cs
@@ -119,17 +119,18 @@ namespace StockSharp.Samples.Strategies
 		{
 			return [(Security, CandleType)];
 		}
-
 		/// <inheritdoc />
 		protected override void OnReseted()
 		{
 			base.OnReseted();
 
 			_stochastic?.Reset();
+			_stochastic = null;
 			_ivSkewSma?.Reset();
+			_ivSkewSma = null;
 
-			_currentIvSkew = 0;
-			_avgIvSkew = 0;
+			_currentIvSkew = default;
+			_avgIvSkew = default;
 		}
 
 		/// <inheritdoc />

--- a/API/0348_Stochastic_Implied_Volatility_Skew/PY/stochastic_implied_volatility_skew_strategy.py
+++ b/API/0348_Stochastic_Implied_Volatility_Skew/PY/stochastic_implied_volatility_skew_strategy.py
@@ -120,8 +120,10 @@ class stochastic_implied_volatility_skew_strategy(Strategy):
         super(stochastic_implied_volatility_skew_strategy, self).OnReseted()
         if self._stochastic:
             self._stochastic.Reset()
+            self._stochastic = None
         if self._iv_skew_sma:
             self._iv_skew_sma.Reset()
+            self._iv_skew_sma = None
         self._current_iv_skew = 0
         self._avg_iv_skew = 0
 

--- a/API/0349_ADX_Sentiment_Momentum/CS/AdxSentimentMomentumStrategy.cs
+++ b/API/0349_ADX_Sentiment_Momentum/CS/AdxSentimentMomentumStrategy.cs
@@ -106,16 +106,16 @@ namespace StockSharp.Samples.Strategies
 		{
 			return [(Security, CandleType)];
 		}
-
 		/// <inheritdoc />
 		protected override void OnReseted()
 		{
 			base.OnReseted();
 
 			_adx?.Reset();
-			_prevSentiment = 0;
-			_currentSentiment = 0;
-			_sentimentMomentum = 0;
+			_adx = null;
+			_prevSentiment = default;
+			_currentSentiment = default;
+			_sentimentMomentum = default;
 		}
 
 		/// <inheritdoc />

--- a/API/0349_ADX_Sentiment_Momentum/PY/adx_sentiment_momentum_strategy.py
+++ b/API/0349_ADX_Sentiment_Momentum/PY/adx_sentiment_momentum_strategy.py
@@ -103,6 +103,7 @@ class adx_sentiment_momentum_strategy(Strategy):
         super(adx_sentiment_momentum_strategy, self).OnReseted()
         if self._adx:
             self._adx.Reset()
+            self._adx = None
         self._prev_sentiment = 0
         self._current_sentiment = 0
         self._sentiment_momentum = 0

--- a/API/0350_CCI_Put_Call_Ratio_Divergence/CS/CciPutCallRatioDivergenceStrategy.cs
+++ b/API/0350_CCI_Put_Call_Ratio_Divergence/CS/CciPutCallRatioDivergenceStrategy.cs
@@ -76,18 +76,19 @@ namespace StockSharp.Samples.Strategies
 		{
 			return [(Security, CandleType)];
 		}
-
 		/// <inheritdoc />
 		protected override void OnReseted()
 		{
 			base.OnReseted();
 
 			_cci?.Reset();
+			_cci = null;
 			_atr?.Reset();
+			_atr = null;
 
-			_prevPcr = 0;
-			_currentPcr = 0;
-			_prevPrice = 0;
+			_prevPcr = default;
+			_currentPcr = default;
+			_prevPrice = default;
 		}
 
 		/// <inheritdoc />

--- a/API/0350_CCI_Put_Call_Ratio_Divergence/PY/cci_put_call_ratio_divergence_strategy.py
+++ b/API/0350_CCI_Put_Call_Ratio_Divergence/PY/cci_put_call_ratio_divergence_strategy.py
@@ -76,8 +76,10 @@ class cci_put_call_ratio_divergence_strategy(Strategy):
         super(cci_put_call_ratio_divergence_strategy, self).OnReseted()
         if self._cci:
             self._cci.Reset()
+            self._cci = None
         if self._atr:
             self._atr.Reset()
+            self._atr = None
         self._prev_pcr = 0.0
         self._current_pcr = 0.0
         self._prev_price = 0.0


### PR DESCRIPTION
## Summary
- clear SuperTrend state during reset in Supertrend Put/Call Ratio strategy
- release indicator references in RSI Option Open Interest strategy
- reset stochastic and SMA indicators in Stochastic IV Skew and related strategies
- align ADX Sentiment Momentum and CCI Put/Call Ratio Divergence resets
- standardize list cleanup in Hull MA IV Breakout and VWAP Behavioral Bias strategies
- consolidate reset logic for Donchian Sentiment Spike, Keltner RL Signal, and Hull MA IV Breakout strategies

## Testing
- `python -m py_compile API/0341_Supertrend_Put_Call_Ratio/PY/supertrend_put_call_ratio_strategy.py API/0342_Donchian_Sentiment_Spike/PY/donchian_with_sentiment_spike_strategy.py API/0343_Keltner_Reinforcement_Learning_Signal/PY/keltner_with_rl_signal_strategy.py API/0344_Hull_MA_Implied_Volatility_Breakout/PY/hull_ma_implied_volatility_breakout_strategy.py API/0345_VWAP_Behavioral_Bias_Filter/PY/vwap_with_behavioral_bias_filter_strategy.py API/0346_Parabolic_SAR_Sentiment_Divergence/PY/parabolic_sar_sentiment_divergence_strategy.py API/0347_RSI_Option_Open_Interest/PY/rsi_with_option_open_interest_strategy.py API/0348_Stochastic_Implied_Volatility_Skew/PY/stochastic_implied_volatility_skew_strategy.py API/0349_ADX_Sentiment_Momentum/PY/adx_sentiment_momentum_strategy.py API/0350_CCI_Put_Call_Ratio_Divergence/PY/cci_put_call_ratio_divergence_strategy.py`
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893160ae50083239bf070605c1a464e