### PR TITLE
Add SMC strategy

### DIFF
--- a/API/1322_SMC_Strategy/CS/SmcStrategy.cs
+++ b/API/1322_SMC_Strategy/CS/SmcStrategy.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
+namespace StockSharp.Samples.Strategies;
+
+/// <summary>
+/// SMC strategy using swing zones and SMA trend filter.
+/// </summary>
+public class SmcStrategy : Strategy
+{
+	private readonly StrategyParam<int> _swingHighLength;
+	private readonly StrategyParam<int> _swingLowLength;
+	private readonly StrategyParam<int> _smaLength;
+	private readonly StrategyParam<int> _orderBlockLength;
+	private readonly StrategyParam<DataType> _candleType;
+
+	private Highest _swingHighIndicator;
+	private Lowest _swingLowIndicator;
+	private SimpleMovingAverage _sma;
+	private Highest _orderBlockHighIndicator;
+	private Lowest _orderBlockLowIndicator;
+
+	private decimal? _swingHigh;
+	private decimal? _swingLow;
+
+	public int SwingHighLength { get => _swingHighLength.Value; set => _swingHighLength.Value = value; }
+	public int SwingLowLength { get => _swingLowLength.Value; set => _swingLowLength.Value = value; }
+	public int SmaLength { get => _smaLength.Value; set => _smaLength.Value = value; }
+	public int OrderBlockLength { get => _orderBlockLength.Value; set => _orderBlockLength.Value = value; }
+	public DataType CandleType { get => _candleType.Value; set => _candleType.Value = value; }
+
+	public SmcStrategy()
+	{
+		_swingHighLength = Param(nameof(SwingHighLength), 8)
+			.SetGreaterThanZero()
+			.SetDisplay("Swing High Length", "Period to detect swing highs", "General")
+			.SetCanOptimize(true);
+
+		_swingLowLength = Param(nameof(SwingLowLength), 8)
+			.SetGreaterThanZero()
+			.SetDisplay("Swing Low Length", "Period to detect swing lows", "General")
+			.SetCanOptimize(true);
+
+		_smaLength = Param(nameof(SmaLength), 50)
+			.SetGreaterThanZero()
+			.SetDisplay("SMA Length", "Length for trend SMA", "General")
+			.SetCanOptimize(true);
+
+		_orderBlockLength = Param(nameof(OrderBlockLength), 20)
+			.SetGreaterThanZero()
+			.SetDisplay("Order Block Length", "Lookback for order blocks", "General")
+			.SetCanOptimize(true);
+
+		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
+			.SetDisplay("Candle Type", "Type of candles", "General");
+	}
+
+	public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
+	{
+		return [(Security, CandleType)];
+	}
+
+	protected override void OnReseted()
+	{
+		base.OnReseted();
+
+		_swingHighIndicator = default;
+		_swingLowIndicator = default;
+		_sma = default;
+		_orderBlockHighIndicator = default;
+		_orderBlockLowIndicator = default;
+		_swingHigh = default;
+		_swingLow = default;
+	}
+
+	protected override void OnStarted(DateTimeOffset time)
+	{
+		base.OnStarted(time);
+
+		_swingHighIndicator = new Highest { Length = SwingHighLength };
+		_swingLowIndicator = new Lowest { Length = SwingLowLength };
+		_sma = new SimpleMovingAverage { Length = SmaLength };
+		_orderBlockHighIndicator = new Highest { Length = OrderBlockLength };
+		_orderBlockLowIndicator = new Lowest { Length = OrderBlockLength };
+
+		var subscription = SubscribeCandles(CandleType);
+		subscription
+			.Bind(_swingHighIndicator, _swingLowIndicator, _sma, _orderBlockHighIndicator, _orderBlockLowIndicator, ProcessCandle)
+			.Start();
+
+		var area = CreateChartArea();
+		if (area != null)
+		{
+			DrawCandles(area, subscription);
+			DrawIndicator(area, _sma);
+			DrawIndicator(area, _swingHighIndicator);
+			DrawIndicator(area, _swingLowIndicator);
+			DrawIndicator(area, _orderBlockHighIndicator);
+			DrawIndicator(area, _orderBlockLowIndicator);
+			DrawOwnTrades(area);
+		}
+	}
+
+	private void ProcessCandle(ICandleMessage candle, decimal swingHighValue, decimal swingLowValue, decimal smaValue, decimal orderBlockHigh, decimal orderBlockLow)
+	{
+		if (candle.State != CandleStates.Finished)
+			return;
+
+		if (candle.HighPrice == swingHighValue)
+			_swingHigh = swingHighValue;
+
+		if (candle.LowPrice == swingLowValue)
+			_swingLow = swingLowValue;
+
+		if (_swingHigh is null || _swingLow is null)
+			return;
+
+		if (!IsFormedAndOnlineAndAllowTrading())
+			return;
+
+		var equilibrium = (_swingHigh.Value + _swingLow.Value) / 2m;
+		var premiumZone = _swingHigh.Value;
+		var discountZone = _swingLow.Value;
+
+		var buySignal = candle.ClosePrice < equilibrium && candle.ClosePrice > discountZone && candle.ClosePrice > smaValue;
+		var sellSignal = candle.ClosePrice > equilibrium && candle.ClosePrice < premiumZone && candle.ClosePrice < smaValue;
+
+		var buySignalOb = buySignal && candle.ClosePrice >= orderBlockLow;
+		var sellSignalOb = sellSignal && candle.ClosePrice <= orderBlockHigh;
+
+		if (buySignalOb && Position <= 0)
+		{
+			var volume = Volume + (Position < 0 ? -Position : 0m);
+			BuyMarket(volume);
+		}
+		else if (sellSignalOb && Position >= 0)
+		{
+			var volume = Volume + (Position > 0 ? Position : 0m);
+			SellMarket(volume);
+		}
+	}
+}

