### PR TITLE
Add Strategic Multi-Step Supertrend strategy

### DIFF
--- a/API/1346_Strategic_Multi_Step_Supertrend/CS/StrategicMultiStepSupertrendStrategy.cs
+++ b/API/1346_Strategic_Multi_Step_Supertrend/CS/StrategicMultiStepSupertrendStrategy.cs
@@ -1,0 +1,251 @@
+using System;
+using System.Collections.Generic;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
+namespace StockSharp.Samples.Strategies;
+
+/// <summary>
+/// Strategy using double Supertrend with multi-step take profits.
+/// </summary>
+public class StrategicMultiStepSupertrendStrategy : Strategy
+{
+	private readonly StrategyParam<bool> _useTakeProfit;
+	private readonly StrategyParam<decimal> _takeProfitPercent1;
+	private readonly StrategyParam<decimal> _takeProfitPercent2;
+	private readonly StrategyParam<decimal> _takeProfitPercent3;
+	private readonly StrategyParam<decimal> _takeProfitPercent4;
+	private readonly StrategyParam<decimal> _takeProfitAmount1;
+	private readonly StrategyParam<decimal> _takeProfitAmount2;
+	private readonly StrategyParam<decimal> _takeProfitAmount3;
+	private readonly StrategyParam<decimal> _takeProfitAmount4;
+	private readonly StrategyParam<int> _numberOfSteps;
+	private readonly StrategyParam<string> _tradeDirection;
+	private readonly StrategyParam<int> _atrPeriod1;
+	private readonly StrategyParam<decimal> _factor1;
+	private readonly StrategyParam<int> _atrPeriod2;
+	private readonly StrategyParam<decimal> _factor2;
+	private readonly StrategyParam<DataType> _candleType;
+	
+	private decimal _prevSupertrend1;
+	private bool _prevAbove1;
+	private decimal _prevSupertrend2;
+	private bool _prevAbove2;
+	private decimal _entryPrice;
+	
+	public bool UseTakeProfit { get => _useTakeProfit.Value; set => _useTakeProfit.Value = value; }
+	public decimal TakeProfitPercent1 { get => _takeProfitPercent1.Value; set => _takeProfitPercent1.Value = value; }
+	public decimal TakeProfitPercent2 { get => _takeProfitPercent2.Value; set => _takeProfitPercent2.Value = value; }
+	public decimal TakeProfitPercent3 { get => _takeProfitPercent3.Value; set => _takeProfitPercent3.Value = value; }
+	public decimal TakeProfitPercent4 { get => _takeProfitPercent4.Value; set => _takeProfitPercent4.Value = value; }
+	public decimal TakeProfitAmount1 { get => _takeProfitAmount1.Value; set => _takeProfitAmount1.Value = value; }
+	public decimal TakeProfitAmount2 { get => _takeProfitAmount2.Value; set => _takeProfitAmount2.Value = value; }
+	public decimal TakeProfitAmount3 { get => _takeProfitAmount3.Value; set => _takeProfitAmount3.Value = value; }
+	public decimal TakeProfitAmount4 { get => _takeProfitAmount4.Value; set => _takeProfitAmount4.Value = value; }
+	public int NumberOfSteps { get => _numberOfSteps.Value; set => _numberOfSteps.Value = value; }
+	public string TradeDirection { get => _tradeDirection.Value; set => _tradeDirection.Value = value; }
+	public int AtrPeriod1 { get => _atrPeriod1.Value; set => _atrPeriod1.Value = value; }
+	public decimal Factor1 { get => _factor1.Value; set => _factor1.Value = value; }
+	public int AtrPeriod2 { get => _atrPeriod2.Value; set => _atrPeriod2.Value = value; }
+	public decimal Factor2 { get => _factor2.Value; set => _factor2.Value = value; }
+	public DataType CandleType { get => _candleType.Value; set => _candleType.Value = value; }
+	
+	public StrategicMultiStepSupertrendStrategy()
+	{
+		_useTakeProfit = Param(nameof(UseTakeProfit), true)
+		.SetDisplay("Use Take Profit", "Enable partial take profit", "Take Profit Settings");
+		
+		_takeProfitPercent1 = Param(nameof(TakeProfitPercent1), 6.0m)
+		.SetDisplay("TP % Step 1", "Take profit percentage step 1", "Take Profit Settings")
+		.SetCanOptimize(true);
+		_takeProfitPercent2 = Param(nameof(TakeProfitPercent2), 12.0m)
+		.SetDisplay("TP % Step 2", "Take profit percentage step 2", "Take Profit Settings")
+		.SetCanOptimize(true);
+		_takeProfitPercent3 = Param(nameof(TakeProfitPercent3), 18.0m)
+		.SetDisplay("TP % Step 3", "Take profit percentage step 3", "Take Profit Settings")
+		.SetCanOptimize(true);
+		_takeProfitPercent4 = Param(nameof(TakeProfitPercent4), 50.0m)
+		.SetDisplay("TP % Step 4", "Take profit percentage step 4", "Take Profit Settings")
+		.SetCanOptimize(true);
+		
+		_takeProfitAmount1 = Param(nameof(TakeProfitAmount1), 12m)
+		.SetDisplay("TP Amount % Step 1", "Quantity percent step 1", "Take Profit Settings")
+		.SetCanOptimize(true);
+		_takeProfitAmount2 = Param(nameof(TakeProfitAmount2), 8m)
+		.SetDisplay("TP Amount % Step 2", "Quantity percent step 2", "Take Profit Settings")
+		.SetCanOptimize(true);
+		_takeProfitAmount3 = Param(nameof(TakeProfitAmount3), 4m)
+		.SetDisplay("TP Amount % Step 3", "Quantity percent step 3", "Take Profit Settings")
+		.SetCanOptimize(true);
+		_takeProfitAmount4 = Param(nameof(TakeProfitAmount4), 0m)
+		.SetDisplay("TP Amount % Step 4", "Quantity percent step 4", "Take Profit Settings")
+		.SetCanOptimize(true);
+		
+		_numberOfSteps = Param(nameof(NumberOfSteps), 3)
+		.SetDisplay("Number of Steps", "Number of take profit steps", "Take Profit Settings")
+		.SetCanOptimize(true);
+		
+		_tradeDirection = Param(nameof(TradeDirection), "Both")
+		.SetDisplay("Trade Direction", "Trade direction (Long/Short/Both)", "Trade Direction");
+		
+		_atrPeriod1 = Param(nameof(AtrPeriod1), 10)
+		.SetGreaterThanZero()
+		.SetDisplay("ATR Period 1", "ATR length for first Supertrend", "Supertrend Settings")
+		.SetCanOptimize(true);
+		_factor1 = Param(nameof(Factor1), 3.0m)
+		.SetDisplay("Factor 1", "Multiplier for first Supertrend", "Supertrend Settings")
+		.SetCanOptimize(true);
+		
+		_atrPeriod2 = Param(nameof(AtrPeriod2), 5)
+		.SetGreaterThanZero()
+		.SetDisplay("ATR Period 2", "ATR length for second Supertrend", "Supertrend Settings")
+		.SetCanOptimize(true);
+		_factor2 = Param(nameof(Factor2), 4.0m)
+		.SetDisplay("Factor 2", "Multiplier for second Supertrend", "Supertrend Settings")
+		.SetCanOptimize(true);
+		
+		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(1).TimeFrame())
+		.SetDisplay("Candle Type", "Type of candles", "General");
+	}
+	
+	
+	/// <inheritdoc />
+	public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
+	=> [(Security, CandleType)];
+	
+	/// <inheritdoc />
+	protected override void OnReseted()
+	{
+		base.OnReseted();
+		_prevSupertrend1 = 0;
+		_prevSupertrend2 = 0;
+		_prevAbove1 = false;
+		_prevAbove2 = false;
+		_entryPrice = 0;
+	}
+	
+	/// <inheritdoc />
+	protected override void OnStarted(DateTimeOffset time)
+	{
+		base.OnStarted(time);
+		
+		var atr1 = new AverageTrueRange { Length = AtrPeriod1 };
+		var atr2 = new AverageTrueRange { Length = AtrPeriod2 };
+		
+		var subscription = SubscribeCandles(CandleType);
+		subscription.Bind(atr1, atr2, ProcessCandle).Start();
+		
+		var area = CreateChartArea();
+		if (area != null)
+		{
+			DrawCandles(area, subscription);
+			DrawOwnTrades(area);
+		}
+	}
+	
+	private void ProcessCandle(ICandleMessage candle, decimal atr1Value, decimal atr2Value)
+	{
+		if (candle.State != CandleStates.Finished)
+		return;
+		
+		if (!IsFormedAndOnlineAndAllowTrading())
+		return;
+		
+		var direction1 = GetDirection(candle, atr1Value, Factor1, ref _prevSupertrend1, ref _prevAbove1);
+		var direction2 = GetDirection(candle, atr2Value, Factor2, ref _prevSupertrend2, ref _prevAbove2);
+		
+		var longCondition = direction1 < 0 && direction2 < 0 && (TradeDirection == "Long" || TradeDirection == "Both");
+		var shortCondition = direction1 > 0 && direction2 > 0 && (TradeDirection == "Short" || TradeDirection == "Both");
+		
+		var longExitCondition = direction1 > 0 && direction2 > 0 && (TradeDirection == "Long" || TradeDirection == "Both");
+		var shortExitCondition = direction1 < 0 && direction2 < 0 && (TradeDirection == "Short" || TradeDirection == "Both");
+		
+		if (longCondition && Position <= 0)
+		{
+			BuyMarket(Volume + Math.Abs(Position));
+			_entryPrice = candle.ClosePrice;
+			PlaceTakeProfitOrders(true);
+		}
+		else if (shortCondition && Position >= 0)
+		{
+			SellMarket(Volume + Math.Abs(Position));
+			_entryPrice = candle.ClosePrice;
+			PlaceTakeProfitOrders(false);
+		}
+		else
+		{
+			if (longExitCondition && Position > 0)
+			{
+				SellMarket(Position);
+			}
+			
+			if (shortExitCondition && Position < 0)
+			{
+				BuyMarket(Math.Abs(Position));
+			}
+		}
+	}
+	
+	private int GetDirection(ICandleMessage candle, decimal atrValue, decimal factor, ref decimal prevSupertrend, ref bool prevAbove)
+	{
+		var median = (candle.HighPrice + candle.LowPrice) / 2m;
+		var upper = median + factor * atrValue;
+		var lower = median - factor * atrValue;
+		
+		decimal st;
+		if (prevSupertrend == 0)
+		{
+			st = candle.ClosePrice > median ? lower : upper;
+		}
+		else if (prevSupertrend <= candle.HighPrice)
+		{
+			st = Math.Max(lower, prevSupertrend);
+		}
+		else if (prevSupertrend >= candle.LowPrice)
+		{
+			st = Math.Min(upper, prevSupertrend);
+		}
+		else
+		{
+			st = candle.ClosePrice > prevSupertrend ? lower : upper;
+		}
+		
+		var isAbove = candle.ClosePrice > st;
+		prevSupertrend = st;
+		prevAbove = isAbove;
+		
+		return isAbove ? 1 : -1;
+	}
+	
+	private void PlaceTakeProfitOrders(bool isLong)
+	{
+		if (!UseTakeProfit || _entryPrice == 0)
+		return;
+		
+		if (NumberOfSteps >= 1 && TakeProfitAmount1 > 0)
+		PlaceTakeProfitOrder(isLong, TakeProfitAmount1, TakeProfitPercent1);
+		if (NumberOfSteps >= 2 && TakeProfitAmount2 > 0)
+		PlaceTakeProfitOrder(isLong, TakeProfitAmount2, TakeProfitPercent2);
+		if (NumberOfSteps >= 3 && TakeProfitAmount3 > 0)
+		PlaceTakeProfitOrder(isLong, TakeProfitAmount3, TakeProfitPercent3);
+		if (NumberOfSteps >= 4 && TakeProfitAmount4 > 0)
+		PlaceTakeProfitOrder(isLong, TakeProfitAmount4, TakeProfitPercent4);
+	}
+	
+	private void PlaceTakeProfitOrder(bool isLong, decimal qtyPercent, decimal percent)
+	{
+		var qty = Volume * (qtyPercent / 100m);
+		if (qty <= 0)
+		return;
+		
+		var price = _entryPrice * (1m + (isLong ? percent : -percent) / 100m);
+		
+		if (isLong)
+		SellLimit(qty, price);
+		else
+		BuyLimit(qty, price);
+	}
+}

