### PR TITLE
Add Overnight Effect High Volatility Crypto strategy

### DIFF
--- a/API/1150_Overnight_Effect_High_Volatility_Crypto/CS/OvernightEffectHighVolatilityCryptoStrategy.cs
+++ b/API/1150_Overnight_Effect_High_Volatility_Crypto/CS/OvernightEffectHighVolatilityCryptoStrategy.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections.Generic;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
+namespace StockSharp.Samples.Strategies;
+
+/// <summary>
+/// Strategy that goes long during high volatility evenings and exits before midnight.
+/// Volatility is measured by standard deviation of log returns compared to median volatility.
+/// </summary>
+public class OvernightEffectHighVolatilityCryptoStrategy : Strategy
+{
+	private readonly StrategyParam<int> _volatilityPeriodDays;
+	private readonly StrategyParam<int> _medianPeriodDays;
+	private readonly StrategyParam<int> _entryHour;
+	private readonly StrategyParam<int> _exitHour;
+	private readonly StrategyParam<bool> _useVolatilityFilter;
+	private readonly StrategyParam<DataType> _candleType;
+
+	private StandardDeviation _volatilityStdDev = null!;
+	private Median _medianVolatility = null!;
+	private decimal _prevClose;
+	private bool _inTrade;
+
+	/// <summary>
+	/// Days used for historical volatility calculation.
+	/// </summary>
+	public int VolatilityPeriodDays
+	{
+		get => _volatilityPeriodDays.Value;
+		set => _volatilityPeriodDays.Value = value;
+	}
+
+	/// <summary>
+	/// Days used for median volatility calculation.
+	/// </summary>
+	public int MedianPeriodDays
+	{
+		get => _medianPeriodDays.Value;
+		set => _medianPeriodDays.Value = value;
+	}
+
+	/// <summary>
+	/// Hour to enter the long position (UTC).
+	/// </summary>
+	public int EntryHour
+	{
+		get => _entryHour.Value;
+		set => _entryHour.Value = value;
+	}
+
+	/// <summary>
+	/// Hour to exit the position (UTC).
+	/// </summary>
+	public int ExitHour
+	{
+		get => _exitHour.Value;
+		set => _exitHour.Value = value;
+	}
+
+	/// <summary>
+	/// Enable high volatility filter.
+	/// </summary>
+	public bool UseVolatilityFilter
+	{
+		get => _useVolatilityFilter.Value;
+		set => _useVolatilityFilter.Value = value;
+	}
+
+	/// <summary>
+	/// Candle type for strategy calculations.
+	/// </summary>
+	public DataType CandleType
+	{
+		get => _candleType.Value;
+		set => _candleType.Value = value;
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the strategy.
+	/// </summary>
+	public OvernightEffectHighVolatilityCryptoStrategy()
+	{
+		_volatilityPeriodDays = Param(nameof(VolatilityPeriodDays), 30)
+			.SetGreaterThanZero()
+			.SetDisplay("Volatility Period (Days)", "Days for historical volatility", "Parameters");
+
+		_medianPeriodDays = Param(nameof(MedianPeriodDays), 208)
+			.SetGreaterThanZero()
+			.SetDisplay("Median Period (Days)", "Days for median volatility", "Parameters");
+
+		_entryHour = Param(nameof(EntryHour), 21)
+			.SetDisplay("Entry Hour", "Hour to enter long position (UTC)", "Parameters");
+
+		_exitHour = Param(nameof(ExitHour), 23)
+			.SetDisplay("Exit Hour", "Hour to exit position (UTC)", "Parameters");
+
+		_useVolatilityFilter = Param(nameof(UseVolatilityFilter), true)
+			.SetDisplay("Use Volatility Filter", "Require high volatility to enter", "Parameters");
+
+		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(1).TimeFrame())
+			.SetDisplay("Candle Type", "Type of candles for strategy", "General");
+	}
+
+	/// <inheritdoc />
+	public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
+	{
+		return [(Security, CandleType)];
+	}
+
+	/// <inheritdoc />
+	protected override void OnReseted()
+	{
+		base.OnReseted();
+
+		_prevClose = 0m;
+		_inTrade = false;
+		_volatilityStdDev = null!;
+		_medianVolatility = null!;
+	}
+
+	/// <inheritdoc />
+	protected override void OnStarted(DateTimeOffset time)
+	{
+		base.OnStarted(time);
+
+		var volLength = VolatilityPeriodDays * 24;
+		var medianLength = MedianPeriodDays * 24;
+
+		_volatilityStdDev = new StandardDeviation { Length = volLength };
+		_medianVolatility = new Median { Length = medianLength };
+
+		var subscription = SubscribeCandles(CandleType);
+		subscription
+			.Bind(ProcessCandle)
+			.Start();
+
+		var area = CreateChartArea();
+		if (area != null)
+		{
+			DrawCandles(area, subscription);
+			DrawOwnTrades(area);
+		}
+	}
+
+	private void ProcessCandle(ICandleMessage candle)
+	{
+		if (candle.State != CandleStates.Finished)
+			return;
+
+		if (_prevClose == 0m)
+		{
+			_prevClose = candle.ClosePrice;
+			return;
+		}
+
+		var logReturn = (decimal)Math.Log((double)(candle.ClosePrice / _prevClose));
+		_prevClose = candle.ClosePrice;
+
+		var vol = _volatilityStdDev.Process(logReturn, candle.OpenTime, true);
+		var median = _medianVolatility.Process(vol ?? 0m, candle.OpenTime, true);
+
+		if (!IsFormedAndOnlineAndAllowTrading())
+			return;
+
+		var currentHour = candle.OpenTime.Hour;
+		var isHighVol = vol is decimal v && median is decimal m && v > m;
+
+		if (currentHour == EntryHour && !_inTrade && (!UseVolatilityFilter || isHighVol))
+		{
+			BuyMarket(Volume + Math.Abs(Position));
+			_inTrade = true;
+			return;
+		}
+
+		if (currentHour == ExitHour && _inTrade && Position > 0)
+		{
+			SellMarket(Math.Abs(Position));
+			_inTrade = false;
+		}
+	}
+}