--- a/API/1322_SMC_Strategy/README.md
+++ b/API/1322_SMC_Strategy/README.md
@@ -1,0 +1,26 @@
+[Русский](README_ru.md) | [中文](README_cn.md)
+
+SMC Strategy defines premium, equilibrium, and discount zones from recent swing highs and lows. It trades in discount or premium zones with an SMA trend filter and simple order block confirmation.
+
+## Details
+
+- **Entry Criteria**: price in discount zone above SMA with order block support; price in premium zone below SMA with order block resistance
+- **Long/Short**: Both
+- **Exit Criteria**: opposite signal
+- **Stops**: No
+- **Default Values**:
+  - `SwingHighLength` = 8
+  - `SwingLowLength` = 8
+  - `SmaLength` = 50
+  - `OrderBlockLength` = 20
+- **Filters**:
+  - Category: Zone
+  - Direction: Both
+  - Indicators: Highest, Lowest, SMA
+  - Stops: No
+  - Complexity: Basic
+  - Timeframe: Intraday
+  - Seasonality: No
+  - Neural networks: No
+  - Divergence: No
+  - Risk level: Medium

--- a/API/1322_SMC_Strategy/README_cn.md
+++ b/API/1322_SMC_Strategy/README_cn.md
@@ -1,0 +1,26 @@
+[English](README.md) | [Русский](README_ru.md)
+
+SMC策略利用最近的摆动高点和低点来定义溢价、均衡和折扣区域。结合SMA趋势过滤和简单订单块确认，在折扣区买入、溢价区卖出。
+
+## 详情
+
+- **入场条件**: 价格在折扣区且高于SMA并得到订单块支撑；价格在溢价区且低于SMA并受订单块阻力
+- **多空方向**: 双向
+- **出场条件**: 相反信号
+- **止损**: 无
+- **默认值**:
+  - `SwingHighLength` = 8
+  - `SwingLowLength` = 8
+  - `SmaLength` = 50
+  - `OrderBlockLength` = 20
+- **过滤器**:
+  - 分类: Zone
+  - 方向: 双向
+  - 指标: Highest, Lowest, SMA
+  - 止损: 无
+  - 复杂度: Basic
+  - 时间框架: Intraday
+  - 季节性: 无
+  - 神经网络: 无
+  - 背离: 无
+  - 风险等级: Medium

--- a/API/1322_SMC_Strategy/README_ru.md
+++ b/API/1322_SMC_Strategy/README_ru.md
@@ -1,0 +1,26 @@
+[English](README.md) | [中文](README_cn.md)
+
+SMC стратегия определяет зоны premium, equilibrium и discount на основе недавних swing high и swing low. Торгует в зонах discount или premium с фильтром тенденции SMA и простым подтверждением order block.
+
+## Детали
+
+- **Условия входа**: цена в зоне discount выше SMA и поддержкой order block; цена в зоне premium ниже SMA и с сопротивлением order block
+- **Длинные/Короткие**: Оба
+- **Условия выхода**: противоположный сигнал
+- **Стопы**: Нет
+- **Значения по умолчанию**:
+  - `SwingHighLength` = 8
+  - `SwingLowLength` = 8
+  - `SmaLength` = 50
+  - `OrderBlockLength` = 20
+- **Фильтры**:
+  - Категория: Zone
+  - Направление: Оба
+  - Индикаторы: Highest, Lowest, SMA
+  - Стопы: Нет
+  - Сложность: Basic
+  - Таймфрейм: Intraday
+  - Сезонность: Нет
+  - Нейросети: Нет
+  - Дивергенция: Нет
+  - Уровень риска: Medium


### PR DESCRIPTION
## Summary
- implement SMC strategy with swing zones, SMA filter and order block confirmation
- document usage and parameters in English, Russian and Chinese READMEs

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c31f0dc1508323bcd742ae7bc3d54b