--- a/API/1346_Strategic_Multi_Step_Supertrend/README.md
+++ b/API/1346_Strategic_Multi_Step_Supertrend/README.md
@@ -1,0 +1,38 @@
+# Strategic Multi Step Supertrend
+[Русский](README_ru.md) | [中文](README_cn.md)
+
+Strategy uses two Supertrend calculations to detect entries and exits with configurable multi-step take profits.
+
+## Details
+
+- **Entry Criteria**: Signals based on two Supertrend directions.
+- **Long/Short**: Configurable.
+- **Exit Criteria**: Opposite Supertrend or take profit levels.
+- **Stops**: Take profit steps.
+- **Default Values**:
+  - `UseTakeProfit` = true
+  - `TakeProfitPercent1` = 6.0
+  - `TakeProfitPercent2` = 12.0
+  - `TakeProfitPercent3` = 18.0
+  - `TakeProfitPercent4` = 50.0
+  - `TakeProfitAmount1` = 12
+  - `TakeProfitAmount2` = 8
+  - `TakeProfitAmount3` = 4
+  - `TakeProfitAmount4` = 0
+  - `NumberOfSteps` = 3
+  - `AtrPeriod1` = 10
+  - `Factor1` = 3.0
+  - `AtrPeriod2` = 5
+  - `Factor2` = 4.0
+  - `CandleType` = TimeSpan.FromMinutes(1)
+- **Filters**:
+  - Category: Trend
+  - Direction: Configurable
+  - Indicators: ATR, Supertrend
+  - Stops: Take profit
+  - Complexity: Intermediate
+  - Timeframe: Intraday
+  - Seasonality: No
+  - Neural Networks: No
+  - Divergence: No
+  - Risk Level: Medium

