### PR TITLE
Add MCOTs Intuition strategy

### DIFF
--- a/API/1039_MCOTs_Intuition/CS/McotsIntuitionStrategy.cs
+++ b/API/1039_MCOTs_Intuition/CS/McotsIntuitionStrategy.cs
@@ -1,0 +1,186 @@
+namespace StockSharp.Samples.Strategies;
+
+using System;
+using System.Collections.Generic;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
+/// <summary>
+/// MCOTs Intuition Strategy.
+/// Uses RSI momentum and its standard deviation to detect entries.
+/// </summary>
+public class McotsIntuitionStrategy : Strategy
+{
+	private readonly StrategyParam<int> _rsiPeriod;
+	private readonly StrategyParam<decimal> _stdDevMultiplier;
+	private readonly StrategyParam<decimal> _exhaustionMultiplier;
+	private readonly StrategyParam<int> _profitTargetTicks;
+	private readonly StrategyParam<int> _stopLossTicks;
+	private readonly StrategyParam<DataType> _candleType;
+
+	private RelativeStrengthIndex _rsi = null!;
+	private StandardDeviation _momentumStdDev = null!;
+
+	private decimal _prevRsi;
+	private decimal _prevMomentum;
+	private decimal _currentStdDev;
+	private decimal _takeProfitPrice;
+	private decimal _stopLossPrice;
+
+	/// <summary>
+	/// RSI calculation period.
+	/// </summary>
+	public int RsiPeriod { get => _rsiPeriod.Value; set => _rsiPeriod.Value = value; }
+
+	/// <summary>
+	/// Multiplier for standard deviation threshold.
+	/// </summary>
+	public decimal StdDevMultiplier { get => _stdDevMultiplier.Value; set => _stdDevMultiplier.Value = value; }
+
+	/// <summary>
+	/// Exhaustion multiplier for momentum comparison.
+	/// </summary>
+	public decimal ExhaustionMultiplier { get => _exhaustionMultiplier.Value; set => _exhaustionMultiplier.Value = value; }
+
+	/// <summary>
+	/// Profit target in ticks.
+	/// </summary>
+	public int ProfitTargetTicks { get => _profitTargetTicks.Value; set => _profitTargetTicks.Value = value; }
+
+	/// <summary>
+	/// Stop loss in ticks.
+	/// </summary>
+	public int StopLossTicks { get => _stopLossTicks.Value; set => _stopLossTicks.Value = value; }
+
+	/// <summary>
+	/// Type of candles to subscribe.
+	/// </summary>
+	public DataType CandleType { get => _candleType.Value; set => _candleType.Value = value; }
+
+	/// <summary>
+	/// Initializes a new instance of <see cref="McotsIntuitionStrategy"/>.
+	/// </summary>
+	public McotsIntuitionStrategy()
+	{
+		_rsiPeriod = Param(nameof(RsiPeriod), 14)
+			.SetDisplay("RSI Period", "RSI calculation period", "Parameters")
+			.SetCanOptimize(true)
+			.SetOptimize(10, 20, 2);
+
+		_stdDevMultiplier = Param(nameof(StdDevMultiplier), 1m)
+			.SetDisplay("StdDev Multiplier", "Standard deviation multiplier", "Parameters")
+			.SetCanOptimize(true)
+			.SetOptimize(0.5m, 2m, 0.5m);
+
+		_exhaustionMultiplier = Param(nameof(ExhaustionMultiplier), 1m)
+			.SetDisplay("Exhaustion Multiplier", "Momentum exhaustion multiplier", "Parameters")
+			.SetCanOptimize(true)
+			.SetOptimize(0.5m, 1.5m, 0.1m);
+
+		_profitTargetTicks = Param(nameof(ProfitTargetTicks), 40)
+			.SetDisplay("Profit Target Ticks", "Profit target in ticks", "Parameters")
+			.SetCanOptimize(true)
+			.SetOptimize(20, 80, 10);
+
+		_stopLossTicks = Param(nameof(StopLossTicks), 160)
+			.SetDisplay("Stop Loss Ticks", "Stop loss in ticks", "Parameters")
+			.SetCanOptimize(true)
+			.SetOptimize(40, 200, 20);
+
+		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
+			.SetDisplay("Candle Type", "Type of candles", "Parameters");
+	}
+
+	/// <inheritdoc />
+	public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
+	{
+		return [(Security, CandleType)];
+	}
+
+	/// <inheritdoc />
+	protected override void OnReseted()
+	{
+		base.OnReseted();
+
+		_prevRsi = default;
+		_prevMomentum = default;
+		_currentStdDev = default;
+		_takeProfitPrice = default;
+		_stopLossPrice = default;
+	}
+
+	/// <inheritdoc />
+	protected override void OnStarted(DateTimeOffset time)
+	{
+		base.OnStarted(time);
+
+		_rsi = new RelativeStrengthIndex { Length = RsiPeriod };
+		_momentumStdDev = new StandardDeviation { Length = RsiPeriod };
+
+		var subscription = SubscribeCandles(CandleType);
+		subscription
+			.Bind(_rsi, ProcessCandle)
+			.Start();
+
+		var area = CreateChartArea();
+		if (area != null)
+		{
+			DrawCandles(area, subscription);
+			DrawIndicator(area, _rsi);
+			DrawOwnTrades(area);
+		}
+
+		StartProtection();
+	}
+
+	private void ProcessCandle(ICandleMessage candle, decimal rsiValue)
+	{
+		if (candle.State != CandleStates.Finished)
+			return;
+
+		var momentum = rsiValue - _prevRsi;
+		var stdValue = _momentumStdDev.Process(momentum, candle.ServerTime, true);
+		_currentStdDev = stdValue.ToDecimal();
+
+		if (!IsFormedAndOnlineAndAllowTrading() || !_momentumStdDev.IsFormed)
+		{
+			_prevRsi = rsiValue;
+			_prevMomentum = momentum;
+			return;
+		}
+
+		var priceStep = Security?.PriceStep ?? 1m;
+
+		if (Position == 0)
+		{
+			if (momentum > _currentStdDev * StdDevMultiplier && momentum < _prevMomentum * ExhaustionMultiplier)
+			{
+				BuyMarket();
+				_takeProfitPrice = candle.ClosePrice + ProfitTargetTicks * priceStep;
+				_stopLossPrice = candle.ClosePrice - StopLossTicks * priceStep;
+			}
+			else if (momentum < -_currentStdDev * StdDevMultiplier && momentum > _prevMomentum * ExhaustionMultiplier)
+			{
+				SellMarket();
+				_takeProfitPrice = candle.ClosePrice - ProfitTargetTicks * priceStep;
+				_stopLossPrice = candle.ClosePrice + StopLossTicks * priceStep;
+			}
+		}
+		else if (Position > 0)
+		{
+			if (candle.HighPrice >= _takeProfitPrice || candle.LowPrice <= _stopLossPrice)
+				ClosePosition();
+		}
+		else if (Position < 0)
+		{
+			if (candle.LowPrice <= _takeProfitPrice || candle.HighPrice >= _stopLossPrice)
+				ClosePosition();
+		}
+
+		_prevRsi = rsiValue;
+		_prevMomentum = momentum;
+	}
+}

