### PR TITLE
Add Keltner Channel strategy by Kevin Davey

### DIFF
--- a/API/0953_Keltner_Channel_Strategy_by_Kevin_Davey/CS/KeltnerChannelStrategyByKevinDaveyStrategy.cs
+++ b/API/0953_Keltner_Channel_Strategy_by_Kevin_Davey/CS/KeltnerChannelStrategyByKevinDaveyStrategy.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
+namespace StockSharp.Samples.Strategies;
+
+/// <summary>
+/// Keltner Channel Strategy by Kevin Davey.
+/// Enters long when price closes below the lower band and short when it closes above the upper band.
+/// </summary>
+public class KeltnerChannelStrategyByKevinDaveyStrategy : Strategy
+{
+	private readonly StrategyParam<int> _emaPeriod;
+	private readonly StrategyParam<int> _atrPeriod;
+	private readonly StrategyParam<decimal> _atrMultiplier;
+	private readonly StrategyParam<DataType> _candleType;
+
+	/// <summary>
+	/// EMA period.
+	/// </summary>
+	public int EmaPeriod { get => _emaPeriod.Value; set => _emaPeriod.Value = value; }
+
+	/// <summary>
+	/// ATR period.
+	/// </summary>
+	public int AtrPeriod { get => _atrPeriod.Value; set => _atrPeriod.Value = value; }
+
+	/// <summary>
+	/// ATR multiplier.
+	/// </summary>
+	public decimal AtrMultiplier { get => _atrMultiplier.Value; set => _atrMultiplier.Value = value; }
+
+	/// <summary>
+	/// Candle type.
+	/// </summary>
+	public DataType CandleType { get => _candleType.Value; set => _candleType.Value = value; }
+
+	/// <summary>
+	/// Initializes a new instance of the strategy.
+	/// </summary>
+	public KeltnerChannelStrategyByKevinDaveyStrategy()
+	{
+		_emaPeriod = Param(nameof(EmaPeriod), 10)
+			.SetDisplay("EMA Period", "Period for Exponential Moving Average", "Indicators")
+			.SetCanOptimize(true)
+			.SetOptimize(5, 30, 1);
+
+		_atrPeriod = Param(nameof(AtrPeriod), 14)
+			.SetDisplay("ATR Period", "Period for Average True Range", "Indicators")
+			.SetCanOptimize(true)
+			.SetOptimize(5, 30, 1);
+
+		_atrMultiplier = Param(nameof(AtrMultiplier), 1.6m)
+			.SetDisplay("ATR Multiplier", "Multiplier for ATR to form channel", "Indicators")
+			.SetCanOptimize(true)
+			.SetOptimize(1m, 3m, 0.1m);
+
+		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
+			.SetDisplay("Candle Type", "Type of candles", "General");
+	}
+
+	/// <inheritdoc />
+	public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
+	{
+		return [(Security, CandleType)];
+	}
+
+	/// <inheritdoc />
+	protected override void OnStarted(DateTimeOffset time)
+	{
+		base.OnStarted(time);
+
+		var ema = new ExponentialMovingAverage { Length = EmaPeriod };
+		var atr = new AverageTrueRange { Length = AtrPeriod };
+
+		var subscription = SubscribeCandles(CandleType);
+		subscription
+			.Bind(ema, atr, ProcessCandle)
+			.Start();
+
+		var area = CreateChartArea();
+		if (area != null)
+		{
+			DrawCandles(area, subscription);
+			DrawIndicator(area, ema);
+			DrawOwnTrades(area);
+		}
+	}
+
+	private void ProcessCandle(ICandleMessage candle, decimal emaValue, decimal atrValue)
+	{
+		if (candle.State != CandleStates.Finished)
+			return;
+
+		if (!IsFormedAndOnlineAndAllowTrading())
+			return;
+
+		var upperBand = emaValue + AtrMultiplier * atrValue;
+		var lowerBand = emaValue - AtrMultiplier * atrValue;
+
+		if (candle.ClosePrice < lowerBand && Position <= 0)
+		{
+			CancelActiveOrders();
+			var volume = Volume + Math.Abs(Position);
+			BuyMarket(volume);
+		}
+		else if (candle.ClosePrice > upperBand && Position >= 0)
+		{
+			CancelActiveOrders();
+			var volume = Volume + Math.Abs(Position);
+			SellMarket(volume);
+		}
+	}
+}

--- a/API/0953_Keltner_Channel_Strategy_by_Kevin_Davey/README.md
+++ b/API/0953_Keltner_Channel_Strategy_by_Kevin_Davey/README.md
@@ -1,0 +1,10 @@
+# Keltner Channel Strategy by Kevin Davey
+[Русский](README_ru.md) | [中文](README_cn.md)
+
+A simple volatility channel system. It buys when the close falls below the lower Keltner band and sells short when the close rises above the upper band. The channel is built from an EMA and an ATR multiple.
+
+## Default Parameters
+- `EmaPeriod` = 10
+- `AtrPeriod` = 14
+- `AtrMultiplier` = 1.6
+- `CandleType` = 5 minute

--- a/API/0953_Keltner_Channel_Strategy_by_Kevin_Davey/README_cn.md
+++ b/API/0953_Keltner_Channel_Strategy_by_Kevin_Davey/README_cn.md
@@ -1,0 +1,10 @@
+# Keltner Channel Strategy by Kevin Davey
+[English](README.md) | [Русский](README_ru.md)
+
+基于Keltner通道的简单策略。收盘价跌破下轨时做多，收盘价升破上轨时做空。通道由EMA和ATR倍数组成。
+
+## 默认参数
+- `EmaPeriod` = 10
+- `AtrPeriod` = 14
+- `AtrMultiplier` = 1.6
+- `CandleType` = 5 分钟

--- a/API/0953_Keltner_Channel_Strategy_by_Kevin_Davey/README_ru.md
+++ b/API/0953_Keltner_Channel_Strategy_by_Kevin_Davey/README_ru.md
@@ -1,0 +1,10 @@
+# Keltner Channel Strategy by Kevin Davey
+[English](README.md) | [中文](README_cn.md)
+
+Простая стратегия на канале Келтнера. Покупает, когда цена закрывается ниже нижней границы, и продаёт, когда закрытие выше верхней границы. Канал строится по EMA и ATR с множителем.
+
+## Параметры по умолчанию
+- `EmaPeriod` = 10
+- `AtrPeriod` = 14
+- `AtrMultiplier` = 1.6
+- `CandleType` = 5 минут


### PR DESCRIPTION
## Summary
- add Keltner Channel strategy that trades when price closes outside the channel bands
- document parameters for EMA length, ATR period, and multiplier in new readmes

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2b3d37efc8323869c7e71590d6c32