--- a/API/1346_Strategic_Multi_Step_Supertrend/README_cn.md
+++ b/API/1346_Strategic_Multi_Step_Supertrend/README_cn.md
@@ -1,0 +1,38 @@
+# Strategic Multi Step Supertrend
+[English](README.md) | [Русский](README_ru.md)
+
+该策略使用两个 Supertrend 指标并带有多级分批止盈。
+
+## 细节
+
+- **入场条件**：基于两个 Supertrend 方向的信号。
+- **多空**：可配置。
+- **出场条件**：相反的 Supertrend 信号或止盈等级。
+- **止损**：分批止盈。
+- **默认值**：
+  - `UseTakeProfit` = true
+  - `TakeProfitPercent1` = 6.0
+  - `TakeProfitPercent2` = 12.0
+  - `TakeProfitPercent3` = 18.0
+  - `TakeProfitPercent4` = 50.0
+  - `TakeProfitAmount1` = 12
+  - `TakeProfitAmount2` = 8
+  - `TakeProfitAmount3` = 4
+  - `TakeProfitAmount4` = 0
+  - `NumberOfSteps` = 3
+  - `AtrPeriod1` = 10
+  - `Factor1` = 3.0
+  - `AtrPeriod2` = 5
+  - `Factor2` = 4.0
+  - `CandleType` = TimeSpan.FromMinutes(1)
+- **筛选器**：
+  - 类别: 趋势
+  - 方向: 可配置
+  - 指标: ATR, Supertrend
+  - 止损: 止盈
+  - 复杂度: 中等
+  - 周期: 日内
+  - 季节性: 否
+  - 神经网络: 否
+  - 背离: 否
+  - 风险等级: 中等

