### PR TITLE
Add Bollinger Bounce Reversal strategy

### DIFF
--- a/API/0596_Bollinger_Bounce_Reversal/CS/BollingerBounceReversalStrategy.cs
+++ b/API/0596_Bollinger_Bounce_Reversal/CS/BollingerBounceReversalStrategy.cs
@@ -1,0 +1,271 @@
+using System;
+using System.Collections.Generic;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
+namespace StockSharp.Samples.Strategies;
+
+/// <summary>
+/// Strategy that trades Bollinger Band bounce reversals with MACD and volume confirmation.
+/// Limits entries per day and applies fixed percent stop loss and take profit.
+/// </summary>
+public class BollingerBounceReversalStrategy : Strategy
+{
+	private readonly StrategyParam<int> _bbPeriod;
+	private readonly StrategyParam<decimal> _bbStdDev;
+	private readonly StrategyParam<int> _macdFast;
+	private readonly StrategyParam<int> _macdSlow;
+	private readonly StrategyParam<int> _macdSignal;
+	private readonly StrategyParam<int> _volumePeriod;
+	private readonly StrategyParam<decimal> _volumeFactor;
+	private readonly StrategyParam<decimal> _stopLossPercent;
+	private readonly StrategyParam<decimal> _takeProfitPercent;
+	private readonly StrategyParam<int> _maxTradesPerDay;
+	private readonly StrategyParam<DataType> _candleType;
+	
+	private MovingAverageConvergenceDivergenceSignal _macd;
+	private BollingerBands _bollinger;
+	private SimpleMovingAverage _volumeSma;
+	
+	private decimal _prevClose;
+	private decimal _prevLowerBand;
+	private decimal _prevUpperBand;
+	private bool _hasPrev;
+	
+	private DateTime _currentDate;
+	private int _tradesToday;
+	
+	/// <summary>
+	/// Bollinger Bands period.
+	/// </summary>
+	public int BollingerPeriod { get => _bbPeriod.Value; set => _bbPeriod.Value = value; }
+	
+	/// <summary>
+	/// Bollinger Bands standard deviation multiplier.
+	/// </summary>
+	public decimal BbStdDev { get => _bbStdDev.Value; set => _bbStdDev.Value = value; }
+	
+	/// <summary>
+	/// MACD fast length.
+	/// </summary>
+	public int MacdFastLength { get => _macdFast.Value; set => _macdFast.Value = value; }
+	
+	/// <summary>
+	/// MACD slow length.
+	/// </summary>
+	public int MacdSlowLength { get => _macdSlow.Value; set => _macdSlow.Value = value; }
+	
+	/// <summary>
+	/// MACD signal length.
+	/// </summary>
+	public int MacdSignalLength { get => _macdSignal.Value; set => _macdSignal.Value = value; }
+	
+	/// <summary>
+	/// Volume moving average period.
+	/// </summary>
+	public int VolumePeriod { get => _volumePeriod.Value; set => _volumePeriod.Value = value; }
+	
+	/// <summary>
+	/// Volume spike factor.
+	/// </summary>
+	public decimal VolumeFactor { get => _volumeFactor.Value; set => _volumeFactor.Value = value; }
+	
+	/// <summary>
+	/// Stop loss percentage.
+	/// </summary>
+	public decimal StopLossPercent { get => _stopLossPercent.Value; set => _stopLossPercent.Value = value; }
+	
+	/// <summary>
+	/// Take profit percentage.
+	/// </summary>
+	public decimal TakeProfitPercent { get => _takeProfitPercent.Value; set => _takeProfitPercent.Value = value; }
+	
+	/// <summary>
+	/// Maximum number of trades per day.
+	/// </summary>
+	public int MaxTradesPerDay { get => _maxTradesPerDay.Value; set => _maxTradesPerDay.Value = value; }
+	
+	/// <summary>
+	/// Candle type for strategy calculation.
+	/// </summary>
+	public DataType CandleType { get => _candleType.Value; set => _candleType.Value = value; }
+	
+	/// <summary>
+	/// Initialize strategy parameters.
+	/// </summary>
+	public BollingerBounceReversalStrategy()
+	{
+		_bbPeriod = Param(nameof(BollingerPeriod), 20)
+		.SetDisplay("BB Period", "Bollinger Bands period", "Indicators");
+		
+		_bbStdDev = Param(nameof(BbStdDev), 2m)
+		.SetDisplay("BB StdDev", "Standard deviation multiplier", "Indicators");
+		
+		_macdFast = Param(nameof(MacdFastLength), 12)
+		.SetDisplay("MACD Fast", "Fast EMA length", "MACD");
+		
+		_macdSlow = Param(nameof(MacdSlowLength), 26)
+		.SetDisplay("MACD Slow", "Slow EMA length", "MACD");
+		
+		_macdSignal = Param(nameof(MacdSignalLength), 9)
+		.SetDisplay("MACD Signal", "Signal EMA length", "MACD");
+		
+		_volumePeriod = Param(nameof(VolumePeriod), 20)
+		.SetDisplay("Volume MA Period", "Volume SMA period", "Indicators");
+		
+		_volumeFactor = Param(nameof(VolumeFactor), 1m)
+		.SetDisplay("Volume Factor", "Volume spike factor", "Indicators");
+		
+		_stopLossPercent = Param(nameof(StopLossPercent), 2m)
+		.SetDisplay("Stop Loss %", "Stop loss percentage", "Risk");
+		
+		_takeProfitPercent = Param(nameof(TakeProfitPercent), 4m)
+		.SetDisplay("Take Profit %", "Take profit percentage", "Risk");
+		
+		_maxTradesPerDay = Param(nameof(MaxTradesPerDay), 5)
+		.SetDisplay("Max Trades/Day", "Maximum number of trades per day", "General");
+		
+		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
+		.SetDisplay("Candle Type", "Type of candles to use", "General");
+	}
+	
+	/// <inheritdoc />
+	public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
+	{
+		return [(Security, CandleType)];
+	}
+	
+	/// <inheritdoc />
+	protected override void OnReseted()
+	{
+		base.OnReseted();
+		_prevClose = 0;
+		_prevLowerBand = 0;
+		_prevUpperBand = 0;
+		_hasPrev = false;
+		_currentDate = DateTime.MinValue;
+		_tradesToday = 0;
+	}
+	
+	/// <inheritdoc />
+	protected override void OnStarted(DateTimeOffset time)
+	{
+		base.OnStarted(time);
+		
+		_bollinger = new BollingerBands
+		{
+			Length = BollingerPeriod,
+			Width = BbStdDev
+		};
+		
+		_macd = new MovingAverageConvergenceDivergenceSignal
+		{
+			Macd =
+			{
+				ShortMa = { Length = MacdFastLength },
+				LongMa = { Length = MacdSlowLength },
+			},
+			SignalMa = { Length = MacdSignalLength }
+		};
+		
+		_volumeSma = new SimpleMovingAverage { Length = VolumePeriod };
+		
+		var subscription = SubscribeCandles(CandleType);
+		subscription
+		.BindEx(_macd, _bollinger, ProcessCandle)
+		.Start();
+		
+		StartProtection(
+		new Unit(TakeProfitPercent, UnitTypes.Percent),
+		new Unit(StopLossPercent, UnitTypes.Percent));
+		
+		var area = CreateChartArea();
+		if (area != null)
+		{
+			DrawCandles(area, subscription);
+			DrawIndicator(area, _bollinger);
+			DrawOwnTrades(area);
+		}
+	}
+	
+	private void ProcessCandle(ICandleMessage candle, IIndicatorValue macdValue, IIndicatorValue bollingerValue)
+	{
+		if (candle.State != CandleStates.Finished)
+		return;
+		
+		var macd = (MovingAverageConvergenceDivergenceSignalValue)macdValue;
+		var bb = (BollingerBandsValue)bollingerValue;
+		
+		if (macd.Macd is not decimal macdLine || macd.Signal is not decimal signalLine)
+		return;
+		
+		if (bb.UpBand is not decimal upperBand || bb.LowBand is not decimal lowerBand)
+		return;
+		
+		var volAvg = _volumeSma.Process(candle.TotalVolume, candle.ServerTime, true).ToDecimal();
+		
+		if (!_bollinger.IsFormed || !_macd.IsFormed || !_volumeSma.IsFormed)
+		{
+			_prevClose = candle.ClosePrice;
+			_prevLowerBand = lowerBand;
+			_prevUpperBand = upperBand;
+			_hasPrev = true;
+			return;
+		}
+		
+		if (!IsFormedAndOnlineAndAllowTrading())
+		{
+			_prevClose = candle.ClosePrice;
+			_prevLowerBand = lowerBand;
+			_prevUpperBand = upperBand;
+			_hasPrev = true;
+			return;
+		}
+		
+		var candleDate = candle.OpenTime.Date;
+		if (candleDate != _currentDate)
+		{
+			_currentDate = candleDate;
+			_tradesToday = 0;
+		}
+		
+		var volumeHigh = candle.TotalVolume >= volAvg * VolumeFactor;
+		
+		var longSignal = _hasPrev &&
+		_prevClose < _prevLowerBand &&
+		candle.ClosePrice > lowerBand &&
+		macdLine > signalLine &&
+		volumeHigh &&
+		_tradesToday < MaxTradesPerDay &&
+		Position <= 0;
+		
+		var shortSignal = _hasPrev &&
+		_prevClose > _prevUpperBand &&
+		candle.ClosePrice < upperBand &&
+		macdLine < signalLine &&
+		volumeHigh &&
+		_tradesToday < MaxTradesPerDay &&
+		Position >= 0;
+		
+		if (longSignal)
+		{
+			RegisterBuy(Volume + Math.Abs(Position));
+			_tradesToday++;
+		}
+		else if (shortSignal)
+		{
+			RegisterSell(Volume + Math.Abs(Position));
+			_tradesToday++;
+		}
+		
+		_prevClose = candle.ClosePrice;
+		_prevLowerBand = lowerBand;
+		_prevUpperBand = upperBand;
+		_hasPrev = true;
+	}
+}
+

