### PR TITLE
feat: add PercentX trend follower strategy

### DIFF
--- a/API/1163_PercentX_Trend_Follower/CS/PercentXTrendFollowerStrategy.cs
+++ b/API/1163_PercentX_Trend_Follower/CS/PercentXTrendFollowerStrategy.cs
@@ -1,0 +1,234 @@
+using System;
+using System.Collections.Generic;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
+namespace StockSharp.Samples.Strategies;
+
+/// <summary>
+/// PercentX Trend Follower strategy based on oscillator ranges.
+/// </summary>
+public class PercentXTrendFollowerStrategy : Strategy
+{
+	public enum BandMode
+	{
+		Keltner,
+		Bollinger,
+	}
+
+	private readonly StrategyParam<BandMode> _bandType;
+	private readonly StrategyParam<int> _maLength;
+	private readonly StrategyParam<int> _loopbackPeriod;
+	private readonly StrategyParam<int> _outerLoopback;
+	private readonly StrategyParam<bool> _useInitialStop;
+	private readonly StrategyParam<int> _atrLength;
+	private readonly StrategyParam<decimal> _trendMultiplier;
+	private readonly StrategyParam<decimal> _reverseMultiplier;
+	private readonly StrategyParam<DataType> _candleType;
+
+	private AverageTrueRange _atr = null!;
+	private BollingerBands _bollinger = null!;
+	private KeltnerChannels _keltner = null!;
+	private Highest _oscHighest = null!;
+	private Lowest _oscLowest = null!;
+	private Highest _overboughtHighest = null!;
+	private Lowest _oversoldLowest = null!;
+
+	private decimal? _prevOscillator;
+	private decimal? _prevUpperRange;
+	private decimal? _prevLowerRange;
+	private decimal _stopPrice;
+
+	/// <summary>
+	/// Band type.
+	/// </summary>
+	public BandMode BandType { get => _bandType.Value; set => _bandType.Value = value; }
+
+	/// <summary>
+	/// Moving average length.
+	/// </summary>
+	public int MaLength { get => _maLength.Value; set => _maLength.Value = value; }
+
+	/// <summary>
+	/// Loopback period for oscillator range.
+	/// </summary>
+	public int LoopbackPeriod { get => _loopbackPeriod.Value; set => _loopbackPeriod.Value = value; }
+
+	/// <summary>
+	/// Loopback period for outer range.
+	/// </summary>
+	public int OuterLoopback { get => _outerLoopback.Value; set => _outerLoopback.Value = value; }
+
+	/// <summary>
+	/// Use ATR based initial stop.
+	/// </summary>
+	public bool UseInitialStop { get => _useInitialStop.Value; set => _useInitialStop.Value = value; }
+
+	/// <summary>
+	/// ATR length.
+	/// </summary>
+	public int AtrLength { get => _atrLength.Value; set => _atrLength.Value = value; }
+
+	/// <summary>
+	/// Multiplier for trend direction.
+	/// </summary>
+	public decimal TrendMultiplier { get => _trendMultiplier.Value; set => _trendMultiplier.Value = value; }
+
+	/// <summary>
+	/// Multiplier for reverse stop.
+	/// </summary>
+	public decimal ReverseMultiplier { get => _reverseMultiplier.Value; set => _reverseMultiplier.Value = value; }
+
+	/// <summary>
+	/// Candle type.
+	/// </summary>
+	public DataType CandleType { get => _candleType.Value; set => _candleType.Value = value; }
+
+	/// <summary>
+	/// Initialize <see cref=\"PercentXTrendFollowerStrategy\"/>.
+	/// </summary>
+	public PercentXTrendFollowerStrategy()
+	{
+		_bandType = Param(nameof(BandType), BandMode.Keltner)
+			.SetDisplay("Band Type", "Indicator for band calculation", "Parameters");
+
+		_maLength = Param(nameof(MaLength), 40)
+			.SetGreaterThanZero()
+			.SetDisplay("MA Length", "Moving average length", "Parameters");
+
+		_loopbackPeriod = Param(nameof(LoopbackPeriod), 80)
+			.SetGreaterThanZero()
+			.SetDisplay("Range Lookback", "Lookback for oscillator range", "Parameters");
+
+		_outerLoopback = Param(nameof(OuterLoopback), 80)
+			.SetGreaterThanZero()
+			.SetDisplay("Outer Range Lookback", "Lookback for outer range", "Parameters");
+
+		_useInitialStop = Param(nameof(UseInitialStop), true)
+			.SetDisplay("Use Initial Stop", "Enable ATR based stop", "Risk");
+
+		_atrLength = Param(nameof(AtrLength), 14)
+			.SetGreaterThanZero()
+			.SetDisplay("ATR Length", "ATR calculation length", "Risk");
+
+		_trendMultiplier = Param(nameof(TrendMultiplier), 1m)
+			.SetDisplay("Trend Mult", "Multiplier for entry distance", "Risk");
+
+		_reverseMultiplier = Param(nameof(ReverseMultiplier), 3m)
+			.SetDisplay("Reverse Mult", "Multiplier for stop distance", "Risk");
+
+		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
+			.SetDisplay("Candle Type", "Type of candles", "General");
+
+		Volume = 1;
+	}
+	/// <inheritdoc />
+	public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
+	{
+		return [(Security, CandleType)];
+	}
+
+	/// <inheritdoc />
+	protected override void OnReseted()
+	{
+		base.OnReseted();
+		_prevOscillator = null;
+		_prevUpperRange = null;
+		_prevLowerRange = null;
+		_stopPrice = 0m;
+	}
+
+	/// <inheritdoc />
+	protected override void OnStarted(DateTimeOffset time)
+	{
+		base.OnStarted(time);
+
+		_atr = new AverageTrueRange { Length = AtrLength };
+		_bollinger = new BollingerBands { Length = MaLength, Width = 2m };
+		_keltner = new KeltnerChannels { Length = MaLength, Multiplier = 2m };
+		_oscHighest = new Highest { Length = LoopbackPeriod };
+		_oscLowest = new Lowest { Length = LoopbackPeriod };
+		_overboughtHighest = new Highest { Length = OuterLoopback };
+		_oversoldLowest = new Lowest { Length = OuterLoopback };
+
+		var subscription = SubscribeCandles(CandleType);
+		subscription
+			.BindEx(_bollinger, _keltner, _atr, ProcessCandle)
+			.Start();
+	}
+
+	private void ProcessCandle(ICandleMessage candle, IIndicatorValue bollingerValue, IIndicatorValue keltnerValue, decimal atr)
+	{
+		if (candle.State != CandleStates.Finished)
+			return;
+
+		decimal middle;
+		decimal upper;
+		decimal lower;
+
+		if (BandType == BandMode.Bollinger)
+		{
+			var bb = (BollingerBandsValue)bollingerValue;
+			if (bb.UpBand is not decimal up || bb.LowBand is not decimal low || bb.MovingAverage is not decimal mid)
+				return;
+
+			middle = mid;
+			upper = up;
+			lower = low;
+		}
+		else
+		{
+			var kc = (KeltnerChannelsValue)keltnerValue;
+			if (kc.UpBand is not decimal up || kc.LowBand is not decimal low || kc.MovingAverage is not decimal mid)
+				return;
+
+			middle = mid;
+			upper = up;
+			lower = low;
+		}
+
+		var denom = middle - lower;
+		if (denom == 0)
+			return;
+
+		var oscillator = (candle.ClosePrice - middle) / denom;
+
+		var overbought = _oscHighest.Process(oscillator).ToDecimal();
+		var oversold = _oscLowest.Process(oscillator).ToDecimal();
+		var upperRange = _overboughtHighest.Process(overbought).ToDecimal();
+		var lowerRange = _oversoldLowest.Process(oversold).ToDecimal();
+
+		var longSignal = _prevOscillator is decimal po && _prevUpperRange is decimal pur && po <= pur && oscillator > upperRange;
+		var shortSignal = _prevOscillator is decimal po2 && _prevLowerRange is decimal plr && po2 >= plr && oscillator < lowerRange;
+
+		_prevOscillator = oscillator;
+		_prevUpperRange = upperRange;
+		_prevLowerRange = lowerRange;
+
+		if (longSignal && Position <= 0)
+		{
+			CancelActiveOrders();
+			BuyMarket(Volume + Math.Abs(Position));
+			if (UseInitialStop)
+				_stopPrice = candle.LowPrice - atr * ReverseMultiplier;
+		}
+		else if (shortSignal && Position >= 0)
+		{
+			CancelActiveOrders();
+			SellMarket(Volume + Math.Abs(Position));
+			if (UseInitialStop)
+				_stopPrice = candle.HighPrice + atr * ReverseMultiplier;
+		}
+
+		if (UseInitialStop)
+		{
+			if (Position > 0 && candle.LowPrice <= _stopPrice)
+				SellMarket(Position);
+			else if (Position < 0 && candle.HighPrice >= _stopPrice)
+				BuyMarket(-Position);
+		}
+	}
+}

