### PR TITLE
Move state reset to OnReseted for RSI Supertrend

### DIFF
--- a/API/0171_MACD_Williams_R/CS/MacdWilliamsRStrategy.cs
+++ b/API/0171_MACD_Williams_R/CS/MacdWilliamsRStrategy.cs
@@ -121,9 +121,15 @@ namespace StockSharp.Samples.Strategies
 			return [(Security, CandleType)];
 		}
 
-		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
-		{
+			/// <inheritdoc />
+			protected override void OnReseted()
+			{
+				base.OnReseted();
+			}
+
+			/// <inheritdoc />
+			protected override void OnStarted(DateTimeOffset time)
+			{
 			base.OnStarted(time);
 
 			// Create indicators

--- a/API/0171_MACD_Williams_R/PY/macd_williams_r_strategy.py
+++ b/API/0171_MACD_Williams_R/PY/macd_williams_r_strategy.py
@@ -104,6 +104,9 @@ class macd_williams_r_strategy(Strategy):
     def candle_type(self, value):
         self._candle_type.Value = value
 
+    def OnReseted(self):
+        super(macd_williams_r_strategy, self).OnReseted()
+
     def OnStarted(self, time):
         """
         Called when the strategy starts. Sets up indicators, subscriptions, and charting.

--- a/API/0172_Bollinger_Williams_R/CS/BollingerWilliamsRStrategy.cs
+++ b/API/0172_Bollinger_Williams_R/CS/BollingerWilliamsRStrategy.cs
@@ -121,9 +121,15 @@ namespace StockSharp.Samples.Strategies
 			return [(Security, CandleType)];
 		}
 
-		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
-		{
+			/// <inheritdoc />
+			protected override void OnReseted()
+			{
+				base.OnReseted();
+			}
+
+			/// <inheritdoc />
+			protected override void OnStarted(DateTimeOffset time)
+			{
 			base.OnStarted(time);
 
 			// Create indicators

--- a/API/0172_Bollinger_Williams_R/PY/bollinger_williams_r_strategy.py
+++ b/API/0172_Bollinger_Williams_R/PY/bollinger_williams_r_strategy.py
@@ -92,6 +92,9 @@ class bollinger_williams_r_strategy(Strategy):
     def CandleType(self, value):
         self._candle_type.Value = value
 
+    def OnReseted(self):
+        super(bollinger_williams_r_strategy, self).OnReseted()
+
     def OnStarted(self, time):
         super(bollinger_williams_r_strategy, self).OnStarted(time)
 

--- a/API/0174_MACD_VWAP/CS/MacdVwapStrategy.cs
+++ b/API/0174_MACD_VWAP/CS/MacdVwapStrategy.cs
@@ -105,9 +105,15 @@ namespace StockSharp.Samples.Strategies
 			return [(Security, CandleType)];
 		}
 
-		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
-		{
+			/// <inheritdoc />
+			protected override void OnReseted()
+			{
+				base.OnReseted();
+			}
+
+			/// <inheritdoc />
+			protected override void OnStarted(DateTimeOffset time)
+			{
 			base.OnStarted(time);
 
 			// Create indicators

--- a/API/0174_MACD_VWAP/PY/macd_vwap_strategy.py
+++ b/API/0174_MACD_VWAP/PY/macd_vwap_strategy.py
@@ -80,6 +80,9 @@ class macd_vwap_strategy(Strategy):
     def candle_type(self, value):
         self._candle_type.Value = value
 
+    def OnReseted(self):
+        super(macd_vwap_strategy, self).OnReseted()
+
     def OnStarted(self, time):
         super(macd_vwap_strategy, self).OnStarted(time)
 

--- a/API/0175_RSI_Supertrend/CS/RsiSupertrendStrategy.cs
+++ b/API/0175_RSI_Supertrend/CS/RsiSupertrendStrategy.cs
@@ -100,22 +100,29 @@ namespace StockSharp.Samples.Strategies
 		}
 
 		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
+		protected override void OnReseted()
 		{
-			base.OnStarted(time);
+			base.OnReseted();
 
 			// Reset state variables
+			_atr = null;
 			_isFirstValue = true;
-			_currentTrend = 1; // Default to uptrend_upValue = 0;
+			_currentTrend = 1;
 			_downValue = 0;
 			_prevUpValue = 0;
 			_prevDownValue = 0;
 			_prevClose = 0;
 			_upValue = 0;
+		}
+
+		/// <inheritdoc />
+		protected override void OnStarted(DateTimeOffset time)
+		{
+			base.OnStarted(time);
 
 			// Create RSI indicator
 			var rsi = new RelativeStrengthIndex { Length = RsiPeriod };
-			
+
 			// Create ATR indicator for Supertrend calculation
 			_atr = new AverageTrueRange { Length = SupertrendPeriod };
 			

--- a/API/0175_RSI_Supertrend/PY/rsi_supertrend_strategy.py
+++ b/API/0175_RSI_Supertrend/PY/rsi_supertrend_strategy.py
@@ -93,6 +93,7 @@ class rsi_supertrend_strategy(Strategy):
         Resets internal state when strategy is reset.
         """
         super(rsi_supertrend_strategy, self).OnReseted()
+        self._atr = None
         self._is_first_value = True
         self._current_trend = 1
         self._down_value = 0
@@ -108,15 +109,6 @@ class rsi_supertrend_strategy(Strategy):
         :param time: The time when the strategy started.
         """
         super(rsi_supertrend_strategy, self).OnStarted(time)
-
-        # Reset state variables
-        self._is_first_value = True
-        self._current_trend = 1  # Default to uptrend
-        self._down_value = 0
-        self._prev_up_value = 0
-        self._prev_down_value = 0
-        self._prev_close = 0
-        self._up_value = 0
 
         # Create RSI indicator
         rsi = RelativeStrengthIndex()

--- a/API/0176_ADX_Bollinger/CS/AdxBollingerStrategy.cs
+++ b/API/0176_ADX_Bollinger/CS/AdxBollingerStrategy.cs
@@ -121,9 +121,15 @@ namespace StockSharp.Samples.Strategies
 			return [(Security, CandleType)];
 		}
 
-		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
-		{
+			/// <inheritdoc />
+			protected override void OnReseted()
+			{
+				base.OnReseted();
+			}
+
+			/// <inheritdoc />
+			protected override void OnStarted(DateTimeOffset time)
+			{
 			base.OnStarted(time);
 
 			// Create indicators

--- a/API/0176_ADX_Bollinger/PY/adx_bollinger_strategy.py
+++ b/API/0176_ADX_Bollinger/PY/adx_bollinger_strategy.py
@@ -94,6 +94,9 @@ class adx_bollinger_strategy(Strategy):
     def candle_type(self, value):
         self._candle_type.Value = value
 
+    def OnReseted(self):
+        super(adx_bollinger_strategy, self).OnReseted()
+
     def OnStarted(self, time):
         """
         Called when the strategy starts. Sets up indicators, subscriptions, and charting.

--- a/API/0177_Ichimoku_Stochastic/CS/IchimokuStochasticStrategy.cs
+++ b/API/0177_Ichimoku_Stochastic/CS/IchimokuStochasticStrategy.cs
@@ -135,11 +135,17 @@ namespace StockSharp.Samples.Strategies
 		public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
 		{
 			return [(Security, CandleType)];
-		}
+			}
 
-		/// <inheritdoc />
-		protected override void OnStarted(DateTimeOffset time)
-		{
+			/// <inheritdoc />
+			protected override void OnReseted()
+			{
+				base.OnReseted();
+			}
+
+			/// <inheritdoc />
+			protected override void OnStarted(DateTimeOffset time)
+			{
 			base.OnStarted(time);
 
 			// Create indicators

--- a/API/0177_Ichimoku_Stochastic/PY/ichimoku_stochastic_strategy.py
+++ b/API/0177_Ichimoku_Stochastic/PY/ichimoku_stochastic_strategy.py
@@ -123,6 +123,9 @@ class ichimoku_stochastic_strategy(Strategy):
     def CandleType(self, value):
         self._candle_type.Value = value
 
+    def OnReseted(self):
+        super(ichimoku_stochastic_strategy, self).OnReseted()
+
     def OnStarted(self, time):
         super(ichimoku_stochastic_strategy, self).OnStarted(time)
 


### PR DESCRIPTION
## Summary
- Relocate RSI Supertrend strategy state reset from `OnStarted` to `OnReseted` in both C# and Python versions
- Ensure tab-based alignment for MACD Williams %R, Bollinger Williams %R, MACD VWAP, ADX Bollinger, and Ichimoku Stochastic C# strategies
- Stub out `OnReseted` overrides for remaining API strategies 0171, 0172, 0174, 0176 and 0177 in C# and Python

## Testing
- `python -m py_compile API/0171_MACD_Williams_R/PY/macd_williams_r_strategy.py API/0172_Bollinger_Williams_R/PY/bollinger_williams_r_strategy.py API/0174_MACD_VWAP/PY/macd_vwap_strategy.py API/0175_RSI_Supertrend/PY/rsi_supertrend_strategy.py API/0176_ADX_Bollinger/PY/adx_bollinger_strategy.py API/0177_Ichimoku_Stochastic/PY/ichimoku_stochastic_strategy.py`
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403  Forbidden [IP: 172.30.1.67 8080])*

------
https://chatgpt.com/codex/tasks/task_e_6893157d5850832385386c8bbd7a05a8