### PR TITLE
Add Dual Supertrend MACD strategy

### DIFF
--- a/API/0713_Dual_Supertrend_MACD/CS/DualSupertrendMacdStrategy.cs
+++ b/API/0713_Dual_Supertrend_MACD/CS/DualSupertrendMacdStrategy.cs
@@ -1,0 +1,261 @@
+using System;
+using System.Collections.Generic;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+using StockSharp.Charting;
+
+namespace StockSharp.Samples.Strategies;
+
+/// <summary>
+/// Dual Supertrend with MACD strategy.
+/// </summary>
+public class DualSupertrendMacdStrategy : Strategy
+{
+	private readonly StrategyParam<DataType> _candleType;
+	private readonly StrategyParam<int> _macdFast;
+	private readonly StrategyParam<int> _macdSlow;
+	private readonly StrategyParam<int> _macdSignal;
+	private readonly StrategyParam<MovingAverageTypeEnum> _oscillatorMaType;
+	private readonly StrategyParam<MovingAverageTypeEnum> _signalMaType;
+	private readonly StrategyParam<int> _atrPeriod1;
+	private readonly StrategyParam<decimal> _factor1;
+	private readonly StrategyParam<int> _atrPeriod2;
+	private readonly StrategyParam<decimal> _factor2;
+	private readonly StrategyParam<string> _tradeDirection;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="DualSupertrendMacdStrategy"/>.
+	/// </summary>
+	public DualSupertrendMacdStrategy()
+	{
+		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(1).TimeFrame())
+						  .SetDisplay("Candle type", "Candle type for strategy calculation.", "General");
+
+		_macdFast =
+			Param(nameof(MacdFast), 12).SetCanOptimize(true).SetDisplay("Fast Length", "MACD fast MA length", "MACD");
+
+		_macdSlow =
+			Param(nameof(MacdSlow), 26).SetCanOptimize(true).SetDisplay("Slow Length", "MACD slow MA length", "MACD");
+
+		_macdSignal =
+			Param(nameof(MacdSignal), 9).SetCanOptimize(true).SetDisplay("Signal Length", "MACD signal length", "MACD");
+
+		_oscillatorMaType = Param(nameof(OscillatorMaType), MovingAverageTypeEnum.Exponential)
+								.SetDisplay("Oscillator MA Type", "Type of MA for MACD fast/slow lines", "MACD");
+
+		_signalMaType = Param(nameof(SignalMaType), MovingAverageTypeEnum.Exponential)
+							.SetDisplay("Signal MA Type", "Type of MA for MACD signal line", "MACD");
+
+		_atrPeriod1 = Param(nameof(AtrPeriod1), 10)
+						  .SetCanOptimize(true)
+						  .SetDisplay("ATR Period 1", "ATR period for first Supertrend", "Supertrend");
+
+		_factor1 = Param(nameof(Factor1), 3.0m)
+					   .SetCanOptimize(true)
+					   .SetDisplay("Factor 1", "ATR multiplier for first Supertrend", "Supertrend");
+
+		_atrPeriod2 = Param(nameof(AtrPeriod2), 20)
+						  .SetCanOptimize(true)
+						  .SetDisplay("ATR Period 2", "ATR period for second Supertrend", "Supertrend");
+
+		_factor2 = Param(nameof(Factor2), 5.0m)
+					   .SetCanOptimize(true)
+					   .SetDisplay("Factor 2", "ATR multiplier for second Supertrend", "Supertrend");
+
+		_tradeDirection = Param(nameof(TradeDirection), "Both")
+							  .SetDisplay("Direction", "Trading direction: Long, Short or Both", "Strategy");
+	}
+
+	/// <summary>
+	/// Candle type for calculations.
+	/// </summary>
+	public DataType CandleType
+	{
+		get => _candleType.Value;
+		set => _candleType.Value = value;
+	}
+
+	/// <summary>
+	/// MACD fast MA length.
+	/// </summary>
+	public int MacdFast
+	{
+		get => _macdFast.Value;
+		set => _macdFast.Value = value;
+	}
+
+	/// <summary>
+	/// MACD slow MA length.
+	/// </summary>
+	public int MacdSlow
+	{
+		get => _macdSlow.Value;
+		set => _macdSlow.Value = value;
+	}
+
+	/// <summary>
+	/// MACD signal length.
+	/// </summary>
+	public int MacdSignal
+	{
+		get => _macdSignal.Value;
+		set => _macdSignal.Value = value;
+	}
+
+	/// <summary>
+	/// Type of MA for MACD fast/slow lines.
+	/// </summary>
+	public MovingAverageTypeEnum OscillatorMaType
+	{
+		get => _oscillatorMaType.Value;
+		set => _oscillatorMaType.Value = value;
+	}
+
+	/// <summary>
+	/// Type of MA for MACD signal line.
+	/// </summary>
+	public MovingAverageTypeEnum SignalMaType
+	{
+		get => _signalMaType.Value;
+		set => _signalMaType.Value = value;
+	}
+
+	/// <summary>
+	/// ATR period for first Supertrend.
+	/// </summary>
+	public int AtrPeriod1
+	{
+		get => _atrPeriod1.Value;
+		set => _atrPeriod1.Value = value;
+	}
+
+	/// <summary>
+	/// ATR multiplier for first Supertrend.
+	/// </summary>
+	public decimal Factor1
+	{
+		get => _factor1.Value;
+		set => _factor1.Value = value;
+	}
+
+	/// <summary>
+	/// ATR period for second Supertrend.
+	/// </summary>
+	public int AtrPeriod2
+	{
+		get => _atrPeriod2.Value;
+		set => _atrPeriod2.Value = value;
+	}
+
+	/// <summary>
+	/// ATR multiplier for second Supertrend.
+	/// </summary>
+	public decimal Factor2
+	{
+		get => _factor2.Value;
+		set => _factor2.Value = value;
+	}
+
+	/// <summary>
+	/// Trading direction.
+	/// </summary>
+	public string TradeDirection
+	{
+		get => _tradeDirection.Value;
+		set => _tradeDirection.Value = value;
+	}
+
+	/// <inheritdoc />
+	public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities() => [(Security, CandleType)];
+
+	/// <inheritdoc />
+	protected override void OnStarted(DateTimeOffset time)
+	{
+		base.OnStarted(time);
+
+		var st1 = new SuperTrend { Length = AtrPeriod1, Multiplier = Factor1 };
+
+		var st2 = new SuperTrend { Length = AtrPeriod2, Multiplier = Factor2 };
+
+		var macd =
+			new MovingAverageConvergenceDivergenceSignal { Macd =
+															   {
+																   ShortMa = CreateMa(OscillatorMaType, MacdFast),
+																   LongMa = CreateMa(OscillatorMaType, MacdSlow),
+															   },
+														   SignalMa = CreateMa(SignalMaType, MacdSignal) };
+
+		var subscription = SubscribeCandles(CandleType);
+		subscription.BindEx(st1, st2, macd, ProcessCandle).Start();
+
+		var area = CreateChartArea();
+		if (area != null)
+		{
+			DrawCandles(area, subscription);
+			DrawIndicator(area, st1);
+			DrawIndicator(area, st2);
+			var macdArea = CreateChartArea();
+			DrawIndicator(macdArea, macd);
+			DrawOwnTrades(area);
+		}
+	}
+
+	private void ProcessCandle(ICandleMessage candle, IIndicatorValue st1Value, IIndicatorValue st2Value,
+							   IIndicatorValue macdValue)
+	{
+		if (candle.State != CandleStates.Finished)
+			return;
+
+		if (!IsFormedAndOnlineAndAllowTrading())
+			return;
+
+		var st1 = st1Value.ToDecimal();
+		var st2 = st2Value.ToDecimal();
+		var macdTyped = (MovingAverageConvergenceDivergenceSignalValue)macdValue;
+		var hist = macdTyped.Histogram;
+		var close = candle.ClosePrice;
+
+		var isBullish = close > st1 && close > st2 && hist > 0;
+		var isBearish = close < st1 && close < st2 && hist < 0;
+		var exitLong = close < st1 || close < st2 || hist < 0;
+		var exitShort = close > st1 || close > st2 || hist > 0;
+
+		var dir = TradeDirection;
+
+		if ((dir == "Long" || dir == "Both") && isBullish && Position <= 0)
+			BuyMarket(Volume + Math.Abs(Position));
+		else if (Position > 0 && exitLong)
+			SellMarket(Position);
+
+		if ((dir == "Short" || dir == "Both") && isBearish && Position >= 0)
+			SellMarket(Volume + Math.Abs(Position));
+		else if (Position < 0 && exitShort)
+			BuyMarket(Math.Abs(Position));
+	}
+
+	private MovingAverage CreateMa(MovingAverageTypeEnum type, int length)
+	{
+		return type switch { MovingAverageTypeEnum.Simple => new SimpleMovingAverage { Length = length },
+							 _ => new ExponentialMovingAverage { Length = length } };
+	}
+
+	/// <summary>
+	/// Moving average type enumeration.
+	/// </summary>
+	public enum MovingAverageTypeEnum
+	{
+		/// <summary>
+		/// Simple Moving Average.
+		/// </summary>
+		Simple,
+
+		/// <summary>
+		/// Exponential Moving Average.
+		/// </summary>
+		Exponential
+	}
+}