--- a/API/0596_Bollinger_Bounce_Reversal/README.md
+++ b/API/0596_Bollinger_Bounce_Reversal/README.md
@@ -1,0 +1,35 @@
+# Bollinger Bounce Reversal Strategy
+[Русский](README_ru.md) | [中文](README_cn.md)
+
+Strategy that captures reversals when price bounces off Bollinger Bands with MACD and volume confirmation. The system limits entries to five trades per day and applies fixed percent stop loss and take profit.
+
+## Details
+
+- **Entry Criteria**:
+  - Long: `Close[1] < LowerBand[1] && Close > LowerBand && MACD > Signal && Volume >= AvgVolume * VolumeFactor`
+  - Short: `Close[1] > UpperBand[1] && Close < UpperBand && MACD < Signal && Volume >= AvgVolume * VolumeFactor`
+- **Long/Short**: Both
+- **Stops**: Percent take profit and stop loss
+- **Default Values**:
+  - `BollingerPeriod` = 20
+  - `BbStdDev` = 2m
+  - `MacdFastLength` = 12
+  - `MacdSlowLength` = 26
+  - `MacdSignalLength` = 9
+  - `VolumePeriod` = 20
+  - `VolumeFactor` = 1m
+  - `StopLossPercent` = 2m
+  - `TakeProfitPercent` = 4m
+  - `MaxTradesPerDay` = 5
+  - `CandleType` = TimeSpan.FromMinutes(5).TimeFrame()
+- **Filters**:
+  - Category: Reversal
+  - Direction: Both
+  - Indicators: Bollinger Bands, MACD, Volume
+  - Stops: Yes
+  - Complexity: Intermediate
+  - Timeframe: Mid-term
+  - Seasonality: No
+  - Neural Networks: No
+  - Divergence: No
+  - Risk Level: Medium