--- a/API/1039_MCOTs_Intuition/README.md
+++ b/API/1039_MCOTs_Intuition/README.md
@@ -1,0 +1,32 @@
+# MCOTs Intuition Strategy
+[Русский](README_ru.md) | [中文](README_cn.md)
+
+Strategy based on RSI momentum relative to its standard deviation. It buys when upward momentum is strong but fading and sells on the opposite. Fixed profit target and stop loss are placed in ticks.
+
+## Details
+
+- **Entry Criteria**:
+  - Long: momentum > stdDev * multiplier and momentum < previousMomentum * exhaustionMultiplier
+  - Short: momentum < -stdDev * multiplier and momentum > previousMomentum * exhaustionMultiplier
+- **Long/Short**: Both
+- **Exit Criteria**:
+  - Fixed profit target and stop loss in ticks
+- **Stops**: Yes
+- **Default Values**:
+  - `RsiPeriod` = 14
+  - `StdDevMultiplier` = 1m
+  - `ExhaustionMultiplier` = 1m
+  - `ProfitTargetTicks` = 40
+  - `StopLossTicks` = 160
+  - `CandleType` = TimeSpan.FromMinutes(5).TimeFrame()
+- **Filters**:
+  - Category: Reversal
+  - Direction: Both
+  - Indicators: RSI, StandardDeviation
+  - Stops: Yes
+  - Complexity: Basic
+  - Timeframe: Mid-term
+  - Seasonality: No
+  - Neural Networks: No
+  - Divergence: No
+  - Risk Level: Medium