--- a/API/0713_Dual_Supertrend_MACD/README.md
+++ b/API/0713_Dual_Supertrend_MACD/README.md
@@ -1,0 +1,34 @@
+# Dual Supertrend MACD
+[Русский](README_ru.md) | [中文](README_cn.md)
+
+Dual Supertrend MACD combines two Supertrend indicators with a MACD filter.
+A long position is opened when price trades above both Supertrend lines and the MACD histogram is positive.
+Short positions appear when price is below both lines and the histogram is negative.
+Positions are closed once any Supertrend flips direction or the MACD histogram crosses zero.
+
+## Details
+- **Data**: Price candles.
+- **Entry Criteria**:
+  - Long: `Close > Supertrend1 && Close > Supertrend2 && MACD Histogram > 0`
+  - Short: `Close < Supertrend1 && Close < Supertrend2 && MACD Histogram < 0`
+- **Exit Criteria**:
+  - Long: `Close < Supertrend1 || Close < Supertrend2 || MACD Histogram < 0`
+  - Short: `Close > Supertrend1 || Close > Supertrend2 || MACD Histogram > 0`
+- **Stops**: None by default.
+- **Default Values**:
+  - `MacdFast` = 12
+  - `MacdSlow` = 26
+  - `MacdSignal` = 9
+  - `OscillatorMaType` = Exponential
+  - `SignalMaType` = Exponential
+  - `AtrPeriod1` = 10
+  - `Factor1` = 3.0
+  - `AtrPeriod2` = 20
+  - `Factor2` = 5.0
+  - `TradeDirection` = "Both"
+- **Filters**:
+  - Category: Trend following
+  - Direction: Configurable
+  - Indicators: Supertrend, MACD
+  - Complexity: Intermediate
+  - Risk level: Medium