--- a/API/0596_Bollinger_Bounce_Reversal/README_cn.md
+++ b/API/0596_Bollinger_Bounce_Reversal/README_cn.md
@@ -1,0 +1,35 @@
+# 布林带反弹反转策略
+[English](README.md) | [Русский](README_ru.md)
+
+该策略在价格从布林带边缘反弹时，结合MACD和成交量确认进行交易。系统每天最多入场五次，并使用固定百分比的止损和止盈。
+
+## 细节
+
+- **入场条件**：
+  - 多头：`Close[1] < LowerBand[1] && Close > LowerBand && MACD > Signal && Volume >= AvgVolume * VolumeFactor`
+  - 空头：`Close[1] > UpperBand[1] && Close < UpperBand && MACD < Signal && Volume >= AvgVolume * VolumeFactor`
+- **多空方向**：双向
+- **止损**：百分比止盈和止损
+- **默认参数**：
+  - `BollingerPeriod` = 20
+  - `BbStdDev` = 2m
+  - `MacdFastLength` = 12
+  - `MacdSlowLength` = 26
+  - `MacdSignalLength` = 9
+  - `VolumePeriod` = 20
+  - `VolumeFactor` = 1m
+  - `StopLossPercent` = 2m
+  - `TakeProfitPercent` = 4m
+  - `MaxTradesPerDay` = 5
+  - `CandleType` = TimeSpan.FromMinutes(5).TimeFrame()
+- **过滤器**：
+  - 类别：反转
+  - 方向：双向
+  - 指标：布林带、MACD、成交量
+  - 止损：是
+  - 复杂度：中等
+  - 时间框架：中期
+  - 季节性：否
+  - 神经网络：否
+  - 背离：否
+  - 风险等级：中等

