### PR TITLE
Fix state reset placement for strategies 185-190

### DIFF
--- a/API/0185_Supertrend_Stochastic/CS/SupertrendStochasticStrategy.cs
+++ b/API/0185_Supertrend_Stochastic/CS/SupertrendStochasticStrategy.cs
@@ -141,6 +141,14 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+			_supertrend = null;
+			_stochastic = null;
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);

--- a/API/0185_Supertrend_Stochastic/PY/supertrend_stochastic_strategy.py
+++ b/API/0185_Supertrend_Stochastic/PY/supertrend_stochastic_strategy.py
@@ -121,6 +121,11 @@ class supertrend_stochastic_strategy(Strategy):
     def StopLossPercent(self, value):
         self._stopLossPercent.Value = value
 
+    def OnReseted(self):
+        super(supertrend_stochastic_strategy, self).OnReseted()
+        self._supertrend = None
+        self._stochastic = None
+
     def OnStarted(self, time):
         """Called when the strategy starts."""
         super(supertrend_stochastic_strategy, self).OnStarted(time)

--- a/API/0187_Donchian_MACD/CS/DonchianMacdStrategy.cs
+++ b/API/0187_Donchian_MACD/CS/DonchianMacdStrategy.cs
@@ -123,6 +123,18 @@ namespace StockSharp.Samples.Strategies
 		{
 			return [(Security, CandleType)];
 		}
+		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+			_previousHighest = 0;
+			_previousLowest = decimal.MaxValue;
+			_previousMacd = 0;
+			_previousSignal = 0;
+			_entryPrice = null;
+			_donchian = null;
+			_macd = null;
+		}
 
 		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
@@ -144,13 +156,6 @@ namespace StockSharp.Samples.Strategies
 				},
 				SignalMa = { Length = MacdSignal }
 			};
-
-			// Reset state variables
-			_previousHighest = 0;
-			_previousLowest = decimal.MaxValue;
-			_previousMacd = 0;
-			_previousSignal = 0;
-			_entryPrice = null;
 
 			// Create subscription and bind indicators
 			var subscription = SubscribeCandles(CandleType);

--- a/API/0187_Donchian_MACD/PY/donchian_macd_strategy.py
+++ b/API/0187_Donchian_MACD/PY/donchian_macd_strategy.py
@@ -105,6 +105,8 @@ class donchian_macd_strategy(Strategy):
         self._previousMacd = 0
         self._previousSignal = 0
         self._entryPrice = None
+        self._donchian = None
+        self._macd = None
 
     def OnStarted(self, time):
         super(donchian_macd_strategy, self).OnStarted(time)
@@ -117,13 +119,6 @@ class donchian_macd_strategy(Strategy):
         self._macd.Macd.ShortMa.Length = self.MacdFast
         self._macd.Macd.LongMa.Length = self.MacdSlow
         self._macd.SignalMa.Length = self.MacdSignal
-
-        # Reset state variables
-        self._previousHighest = 0
-        self._previousLowest = float('inf')
-        self._previousMacd = 0
-        self._previousSignal = 0
-        self._entryPrice = None
 
         # Create subscription and bind indicators
         subscription = self.SubscribeCandles(self.CandleType)

--- a/API/0188_Parabolic_SAR_Volume/CS/ParabolicSarVolumeStrategy.cs
+++ b/API/0188_Parabolic_SAR_Volume/CS/ParabolicSarVolumeStrategy.cs
@@ -92,6 +92,17 @@ namespace StockSharp.Samples.Strategies
 		{
 			return [(Security, CandleType)];
 		}
+		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+			_prevSar = 0;
+			_currentAvgVolume = 0;
+			_prevPriceAboveSar = false;
+			_parabolicSar = null;
+			_volumeIndicator = null;
+			_volumeAverage = null;
+		}
 
 		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
@@ -111,11 +122,6 @@ namespace StockSharp.Samples.Strategies
 			{
 				Length = VolumePeriod
 			};
