### PR TITLE
Move state resets into OnReseted for strategies 321-330

### DIFF
--- a/API/0323_Donchian_Seasonal_Filter/CS/DonchianSeasonalStrategy.cs
+++ b/API/0323_Donchian_Seasonal_Filter/CS/DonchianSeasonalStrategy.cs
@@ -112,9 +112,9 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
+			base.OnReseted();
 
 			_isLongPosition = false;
 			_isShortPosition = false;
@@ -122,6 +122,12 @@ namespace StockSharp.Samples.Strategies
 			_middleBand = 0;
 			_lowerBand = 0;
 			_seasonalStrength = 0;
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Create Donchian Channel indicator
 			_donchian = new DonchianChannels

--- a/API/0323_Donchian_Seasonal_Filter/PY/donchian_seasonal_filter_strategy.py
+++ b/API/0323_Donchian_Seasonal_Filter/PY/donchian_seasonal_filter_strategy.py
@@ -110,15 +110,17 @@ class donchian_seasonal_filter_strategy(Strategy):
     def GetWorkingSecurities(self):
         return [(self.Security, self.CandleType)]
 
-    def OnStarted(self, time):
-        super(donchian_seasonal_filter_strategy, self).OnStarted(time)
-
+    def OnReseted(self):
+        super(donchian_seasonal_filter_strategy, self).OnReseted()
         self._is_long_position = False
         self._is_short_position = False
         self._upper_band = 0.0
         self._middle_band = 0.0
         self._lower_band = 0.0
         self._seasonal_strength = 0.0
+
+    def OnStarted(self, time):
+        super(donchian_seasonal_filter_strategy, self).OnStarted(time)
 
         # Create Donchian Channel indicator
         self._donchian = DonchianChannels()

--- a/API/0324_Keltner_Kalman_Filter/CS/KeltnerKalmanStrategy.cs
+++ b/API/0324_Keltner_Kalman_Filter/CS/KeltnerKalmanStrategy.cs
@@ -149,6 +149,8 @@ namespace StockSharp.Samples.Strategies
 			_atrValue = 0;
 			_upperBand = 0;
 			_lowerBand = 0;
+			_ema = null;
+			_atr = null;
 		}
 
 		protected override void OnStarted(DateTimeOffset time)

--- a/API/0324_Keltner_Kalman_Filter/PY/keltner_kalman_strategy.py
+++ b/API/0324_Keltner_Kalman_Filter/PY/keltner_kalman_strategy.py
@@ -28,6 +28,8 @@ class keltner_kalman_strategy(Strategy):
         self._atr_value = 0
         self._upper_band = 0
         self._lower_band = 0
+        self._ema = None
+        self._atr = None
         self._is_long_position = False
         self._is_short_position = False
 
@@ -130,6 +132,8 @@ class keltner_kalman_strategy(Strategy):
         self._atr_value = 0
         self._upper_band = 0
         self._lower_band = 0
+        self._ema = None
+        self._atr = None
 
     def OnStarted(self, time):
         super(keltner_kalman_strategy, self).OnStarted(time)

--- a/API/0325_Hull_MA_Volatility_Contraction/CS/HullMaVolatilityContractionStrategy.cs
+++ b/API/0325_Hull_MA_Volatility_Contraction/CS/HullMaVolatilityContractionStrategy.cs
@@ -109,6 +109,8 @@ namespace StockSharp.Samples.Strategies
 			_isLongPosition = false;
 			_isShortPosition = false;
 			_atrValues.Clear();
+			_hma = null;
+			_atr = null;
 		}
 
 		protected override void OnStarted(DateTimeOffset time)

--- a/API/0325_Hull_MA_Volatility_Contraction/PY/hull_ma_volatility_contraction_strategy.py
+++ b/API/0325_Hull_MA_Volatility_Contraction/PY/hull_ma_volatility_contraction_strategy.py
@@ -93,7 +93,9 @@ class hull_ma_volatility_contraction_strategy(Strategy):
         self._current_hma_value = 0.0
         self._is_long_position = False
         self._is_short_position = False
-        self._atr_values = []
+        self._atr_values.clear()
+        self._hma = None
+        self._atr = None
 
     def OnStarted(self, time):
         super(hull_ma_volatility_contraction_strategy, self).OnStarted(time)