--- a/API/0596_Bollinger_Bounce_Reversal/README_ru.md
+++ b/API/0596_Bollinger_Bounce_Reversal/README_ru.md
@@ -1,0 +1,35 @@
+# Стратегия Bollinger Bounce Reversal
+[English](README.md) | [中文](README_cn.md)
+
+Стратегия ищет развороты, когда цена возвращается от полос Боллинджера при подтверждении индикаторами MACD и объёмом. Система ограничивает количество входов пятью сделками в день и использует фиксированные проценты стоп‑лосса и тейк‑профита.
+
+## Детали
+
+- **Условия входа**:
+  - Long: `Close[1] < LowerBand[1] && Close > LowerBand && MACD > Signal && Volume >= AvgVolume * VolumeFactor`
+  - Short: `Close[1] > UpperBand[1] && Close < UpperBand && MACD < Signal && Volume >= AvgVolume * VolumeFactor`
+- **Long/Short**: Оба направления
+- **Стопы**: Процентный тейк‑профит и стоп‑лосс
+- **Значения по умолчанию**:
+  - `BollingerPeriod` = 20
+  - `BbStdDev` = 2m
+  - `MacdFastLength` = 12
+  - `MacdSlowLength` = 26
+  - `MacdSignalLength` = 9
+  - `VolumePeriod` = 20
+  - `VolumeFactor` = 1m
+  - `StopLossPercent` = 2m
+  - `TakeProfitPercent` = 4m
+  - `MaxTradesPerDay` = 5
+  - `CandleType` = TimeSpan.FromMinutes(5).TimeFrame()
+- **Фильтры**:
+  - Категория: Разворот
+  - Направление: Оба
+  - Индикаторы: Полосы Боллинджера, MACD, Объём
+  - Стопы: Да
+  - Сложность: Средняя
+  - Таймфрейм: Среднесрочный
+  - Сезонность: Нет
+  - Нейросети: Нет
+  - Дивергенция: Нет
+  - Уровень риска: Средний


### PR DESCRIPTION
## Summary
- add Bollinger Bounce Reversal strategy with Bollinger Bands, MACD and volume confirmation
- document entry rules, defaults and filters for the new strategy

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c12ec856fc8323a0895f61ab2a4867