--- a/API/1163_PercentX_Trend_Follower/README.md
+++ b/API/1163_PercentX_Trend_Follower/README.md
@@ -1,0 +1,35 @@
+# PercentX Trend Follower
+[Русский](README_ru.md) | [中文](README_cn.md)
+
+Strategy derived from PercentX Trend Follower by Trendoscope.
+
+The strategy normalizes price distance from a selected band (Keltner or Bollinger) and trades when this oscillator crosses dynamic extreme ranges. ATR is used for stop placement.
+
+## Details
+
+- **Entry Criteria**: Oscillator crossing above upper range for long, below lower range for short.
+- **Long/Short**: Both directions.
+- **Exit Criteria**: ATR-based stop.
+- **Stops**: Initial ATR stop.
+- **Default Values**:
+  - `BandType` = Keltner
+  - `MaLength` = 40
+  - `LoopbackPeriod` = 80
+  - `OuterLoopback` = 80
+  - `UseInitialStop` = true
+  - `AtrLength` = 14
+  - `TrendMultiplier` = 1
+  - `ReverseMultiplier` = 3
+  - `CandleType` = TimeSpan.FromMinutes(5)
+- **Filters**:
+  - Category: Trend
+  - Direction: Both
+  - Indicators: BollingerBands, KeltnerChannels, ATR, Highest, Lowest
+  - Stops: ATR
+  - Complexity: Intermediate
+  - Timeframe: Intraday (5m)
+  - Seasonality: No
+  - Neural Networks: No
+  - Divergence: No
+  - Risk Level: Medium
+