--- a/API/0713_Dual_Supertrend_MACD/README_cn.md
+++ b/API/0713_Dual_Supertrend_MACD/README_cn.md
@@ -1,0 +1,34 @@
+# Dual Supertrend MACD
+[English](README.md) | [Русский](README_ru.md)
+
+**Dual Supertrend MACD** 策略结合两条 Supertrend 与 MACD 筛选。
+当价格位于两条 Supertrend 之上且 MACD 柱线为正时做多；
+当价格位于两条 Supertrend 之下且 MACD 柱线为负时做空。
+任一 Supertrend 反向或 MACD 柱线穿越零轴时平仓。
+
+## 详情
+- **数据**: 价格K线。
+- **入场条件**:
+  - 多头: `Close > Supertrend1 && Close > Supertrend2 && MACD Histogram > 0`
+  - 空头: `Close < Supertrend1 && Close < Supertrend2 && MACD Histogram < 0`
+- **出场条件**:
+  - 多头: `Close < Supertrend1 || Close < Supertrend2 || MACD Histogram < 0`
+  - 空头: `Close > Supertrend1 || Close > Supertrend2 || MACD Histogram > 0`
+- **止损**: 默认无。
+- **默认参数**:
+  - `MacdFast` = 12
+  - `MacdSlow` = 26
+  - `MacdSignal` = 9
+  - `OscillatorMaType` = Exponential
+  - `SignalMaType` = Exponential
+  - `AtrPeriod1` = 10
+  - `Factor1` = 3.0
+  - `AtrPeriod2` = 20
+  - `Factor2` = 5.0
+  - `TradeDirection` = "Both"
+- **筛选**:
+  - 类别: 趋势跟随
+  - 方向: 可配置
+  - 指标: Supertrend, MACD
+  - 复杂度: 中等
+  - 风险级别: 中等

--- a/API/0713_Dual_Supertrend_MACD/README_ru.md
+++ b/API/0713_Dual_Supertrend_MACD/README_ru.md
@@ -1,0 +1,34 @@
+# Dual Supertrend MACD
+[English](README.md) | [中文](README_cn.md)
+
+Стратегия **Dual Supertrend MACD** сочетает два индикатора Supertrend и фильтр MACD.
+Длинная позиция открывается, когда цена выше обеих линий Supertrend и гистограмма MACD положительная.
+Короткая позиция появляется при цене ниже обеих линий и отрицательной гистограмме.
+Выход происходит, когда любая линия Supertrend меняет направление или гистограмма MACD пересекает ноль.
+
+## Подробности
+- **Данные**: свечи цены.
+- **Условия входа**:
+  - Лонг: `Close > Supertrend1 && Close > Supertrend2 && MACD Histogram > 0`
+  - Шорт: `Close < Supertrend1 && Close < Supertrend2 && MACD Histogram < 0`
+- **Условия выхода**:
+  - Лонг: `Close < Supertrend1 || Close < Supertrend2 || MACD Histogram < 0`
+  - Шорт: `Close > Supertrend1 || Close > Supertrend2 || MACD Histogram > 0`
+- **Стопы**: не используются.
+- **Параметры по умолчанию**:
+  - `MacdFast` = 12
+  - `MacdSlow` = 26
+  - `MacdSignal` = 9
+  - `OscillatorMaType` = Exponential
+  - `SignalMaType` = Exponential
+  - `AtrPeriod1` = 10
+  - `Factor1` = 3.0
+  - `AtrPeriod2` = 20
+  - `Factor2` = 5.0
+  - `TradeDirection` = "Both"
+- **Фильтры**:
+  - Категория: следование тренду
+  - Направление: настраиваемое
+  - Индикаторы: Supertrend, MACD
+  - Сложность: средняя
+  - Уровень риска: средний


### PR DESCRIPTION
## Summary
- convert TradingView "Dual-Supertrend with MACD" strategy to StockSharp
- support configurable MA types, MACD lengths and dual SuperTrend filters
- add multilingual docs for the new strategy

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ffae6aec8323bed7101f736884dc