--- a/API/0326_VWAP_Stochastic_Divergence/CS/VwapAdxTrendStrategy.cs
+++ b/API/0326_VWAP_Stochastic_Divergence/CS/VwapAdxTrendStrategy.cs
@@ -104,6 +104,9 @@ namespace StockSharp.Samples.Strategies
 			_adxValue = default;
 			_plusDiValue = default;
 			_minusDiValue = default;
+			_vwap = null;
+			_adx = null;
+			_di = null;
 		}
 
 		protected override void OnStarted(DateTimeOffset time)

--- a/API/0326_VWAP_Stochastic_Divergence/PY/vwap_adx_trend_strategy.py
+++ b/API/0326_VWAP_Stochastic_Divergence/PY/vwap_adx_trend_strategy.py
@@ -91,6 +91,9 @@ class vwap_adx_trend_strategy(Strategy):
         self._adx_value = 0.0
         self._plus_di_value = 0.0
         self._minus_di_value = 0.0
+        self._vwap = None
+        self._adx = None
+        self._di = None
 
     def OnStarted(self, time):
         super(vwap_adx_trend_strategy, self).OnStarted(time)

--- a/API/0327_Parabolic_SAR_Hurst_Filter/CS/ParabolicSarHurstStrategy.cs
+++ b/API/0327_Parabolic_SAR_Hurst_Filter/CS/ParabolicSarHurstStrategy.cs
@@ -92,13 +92,18 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_prevSarValue = 0;
+			_hurstValue = 0.5m;
+		}
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
-
-			// Initialize values
-			_prevSarValue = 0;
-			_hurstValue = 0.5m; // Default value (random walk)
 
 			// Create indicators
 			var parabolicSar = new ParabolicSar

--- a/API/0327_Parabolic_SAR_Hurst_Filter/PY/parabolic_sar_hurst_strategy.py
+++ b/API/0327_Parabolic_SAR_Hurst_Filter/PY/parabolic_sar_hurst_strategy.py
@@ -85,12 +85,13 @@ class parabolic_sar_hurst_strategy(Strategy):
     def GetWorkingSecurities(self):
         return [(self.Security, self.CandleType)]
 
-    def OnStarted(self, time):
-        super(parabolic_sar_hurst_strategy, self).OnStarted(time)
-
-        # Initialize values
+    def OnReseted(self):
+        super(parabolic_sar_hurst_strategy, self).OnReseted()
         self._prev_sar_value = 0
         self._hurst_value = 0.5  # Default value (random walk)
+
+    def OnStarted(self, time):
+        super(parabolic_sar_hurst_strategy, self).OnStarted(time)
 
         # Create indicators
         parabolic_sar = ParabolicSar()

--- a/API/0328_Bollinger_Kalman_Filter/CS/BollingerKalmanFilterStrategy.cs
+++ b/API/0328_Bollinger_Kalman_Filter/CS/BollingerKalmanFilterStrategy.cs
@@ -19,6 +19,10 @@ namespace StockSharp.Samples.Strategies
 		private readonly StrategyParam<decimal> _kalmanQ; // Process noise
 		private readonly StrategyParam<decimal> _kalmanR; // Measurement noise
 		private readonly StrategyParam<DataType> _candleType;
+		private decimal _upperBand;
+		private decimal _lowerBand;
+		private decimal _midBand;
+		private decimal _kalmanValue;
 
 		/// <summary>
 		/// Bollinger Bands length.
