### PR TITLE
Move state reset to OnReseted for strategies 193-200

### DIFF
--- a/API/0193_Supertrend_ADX/CS/SupertrendAdxStrategy.cs
+++ b/API/0193_Supertrend_ADX/CS/SupertrendAdxStrategy.cs
@@ -115,12 +115,19 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_lastSupertrend = default;
+			_isAboveSupertrend = default;
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
 
-			_lastSupertrend = 0;
-			_isAboveSupertrend = false;
 
 			// Create indicators
 			var atr = new AverageTrueRange { Length = SupertrendPeriod };

--- a/API/0193_Supertrend_ADX/PY/supertrend_adx_strategy.py
+++ b/API/0193_Supertrend_ADX/PY/supertrend_adx_strategy.py
@@ -53,8 +53,6 @@ class supertrend_adx_strategy(Strategy):
         self._candle_type = self.Param("CandleType", tf(15)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
-        self._last_supertrend = 0
-        self._is_above_supertrend = False
 
     @property
     def SupertrendPeriod(self):
@@ -104,11 +102,14 @@ class supertrend_adx_strategy(Strategy):
     def GetWorkingSecurities(self):
         return [(self.Security, self.CandleType)]
 
+    def OnReseted(self):
+        super(supertrend_adx_strategy, self).OnReseted()
+        self._last_supertrend = 0
+        self._is_above_supertrend = False
+
     def OnStarted(self, time):
         super(supertrend_adx_strategy, self).OnStarted(time)
 
-        self._last_supertrend = 0
-        self._is_above_supertrend = False
 
         # Create indicators
         atr = AverageTrueRange()

--- a/API/0194_Keltner_MACD/CS/KeltnerMacdStrategy.cs
+++ b/API/0194_Keltner_MACD/CS/KeltnerMacdStrategy.cs
@@ -165,6 +165,18 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_ema = default;
+			_atr = default;
+			_macd = default;
+			_prevMacd = default;
+			_prevSignal = default;
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
@@ -182,9 +194,6 @@ namespace StockSharp.Samples.Strategies
 				},
 				SignalMa = { Length = MacdSignalPeriod }
 			};
-			// Initialize variables
-			_prevMacd = 0;
-			_prevSignal = 0;
 
 			// Create subscription
 			var subscription = SubscribeCandles(CandleType);

--- a/API/0194_Keltner_MACD/PY/keltner_macd_strategy.py
+++ b/API/0194_Keltner_MACD/PY/keltner_macd_strategy.py
@@ -66,8 +66,6 @@ class keltner_macd_strategy(Strategy):
         self._macd = None
 
         # Previous MACD values for cross detection
-        self._prevMacd = 0.0
-        self._prevSignal = 0.0
 
     @property
     def EmaPeriod(self):
@@ -153,6 +151,14 @@ class keltner_macd_strategy(Strategy):
     def GetWorkingSecurities(self):
         return [(self.Security, self.CandleType)]
 
+    def OnReseted(self):
+        super(keltner_macd_strategy, self).OnReseted()
+        self._ema = None
+        self._atr = None
+        self._macd = None
+        self._prevMacd = 0.0
+        self._prevSignal = 0.0
+
     def OnStarted(self, time):
         """Called when the strategy starts."""
         super(keltner_macd_strategy, self).OnStarted(time)
@@ -169,9 +175,6 @@ class keltner_macd_strategy(Strategy):
         self._macd.Macd.LongMa.Length = self.MacdSlowPeriod
         self._macd.SignalMa.Length = self.MacdSignalPeriod
 
-        # Reset previous values
-        self._prevMacd = 0.0
-        self._prevSignal = 0.0
 
         # Subscribe to candles and bind indicators
         subscription = self.SubscribeCandles(self.CandleType)

--- a/API/0197_Hull_MA_ADX/CS/HullMaAdxStrategy.cs
+++ b/API/0197_Hull_MA_ADX/CS/HullMaAdxStrategy.cs
@@ -111,6 +111,18 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_hma = default;
+			_adx = default;
+			_atr = default;
+			_prevHmaValue = default;
+			_prevAdxValue = default;
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
@@ -120,9 +132,6 @@ namespace StockSharp.Samples.Strategies
 			_adx = new() { Length = AdxPeriod };
 			_atr = new() { Length = 14 };
 
-			// Initialize variables
-			_prevHmaValue = 0;
-			_prevAdxValue = 0;
 
 			// Create subscription
 			var subscription = SubscribeCandles(CandleType);

--- a/API/0197_Hull_MA_ADX/PY/hull_ma_adx_strategy.py
+++ b/API/0197_Hull_MA_ADX/PY/hull_ma_adx_strategy.py
@@ -106,6 +106,9 @@ class hull_ma_adx_strategy(Strategy):
     def OnReseted(self):
         """Resets internal state when strategy is reset."""
         super(hull_ma_adx_strategy, self).OnReseted()