--- a/API/1346_Strategic_Multi_Step_Supertrend/README_ru.md
+++ b/API/1346_Strategic_Multi_Step_Supertrend/README_ru.md
@@ -1,0 +1,38 @@
+# Strategic Multi Step Supertrend
+[English](README.md) | [中文](README_cn.md)
+
+Стратегия использует два индикатора Supertrend и многошаговый тейк-профит.
+
+## Детали
+
+- **Критерии входа**: Сигналы по направлению двух Supertrend.
+- **Лонг/Шорт**: Настраивается.
+- **Критерии выхода**: Обратный сигнал Supertrend или уровни тейк-профита.
+- **Стопы**: Тейк-профит по шагам.
+- **Значения по умолчанию**:
+  - `UseTakeProfit` = true
+  - `TakeProfitPercent1` = 6.0
+  - `TakeProfitPercent2` = 12.0
+  - `TakeProfitPercent3` = 18.0
+  - `TakeProfitPercent4` = 50.0
+  - `TakeProfitAmount1` = 12
+  - `TakeProfitAmount2` = 8
+  - `TakeProfitAmount3` = 4
+  - `TakeProfitAmount4` = 0
+  - `NumberOfSteps` = 3
+  - `AtrPeriod1` = 10
+  - `Factor1` = 3.0
+  - `AtrPeriod2` = 5
+  - `Factor2` = 4.0
+  - `CandleType` = TimeSpan.FromMinutes(1)
+- **Фильтры**:
+  - Категория: Trend
+  - Направление: Настраивается
+  - Индикаторы: ATR, Supertrend
+  - Стопы: Тейк-профит
+  - Сложность: Средняя
+  - Таймфрейм: Внутридневной
+  - Сезонность: Нет
+  - Нейросети: Нет
+  - Дивергенции: Нет
+  - Уровень риска: Средний


### PR DESCRIPTION
## Summary
- port Strategic Multi-Step Supertrend from TradingView using double Supertrend signals and multi-step take profit exits
- document parameters and default values

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c31f8eadd88323a4d67f13492765b6