@@ -105,6 +109,18 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
+		protected override void OnReseted()
+		{
+			base.OnReseted();
+
+			_upperBand = 0;
+			_lowerBand = 0;
+			_midBand = 0;
+			_kalmanValue = 0;
+		}
+
+
+		/// <inheritdoc />
 		protected override void OnStarted(DateTimeOffset time)
 		{
 			base.OnStarted(time);
@@ -170,6 +186,10 @@ namespace StockSharp.Samples.Strategies
 				return;
 
 			decimal kalmanFilterValue = kalmanValue.ToDecimal();
+			_upperBand = upperBand;
+			_lowerBand = lowerBand;
+			_midBand = midBand;
+			_kalmanValue = kalmanFilterValue;
 			
 			// Log the values
 			LogInfo($"Price: {candle.ClosePrice}, Kalman: {kalmanFilterValue}, BB middle: {midBand}, BB upper: {upperBand}, BB lower: {lowerBand}");

--- a/API/0328_Bollinger_Kalman_Filter/PY/bollinger_kalman_filter_strategy.py
+++ b/API/0328_Bollinger_Kalman_Filter/PY/bollinger_kalman_filter_strategy.py
@@ -48,6 +48,12 @@ class bollinger_kalman_filter_strategy(Strategy):
         self._candle_type = self.Param("CandleType", tf(5)) \
             .SetDisplay("Candle Type", "Type of candles to use", "General")
 
+        # Internal state variables
+        self._upper_band = 0.0
+        self._lower_band = 0.0
+        self._mid_band = 0.0
+        self._kalman_value = 0.0
+
     @property
     def BollingerLength(self):
         """Bollinger Bands length."""
@@ -95,6 +101,13 @@ class bollinger_kalman_filter_strategy(Strategy):
 
     def GetWorkingSecurities(self):
         return [(self.Security, self.CandleType)]
+
+    def OnReseted(self):
+        super(bollinger_kalman_filter_strategy, self).OnReseted()
+        self._upper_band = 0.0
+        self._lower_band = 0.0
+        self._mid_band = 0.0
+        self._kalman_value = 0.0
 
     def OnStarted(self, time):
         super(bollinger_kalman_filter_strategy, self).OnStarted(time)
@@ -151,6 +164,12 @@ class bollinger_kalman_filter_strategy(Strategy):
         mid_band = float(mid_band)
 
         kalman_filter_value = float(kalman_value)
+
+        # Save latest indicator values
+        self._upper_band = upper_band
+        self._lower_band = lower_band
+        self._mid_band = mid_band
+        self._kalman_value = kalman_filter_value
 
         # Log the values
         self.LogInfo(

--- a/API/0329_MACD_Volume_Cluster/PY/macd_volume_cluster_strategy.py
+++ b/API/0329_MACD_Volume_Cluster/PY/macd_volume_cluster_strategy.py
@@ -127,12 +127,6 @@ class macd_volume_cluster_strategy(Strategy):
         self._volume_std_dev = 0
         self._processed_candles = 0
 
-    def OnReseted(self):
-        super(macd_volume_cluster_strategy, self).OnReseted()
-        self._avg_volume = 0
-        self._volume_std_dev = 0
-        self._processed_candles = 0
-
     def OnStarted(self, time):
         """
         Called when the strategy starts. Sets up indicators, subscriptions, and charting.

--- a/API/0330_Ichimoku_Volatility_Contraction/CS/IchimokuVolatilityContractionStrategy.cs
+++ b/API/0330_Ichimoku_Volatility_Contraction/CS/IchimokuVolatilityContractionStrategy.cs
@@ -125,14 +125,19 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
+			base.OnReseted();
 
-			// Initialize values
 			_avgAtr = 0;
 			_atrStdDev = 0;
 			_processedCandles = 0;
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Create Ichimoku indicator
 			var ichimoku = new Ichimoku

--- a/API/0330_Ichimoku_Volatility_Contraction/PY/ichimoku_volatility_contraction_strategy.py
+++ b/API/0330_Ichimoku_Volatility_Contraction/PY/ichimoku_volatility_contraction_strategy.py
@@ -115,14 +115,15 @@ class ichimoku_volatility_contraction_strategy(Strategy):
     def GetWorkingSecurities(self):
         return [(self.Security, self.candle_type)]
 
-    def OnStarted(self, time):
-        """Initialize strategy."""
-        super(ichimoku_volatility_contraction_strategy, self).OnStarted(time)
-
-        # Initialize values
+    def OnReseted(self):
+        super(ichimoku_volatility_contraction_strategy, self).OnReseted()
         self._avg_atr = 0
         self._atr_std_dev = 0
         self._processed_candles = 0
+
+    def OnStarted(self, time):
+        """Initialize strategy."""
+        super(ichimoku_volatility_contraction_strategy, self).OnStarted(time)
 
         # Create Ichimoku indicator
         ichimoku = Ichimoku()


### PR DESCRIPTION
## Summary
- move Donchian seasonal strategy state clearing to `OnReseted` in C# and Python
- add `OnReseted` to Parabolic SAR Hurst filter and Ichimoku volatility contraction strategies for proper state reset
- track Bollinger/Kalman indicator values and reset them in `OnReseted`
- remove duplicate `OnReseted` in MACD volume cluster Python strategy
- clear indicator references in Keltner Kalman filter, Hull MA volatility contraction, and VWAP ADX trend strategies during `OnReseted`

## Testing
- `pytest`
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689315f9cbe88323b61af2cb83be6cec