+        self._hma = None
+        self._adx = None
+        self._atr = None
         self._prev_hma_value = 0.0
         self._prev_adx_value = 0.0
 
@@ -120,9 +123,6 @@ class hull_ma_adx_strategy(Strategy):
         self._atr = AverageTrueRange()
         self._atr.Length = 14
 
-        # Initialize variables
-        self._prev_hma_value = 0.0
-        self._prev_adx_value = 0.0
 
         # Create subscription
         subscription = self.SubscribeCandles(self.candle_type)

--- a/API/0198_VWAP_MACD/CS/VwapMacdStrategy.cs
+++ b/API/0198_VWAP_MACD/CS/VwapMacdStrategy.cs
@@ -106,6 +106,17 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_macd = default;
+			_vwap = default;
+			_prevMacd = default;
+			_prevSignal = default;
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
@@ -122,9 +133,6 @@ namespace StockSharp.Samples.Strategies
 				SignalMa = { Length = MacdSignalPeriod }
 			};
 			_vwap = new() { Length = MacdSignalPeriod };
-			// Initialize variables
-			_prevMacd = 0;
-			_prevSignal = 0;
 
 			// Enable position protection
 			StartProtection(new Unit(StopLossPercent, UnitTypes.Percent), new Unit(StopLossPercent, UnitTypes.Percent));

--- a/API/0198_VWAP_MACD/PY/vwap_macd_strategy.py
+++ b/API/0198_VWAP_MACD/PY/vwap_macd_strategy.py
@@ -46,8 +46,6 @@ class vwap_macd_strategy(Strategy):
 
         self._macd = None
         self._vwap = None
-        self._prev_macd = 0
-        self._prev_signal = 0
 
     @property
     def macd_fast_period(self):
@@ -89,6 +87,13 @@ class vwap_macd_strategy(Strategy):
     def candle_type(self, value):
         self._candle_type.Value = value
 
+    def OnReseted(self):
+        super(vwap_macd_strategy, self).OnReseted()
+        self._macd = None
+        self._vwap = None
+        self._prev_macd = 0
+        self._prev_signal = 0
+
     def OnStarted(self, time):
         super(vwap_macd_strategy, self).OnStarted(time)
 
@@ -100,9 +105,6 @@ class vwap_macd_strategy(Strategy):
         self._vwap = VolumeWeightedMovingAverage()
         self._vwap.Length = self.macd_signal_period
 
-        # Initialize variables
-        self._prev_macd = 0
-        self._prev_signal = 0
 
         # Enable position protection
         self.StartProtection(

--- a/API/0200_Ichimoku_ADX/CS/IchimokuAdxStrategy.cs
+++ b/API/0200_Ichimoku_ADX/CS/IchimokuAdxStrategy.cs
@@ -133,14 +133,20 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_isPriceAboveCloud = default;
+			_isTenkanAboveKijun = default;
+			_lastAdxValue = default;
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
 
-			// Reset state tracking variables
-			_isPriceAboveCloud = default;
-			_isTenkanAboveKijun = default;
-			_lastAdxValue = default;
 
 			// Create indicators
 			var ichimoku = new Ichimoku

--- a/API/0200_Ichimoku_ADX/PY/ichimoku_adx_strategy.py
+++ b/API/0200_Ichimoku_ADX/PY/ichimoku_adx_strategy.py
@@ -127,13 +127,15 @@ class ichimoku_adx_strategy(Strategy):
     def GetWorkingSecurities(self):
         return [(self.Security, self.CandleType)]
 
-    def OnStarted(self, time):
-        super(ichimoku_adx_strategy, self).OnStarted(time)
-
-        # Reset state tracking variables
+    def OnReseted(self):
+        super(ichimoku_adx_strategy, self).OnReseted()
         self._is_price_above_cloud = False
         self._is_tenkan_above_kijun = False
         self._last_adx_value = 0.0
+
+    def OnStarted(self, time):
+        super(ichimoku_adx_strategy, self).OnStarted(time)
+
 
         # Create indicators
         ichimoku = Ichimoku()


### PR DESCRIPTION
## Summary
- Ensure Supertrend ADX strategy clears its state in `OnReseted` rather than `OnStarted`
- Move state resets for Keltner MACD, Hull MA ADX, VWAP MACD and Ichimoku ADX strategies into `OnReseted`
- Align Python counterparts with the same reset behavior

## Testing
- `dotnet test` *(failed: command not found)*
- `apt-get update` *(failed: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689315885e648323bb68f11eb6642c9c