--- a/API/1150_Overnight_Effect_High_Volatility_Crypto/README.md
+++ b/API/1150_Overnight_Effect_High_Volatility_Crypto/README.md
@@ -1,0 +1,30 @@
+# Overnight Effect High Volatility Crypto Strategy
+[Русский](README_ru.md) | [中文](README_cn.md)
+
+Strategy that enters a long position during high-volatility evenings and closes before midnight. Volatility is measured by the standard deviation of log returns over a configurable period and compared against the median of historical volatility.
+
+## Details
+
+- **Entry Criteria**:
+  - `currentHour == EntryHour && highVolatility` when `UseVolatilityFilter`
+  - `currentHour == EntryHour` when filter disabled
+- **Long/Short**: Long
+- **Stops**: None
+- **Default Values**:
+  - `VolatilityPeriodDays` = 30
+  - `MedianPeriodDays` = 208
+  - `EntryHour` = 21
+  - `ExitHour` = 23
+  - `UseVolatilityFilter` = true
+  - `CandleType` = TimeSpan.FromHours(1).TimeFrame()
+- **Filters**:
+  - Category: Time-based
+  - Direction: Long
+  - Indicators: StandardDeviation, Median
+  - Stops: No
+  - Complexity: Beginner
+  - Timeframe: Intraday
+  - Seasonality: No
+  - Neural Networks: No
+  - Divergence: No
+  - Risk Level: Low

--- a/API/1150_Overnight_Effect_High_Volatility_Crypto/README_cn.md
+++ b/API/1150_Overnight_Effect_High_Volatility_Crypto/README_cn.md
@@ -1,0 +1,30 @@
+# 隔夜高波动加密策略
+[English](README.md) | [Русский](README_ru.md)
+
+该策略在高波动的夜间入场做多，并在午夜前平仓。波动率通过指定周期的对数收益标准差计算，并与历史波动率的中位数比较。
+
+## 细节
+
+- **入场条件**：
+  - 启用 `UseVolatilityFilter` 时：`currentHour == EntryHour && highVolatility`
+  - 关闭过滤器时：`currentHour == EntryHour`
+- **多空方向**：多头
+- **止损**：无
+- **默认参数**：
+  - `VolatilityPeriodDays` = 30
+  - `MedianPeriodDays` = 208
+  - `EntryHour` = 21
+  - `ExitHour` = 23
+  - `UseVolatilityFilter` = true
+  - `CandleType` = TimeSpan.FromHours(1).TimeFrame()
+- **过滤器**：
+  - 类别：时间
+  - 方向：多头
+  - 指标：StandardDeviation，Median
+  - 止损：否
+  - 复杂度：初级
+  - 时间框架：日内
+  - 季节性：否
+  - 神经网络：否
+  - 背离：否
+  - 风险等级：低

--- a/API/1150_Overnight_Effect_High_Volatility_Crypto/README_ru.md
+++ b/API/1150_Overnight_Effect_High_Volatility_Crypto/README_ru.md
@@ -1,0 +1,30 @@
+# Стратегия Overnight Effect High Volatility Crypto
+[English](README.md) | [中文](README_cn.md)
+
+Стратегия открывает длинную позицию вечером в дни повышенной волатильности и закрывает её перед полуночью. Волатильность измеряется стандартным отклонением логарифмической доходности за заданный период и сравнивается с медианой исторической волатильности.
+
+## Детали
+
+- **Условия входа**:
+  - `currentHour == EntryHour && highVolatility` при активном `UseVolatilityFilter`
+  - `currentHour == EntryHour` если фильтр отключён
+- **Long/Short**: Long
+- **Стопы**: Нет
+- **Значения по умолчанию**:
+  - `VolatilityPeriodDays` = 30
+  - `MedianPeriodDays` = 208
+  - `EntryHour` = 21
+  - `ExitHour` = 23
+  - `UseVolatilityFilter` = true
+  - `CandleType` = TimeSpan.FromHours(1).TimeFrame()
+- **Фильтры**:
+  - Категория: Время
+  - Направление: Long
+  - Индикаторы: StandardDeviation, Median
+  - Стопы: Нет
+  - Сложность: Новичок
+  - Таймфрейм: Внутридневной
+  - Сезонность: Нет
+  - Нейросети: Нет
+  - Дивергенция: Нет
+  - Уровень риска: Низкий


### PR DESCRIPTION
## Summary
- implement Overnight Effect High Volatility Crypto strategy entering and exiting based on hourly volatility and time filters
- document usage and parameters in English, Russian, and Chinese readmes

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden when attempting to install dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e75db95883239d62fd34afd9b4b0