--- a/API/1039_MCOTs_Intuition/README_cn.md
+++ b/API/1039_MCOTs_Intuition/README_cn.md
@@ -1,0 +1,32 @@
+# MCOTs Intuition 策略
+[English](README.md) | [Русский](README_ru.md)
+
+该策略基于 RSI 动量与其标准差的关系。当上升动量强但开始减弱时买入，动量反向且减弱时做空。使用固定的获利和止损目标（以 ticks 表示）。
+
+## 细节
+
+- **入场条件**：
+  - 多头：momentum > stdDev * multiplier 且 momentum < previousMomentum * exhaustionMultiplier
+  - 空头：momentum < -stdDev * multiplier 且 momentum > previousMomentum * exhaustionMultiplier
+- **多空方向**：皆可
+- **出场条件**：
+  - 固定的获利与止损 ticks
+- **止损**：是
+- **默认值**：
+  - `RsiPeriod` = 14
+  - `StdDevMultiplier` = 1m
+  - `ExhaustionMultiplier` = 1m
+  - `ProfitTargetTicks` = 40
+  - `StopLossTicks` = 160
+  - `CandleType` = TimeSpan.FromMinutes(5).TimeFrame()
+- **筛选**：
+  - 分类：反转
+  - 方向：双向
+  - 指标：RSI、StandardDeviation
+  - 止损：是
+  - 复杂度：基础
+  - 时间框架：中期
+  - 季节性：否
+  - 神经网络：否
+  - 背离：否
+  - 风险等级：中等

--- a/API/1039_MCOTs_Intuition/README_ru.md
+++ b/API/1039_MCOTs_Intuition/README_ru.md
@@ -1,0 +1,32 @@
+# Стратегия MCOTs Intuition
+[English](README.md) | [中文](README_cn.md)
+
+Стратегия использует импульс RSI и его стандартное отклонение. Покупает при сильном, но ослабевающем положительном импульсе и продаёт при зеркальных условиях. Устанавливает фиксированную цель прибыли и стоп в тиках.
+
+## Детали
+
+- **Условия входа**:
+  - Long: momentum > stdDev * multiplier и momentum < previousMomentum * exhaustionMultiplier
+  - Short: momentum < -stdDev * multiplier и momentum > previousMomentum * exhaustionMultiplier
+- **Направление**: Оба
+- **Условия выхода**:
+  - Фиксированная цель прибыли и стоп в тиках
+- **Стопы**: Да
+- **Значения по умолчанию**:
+  - `RsiPeriod` = 14
+  - `StdDevMultiplier` = 1m
+  - `ExhaustionMultiplier` = 1m
+  - `ProfitTargetTicks` = 40
+  - `StopLossTicks` = 160
+  - `CandleType` = TimeSpan.FromMinutes(5).TimeFrame()
+- **Фильтры**:
+  - Категория: Разворот
+  - Направление: Оба
+  - Индикаторы: RSI, StandardDeviation
+  - Стопы: Да
+  - Сложность: Базовая
+  - Таймфрейм: Среднесрочный
+  - Сезонность: Нет
+  - Нейросети: Нет
+  - Дивергенция: Нет
+  - Уровень риска: Средний


### PR DESCRIPTION
## Summary
- implement MCOTs Intuition high-level strategy with RSI momentum and tick-based targets
- document parameters and logic in English, Russian, and Chinese readmes

## Testing
- ⚠️ `dotnet build AlgoTrading.sln` *(command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68c2cae737a48323905e4e942f4bedc3