--- a/API/1163_PercentX_Trend_Follower/README_cn.md
+++ b/API/1163_PercentX_Trend_Follower/README_cn.md
@@ -1,0 +1,35 @@
+# PercentX Trend Follower
+[English](README.md) | [Русский](README_ru.md)
+
+基于 Trendoscope 的 PercentX Trend Follower 策略。
+
+该策略通过选择的通道（Keltner 或 Bollinger）计算价格与中线的距离，构建振荡器，当振荡器突破动态区间时开仓，ATR 用于止损。
+
+## 细节
+
+- **入场条件**：振荡器上穿上区间做多，下破下区间做空。
+- **多空方向**：双向。
+- **出场条件**：基于 ATR 的止损。
+- **止损**：初始 ATR 止损。
+- **默认值**：
+  - `BandType` = Keltner
+  - `MaLength` = 40
+  - `LoopbackPeriod` = 80
+  - `OuterLoopback` = 80
+  - `UseInitialStop` = true
+  - `AtrLength` = 14
+  - `TrendMultiplier` = 1
+  - `ReverseMultiplier` = 3
+  - `CandleType` = TimeSpan.FromMinutes(5)
+- **过滤器**：
+  - 分类: Trend
+  - 方向: Both
+  - 指标: BollingerBands, KeltnerChannels, ATR, Highest, Lowest
+  - 止损: ATR
+  - 复杂度: 中等
+  - 时间框架: 日内 (5m)
+  - 季节性: 无
+  - 神经网络: 无
+  - 背离: 无
+  - 风险等级: 中等
+

--- a/API/1163_PercentX_Trend_Follower/README_ru.md
+++ b/API/1163_PercentX_Trend_Follower/README_ru.md
@@ -1,0 +1,35 @@
+# PercentX Trend Follower
+[English](README.md) | [中文](README_cn.md)
+
+Стратегия, основанная на PercentX Trend Follower от Trendoscope.
+
+Стратегия нормализует расстояние цены от выбранного канала (Keltner или Bollinger) и торгует при пересечении осциллятором динамических экстремальных диапазонов. Для установки стопов используется ATR.
+
+## Детали
+
+- **Условия входа**: Осциллятор пересекает верхний диапазон для лонга, нижний диапазон для шорта.
+- **Длинные/Короткие**: Оба направления.
+- **Условия выхода**: Стоп по ATR.
+- **Стопы**: Начальный стоп по ATR.
+- **Значения по умолчанию**:
+  - `BandType` = Keltner
+  - `MaLength` = 40
+  - `LoopbackPeriod` = 80
+  - `OuterLoopback` = 80
+  - `UseInitialStop` = true
+  - `AtrLength` = 14
+  - `TrendMultiplier` = 1
+  - `ReverseMultiplier` = 3
+  - `CandleType` = TimeSpan.FromMinutes(5)
+- **Фильтры**:
+  - Категория: Trend
+  - Направление: Both
+  - Индикаторы: BollingerBands, KeltnerChannels, ATR, Highest, Lowest
+  - Стопы: ATR
+  - Сложность: Средняя
+  - Таймфрейм: Интрадей (5м)
+  - Сезонность: Нет
+  - Нейросети: Нет
+  - Дивергенция: Нет
+  - Уровень риска: Средний
+


### PR DESCRIPTION
## Summary
- add PercentX Trend Follower strategy using Bollinger or Keltner bands
- document PercentX Trend Follower strategy

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e7ad14808323adb9f2a06252c704