-
-			// Reset state variables
-			_prevSar = 0;
-			_currentAvgVolume = 0;
-			_prevPriceAboveSar = false;
 
 			// Create candle subscription
 			var subscription = SubscribeCandles(CandleType);

--- a/API/0188_Parabolic_SAR_Volume/PY/parabolic_sar_volume_strategy.py
+++ b/API/0188_Parabolic_SAR_Volume/PY/parabolic_sar_volume_strategy.py
@@ -104,11 +104,6 @@ class parabolic_sar_volume_strategy(Strategy):
         self._volumeAverage = SimpleMovingAverage()
         self._volumeAverage.Length = self.VolumePeriod
 
-        # Reset state variables
-        self._prevSar = 0
-        self._currentAvgVolume = 0
-        self._prevPriceAboveSar = False
-
         # Create candle subscription
         subscription = self.SubscribeCandles(self.CandleType)
 
@@ -132,6 +127,15 @@ class parabolic_sar_volume_strategy(Strategy):
             self.DrawIndicator(volumeArea, self._volumeAverage)
 
             self.DrawOwnTrades(area)
+
+    def OnReseted(self):
+        super(parabolic_sar_volume_strategy, self).OnReseted()
+        self._prevSar = 0
+        self._currentAvgVolume = 0
+        self._prevPriceAboveSar = False
+        self._parabolicSar = None
+        self._volumeIndicator = None
+        self._volumeAverage = None
 
     def ProcessIndicators(self, candle, sarValue, volumeValue):
         self._currentAvgVolume = float(process_float(self._volumeAverage, volumeValue, candle.ServerTime, candle.State == CandleStates.Finished))

--- a/API/0190_VWAP_ADX/CS/VwapAdxStrategy.cs
+++ b/API/0190_VWAP_ADX/CS/VwapAdxStrategy.cs
@@ -75,13 +75,19 @@ namespace StockSharp.Samples.Strategies
 		{
 			return [(Security, CandleType)];
 		}
+		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+			_prevAdxValue = default;
+			_adx = null;
+			_vwap = null;
+		}
 
 		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
-
-			_prevAdxValue = default;
 
 			// Create ADX indicator
 			_adx = new() { Length = AdxPeriod };

--- a/API/0190_VWAP_ADX/PY/vwap_adx_strategy.py
+++ b/API/0190_VWAP_ADX/PY/vwap_adx_strategy.py
@@ -70,8 +70,6 @@ class vwap_adx_strategy(Strategy):
     def OnStarted(self, time):
         super(vwap_adx_strategy, self).OnStarted(time)
 
-        self._prev_adx_value = 0
-
         # Create ADX indicator
         self._adx = AverageDirectionalIndex()
         self._adx.Length = self.AdxPeriod
@@ -95,6 +93,12 @@ class vwap_adx_strategy(Strategy):
             self.DrawCandles(area, subscription)
             self.DrawIndicator(area, self._adx)
             self.DrawOwnTrades(area)
+
+    def OnReseted(self):
+        super(vwap_adx_strategy, self).OnReseted()
+        self._prev_adx_value = 0
+        self._adx = None
+        self._vwap = None
 
     def ProcessCandle(self, candle, adx_value):
         # Skip unfinished candles


### PR DESCRIPTION
## Summary
- move reset logic to OnReseted for Supertrend Stochastic, Donchian MACD, Parabolic SAR Volume, and VWAP ADX strategies
- ensure both C# and Python versions clear state in OnReseted instead of OnStarted
- clean up C# indentation to use tabs consistently

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*
- `python -m py_compile API/0185_Supertrend_Stochastic/PY/supertrend_stochastic_strategy.py API/0187_Donchian_MACD/PY/donchian_macd_strategy.py API/0188_Parabolic_SAR_Volume/PY/parabolic_sar_volume_strategy.py API/0190_VWAP_ADX/PY/vwap_adx_strategy.py`


------
https://chatgpt.com/codex/tasks/task_e_689315824c18832396f9b6a4636adfcb