### PR TITLE
Refactor direction to nullable Sides

### DIFF
--- a/API/0460_Smc_OrderBlock_Zones/CS/SmcOrderBlockZonesStrategy.cs
+++ b/API/0460_Smc_OrderBlock_Zones/CS/SmcOrderBlockZonesStrategy.cs
@@ -14,32 +14,22 @@ namespace StockSharp.Samples.Strategies;
 public class SmcOrderBlockZonesStrategy : Strategy
 {
 	private readonly StrategyParam<DataType> _candleType;
-	private readonly StrategyParam<TradeDirection> _direction;
+	private readonly StrategyParam<Sides?> _direction;
 	private readonly StrategyParam<int> _swingHighLength;
 	private readonly StrategyParam<int> _swingLowLength;
 	private readonly StrategyParam<int> _smaLength;
 	private readonly StrategyParam<int> _orderBlockLength;
 	private readonly StrategyParam<decimal> _stopLossPercent;
-
+	
 	private SimpleMovingAverage _sma;
 	private Highest _swingHighIndicator;
 	private Lowest _swingLowIndicator;
 	private Highest _orderBlockHighIndicator;
 	private Lowest _orderBlockLowIndicator;
-
+	
 	private decimal? _swingHigh;
 	private decimal? _swingLow;
-
-	/// <summary>
-	/// Trade direction.
-	/// </summary>
-	public enum TradeDirection
-	{
-		LongOnly,
-		ShortOnly,
-		Both
-	}
-
+	
 	/// <summary>
 	/// Candle type for strategy calculation.
 	/// </summary>
@@ -48,16 +38,16 @@ public class SmcOrderBlockZonesStrategy : Strategy
 		get => _candleType.Value;
 		set => _candleType.Value = value;
 	}
-
+	
 	/// <summary>
 	/// Trade direction filter.
 	/// </summary>
-	public TradeDirection Direction
+	public Sides? Direction
 	{
 		get => _direction.Value;
 		set => _direction.Value = value;
 	}
-
+	
 	/// <summary>
 	/// Swing high length.
 	/// </summary>
@@ -66,7 +56,7 @@ public class SmcOrderBlockZonesStrategy : Strategy
 		get => _swingHighLength.Value;
 		set => _swingHighLength.Value = value;
 	}
-
+	
 	/// <summary>
 	/// Swing low length.
 	/// </summary>
@@ -75,7 +65,7 @@ public class SmcOrderBlockZonesStrategy : Strategy
 		get => _swingLowLength.Value;
 		set => _swingLowLength.Value = value;
 	}
-
+	
 	/// <summary>
 	/// SMA length.
 	/// </summary>
@@ -84,7 +74,7 @@ public class SmcOrderBlockZonesStrategy : Strategy
 		get => _smaLength.Value;
 		set => _smaLength.Value = value;
 	}
-
+	
 	/// <summary>
 	/// Order block length.
 	/// </summary>
@@ -93,7 +83,7 @@ public class SmcOrderBlockZonesStrategy : Strategy
 		get => _orderBlockLength.Value;
 		set => _orderBlockLength.Value = value;
 	}
-
+	
 	/// <summary>
 	/// Stop loss percent.
 	/// </summary>
@@ -102,7 +92,7 @@ public class SmcOrderBlockZonesStrategy : Strategy
 		get => _stopLossPercent.Value;
 		set => _stopLossPercent.Value = value;
 	}
-
+	
 	/// <summary>
 	/// Initializes a new instance of the <see cref="SmcOrderBlockZonesStrategy"/> class.
 	/// </summary>
@@ -110,53 +100,53 @@ public class SmcOrderBlockZonesStrategy : Strategy
 	{
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
 		.SetDisplay("Candle Type", "Type of candles", "General");
-
-		_direction = Param(nameof(Direction), TradeDirection.Both)
+		
+		_direction = Param(nameof(Direction), (Sides?)null)
 		.SetDisplay("Trade Direction", "Allowed trade side", "General");
-
+		
 		_swingHighLength = Param(nameof(SwingHighLength), 8)
 		.SetGreaterThanZero()
 		.SetDisplay("Swing High Length", "Bars for swing high", "Parameters");
-
+		
 		_swingLowLength = Param(nameof(SwingLowLength), 8)
 		.SetGreaterThanZero()
 		.SetDisplay("Swing Low Length", "Bars for swing low", "Parameters");
-
+		
 		_smaLength = Param(nameof(SmaLength), 50)
 		.SetGreaterThanZero()
 		.SetDisplay("SMA Length", "Moving average length", "Parameters");
-
+		
 		_orderBlockLength = Param(nameof(OrderBlockLength), 20)
 		.SetGreaterThanZero()
 		.SetDisplay("Order Block Length", "Bars for order block", "Parameters");
-
+		
 		_stopLossPercent = Param(nameof(StopLossPercent), 2m)
 		.SetNotNegative()
 		.SetDisplay("Stop Loss %", "Stop loss percent", "Risk");
 	}
-
+	
 	/// <inheritdoc />
 	public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
 	{
 		return [(Security, CandleType)];
 	}
-
+	
 	/// <inheritdoc />
 	protected override void OnStarted(DateTimeOffset time)
 	{
 		base.OnStarted(time);
-
+		
 		_sma = new SimpleMovingAverage { Length = SmaLength };
 		_swingHighIndicator = new Highest { Length = SwingHighLength };
 		_swingLowIndicator = new Lowest { Length = SwingLowLength };
 		_orderBlockHighIndicator = new Highest { Length = OrderBlockLength };
 		_orderBlockLowIndicator = new Lowest { Length = OrderBlockLength };
-
+		
 		var subscription = SubscribeCandles(CandleType);
 		subscription
 		.Bind(ProcessCandle)
 		.Start();
-
+		
 		var area = CreateChartArea();
 		if (area != null)
 		{
@@ -164,70 +154,70 @@ public class SmcOrderBlockZonesStrategy : Strategy
 			DrawIndicator(area, _sma);
 			DrawOwnTrades(area);
 		}
-
+		
 		StartProtection(new Unit(), new Unit(StopLossPercent, UnitTypes.Percent));
 	}
-
+	
 	private void ProcessCandle(ICandleMessage candle)
 	{
 		if (candle.State != CandleStates.Finished)
 		return;
-
+		
 		var smaValue = _sma.Process(candle).ToNullableDecimal();
 		var swingHighValue = _swingHighIndicator.Process(new DecimalIndicatorValue(_swingHighIndicator, candle.HighPrice)).ToNullableDecimal();
 		var swingLowValue = _swingLowIndicator.Process(new DecimalIndicatorValue(_swingLowIndicator, candle.LowPrice)).ToNullableDecimal();
 		var orderBlockHigh = _orderBlockHighIndicator.Process(new DecimalIndicatorValue(_orderBlockHighIndicator, candle.HighPrice)).ToNullableDecimal();
 		var orderBlockLow = _orderBlockLowIndicator.Process(new DecimalIndicatorValue(_orderBlockLowIndicator, candle.LowPrice)).ToNullableDecimal();
-
+		
 		if (smaValue is not decimal sma ||
 		swingHighValue is not decimal swingHighCurr ||
 		swingLowValue is not decimal swingLowCurr ||
 		orderBlockHigh is not decimal obHigh ||
 		orderBlockLow is not decimal obLow)
 		return;
-
+		
 		if (candle.HighPrice == swingHighCurr)
 		_swingHigh = swingHighCurr;
-
+		
 		if (candle.LowPrice == swingLowCurr)
 		_swingLow = swingLowCurr;
-
+		
 		if (_swingHigh is not decimal swingHigh || _swingLow is not decimal swingLow)
 		return;
-
+		
 		if (!_sma.IsFormed || !_orderBlockHighIndicator.IsFormed || !_orderBlockLowIndicator.IsFormed || !_swingHighIndicator.IsFormed || !_swingLowIndicator.IsFormed)
 		return;
-
+		
 		if (!IsFormedAndOnlineAndAllowTrading())
 		return;
-
+		
 		var equilibrium = (swingHigh + swingLow) / 2m;
 		var premiumZone = swingHigh;
 		var discountZone = swingLow;
-
+		
 		var buySignal = candle.ClosePrice < equilibrium && candle.ClosePrice > discountZone && candle.ClosePrice > sma;
 		var sellSignal = candle.ClosePrice > equilibrium && candle.ClosePrice < premiumZone && candle.ClosePrice < sma;
-
+		
 		var buySignalOb = buySignal && candle.ClosePrice >= obLow;
 		var sellSignalOb = sellSignal && candle.ClosePrice <= obHigh;
-
+		
 		switch (Direction)
 		{
-			case TradeDirection.LongOnly:
+			case Sides.Buy:
 			if (Position > 0 && sellSignalOb)
 			SellMarket(Position);
 			if (buySignalOb && Position <= 0)
 			BuyMarket(Volume + Math.Abs(Position));
 			break;
-
-			case TradeDirection.ShortOnly:
+			
+			case Sides.Sell:
 			if (Position < 0 && buySignalOb)
 			BuyMarket(-Position);
 			if (sellSignalOb && Position >= 0)
 			SellMarket(Volume + Math.Abs(Position));
 			break;
-
-			case TradeDirection.Both:
+			
+			case null:
 			if (buySignalOb && Position <= 0)
 			BuyMarket(Volume + Math.Abs(Position));
 			if (sellSignalOb && Position >= 0)

--- a/API/0501_Advanced_Multi_Seasonality/CS/AdvancedMultiSeasonalityStrategy.cs
+++ b/API/0501_Advanced_Multi_Seasonality/CS/AdvancedMultiSeasonalityStrategy.cs
@@ -14,133 +14,133 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class AdvancedMultiSeasonalityStrategy : Strategy
 {
-private readonly StrategyParam<DataType> _candleType;
-private readonly StrategyParam<bool>[] _enabled = new StrategyParam<bool>[4];
-private readonly StrategyParam<int>[] _entryMonth = new StrategyParam<int>[4];
-private readonly StrategyParam<int>[] _entryDay = new StrategyParam<int>[4];
-private readonly StrategyParam<int>[] _holdingDays = new StrategyParam<int>[4];
-private readonly StrategyParam<string>[] _direction = new StrategyParam<string>[4];
-
-private readonly bool[] _inTrade = new bool[4];
-private readonly bool[] _isLong = new bool[4];
-private readonly int[] _barsSinceEntry = new int[4];
-
-/// <summary>
-/// Candle type for calculations.
-/// </summary>
-public DataType CandleType
-{
-get => _candleType.Value;
-set => _candleType.Value = value;
-}
-
-/// <summary>
-/// Initialize <see cref="AdvancedMultiSeasonalityStrategy"/>.
-/// </summary>
-public AdvancedMultiSeasonalityStrategy()
-{
-_candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
-.SetDisplay("Candle Type", "Type of candles", "General");
-
-for (var i = 0; i < 4; i++)
-{
-var group = $"Period {i + 1}";
-_enabled[i] = Param($"Period{i + 1}Enabled", i == 0)
-.SetDisplay("Activate", $"Use period {i + 1}", group);
-_entryMonth[i] = Param($"EntryMonth{i + 1}", new[] {12,1,6,9}[i])
-.SetDisplay("Entry Month", "Entry month", group);
-_entryDay[i] = Param($"EntryDay{i + 1}", new[] {1,15,1,15}[i])
-.SetDisplay("Entry Day", "Entry day", group);
-_holdingDays[i] = Param($"HoldingDays{i + 1}", new[] {20,10,15,10}[i])
-.SetDisplay("Holding Days", "Bars to hold", group);
-_direction[i] = Param($"TradeDirection{i + 1}", "Long")
-.SetDisplay("Direction", "Long or Short", group);
-}
-}
-
-/// <inheritdoc />
-public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
-=> [(Security, CandleType)];
-
-/// <inheritdoc />
-protected override void OnReseted()
-{
-base.OnReseted();
-for (var i = 0; i < 4; i++)
-{
-_inTrade[i] = false;
-_barsSinceEntry[i] = 0;
-}
-}
-
-/// <inheritdoc />
-protected override void OnStarted(DateTimeOffset time)
-{
-base.OnStarted(time);
-
-var subscription = SubscribeCandles(CandleType);
-subscription.Bind(ProcessCandle).Start();
-
-var area = CreateChartArea();
-if (area != null)
-{
-DrawCandles(area, subscription);
-DrawOwnTrades(area);
-}
-}
-
-private void ProcessCandle(ICandleMessage candle)
-{
-if (candle.State != CandleStates.Finished)
-return;
-
-if (!IsFormedAndOnlineAndAllowTrading())
-return;
-
-for (var i = 0; i < 4; i++)
-{
-if (_inTrade[i])
-{
-_barsSinceEntry[i]++;
-if (_barsSinceEntry[i] >= _holdingDays[i].Value)
-{
-if (_isLong[i] && Position > 0)
-SellMarket(Math.Abs(Position));
-else if (!_isLong[i] && Position < 0)
-BuyMarket(Math.Abs(Position));
-
-_inTrade[i] = false;
-}
-}
-}
-
-var month = candle.OpenTime.Month;
-var day = candle.OpenTime.Day;
-
-if (Position != 0)
-return;
-
-for (var i = 0; i < 4; i++)
-{
-if (_enabled[i].Value && !_inTrade[i] && month == _entryMonth[i].Value && day == _entryDay[i].Value)
-{
-var volume = Volume + Math.Abs(Position);
-if (_direction[i].Value.Equals("Long", StringComparison.OrdinalIgnoreCase))
-{
-BuyMarket(volume);
-_isLong[i] = true;
-}
-else
-{
-SellMarket(volume);
-_isLong[i] = false;
-}
-
-_inTrade[i] = true;
-_barsSinceEntry[i] = 0;
-break;
-}
-}
-}
+	private readonly StrategyParam<DataType> _candleType;
+	private readonly StrategyParam<bool>[] _enabled = new StrategyParam<bool>[4];
+	private readonly StrategyParam<int>[] _entryMonth = new StrategyParam<int>[4];
+	private readonly StrategyParam<int>[] _entryDay = new StrategyParam<int>[4];
+	private readonly StrategyParam<int>[] _holdingDays = new StrategyParam<int>[4];
+	private readonly StrategyParam<Sides?>[] _direction = new StrategyParam<Sides?>[4];
+	
+	private readonly bool[] _inTrade = new bool[4];
+	private readonly bool[] _isLong = new bool[4];
+	private readonly int[] _barsSinceEntry = new int[4];
+	
+	/// <summary>
+	/// Candle type for calculations.
+	/// </summary>
+	public DataType CandleType
+	{
+		get => _candleType.Value;
+		set => _candleType.Value = value;
+	}
+	
+	/// <summary>
+	/// Initialize <see cref="AdvancedMultiSeasonalityStrategy"/>.
+	/// </summary>
+	public AdvancedMultiSeasonalityStrategy()
+	{
+		_candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
+		.SetDisplay("Candle Type", "Type of candles", "General");
+		
+		for (var i = 0; i < 4; i++)
+		{
+			var group = $"Period {i + 1}";
+			_enabled[i] = Param($"Period{i + 1}Enabled", i == 0)
+			.SetDisplay("Activate", $"Use period {i + 1}", group);
+			_entryMonth[i] = Param($"EntryMonth{i + 1}", new[] {12,1,6,9}[i])
+			.SetDisplay("Entry Month", "Entry month", group);
+			_entryDay[i] = Param($"EntryDay{i + 1}", new[] {1,15,1,15}[i])
+			.SetDisplay("Entry Day", "Entry day", group);
+			_holdingDays[i] = Param($"HoldingDays{i + 1}", new[] {20,10,15,10}[i])
+			.SetDisplay("Holding Days", "Bars to hold", group);
+			_direction[i] = Param<Sides?>($"TradeDirection{i + 1}", Sides.Buy)
+			.SetDisplay("Direction", "Long or Short", group);
+		}
+	}
+	
+	/// <inheritdoc />
+	public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
+	=> [(Security, CandleType)];
+	
+	/// <inheritdoc />
+	protected override void OnReseted()
+	{
+		base.OnReseted();
+		for (var i = 0; i < 4; i++)
+		{
+			_inTrade[i] = false;
+			_barsSinceEntry[i] = 0;
+		}
+	}
+	
+	/// <inheritdoc />
+	protected override void OnStarted(DateTimeOffset time)
+	{
+		base.OnStarted(time);
+		
+		var subscription = SubscribeCandles(CandleType);
+		subscription.Bind(ProcessCandle).Start();
+		
+		var area = CreateChartArea();
+		if (area != null)
+		{
+			DrawCandles(area, subscription);
+			DrawOwnTrades(area);
+		}
+	}
+	
+	private void ProcessCandle(ICandleMessage candle)
+	{
+		if (candle.State != CandleStates.Finished)
+		return;
+		
+		if (!IsFormedAndOnlineAndAllowTrading())
+		return;
+		
+		for (var i = 0; i < 4; i++)
+		{
+			if (_inTrade[i])
+			{
+				_barsSinceEntry[i]++;
+				if (_barsSinceEntry[i] >= _holdingDays[i].Value)
+				{
+					if (_isLong[i] && Position > 0)
+					SellMarket(Math.Abs(Position));
+					else if (!_isLong[i] && Position < 0)
+					BuyMarket(Math.Abs(Position));
+					
+					_inTrade[i] = false;
+				}
+			}
+		}
+		
+		var month = candle.OpenTime.Month;
+		var day = candle.OpenTime.Day;
+		
+		if (Position != 0)
+		return;
+		
+		for (var i = 0; i < 4; i++)
+		{
+			if (_enabled[i].Value && !_inTrade[i] && month == _entryMonth[i].Value && day == _entryDay[i].Value)
+			{
+				var volume = Volume + Math.Abs(Position);
+				if (_direction[i].Value != Sides.Sell)
+				{
+					BuyMarket(volume);
+					_isLong[i] = true;
+				}
+				else
+				{
+					SellMarket(volume);
+					_isLong[i] = false;
+				}
+				
+				_inTrade[i] = true;
+				_barsSinceEntry[i] = 0;
+				break;
+			}
+		}
+	}
 }
 

--- a/API/0557_Bbtrend_Supertrend_Decision/CS/BbtrendSupertrendDecisionStrategy.cs
+++ b/API/0557_Bbtrend_Supertrend_Decision/CS/BbtrendSupertrendDecisionStrategy.cs
@@ -21,18 +21,18 @@ public class BbtrendSupertrendDecisionStrategy : Strategy
 	private readonly StrategyParam<decimal> _stdDev;
 	private readonly StrategyParam<int> _supertrendLength;
 	private readonly StrategyParam<decimal> _supertrendMultiplier;
-	private readonly StrategyParam<TradeDirection> _tradeDirection;
+	private readonly StrategyParam<Sides?> _tradeDirection;
 	private readonly StrategyParam<TpSlMode> _tpSlCondition;
 	private readonly StrategyParam<decimal> _takeProfitPerc;
 	private readonly StrategyParam<decimal> _stopLossPerc;
 	private readonly StrategyParam<DataType> _candleType;
-
+	
 	private decimal? _previousBbTrend;
 	private decimal? _prevUp;
 	private decimal? _prevDn;
 	private decimal? _prevAtr;
 	private decimal? _prevSt;
-
+	
 	/// <summary>
 	/// Short Bollinger Bands length.
 	/// </summary>
@@ -41,7 +41,7 @@ public class BbtrendSupertrendDecisionStrategy : Strategy
 		get => _shortBbLength.Value;
 		set => _shortBbLength.Value = value;
 	}
-
+	
 	/// <summary>
 	/// Long Bollinger Bands length.
 	/// </summary>
@@ -50,7 +50,7 @@ public class BbtrendSupertrendDecisionStrategy : Strategy
 		get => _longBbLength.Value;
 		set => _longBbLength.Value = value;
 	}
-
+	
 	/// <summary>
 	/// Bollinger Bands standard deviation.
 	/// </summary>
@@ -59,7 +59,7 @@ public class BbtrendSupertrendDecisionStrategy : Strategy
 		get => _stdDev.Value;
 		set => _stdDev.Value = value;
 	}
-
+	
 	/// <summary>
 	/// SuperTrend ATR period.
 	/// </summary>
@@ -68,7 +68,7 @@ public class BbtrendSupertrendDecisionStrategy : Strategy
 		get => _supertrendLength.Value;
 		set => _supertrendLength.Value = value;
 	}
-
+	
 	/// <summary>
 	/// SuperTrend multiplier.
 	/// </summary>
@@ -77,16 +77,16 @@ public class BbtrendSupertrendDecisionStrategy : Strategy
 		get => _supertrendMultiplier.Value;
 		set => _supertrendMultiplier.Value = value;
 	}
-
+	
 	/// <summary>
 	/// Trading direction.
 	/// </summary>
-	public TradeDirection TradeDirection
+	public Sides? TradeDirection
 	{
 		get => _tradeDirection.Value;
 		set => _tradeDirection.Value = value;
 	}
-
+	
 	/// <summary>
 	/// Take profit / stop loss mode.
 	/// </summary>
@@ -95,7 +95,7 @@ public class BbtrendSupertrendDecisionStrategy : Strategy
 		get => _tpSlCondition.Value;
 		set => _tpSlCondition.Value = value;
 	}
-
+	
 	/// <summary>
 	/// Take profit percentage.
 	/// </summary>
@@ -104,7 +104,7 @@ public class BbtrendSupertrendDecisionStrategy : Strategy
 		get => _takeProfitPerc.Value;
 		set => _takeProfitPerc.Value = value;
 	}
-
+	
 	/// <summary>
 	/// Stop loss percentage.
 	/// </summary>
@@ -113,7 +113,7 @@ public class BbtrendSupertrendDecisionStrategy : Strategy
 		get => _stopLossPerc.Value;
 		set => _stopLossPerc.Value = value;
 	}
-
+	
 	/// <summary>
 	/// Candle type for strategy calculation.
 	/// </summary>
@@ -122,77 +122,77 @@ public class BbtrendSupertrendDecisionStrategy : Strategy
 		get => _candleType.Value;
 		set => _candleType.Value = value;
 	}
-
+	
 	/// <summary>
 	/// Constructor.
 	/// </summary>
 	public BbtrendSupertrendDecisionStrategy()
 	{
 		_shortBbLength = Param(nameof(ShortBbLength), 20)
-			.SetGreaterThanZero()
-			.SetDisplay("Short BB Length", "Short Bollinger Bands length", "BBTrend")
-			.SetCanOptimize(true)
-			.SetOptimize(10, 40, 5);
-
+		.SetGreaterThanZero()
+		.SetDisplay("Short BB Length", "Short Bollinger Bands length", "BBTrend")
+		.SetCanOptimize(true)
+		.SetOptimize(10, 40, 5);
+		
 		_longBbLength = Param(nameof(LongBbLength), 50)
-			.SetGreaterThanZero()
-			.SetDisplay("Long BB Length", "Long Bollinger Bands length", "BBTrend")
-			.SetCanOptimize(true)
-			.SetOptimize(30, 100, 5);
-
+		.SetGreaterThanZero()
+		.SetDisplay("Long BB Length", "Long Bollinger Bands length", "BBTrend")
+		.SetCanOptimize(true)
+		.SetOptimize(30, 100, 5);
+		
 		_stdDev = Param(nameof(StdDev), 2m)
-			.SetGreaterThanZero()
-			.SetDisplay("Std Dev", "Standard deviation", "BBTrend");
-
+		.SetGreaterThanZero()
+		.SetDisplay("Std Dev", "Standard deviation", "BBTrend");
+		
 		_supertrendLength = Param(nameof(SupertrendLength), 10)
-			.SetGreaterThanZero()
-			.SetDisplay("ST Length", "SuperTrend ATR period", "SuperTrend")
-			.SetCanOptimize(true)
-			.SetOptimize(5, 20, 1);
-
+		.SetGreaterThanZero()
+		.SetDisplay("ST Length", "SuperTrend ATR period", "SuperTrend")
+		.SetCanOptimize(true)
+		.SetOptimize(5, 20, 1);
+		
 		_supertrendMultiplier = Param(nameof(SupertrendMultiplier), 7m)
-			.SetGreaterThanZero()
-			.SetDisplay("ST Factor", "SuperTrend multiplier", "SuperTrend")
-			.SetCanOptimize(true)
-			.SetOptimize(1m, 10m, 1m);
-
-		_tradeDirection = Param(nameof(TradeDirection), Strategies.TradeDirection.Both)
-			.SetDisplay("Direction", "Allowed trading direction", "Trading");
-
+		.SetGreaterThanZero()
+		.SetDisplay("ST Factor", "SuperTrend multiplier", "SuperTrend")
+		.SetCanOptimize(true)
+		.SetOptimize(1m, 10m, 1m);
+		
+		_tradeDirection = Param(nameof(TradeDirection), (Sides?)null)
+		.SetDisplay("Direction", "Allowed trading direction", "Trading");
+		
 		_tpSlCondition = Param(nameof(TpSlCondition), Strategies.TpSlMode.None)
-			.SetDisplay("TP/SL Mode", "Protection mode", "Risk");
-
+		.SetDisplay("TP/SL Mode", "Protection mode", "Risk");
+		
 		_takeProfitPerc = Param(nameof(TakeProfitPerc), 30m)
-			.SetGreaterThanZero()
-			.SetDisplay("Take Profit (%)", "Take profit percentage", "Risk");
-
+		.SetGreaterThanZero()
+		.SetDisplay("Take Profit (%)", "Take profit percentage", "Risk");
+		
 		_stopLossPerc = Param(nameof(StopLossPerc), 20m)
-			.SetGreaterThanZero()
-			.SetDisplay("Stop Loss (%)", "Stop loss percentage", "Risk");
-
+		.SetGreaterThanZero()
+		.SetDisplay("Stop Loss (%)", "Stop loss percentage", "Risk");
+		
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(1).TimeFrame())
-			.SetDisplay("Candle Type", "Type of candles", "General");
+		.SetDisplay("Candle Type", "Type of candles", "General");
 	}
-
+	
 	/// <inheritdoc />
 	public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
 	{
 		return [(Security, CandleType)];
 	}
-
+	
 	/// <inheritdoc />
 	protected override void OnStarted(DateTimeOffset time)
 	{
 		base.OnStarted(time);
-
+		
 		var shortBb = new BollingerBands { Length = ShortBbLength, Width = StdDev };
 		var longBb = new BollingerBands { Length = LongBbLength, Width = StdDev };
-
+		
 		var subscription = SubscribeCandles(CandleType);
 		subscription
-			.Bind(shortBb, longBb, ProcessCandle)
-			.Start();
-
+		.Bind(shortBb, longBb, ProcessCandle)
+		.Start();
+		
 		var area = CreateChartArea();
 		if (area != null)
 		{
@@ -201,87 +201,77 @@ public class BbtrendSupertrendDecisionStrategy : Strategy
 			DrawIndicator(area, longBb);
 			DrawOwnTrades(area);
 		}
-
+		
 		Unit tp = default;
 		Unit sl = default;
 		if (TpSlCondition == TpSlMode.TP || TpSlCondition == TpSlMode.Both)
-			tp = TakeProfitPerc.Percents();
+		tp = TakeProfitPerc.Percents();
 		if (TpSlCondition == TpSlMode.SL || TpSlCondition == TpSlMode.Both)
-			sl = StopLossPerc.Percents();
+		sl = StopLossPerc.Percents();
 		if (tp != default || sl != default)
-			StartProtection(tp, sl);
+		StartProtection(tp, sl);
 	}
-
+	
 	private void ProcessCandle(ICandleMessage candle,
-		decimal shortMiddle, decimal shortUpper, decimal shortLower,
-		decimal longMiddle, decimal longUpper, decimal longLower)
+	decimal shortMiddle, decimal shortUpper, decimal shortLower,
+	decimal longMiddle, decimal longUpper, decimal longLower)
 	{
 		if (candle.State != CandleStates.Finished)
-			return;
-
+		return;
+		
 		var bbTrend = (Math.Abs(shortLower - longLower) - Math.Abs(shortUpper - longUpper)) / shortMiddle * 100m;
-
+		
 		if (_previousBbTrend is null)
 		{
 			_previousBbTrend = bbTrend;
 			return;
 		}
-
+		
 		var open = _previousBbTrend.Value;
 		var close = bbTrend;
 		var high = Math.Max(open, close);
 		var low = Math.Min(open, close);
-
+		
 		var tr = Math.Max(Math.Max(high - low, Math.Abs(high - open)), Math.Abs(low - open));
 		var atr = _prevAtr is null ? tr : _prevAtr.Value + (tr - _prevAtr.Value) / SupertrendLength;
-
+		
 		var hl2 = (high + low) / 2m;
 		var up = hl2 + SupertrendMultiplier * atr;
 		if (_prevUp is not null && !((up < _prevUp.Value) || (open > _prevUp.Value)))
-			up = _prevUp.Value;
+		up = _prevUp.Value;
 		var dn = hl2 - SupertrendMultiplier * atr;
 		if (_prevDn is not null && !((dn > _prevDn.Value) || (open < _prevDn.Value)))
-			dn = _prevDn.Value;
-
+		dn = _prevDn.Value;
+		
 		int dir;
 		if (_prevAtr is null)
-			dir = 1;
+		dir = 1;
 		else if (_prevSt.HasValue && _prevUp.HasValue && _prevSt.Value == _prevUp.Value)
-			dir = close > up ? -1 : 1;
+		dir = close > up ? -1 : 1;
 		else
-			dir = close < dn ? 1 : -1;
-
+		dir = close < dn ? 1 : -1;
+		
 		var st = dir == -1 ? dn : up;
-
-		var allowLong = TradeDirection == TradeDirection.Both || TradeDirection == TradeDirection.Long;
-		var allowShort = TradeDirection == TradeDirection.Both || TradeDirection == TradeDirection.Short;
-
+		
+		var allowLong = TradeDirection == null || TradeDirection == Sides.Buy;
+		var allowShort = TradeDirection == null || TradeDirection == Sides.Sell;
+		
 		if (dir > 0 && Position > 0)
-			SellMarket();
+		SellMarket();
 		if (dir < 0 && Position < 0)
-			BuyMarket();
-
+		BuyMarket();
+		
 		if (allowLong && dir < 0 && Position <= 0 && IsFormedAndOnlineAndAllowTrading())
-			BuyMarket();
+		BuyMarket();
 		if (allowShort && dir > 0 && Position >= 0 && IsFormedAndOnlineAndAllowTrading())
-			SellMarket();
-
+		SellMarket();
+		
 		_previousBbTrend = close;
 		_prevAtr = atr;
 		_prevUp = up;
 		_prevDn = dn;
 		_prevSt = st;
 	}
-}
-
-/// <summary>
-/// Trading direction options.
-/// </summary>
-public enum TradeDirection
-{
-	Both,
-	Long,
-	Short
 }
 
 /// <summary>

--- a/API/0563_Breaks_and_Retests/CS/BreaksAndRetestsStrategy.cs
+++ b/API/0563_Breaks_and_Retests/CS/BreaksAndRetestsStrategy.cs
@@ -13,140 +13,133 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class BreaksAndRetestsStrategy : Strategy
 {
-	public enum Direction
-	{
-		Both,
-		LongOnly,
-		ShortOnly
-	}
-
 	private readonly StrategyParam<int> _lookbackPeriod;
 	private readonly StrategyParam<int> _retestBarsSinceBreakout;
 	private readonly StrategyParam<int> _retestDetectionLimit;
 	private readonly StrategyParam<bool> _enableBreakouts;
 	private readonly StrategyParam<bool> _enableRetests;
-	private readonly StrategyParam<Direction> _tradeDirection;
+	private readonly StrategyParam<Sides?> _tradeDirection;
 	private readonly StrategyParam<decimal> _profitThresholdPercent;
 	private readonly StrategyParam<decimal> _trailingStopGapPercent;
 	private readonly StrategyParam<decimal> _stopLossPercent;
 	private readonly StrategyParam<DataType> _candleType;
-
+	
 	private Highest _highest;
 	private Lowest _lowest;
-
+	
 	private decimal _prevHighest;
 	private decimal _prevLowest;
 	private decimal? _resistanceLevel;
 	private decimal? _supportLevel;
 	private int _barsSinceResBreak = int.MaxValue;
 	private int _barsSinceSupBreak = int.MaxValue;
-
+	
 	private bool _trailingStopActive;
 	private decimal _entryPrice;
 	private decimal _highestSinceTrailing;
 	private decimal _lowestSinceTrailing;
-
+	
 	/// <summary>
 	/// Lookback period for support and resistance calculation.
 	/// </summary>
 	public int LookbackPeriod { get => _lookbackPeriod.Value; set => _lookbackPeriod.Value = value; }
-
+	
 	/// <summary>
 	/// Bars after breakout before checking retest.
 	/// </summary>
 	public int RetestBarsSinceBreakout { get => _retestBarsSinceBreakout.Value; set => _retestBarsSinceBreakout.Value = value; }
-
+	
 	/// <summary>
 	/// Maximum bars to validate retest.
 	/// </summary>
 	public int RetestDetectionLimit { get => _retestDetectionLimit.Value; set => _retestDetectionLimit.Value = value; }
-
+	
 	/// <summary>
 	/// Enable breakout entries.
 	/// </summary>
 	public bool EnableBreakouts { get => _enableBreakouts.Value; set => _enableBreakouts.Value = value; }
-
+	
 	/// <summary>
 	/// Enable retest entries.
 	/// </summary>
 	public bool EnableRetests { get => _enableRetests.Value; set => _enableRetests.Value = value; }
-
+	
 	/// <summary>
 	/// Trade direction.
 	/// </summary>
-	public Direction TradeDirection { get => _tradeDirection.Value; set => _tradeDirection.Value = value; }
-
+	public Sides? TradeDirection { get => _tradeDirection.Value; set => _tradeDirection.Value = value; }
+	
 	/// <summary>
 	/// Profit percent threshold to activate trailing stop.
 	/// </summary>
 	public decimal ProfitThresholdPercent { get => _profitThresholdPercent.Value; set => _profitThresholdPercent.Value = value; }
-
+	
 	/// <summary>
 	/// Gap of trailing stop in percent.
 	/// </summary>
 	public decimal TrailingStopGapPercent { get => _trailingStopGapPercent.Value; set => _trailingStopGapPercent.Value = value; }
-
+	
 	/// <summary>
 	/// Initial stop loss in percent.
 	/// </summary>
 	public decimal StopLossPercent { get => _stopLossPercent.Value; set => _stopLossPercent.Value = value; }
-
+	
 	/// <summary>
 	/// Candle type to process.
 	/// </summary>
 	public DataType CandleType { get => _candleType.Value; set => _candleType.Value = value; }
-
-	private bool AllowLong => TradeDirection != Direction.ShortOnly;
-	private bool AllowShort => TradeDirection != Direction.LongOnly;
-
+	
+	private bool AllowLong => TradeDirection != Sides.Sell;
+	private bool AllowShort => TradeDirection != Sides.Buy;
+	
 	/// <summary>
 	/// Constructor.
 	/// </summary>
 	public BreaksAndRetestsStrategy()
 	{
 		_lookbackPeriod = Param(nameof(LookbackPeriod), 20)
-			.SetGreaterThanZero()
-			.SetDisplay("Lookback Period", "Number of bars for support/resistance", "Levels");
-
+		.SetGreaterThanZero()
+		.SetDisplay("Lookback Period", "Number of bars for support/resistance", "Levels");
+		
 		_retestBarsSinceBreakout = Param(nameof(RetestBarsSinceBreakout), 2)
-			.SetGreaterThanZero()
-			.SetDisplay("Bars Since Breakout", "Bars after breakout before retest", "Retest");
-
+		.SetGreaterThanZero()
+		.SetDisplay("Bars Since Breakout", "Bars after breakout before retest", "Retest");
+		
 		_retestDetectionLimit = Param(nameof(RetestDetectionLimit), 2)
-			.SetGreaterThanZero()
-			.SetDisplay("Retest Detection Limit", "Max bars to validate retest", "Retest");
-
+		.SetGreaterThanZero()
+		.SetDisplay("Retest Detection Limit", "Max bars to validate retest", "Retest");
+		
 		_enableBreakouts = Param(nameof(EnableBreakouts), true)
-			.SetDisplay("Breakouts", "Allow breakout entries", "General");
-
+		.SetDisplay("Breakouts", "Allow breakout entries", "General");
+		
 		_enableRetests = Param(nameof(EnableRetests), true)
-			.SetDisplay("Retests", "Allow retest entries", "General");
-
-		_tradeDirection = Param(nameof(TradeDirection), Direction.Both)
-			.SetDisplay("Trade Direction", "Allowed direction", "General");
-
+		.SetDisplay("Retests", "Allow retest entries", "General");
+		
+		_tradeDirection = Param(nameof(TradeDirection), (Sides?)null)
+		.SetDisplay("Trade Direction", "Allowed direction", "General");
+		
 		_profitThresholdPercent = Param(nameof(ProfitThresholdPercent), 5m)
-			.SetGreaterThanZero()
-			.SetDisplay("Profit Threshold %", "Activate trailing after profit", "Risk");
-
+		.SetGreaterThanZero()
+		.SetDisplay("Profit Threshold %", "Activate trailing after profit", "Risk");
+		
 		_trailingStopGapPercent = Param(nameof(TrailingStopGapPercent), 1m)
-			.SetGreaterThanZero()
-			.SetDisplay("Trailing Gap %", "Gap for trailing stop", "Risk");
-
+		.SetGreaterThanZero()
+		.SetDisplay("Trailing Gap %", "Gap for trailing stop", "Risk");
+		
 		_stopLossPercent = Param(nameof(StopLossPercent), 2m)
-			.SetGreaterThanZero()
-			.SetDisplay("Stop Loss %", "Initial stop loss", "Risk");
-
+		.SetGreaterThanZero()
+		.SetDisplay("Stop Loss %", "Initial stop loss", "Risk");
+		
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
-			.SetDisplay("Candle Type", "Candles for calculations", "General");
+		.SetDisplay("Candle Type", "Candles for calculations", "General");
 	}
-
+	
 	/// <inheritdoc />
 	public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
 	{
 		return [(Security, CandleType)];
 	}
-
+	
 	/// <inheritdoc />
 	protected override void OnReseted()
 	{
@@ -162,38 +155,38 @@ public class BreaksAndRetestsStrategy : Strategy
 		_highestSinceTrailing = 0m;
 		_lowestSinceTrailing = 0m;
 	}
-
+	
 	/// <inheritdoc />
 	protected override void OnStarted(DateTimeOffset time)
 	{
 		base.OnStarted(time);
-
+		
 		_highest = new Highest { Length = LookbackPeriod };
 		_lowest = new Lowest { Length = LookbackPeriod };
-
+		
 		var subscription = SubscribeCandles(CandleType);
 		subscription
-			.Bind(_highest, _lowest, ProcessCandle)
-			.Start();
-
+		.Bind(_highest, _lowest, ProcessCandle)
+		.Start();
+		
 		var area = CreateChartArea();
 		if (area != null)
 		{
 			DrawCandles(area, subscription);
 			DrawOwnTrades(area);
 		}
-
+		
 		StartProtection();
 	}
-
+	
 	private void ProcessCandle(ICandleMessage candle, decimal highest, decimal lowest)
 	{
 		if (candle.State != CandleStates.Finished)
-			return;
-
+		return;
+		
 		if (!IsFormedAndOnlineAndAllowTrading())
-			return;
-
+		return;
+		
 		if (_highest.IsFormed && candle.ClosePrice > _prevHighest)
 		{
 			_resistanceLevel = _prevHighest;
@@ -209,7 +202,7 @@ public class BreaksAndRetestsStrategy : Strategy
 		{
 			_barsSinceResBreak++;
 		}
-
+		
 		if (_lowest.IsFormed && candle.ClosePrice < _prevLowest)
 		{
 			_supportLevel = _prevLowest;
@@ -225,10 +218,10 @@ public class BreaksAndRetestsStrategy : Strategy
 		{
 			_barsSinceSupBreak++;
 		}
-
+		
 		if (EnableRetests && AllowLong && Position <= 0 && _resistanceLevel is decimal res &&
-			_barsSinceResBreak > RetestBarsSinceBreakout && _barsSinceResBreak <= RetestDetectionLimit &&
-			candle.LowPrice <= res && candle.ClosePrice >= res)
+		_barsSinceResBreak > RetestBarsSinceBreakout && _barsSinceResBreak <= RetestDetectionLimit &&
+		candle.LowPrice <= res && candle.ClosePrice >= res)
 		{
 			CancelActiveOrders();
 			BuyMarket();
@@ -236,10 +229,10 @@ public class BreaksAndRetestsStrategy : Strategy
 			_resistanceLevel = null;
 			_barsSinceResBreak = int.MaxValue;
 		}
-
+		
 		if (EnableRetests && AllowShort && Position >= 0 && _supportLevel is decimal sup &&
-			_barsSinceSupBreak > RetestBarsSinceBreakout && _barsSinceSupBreak <= RetestDetectionLimit &&
-			candle.HighPrice >= sup && candle.ClosePrice <= sup)
+		_barsSinceSupBreak > RetestBarsSinceBreakout && _barsSinceSupBreak <= RetestDetectionLimit &&
+		candle.HighPrice >= sup && candle.ClosePrice <= sup)
 		{
 			CancelActiveOrders();
 			SellMarket();
@@ -247,13 +240,13 @@ public class BreaksAndRetestsStrategy : Strategy
 			_supportLevel = null;
 			_barsSinceSupBreak = int.MaxValue;
 		}
-
+		
 		_prevHighest = highest;
 		_prevLowest = lowest;
-
+		
 		HandleStop(candle);
 	}
-
+	
 	private void HandleStop(ICandleMessage candle)
 	{
 		if (Position > 0)
@@ -264,7 +257,7 @@ public class BreaksAndRetestsStrategy : Strategy
 				_trailingStopActive = true;
 				_highestSinceTrailing = candle.ClosePrice;
 			}
-
+			
 			if (_trailingStopActive)
 			{
 				_highestSinceTrailing = Math.Max(_highestSinceTrailing, candle.ClosePrice);
@@ -297,7 +290,7 @@ public class BreaksAndRetestsStrategy : Strategy
 				_trailingStopActive = true;
 				_lowestSinceTrailing = candle.ClosePrice;
 			}
-
+			
 			if (_trailingStopActive)
 			{
 				_lowestSinceTrailing = Math.Min(_lowestSinceTrailing, candle.ClosePrice);

--- a/API/0576_Bitcoin_Leverage_Sentiment/CS/BitcoinLeverageSentimentStrategy.cs
+++ b/API/0576_Bitcoin_Leverage_Sentiment/CS/BitcoinLeverageSentimentStrategy.cs
@@ -15,69 +15,69 @@ public class BitcoinLeverageSentimentStrategy : Strategy
 {
 	private readonly StrategyParam<Security> _longsSecurity;
 	private readonly StrategyParam<Security> _shortsSecurity;
-	private readonly StrategyParam<TradeDirection> _tradeDirection;
+	private readonly StrategyParam<Sides?> _tradeDirection;
 	private readonly StrategyParam<int> _zScoreLength;
 	private readonly StrategyParam<decimal> _thresholdLongEntry;
 	private readonly StrategyParam<decimal> _thresholdLongExit;
 	private readonly StrategyParam<decimal> _thresholdShortEntry;
 	private readonly StrategyParam<decimal> _thresholdShortExit;
 	private readonly StrategyParam<DataType> _candleType;
-
+	
 	private SimpleMovingAverage _sma;
 	private StandardDeviation _stdDev;
 	private decimal _lastLong;
 	private decimal _lastShort;
 	private decimal _prevZ;
-
+	
 	public Security LongsSecurity { get => _longsSecurity.Value; set => _longsSecurity.Value = value; }
 	public Security ShortsSecurity { get => _shortsSecurity.Value; set => _shortsSecurity.Value = value; }
-	public TradeDirection Direction { get => _tradeDirection.Value; set => _tradeDirection.Value = value; }
+	public Sides? Direction { get => _tradeDirection.Value; set => _tradeDirection.Value = value; }
 	public int ZScoreLength { get => _zScoreLength.Value; set => _zScoreLength.Value = value; }
 	public decimal LongEntryThreshold { get => _thresholdLongEntry.Value; set => _thresholdLongEntry.Value = value; }
 	public decimal LongExitThreshold { get => _thresholdLongExit.Value; set => _thresholdLongExit.Value = value; }
 	public decimal ShortEntryThreshold { get => _thresholdShortEntry.Value; set => _thresholdShortEntry.Value = value; }
 	public decimal ShortExitThreshold { get => _thresholdShortExit.Value; set => _thresholdShortExit.Value = value; }
 	public DataType CandleType { get => _candleType.Value; set => _candleType.Value = value; }
-
+	
 	public BitcoinLeverageSentimentStrategy()
 	{
 		_longsSecurity = Param<Security>(nameof(LongsSecurity), null)
-			.SetDisplay("BTC Longs", "Security with BTC longs data", "Data");
-
+		.SetDisplay("BTC Longs", "Security with BTC longs data", "Data");
+		
 		_shortsSecurity = Param<Security>(nameof(ShortsSecurity), null)
-			.SetDisplay("BTC Shorts", "Security with BTC shorts data", "Data");
-
-		_tradeDirection = Param(nameof(Direction), TradeDirection.Both)
-			.SetDisplay("Trade Direction", "Allowed trade direction", "General");
-
+		.SetDisplay("BTC Shorts", "Security with BTC shorts data", "Data");
+		
+		_tradeDirection = Param(nameof(Direction), (Sides?)null)
+		.SetDisplay("Trade Direction", "Allowed trade direction", "General");
+		
 		_zScoreLength = Param(nameof(ZScoreLength), 252)
-			.SetGreaterThanZero()
-			.SetDisplay("Z-Score Length", "Period for Z-Score calculation", "General");
-
+		.SetGreaterThanZero()
+		.SetDisplay("Z-Score Length", "Period for Z-Score calculation", "General");
+		
 		_thresholdLongEntry = Param(nameof(LongEntryThreshold), 1m)
-			.SetDisplay("Long Entry", "Z-Score threshold for long entry", "Thresholds");
-
+		.SetDisplay("Long Entry", "Z-Score threshold for long entry", "Thresholds");
+		
 		_thresholdLongExit = Param(nameof(LongExitThreshold), -1.618m)
-			.SetDisplay("Long Exit", "Z-Score threshold for long exit", "Thresholds");
-
+		.SetDisplay("Long Exit", "Z-Score threshold for long exit", "Thresholds");
+		
 		_thresholdShortEntry = Param(nameof(ShortEntryThreshold), -1.618m)
-			.SetDisplay("Short Entry", "Z-Score threshold for short entry", "Thresholds");
-
+		.SetDisplay("Short Entry", "Z-Score threshold for short entry", "Thresholds");
+		
 		_thresholdShortExit = Param(nameof(ShortExitThreshold), 1m)
-			.SetDisplay("Short Exit", "Z-Score threshold for short exit", "Thresholds");
-
+		.SetDisplay("Short Exit", "Z-Score threshold for short exit", "Thresholds");
+		
 		_candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
-			.SetDisplay("Candle Type", "Time frame for longs/shorts data", "Data");
+		.SetDisplay("Candle Type", "Time frame for longs/shorts data", "Data");
 	}
-
+	
 	public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
 	{
 		if (LongsSecurity == null || ShortsSecurity == null)
-			throw new InvalidOperationException("Both longs and shorts securities must be set.");
-
+		throw new InvalidOperationException("Both longs and shorts securities must be set.");
+		
 		return [(Security, CandleType), (LongsSecurity, CandleType), (ShortsSecurity, CandleType)];
 	}
-
+	
 	protected override void OnReseted()
 	{
 		base.OnReseted();
@@ -85,28 +85,28 @@ public class BitcoinLeverageSentimentStrategy : Strategy
 		_lastShort = 0m;
 		_prevZ = 0m;
 	}
-
+	
 	protected override void OnStarted(DateTimeOffset time)
 	{
 		if (LongsSecurity == null || ShortsSecurity == null)
-			throw new InvalidOperationException("Both longs and shorts securities must be set.");
-
+		throw new InvalidOperationException("Both longs and shorts securities must be set.");
+		
 		base.OnStarted(time);
-
+		
 		_sma = new SimpleMovingAverage { Length = ZScoreLength };
 		_stdDev = new StandardDeviation { Length = ZScoreLength };
-
+		
 		SubscribeCandles(CandleType, true, LongsSecurity)
-			.Bind(ProcessLongs)
-			.Start();
-
+		.Bind(ProcessLongs)
+		.Start();
+		
 		SubscribeCandles(CandleType, true, ShortsSecurity)
-			.Bind(ProcessShorts)
-			.Start();
-
+		.Bind(ProcessShorts)
+		.Start();
+		
 		var mainSub = SubscribeCandles(CandleType);
 		mainSub.Start();
-
+		
 		var area = CreateChartArea();
 		if (area != null)
 		{
@@ -114,64 +114,64 @@ public class BitcoinLeverageSentimentStrategy : Strategy
 			DrawOwnTrades(area);
 		}
 	}
-
+	
 	private void ProcessLongs(ICandleMessage candle)
 	{
 		if (candle.State != CandleStates.Finished)
-			return;
-
+		return;
+		
 		_lastLong = candle.ClosePrice;
 		ProcessRatio(candle);
 	}
-
+	
 	private void ProcessShorts(ICandleMessage candle)
 	{
 		if (candle.State != CandleStates.Finished)
-			return;
-
+		return;
+		
 		_lastShort = candle.ClosePrice;
 		ProcessRatio(candle);
 	}
-
+	
 	private void ProcessRatio(ICandleMessage candle)
 	{
 		if (_lastLong <= 0m || _lastShort <= 0m)
-			return;
-
+		return;
+		
 		var ratio = _lastLong / (_lastLong + _lastShort);
-
+		
 		var mean = _sma.Process(ratio, candle.ServerTime, true).ToDecimal();
 		var std = _stdDev.Process(ratio, candle.ServerTime, true).ToDecimal();
-
+		
 		if (!_sma.IsFormed || !_stdDev.IsFormed || std == 0m)
-			return;
-
+		return;
+		
 		var z = (ratio - mean) / std;
-
+		
 		if (!IsFormedAndOnlineAndAllowTrading())
 		{
 			_prevZ = z;
 			return;
 		}
-
-		if (Direction != TradeDirection.Short && Position <= 0 && _prevZ < LongEntryThreshold && z >= LongEntryThreshold)
+		
+		if (Direction != Sides.Sell && Position <= 0 && _prevZ < LongEntryThreshold && z >= LongEntryThreshold)
 		{
 			BuyMarket();
 		}
-		else if (Direction != TradeDirection.Short && Position > 0 && _prevZ > LongExitThreshold && z <= LongExitThreshold)
+		else if (Direction != Sides.Sell && Position > 0 && _prevZ > LongExitThreshold && z <= LongExitThreshold)
 		{
 			SellMarket();
 		}
-
-		if (Direction != TradeDirection.Long && Position >= 0 && _prevZ > ShortEntryThreshold && z <= ShortEntryThreshold)
+		
+		if (Direction != Sides.Buy && Position >= 0 && _prevZ > ShortEntryThreshold && z <= ShortEntryThreshold)
 		{
 			SellMarket();
 		}
-		else if (Direction != TradeDirection.Long && Position < 0 && _prevZ < ShortExitThreshold && z >= ShortExitThreshold)
+		else if (Direction != Sides.Buy && Position < 0 && _prevZ < ShortExitThreshold && z >= ShortExitThreshold)
 		{
 			BuyMarket();
 		}
-
+		
 		_prevZ = z;
 	}
 }

--- a/API/0584_Boilerplate_Configurable/CS/BoilerplateConfigurableStrategy.cs
+++ b/API/0584_Boilerplate_Configurable/CS/BoilerplateConfigurableStrategy.cs
@@ -19,24 +19,17 @@ public class BoilerplateConfigurableStrategy : Strategy
 		SmaCross
 	}
 
-	public enum TradeSide
-	{
-		Long,
-		Short,
-		Both
-	}
-
-	public enum RrMode
-	{
-		Atr,
-		Static
-	}
+       public enum RrMode
+       {
+               Atr,
+               Static
+       }
 
 	private readonly StrategyParam<StrategyMode> _mode;
 	private readonly StrategyParam<int> _length;
 	private readonly StrategyParam<decimal> _wideMultiplier;
 	private readonly StrategyParam<decimal> _narrowMultiplier;
-	private readonly StrategyParam<TradeSide> _tradeDirection;
+       private readonly StrategyParam<Sides?> _direction;
 	private readonly StrategyParam<bool> _tradeInverse;
 	private readonly StrategyParam<decimal> _maxLossPerc;
 	private readonly StrategyParam<RrMode> _rrMode;
@@ -80,7 +73,7 @@ public class BoilerplateConfigurableStrategy : Strategy
 	public int Length { get => _length.Value; set => _length.Value = value; }
 	public decimal WideMultiplier { get => _wideMultiplier.Value; set => _wideMultiplier.Value = value; }
 	public decimal NarrowMultiplier { get => _narrowMultiplier.Value; set => _narrowMultiplier.Value = value; }
-	public TradeSide TradeDirection { get => _tradeDirection.Value; set => _tradeDirection.Value = value; }
+	public Sides? Direction { get => _direction.Value; set => _direction.Value = value; }
 	public bool TradeInverse { get => _tradeInverse.Value; set => _tradeInverse.Value = value; }
 	public decimal MaxLossPerc { get => _maxLossPerc.Value; set => _maxLossPerc.Value = value; }
 	public RrMode RiskRewardMode { get => _rrMode.Value; set => _rrMode.Value = value; }
@@ -121,8 +114,8 @@ public class BoilerplateConfigurableStrategy : Strategy
 			.SetRange(0.1m, decimal.MaxValue)
 			.SetDisplay("Narrow BB Mult", "Narrow Bollinger multiplier", "Squeeze");
 
-		_tradeDirection = Param(nameof(TradeDirection), TradeSide.Both)
-			.SetDisplay("Trade Direction", "Allowed trade direction", "Trading");
+               _direction = Param(nameof(Direction), (Sides?)null)
+                       .SetDisplay("Trade Direction", "Allowed trade direction", "Trading");
 
 		_tradeInverse = Param(nameof(TradeInverse), false)
 			.SetDisplay("Inverse", "Inverse trade side", "Trading");
@@ -300,8 +293,8 @@ public class BoilerplateConfigurableStrategy : Strategy
 			shortCondition = tmp;
 		}
 
-		var allowLong = TradeDirection == TradeSide.Long || TradeDirection == TradeSide.Both;
-		var allowShort = TradeDirection == TradeSide.Short || TradeDirection == TradeSide.Both;
+               var allowLong = Direction is null or Sides.Buy;
+               var allowShort = Direction is null or Sides.Sell;
 
 		if (allowLong && longCondition && Position <= 0)
 			Enter(true, candle.ClosePrice, atrVal);

--- a/API/0597_Bollinger_Breakout_Direction/CS/BollingerBreakoutDirectionStrategy.cs
+++ b/API/0597_Bollinger_Breakout_Direction/CS/BollingerBreakoutDirectionStrategy.cs
@@ -20,7 +20,7 @@ public class BollingerBreakoutDirectionStrategy : Strategy
 	private readonly StrategyParam<decimal> _rsiMidline;
 	private readonly StrategyParam<decimal> _stopLossPercent;
 	private readonly StrategyParam<decimal> _riskRewardRatio;
-	private readonly StrategyParam<TradeDirection> _direction;
+       private readonly StrategyParam<Sides?> _direction;
 
 	private BollingerBands _bollinger = null!;
 	private RelativeStrengthIndex _rsi = null!;
@@ -31,13 +31,6 @@ public class BollingerBreakoutDirectionStrategy : Strategy
 	/// <summary>
 	/// Trade direction.
 	/// </summary>
-	public enum TradeDirection
-	{
-		LongOnly,
-		ShortOnly,
-		Both
-	}
-
 	/// <summary>
 	/// Candle type for strategy calculation.
 	/// </summary>
@@ -76,7 +69,7 @@ public class BollingerBreakoutDirectionStrategy : Strategy
 	/// <summary>
 	/// Trade direction filter.
 	/// </summary>
-	public TradeDirection Direction { get => _direction.Value; set => _direction.Value = value; }
+	public Sides? Direction { get => _direction.Value; set => _direction.Value = value; }
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="BollingerBreakoutDirectionStrategy"/> class.
@@ -109,8 +102,8 @@ public class BollingerBreakoutDirectionStrategy : Strategy
 			.SetGreaterThanZero()
 			.SetDisplay("Risk/Reward", "Risk reward ratio", "Risk");
 
-		_direction = Param(nameof(Direction), TradeDirection.Both)
-			.SetDisplay("Trade Direction", "Allowed side", "General");
+               _direction = Param(nameof(Direction), (Sides?)null)
+                       .SetDisplay("Trade Direction", "Allowed side", "General");
 	}
 
 	/// <inheritdoc />
@@ -147,9 +140,8 @@ public class BollingerBreakoutDirectionStrategy : Strategy
 
 		if (!_bollinger.IsFormed || !_rsi.IsFormed)
 			return;
-
-		var longAllowed = Direction != TradeDirection.ShortOnly;
-		var shortAllowed = Direction != TradeDirection.LongOnly;
+		var longAllowed = Direction is null or Sides.Buy;
+		var shortAllowed = Direction is null or Sides.Sell;
 
 		var longSignal = longAllowed && candle.ClosePrice > upperBand && rsiValue > RsiMidline && Position <= 0;
 		var shortSignal = shortAllowed && candle.ClosePrice < lowerBand && rsiValue < RsiMidline && Position >= 0;

--- a/API/0642_Crypto_MVRV_ZScore/CS/CryptoMvrvZScoreStrategy.cs
+++ b/API/0642_Crypto_MVRV_ZScore/CS/CryptoMvrvZScoreStrategy.cs
@@ -8,13 +8,6 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-public enum TradeDirectionOption
-{
-	Both,
-	Long,
-	Short,
-}
-
 /// <summary>
 /// Crypto MVRV ZScore Strategy (642).
 /// Converts the MVRV Z-Score concept into a trading system.
@@ -24,7 +17,7 @@ public class CryptoMvrvZScoreStrategy : Strategy
 	private readonly StrategyParam<int> _zScorePeriod;
 	private readonly StrategyParam<decimal> _longEntryThreshold;
 	private readonly StrategyParam<decimal> _shortEntryThreshold;
-	private readonly StrategyParam<TradeDirectionOption> _tradeDirection;
+	private readonly StrategyParam<Sides?> _direction;
 	private readonly StrategyParam<DataType> _candleType;
 
 	private SimpleMovingAverage _realMarketCap;
@@ -65,11 +58,11 @@ public class CryptoMvrvZScoreStrategy : Strategy
 	/// <summary>
 	/// Allowed trade direction.
 	/// </summary>
-	public TradeDirectionOption TradeDirection
-	{
-		get => _tradeDirection.Value;
-		set => _tradeDirection.Value = value;
-	}
+	public Sides? Direction
+       {
+               get => _direction.Value;
+               set => _direction.Value = value;
+       }
 
 	/// <summary>
 	/// Candle type to use.
@@ -101,8 +94,8 @@ public class CryptoMvrvZScoreStrategy : Strategy
 			.SetCanOptimize(true)
 			.SetOptimize(-0.5m, -0.2m, 0.05m);
 
-		_tradeDirection = Param(nameof(TradeDirection), TradeDirectionOption.Both)
-			.SetDisplay("Trade Direction", "Allowed trade direction", "Parameters");
+               _direction = Param(nameof(Direction), (Sides?)null)
+                       .SetDisplay("Trade Direction", "Allowed trade direction", "Parameters");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
 			.SetDisplay("Candle Type", "Type of candles to use", "Parameters");
@@ -189,21 +182,19 @@ public class CryptoMvrvZScoreStrategy : Strategy
 
 		if (!IsFormedAndOnlineAndAllowTrading())
 			return;
-
-		if (longEntry && (TradeDirection == TradeDirectionOption.Long || TradeDirection == TradeDirectionOption.Both) && Position <= 0)
+		if (longEntry && (Direction is null or Sides.Buy) && Position <= 0)
 		{
 			BuyMarket(Volume + Math.Abs(Position));
 		}
-		else if (longExit && (TradeDirection == TradeDirectionOption.Long || TradeDirection == TradeDirectionOption.Both) && Position > 0)
+		else if (longExit && (Direction is null or Sides.Buy) && Position > 0)
 		{
 			SellMarket(Math.Abs(Position));
 		}
-
-		if (shortEntry && (TradeDirection == TradeDirectionOption.Short || TradeDirection == TradeDirectionOption.Both) && Position >= 0)
+		if (shortEntry && (Direction is null or Sides.Sell) && Position >= 0)
 		{
 			SellMarket(Volume + Math.Abs(Position));
 		}
-		else if (shortExit && (TradeDirection == TradeDirectionOption.Short || TradeDirection == TradeDirectionOption.Both) && Position < 0)
+		else if (shortExit && (Direction is null or Sides.Sell) && Position < 0)
 		{
 			BuyMarket(Math.Abs(Position));
 		}

--- a/API/0681_Divergence_Strategy/CS/DivergenceStrategy.cs
+++ b/API/0681_Divergence_Strategy/CS/DivergenceStrategy.cs
@@ -13,7 +13,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class DivergenceStrategy : Strategy
 {
-	private readonly StrategyParam<Direction> _direction;
+	private readonly StrategyParam<Sides?> _direction;
 	private readonly StrategyParam<int> _rsiPeriod;
 	private readonly StrategyParam<decimal> _stopLossPercent;
 	private readonly StrategyParam<decimal> _riskReward;
@@ -32,7 +32,7 @@ public class DivergenceStrategy : Strategy
 	/// <summary>
 	/// Trade direction.
 	/// </summary>
-	public Direction TradeDirection
+	public Sides? Direction
 	{
 		get => _direction.Value;
 		set => _direction.Value = value;
@@ -77,20 +77,13 @@ public class DivergenceStrategy : Strategy
 	/// <summary>
 	/// Trade direction options.
 	/// </summary>
-	public enum Direction
-	{
-		Long,
-		Short,
-		Both,
-	}
-
 	/// <summary>
 	/// Initializes a new instance of the <see cref="DivergenceStrategy"/>.
 	/// </summary>
-	public DivergenceStrategy()
-	{
-		_direction = Param(nameof(TradeDirection), Direction.Both)
-			.SetDisplay("Direction", "Trade direction", "General");
+public DivergenceStrategy()
+{
+_direction = Param(nameof(Direction), (Sides?)null)
+.SetDisplay("Direction", "Trade direction", "General");
 
 		_rsiPeriod = Param(nameof(RsiPeriod), 14)
 			.SetRange(5, 50)
@@ -174,7 +167,7 @@ public class DivergenceStrategy : Strategy
 
 			if (_prevHighPrice != null && _prevHighRsi != null && _lastHighPrice > _prevHighPrice && _lastHighRsi < _prevHighRsi)
 			{
-				if ((TradeDirection == Direction.Short || TradeDirection == Direction.Both) && Position >= 0)
+			if ((Direction is null or Sides.Sell) && Position >= 0)
 				{
 					var volume = Volume + Math.Abs(Position);
 					SellMarket(volume);
@@ -192,7 +185,7 @@ public class DivergenceStrategy : Strategy
 
 			if (_prevLowPrice != null && _prevLowRsi != null && _lastLowPrice < _prevLowPrice && _lastLowRsi > _prevLowRsi)
 			{
-				if ((TradeDirection == Direction.Long || TradeDirection == Direction.Both) && Position <= 0)
+			if ((Direction is null or Sides.Buy) && Position <= 0)
 				{
 					var volume = Volume + Math.Abs(Position);
 					BuyMarket(volume);

--- a/API/0691_Double_AI_Super_Trend_Trading/CS/DoubleAiSuperTrendTradingStrategy.cs
+++ b/API/0691_Double_AI_Super_Trend_Trading/CS/DoubleAiSuperTrendTradingStrategy.cs
@@ -7,7 +7,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-/// <summary>
+	/// <summary>
 /// Double AI Super Trend Trading Strategy - combines two SuperTrend indicators with WMA filters.
 /// </summary>
 public class DoubleAiSuperTrendTradingStrategy : Strategy
@@ -21,7 +21,7 @@ public class DoubleAiSuperTrendTradingStrategy : Strategy
 	private readonly StrategyParam<int> _superWmaLength1;
 	private readonly StrategyParam<int> _priceWmaLength2;
 	private readonly StrategyParam<int> _superWmaLength2;
-	private readonly StrategyParam<string> _tradeDirection;
+private readonly StrategyParam<Sides?> _direction;
 	
 	private SuperTrend _superTrend1;
 	private SuperTrend _superTrend2;
@@ -116,10 +116,10 @@ public class DoubleAiSuperTrendTradingStrategy : Strategy
 	/// <summary>
 	/// Trading direction (Long/Short/Both).
 	/// </summary>
-	public string TradeDirection
+	public Sides? Direction
 	{
-		get => _tradeDirection.Value;
-		set => _tradeDirection.Value = value;
+		get => _direction.Value;
+		set => _direction.Value = value;
 	}
 	
 	/// <summary>
@@ -162,8 +162,8 @@ public class DoubleAiSuperTrendTradingStrategy : Strategy
 		.SetGreaterThanZero()
 		.SetDisplay("SuperTrend WMA Length 2", "SuperTrend WMA length for second SuperTrend", "AI");
 		
-		_tradeDirection = Param(nameof(TradeDirection), "Both")
-		.SetDisplay("Direction", "Trading direction (Long/Short/Both)", "Trading");
+_direction = Param(nameof(Direction), (Sides?)null)
+.SetDisplay("Direction", "Trading direction (Long/Short/Both)", "Trading");
 	}
 	
 	/// <inheritdoc />
@@ -224,11 +224,11 @@ public class DoubleAiSuperTrendTradingStrategy : Strategy
 		var longStop = st1Value - atr1Value * AtrFactor1;
 		var shortStop = st1Value + atr1Value * AtrFactor1;
 		
-		if ((TradeDirection == "Long" || TradeDirection == "Both") && longCondition && Position <= 0)
-		BuyMarket();
-		
-		if ((TradeDirection == "Short" || TradeDirection == "Both") && shortCondition && Position >= 0)
-		SellMarket();
+		if ((Direction is null or Sides.Buy) && longCondition && Position <= 0)
+			BuyMarket();
+
+		if ((Direction is null or Sides.Sell) && shortCondition && Position >= 0)
+			SellMarket();
 		
 		if (Position > 0 && (longExit || candle.LowPrice <= longStop))
 		SellMarket();

--- a/API/0696_Double_Vegas_SuperTrend_Enhanced/CS/DoubleVegasSuperTrendEnhancedStrategy.cs
+++ b/API/0696_Double_Vegas_SuperTrend_Enhanced/CS/DoubleVegasSuperTrendEnhancedStrategy.cs
@@ -24,9 +24,9 @@ public class DoubleVegasSuperTrendEnhancedStrategy : Strategy
 	private readonly StrategyParam<int> _atrPeriod2;
 	private readonly StrategyParam<int> _vegasWindow2;
 	private readonly StrategyParam<decimal> _multiplier2;
-	private readonly StrategyParam<decimal> _volatilityAdjustment2;
-	private readonly StrategyParam<string> _tradeDirection;
-	private readonly StrategyParam<bool> _useHoldDays;
+private readonly StrategyParam<decimal> _volatilityAdjustment2;
+private readonly StrategyParam<Sides?> _direction;
+private readonly StrategyParam<bool> _useHoldDays;
 	private readonly StrategyParam<int> _holdDays;
 	private readonly StrategyParam<string> _tpslCondition;
 	private readonly StrategyParam<decimal> _takeProfitPerc;
@@ -76,8 +76,8 @@ public class DoubleVegasSuperTrendEnhancedStrategy : Strategy
 			Param(nameof(VolatilityAdjustment2), 7m)
 				.SetDisplay("Volatility Adjustment 2", "Volatility factor for second SuperTrend", "SuperTrend 2");
 
-		_tradeDirection =
-			Param(nameof(TradeDirection), "Both").SetDisplay("Trade Direction", "Allowed trading direction", "General");
+_direction =
+Param(nameof(Direction), (Sides?)null).SetDisplay("Trade Direction", "Allowed trading direction", "General");
 
 		_useHoldDays = Param(nameof(UseHoldDays), true).SetDisplay("Use Hold Days", "Enable holding period", "Exits");
 
@@ -147,11 +147,11 @@ public class DoubleVegasSuperTrendEnhancedStrategy : Strategy
 		set => _volatilityAdjustment2.Value = value;
 	}
 
-	public string TradeDirection
-	{
-		get => _tradeDirection.Value;
-		set => _tradeDirection.Value = value;
-	}
+public Sides? Direction
+{
+get => _direction.Value;
+set => _direction.Value = value;
+}
 
 	public bool UseHoldDays
 	{
@@ -286,8 +286,8 @@ public class DoubleVegasSuperTrendEnhancedStrategy : Strategy
 		var exitLong = _trend1 == -1 || _trend2 == -1;
 		var exitShort = _trend1 == 1 || _trend2 == 1;
 
-		var allowLong = TradeDirection == "Long" || TradeDirection == "Both";
-		var allowShort = TradeDirection == "Short" || TradeDirection == "Both";
+var allowLong = Direction is null or Sides.Buy;
+var allowShort = Direction is null or Sides.Sell;
 		var now = candle.OpenTime;
 
 		if (UseHoldDays)

--- a/API/0709_Dual_Rsi_Differential/CS/DualRsiDifferentialStrategy.cs
+++ b/API/0709_Dual_Rsi_Differential/CS/DualRsiDifferentialStrategy.cs
@@ -25,7 +25,7 @@ public class DualRsiDifferentialStrategy : Strategy
 	private readonly StrategyParam<TpslCondition> _condition;
 	private readonly StrategyParam<decimal> _takeProfitPerc;
 	private readonly StrategyParam<decimal> _stopLossPerc;
-	private readonly StrategyParam<TradeDirection> _direction;
+private readonly StrategyParam<Sides?> _direction;
 
 	private decimal _entryPrice;
 	private DateTimeOffset? _entryTime;
@@ -33,17 +33,10 @@ public class DualRsiDifferentialStrategy : Strategy
 	/// <summary>
 	/// Trade direction options.
 	/// </summary>
-	public enum TradeDirection
-	{
-		Long,
-		Short,
-		Both
-	}
-
-	/// <summary>
-	/// Take profit and stop loss mode.
-	/// </summary>
-	public enum TpslCondition
+/// <summary>
+/// Take profit and stop loss mode.
+/// </summary>
+public enum TpslCondition
 	{
 		None,
 		TP,
@@ -99,7 +92,7 @@ public class DualRsiDifferentialStrategy : Strategy
 	/// <summary>
 	/// Allowed trade direction.
 	/// </summary>
-	public TradeDirection Direction { get => _direction.Value; set => _direction.Value = value; }
+public Sides? Direction { get => _direction.Value; set => _direction.Value = value; }
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="DualRsiDifferentialStrategy"/> class.
@@ -139,8 +132,8 @@ public class DualRsiDifferentialStrategy : Strategy
 		.SetGreaterThanZero()
 		.SetDisplay("Stop Loss %", "Stop loss percentage", "Risk");
 
-		_direction = Param(nameof(Direction), TradeDirection.Both)
-		.SetDisplay("Trade Direction", "Allowed side", "General");
+_direction = Param(nameof(Direction), (Sides?)null)
+.SetDisplay("Trade Direction", "Allowed side", "General");
 	}
 
 	/// <inheritdoc />
@@ -181,8 +174,8 @@ public class DualRsiDifferentialStrategy : Strategy
 		return;
 
 		var diff = longRsi - shortRsi;
-		var allowLong = Direction == TradeDirection.Both || Direction == TradeDirection.Long;
-		var allowShort = Direction == TradeDirection.Both || Direction == TradeDirection.Short;
+var allowLong = Direction is null or Sides.Buy;
+var allowShort = Direction is null or Sides.Sell;
 
 		if (allowLong && diff < -RsiDiffLevel && Position <= 0)
 		{

--- a/API/0712_Dual_Phase_Trend_Regime/CS/DualPhaseTrendRegimeStrategy.cs
+++ b/API/0712_Dual_Phase_Trend_Regime/CS/DualPhaseTrendRegimeStrategy.cs
@@ -14,7 +14,7 @@ namespace StockSharp.Samples.Strategies;
 public class DualPhaseTrendRegimeStrategy : Strategy
 {
 private readonly StrategyParam<DataType> _candleType;
-private readonly StrategyParam<TradeDirection> _direction;
+private readonly StrategyParam<Sides?> _direction;
 private readonly StrategyParam<SignalSource> _signalSource;
 private readonly StrategyParam<int> _lengthSlow;
 private readonly StrategyParam<int> _lengthFast;
@@ -39,16 +39,6 @@ private LinearRegression _oscSlow = null!;
 private LinearRegression _oscFast = null!;
 
 /// <summary>
-/// Trade direction options.
-/// </summary>
-public enum TradeDirection
-{
-LongShort,
-LongOnly,
-ShortOnly
-}
-
-/// <summary>
 /// Signal source options.
 /// </summary>
 public enum SignalSource
@@ -65,7 +55,7 @@ public DataType CandleType { get => _candleType.Value; set => _candleType.Value 
 /// <summary>
 /// Allowed trade direction.
 /// </summary>
-public TradeDirection Direction { get => _direction.Value; set => _direction.Value = value; }
+public Sides? Direction { get => _direction.Value; set => _direction.Value = value; }
 
 /// <summary>
 /// Source of entry signals.
@@ -105,7 +95,7 @@ public DualPhaseTrendRegimeStrategy()
 _candleType = Param(nameof(CandleType), TimeSpan.FromHours(1).TimeFrame())
 .SetDisplay("Candle Type", "Timeframe for candles", "General");
 
-_direction = Param(nameof(Direction), TradeDirection.LongShort)
+_direction = Param(nameof(Direction), (Sides?)null)
 .SetDisplay("Trade Direction", "Allowed trade direction", "General");
 
 _signalSource = Param(nameof(Source), SignalSource.RegimeShift)
@@ -244,14 +234,14 @@ longX = crossDown;
 shortX = crossUp;
 }
 
-if (longE && Direction != TradeDirection.ShortOnly)
+if (longE && Direction != Sides.Sell)
 {
 if (Position < 0)
 BuyMarket(-Position);
 BuyMarket();
 }
 
-if (shortE && Direction != TradeDirection.LongOnly)
+if (shortE && Direction != Sides.Buy)
 {
 if (Position > 0)
 SellMarket(Position);

--- a/API/0713_Dual_Supertrend_MACD/CS/DualSupertrendMacdStrategy.cs
+++ b/API/0713_Dual_Supertrend_MACD/CS/DualSupertrendMacdStrategy.cs
@@ -24,8 +24,8 @@ public class DualSupertrendMacdStrategy : Strategy
 	private readonly StrategyParam<int> _atrPeriod1;
 	private readonly StrategyParam<decimal> _factor1;
 	private readonly StrategyParam<int> _atrPeriod2;
-	private readonly StrategyParam<decimal> _factor2;
-	private readonly StrategyParam<string> _tradeDirection;
+private readonly StrategyParam<decimal> _factor2;
+private readonly StrategyParam<Sides?> _direction;
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="DualSupertrendMacdStrategy"/>.
@@ -66,8 +66,8 @@ public class DualSupertrendMacdStrategy : Strategy
 					   .SetCanOptimize(true)
 					   .SetDisplay("Factor 2", "ATR multiplier for second Supertrend", "Supertrend");
 
-		_tradeDirection = Param(nameof(TradeDirection), "Both")
-							  .SetDisplay("Direction", "Trading direction: Long, Short or Both", "Strategy");
+_direction = Param(nameof(Direction), (Sides?)null)
+.SetDisplay("Direction", "Trading direction: Long, Short or Both", "Strategy");
 	}
 
 	/// <summary>
@@ -163,11 +163,11 @@ public class DualSupertrendMacdStrategy : Strategy
 	/// <summary>
 	/// Trading direction.
 	/// </summary>
-	public string TradeDirection
-	{
-		get => _tradeDirection.Value;
-		set => _tradeDirection.Value = value;
-	}
+public Sides? Direction
+{
+get => _direction.Value;
+set => _direction.Value = value;
+}
 
 	/// <inheritdoc />
 	public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities() => [(Security, CandleType)];
@@ -224,17 +224,17 @@ public class DualSupertrendMacdStrategy : Strategy
 		var exitLong = close < st1 || close < st2 || hist < 0;
 		var exitShort = close > st1 || close > st2 || hist > 0;
 
-		var dir = TradeDirection;
+var dir = Direction;
 
-		if ((dir == "Long" || dir == "Both") && isBullish && Position <= 0)
-			BuyMarket(Volume + Math.Abs(Position));
-		else if (Position > 0 && exitLong)
-			SellMarket(Position);
+if ((dir is null or Sides.Buy) && isBullish && Position <= 0)
+BuyMarket(Volume + Math.Abs(Position));
+else if (Position > 0 && exitLong)
+SellMarket(Position);
 
-		if ((dir == "Short" || dir == "Both") && isBearish && Position >= 0)
-			SellMarket(Volume + Math.Abs(Position));
-		else if (Position < 0 && exitShort)
-			BuyMarket(Math.Abs(Position));
+if ((dir is null or Sides.Sell) && isBearish && Position >= 0)
+SellMarket(Volume + Math.Abs(Position));
+else if (Position < 0 && exitShort)
+BuyMarket(Math.Abs(Position));
 	}
 
 	private MovingAverage CreateMa(MovingAverageTypeEnum type, int length)

--- a/API/0736_Ema_Cross_Macd_Session_Start/CS/EmaCrossMacdSessionStartStrategy.cs
+++ b/API/0736_Ema_Cross_Macd_Session_Start/CS/EmaCrossMacdSessionStartStrategy.cs
@@ -13,19 +13,12 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class EmaCrossMacdSessionStartStrategy : Strategy
 {
-	public enum TradeDirection
-	{
-		Long,
-		Short,
-		Both
-	}
-
-	private readonly StrategyParam<int> _fastEmaLength;
-	private readonly StrategyParam<int> _slowEmaLength;
-	private readonly StrategyParam<int> _macdFastLength;
-	private readonly StrategyParam<int> _macdSlowLength;
-	private readonly StrategyParam<int> _macdSignalLength;
-	private readonly StrategyParam<TradeDirection> _tradeDirection;
+private readonly StrategyParam<int> _fastEmaLength;
+private readonly StrategyParam<int> _slowEmaLength;
+private readonly StrategyParam<int> _macdFastLength;
+private readonly StrategyParam<int> _macdSlowLength;
+private readonly StrategyParam<int> _macdSignalLength;
+private readonly StrategyParam<Sides?> _direction;
 	private readonly StrategyParam<DateTimeOffset> _startDate;
 	private readonly StrategyParam<DateTimeOffset> _endDate;
 	private readonly StrategyParam<string> _session;
@@ -63,7 +56,7 @@ public class EmaCrossMacdSessionStartStrategy : Strategy
 	/// <summary>
 	/// Allowed trade direction.
 	/// </summary>
-	public TradeDirection Direction { get => _tradeDirection.Value; set => _tradeDirection.Value = value; }
+public Sides? Direction { get => _direction.Value; set => _direction.Value = value; }
 
 	/// <summary>
 	/// Trading start date.
@@ -120,8 +113,8 @@ public class EmaCrossMacdSessionStartStrategy : Strategy
 			.SetCanOptimize(true)
 			.SetOptimize(5, 15, 1);
 
-		_tradeDirection = Param(nameof(Direction), TradeDirection.Both)
-			.SetDisplay("Trade Direction", "Allowed trade direction", "General");
+_direction = Param(nameof(Direction), (Sides?)null)
+.SetDisplay("Trade Direction", "Allowed trade direction", "General");
 
 		_startDate = Param(nameof(StartDate), new DateTimeOffset(new DateTime(1970, 1, 1)))
 			.SetDisplay("Start Date", "Trading start date", "General");
@@ -205,8 +198,8 @@ public class EmaCrossMacdSessionStartStrategy : Strategy
 		var macdOkLong = histogram > 0m;
 		var macdOkShort = histogram < 0m;
 
-		var longAllowed = Direction != TradeDirection.Short;
-		var shortAllowed = Direction != TradeDirection.Long;
+var longAllowed = Direction is null or Sides.Buy;
+var shortAllowed = Direction is null or Sides.Sell;
 
 		if (inDateRange && inSession && longAllowed && macdOkLong && (longSignal || (justSessionStart && fastEma > slowEma)) && Position <= 0)
 		{

--- a/API/0789_Fibonacci_Trend_Reversal/CS/FibonacciTrendReversalStrategy.cs
+++ b/API/0789_Fibonacci_Trend_Reversal/CS/FibonacciTrendReversalStrategy.cs
@@ -19,7 +19,7 @@ public class FibonacciTrendReversalStrategy : Strategy
 	private readonly StrategyParam<decimal> _atrMultiplier;
 	private readonly StrategyParam<decimal> _riskReward;
 	private readonly StrategyParam<bool> _usePartialTp;
-	private readonly StrategyParam<TradeDirection> _direction;
+private readonly StrategyParam<Sides?> _direction;
 	
 	private Highest _highest;
 	private Lowest _lowest;
@@ -34,11 +34,11 @@ public class FibonacciTrendReversalStrategy : Strategy
 	/// <summary>
 	/// Allowed trade direction.
 	/// </summary>
-	public TradeDirection Direction
-	{
-		get => _direction.Value;
-		set => _direction.Value = value;
-	}
+public Sides? Direction
+{
+get => _direction.Value;
+set => _direction.Value = value;
+}
 	
 	/// <summary>
 	/// Candle type.
@@ -94,19 +94,9 @@ public class FibonacciTrendReversalStrategy : Strategy
 		set => _usePartialTp.Value = value;
 	}
 	
-	/// <summary>
-	/// Direction options.
-	/// </summary>
-	public enum TradeDirection
-	{
-		LongOnly,
-		ShortOnly,
-		Both
-	}
-	
-	/// <summary>
-	/// Initializes a new instance of <see cref="FibonacciTrendReversalStrategy"/>.
-	/// </summary>
+/// <summary>
+/// Initializes a new instance of <see cref="FibonacciTrendReversalStrategy"/>.
+/// </summary>
 	public FibonacciTrendReversalStrategy()
 	{
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
@@ -130,8 +120,8 @@ public class FibonacciTrendReversalStrategy : Strategy
 		_usePartialTp = Param(nameof(UsePartialTp), true)
 		.SetDisplay("Use Partial TP", "Close half position at first target", "Risk");
 		
-		_direction = Param(nameof(Direction), TradeDirection.Both)
-		.SetDisplay("Trade Direction", "Allowed trade direction", "General");
+_direction = Param(nameof(Direction), (Sides?)null)
+.SetDisplay("Trade Direction", "Allowed trade direction", "General");
 	}
 	
 	/// <inheritdoc />
@@ -187,8 +177,8 @@ public class FibonacciTrendReversalStrategy : Strategy
 		var canLong = candle.ClosePrice >= midLine && candle.OpenPrice < midLine;
 		var canShort = candle.ClosePrice <= midLine && candle.OpenPrice > midLine;
 		
-		var allowLong = Direction != TradeDirection.ShortOnly;
-		var allowShort = Direction != TradeDirection.LongOnly;
+var allowLong = Direction != Sides.Sell;
+var allowShort = Direction != Sides.Buy;
 		
 		if (Position == 0)
 		{

--- a/API/0801_FlexiMA_Variance_Tracker/CS/FlexiMaVarianceTrackerStrategy.cs
+++ b/API/0801_FlexiMA_Variance_Tracker/CS/FlexiMaVarianceTrackerStrategy.cs
@@ -16,27 +16,20 @@ public class FlexiMaVarianceTrackerStrategy : Strategy
 	private readonly StrategyParam<decimal> _stdMultiplier;
 	private readonly StrategyParam<int> _stAtrPeriod;
 	private readonly StrategyParam<decimal> _stMultiplier;
-	private readonly StrategyParam<TradeDirection> _direction;
+private readonly StrategyParam<Sides?> _direction;
 
 	private SimpleMovingAverage _ma;
 	private SimpleMovingAverage _diffAvg;
 	private StandardDeviation _stdDev;
 	private SuperTrend _superTrend;
 
-	public enum TradeDirection
-	{
-		Long,
-		Short,
-		Both
-	}
-
-	public DataType CandleType { get => _candleType.Value; set => _candleType.Value = value; }
+public DataType CandleType { get => _candleType.Value; set => _candleType.Value = value; }
 	public int MaLength { get => _maLength.Value; set => _maLength.Value = value; }
 	public int StdLength { get => _stdLength.Value; set => _stdLength.Value = value; }
 	public decimal StdMultiplier { get => _stdMultiplier.Value; set => _stdMultiplier.Value = value; }
 	public int StAtrPeriod { get => _stAtrPeriod.Value; set => _stAtrPeriod.Value = value; }
 	public decimal StMultiplier { get => _stMultiplier.Value; set => _stMultiplier.Value = value; }
-	public TradeDirection Direction { get => _direction.Value; set => _direction.Value = value; }
+public Sides? Direction { get => _direction.Value; set => _direction.Value = value; }
 
 	public FlexiMaVarianceTrackerStrategy()
 	{
@@ -63,8 +56,8 @@ public class FlexiMaVarianceTrackerStrategy : Strategy
 			.SetGreaterThanZero()
 			.SetDisplay("ATR Mult", "ATR multiplier for SuperTrend", "SuperTrend");
 
-		_direction = Param(nameof(Direction), TradeDirection.Both)
-			.SetDisplay("Trade Direction", "Allowed trading direction", "General");
+_direction = Param(nameof(Direction), (Sides?)null)
+.SetDisplay("Trade Direction", "Allowed trading direction", "General");
 	}
 
 	public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
@@ -101,8 +94,8 @@ public class FlexiMaVarianceTrackerStrategy : Strategy
 		var std = _stdDev.Process(diff).GetValue<decimal>();
 		var threshold = diffAvg + StdMultiplier * std;
 
-		var allowLong = Direction == TradeDirection.Both || Direction == TradeDirection.Long;
-		var allowShort = Direction == TradeDirection.Both || Direction == TradeDirection.Short;
+var allowLong = Direction is null or Sides.Buy;
+var allowShort = Direction is null or Sides.Sell;
 
 		var longCond = st.IsUpTrend && diff > threshold;
 		var shortCond = st.IsDownTrend && diff < -threshold;

--- a/API/0802_FlexiMA_x_FlexiST/CS/FlexiMaXFlexiStStrategy.cs
+++ b/API/0802_FlexiMA_x_FlexiST/CS/FlexiMaXFlexiStStrategy.cs
@@ -19,21 +19,11 @@ public class FlexiMaXFlexiStStrategy : Strategy
 	private readonly StrategyParam<int> _maPeriod;
 	private readonly StrategyParam<int> _stAtrPeriod;
 	private readonly StrategyParam<decimal> _stMultiplier;
-	private readonly StrategyParam<TradeDirection> _direction;
+private readonly StrategyParam<Sides?> _direction;
 
-	/// <summary>
-	/// Trade direction.
-	/// </summary>
-	public enum TradeDirection
-	{
-		Long,
-		Short,
-		Both
-	}
-
-	/// <summary>
-	/// Candle type for calculations.
-	/// </summary>
+/// <summary>
+/// Candle type for calculations.
+/// </summary>
 	public DataType CandleType { get => _candleType.Value; set => _candleType.Value = value; }
 
 	/// <summary>
@@ -52,9 +42,9 @@ public class FlexiMaXFlexiStStrategy : Strategy
 	public decimal StMultiplier { get => _stMultiplier.Value; set => _stMultiplier.Value = value; }
 
 	/// <summary>
-	/// Allowed trade direction.
-	/// </summary>
-	public TradeDirection Direction { get => _direction.Value; set => _direction.Value = value; }
+/// Allowed trade direction.
+/// </summary>
+public Sides? Direction { get => _direction.Value; set => _direction.Value = value; }
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="FlexiMaXFlexiStStrategy"/> class.
@@ -76,8 +66,8 @@ public class FlexiMaXFlexiStStrategy : Strategy
 			.SetGreaterThanZero()
 			.SetDisplay("Multiplier", "ATR multiplier for SuperTrend", "FlexiST");
 
-		_direction = Param(nameof(Direction), TradeDirection.Both)
-			.SetDisplay("Trade Direction", "Allowed trading direction", "General");
+_direction = Param(nameof(Direction), (Sides?)null)
+.SetDisplay("Trade Direction", "Allowed trading direction", "General");
 	}
 
 	/// <inheritdoc />
@@ -120,8 +110,8 @@ public class FlexiMaXFlexiStStrategy : Strategy
 		var maDiff = candle.ClosePrice - maValue;
 		var stDiff = candle.ClosePrice - stValue;
 
-		var allowLong = Direction == TradeDirection.Both || Direction == TradeDirection.Long;
-		var allowShort = Direction == TradeDirection.Both || Direction == TradeDirection.Short;
+var allowLong = Direction is null or Sides.Buy;
+var allowShort = Direction is null or Sides.Sell;
 
 		if (allowLong && maDiff > 0 && stDiff > 0 && Position <= 0)
 			BuyMarket(Volume + Math.Abs(Position));

--- a/API/0810_Four_WMA_Strategy_with_TP_and_SL/CS/FourWmaTpSlStrategy.cs
+++ b/API/0810_Four_WMA_Strategy_with_TP_and_SL/CS/FourWmaTpSlStrategy.cs
@@ -22,13 +22,6 @@ Vwma,
 Rma
 }
 
-public enum TradeDirection
-{
-LongOnly,
-ShortOnly,
-Both
-}
-
 public enum AltExitMa
 {
 LongMa1,
@@ -45,7 +38,7 @@ private readonly StrategyParam<MaMode> _maType;
 private readonly StrategyParam<bool> _enableTpSl;
 private readonly StrategyParam<decimal> _takeProfitPercent;
 private readonly StrategyParam<decimal> _stopLossPercent;
-private readonly StrategyParam<TradeDirection> _direction;
+private readonly StrategyParam<Sides?> _direction;
 private readonly StrategyParam<bool> _enableAltExit;
 private readonly StrategyParam<AltExitMa> _altExitMa;
 private readonly StrategyParam<DataType> _candleType;
@@ -98,7 +91,7 @@ public decimal StopLossPercent { get => _stopLossPercent.Value; set => _stopLoss
 /// <summary>
 /// Allowed trade direction.
 /// </summary>
-public TradeDirection Direction { get => _direction.Value; set => _direction.Value = value; }
+public Sides? Direction { get => _direction.Value; set => _direction.Value = value; }
 
 /// <summary>
 /// Enable alternate exit condition.
@@ -154,7 +147,7 @@ _stopLossPercent = Param(nameof(StopLossPercent), 1m)
 .SetGreaterOrEqualZero()
 .SetDisplay("Stop Loss %", "Stop loss percentage", "Risk");
 
-_direction = Param(nameof(Direction), TradeDirection.Both)
+_direction = Param(nameof(Direction), (Sides?)null)
 .SetDisplay("Direction", "Allowed trade direction", "General");
 
 _enableAltExit = Param(nameof(EnableAltExit), false)
@@ -266,7 +259,7 @@ if (_prevLongMa1.HasValue && _prevLongMa2.HasValue)
 var longCrossUp = _prevLongMa1 <= _prevLongMa2 && longMa1 > longMa2;
 var longCrossDown = _prevLongMa1 >= _prevLongMa2 && longMa1 < longMa2;
 
-if ((Direction == TradeDirection.Both || Direction == TradeDirection.LongOnly) && Position <= 0 && longCrossUp)
+if ((Direction is null or Sides.Buy) && Position <= 0 && longCrossUp)
 BuyMarket();
 
 if (Position > 0 && (longCrossDown || priceCrossAltExit))
@@ -278,7 +271,7 @@ if (_prevShortMa1.HasValue && _prevShortMa2.HasValue)
 var shortCrossDown = _prevShortMa1 >= _prevShortMa2 && shortMa1 < shortMa2;
 var shortCrossUp = _prevShortMa1 <= _prevShortMa2 && shortMa1 > shortMa2;
 
-if ((Direction == TradeDirection.Both || Direction == TradeDirection.ShortOnly) && Position >= 0 && shortCrossDown)
+if ((Direction is null or Sides.Sell) && Position >= 0 && shortCrossDown)
 SellMarket();
 
 if (Position < 0 && (shortCrossUp || priceCrossAltExit))

--- a/API/0881_High_Low_Breakout_ATR_Trailing/CS/HighLowBreakoutAtrTrailingStopStrategy.cs
+++ b/API/0881_High_Low_Breakout_ATR_Trailing/CS/HighLowBreakoutAtrTrailingStopStrategy.cs
@@ -13,19 +13,12 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class HighLowBreakoutAtrTrailingStopStrategy : Strategy
 {
-	public enum TradeDirection
-	{
-		Both,
-		LongOnly,
-		ShortOnly
-	}
-
-	private readonly StrategyParam<int> _atrPeriod;
-	private readonly StrategyParam<decimal> _atrMultiplier;
-	private readonly StrategyParam<decimal> _riskPerTrade;
-	private readonly StrategyParam<decimal> _accountSize;
-	private readonly StrategyParam<TradeDirection> _direction;
-	private readonly StrategyParam<int> _sessionStartHour;
+private readonly StrategyParam<int> _atrPeriod;
+private readonly StrategyParam<decimal> _atrMultiplier;
+private readonly StrategyParam<decimal> _riskPerTrade;
+private readonly StrategyParam<decimal> _accountSize;
+private readonly StrategyParam<Sides?> _direction;
+private readonly StrategyParam<int> _sessionStartHour;
 	private readonly StrategyParam<int> _sessionStartMinute;
 	private readonly StrategyParam<int> _exitHour;
 	private readonly StrategyParam<int> _exitMinute;
@@ -78,11 +71,11 @@ public class HighLowBreakoutAtrTrailingStopStrategy : Strategy
 	/// <summary>
 	/// Allowed trading direction.
 	/// </summary>
-	public TradeDirection Direction
-	{
-		get => _direction.Value;
-		set => _direction.Value = value;
-	}
+public Sides? Direction
+{
+	get => _direction.Value;
+	set => _direction.Value = value;
+}
 
 	/// <summary>
 	/// Session start hour.
@@ -149,9 +142,8 @@ public class HighLowBreakoutAtrTrailingStopStrategy : Strategy
 		_accountSize = Param(nameof(AccountSize), 10000m)
 			.SetDisplay("Account Size", "Total account size", "Risk")
 			.SetGreaterThanZero();
-
-		_direction = Param(nameof(Direction), TradeDirection.Both)
-			.SetDisplay("Trade Direction", "Allowed trading direction", "General");
+	 _direction = Param(nameof(Direction), null)
+	        .SetDisplay("Trade Direction", "Allowed trading direction", "General");
 
 		_sessionStartHour = Param(nameof(SessionStartHour), 9)
 			.SetDisplay("Session Start Hour", "Trading session start hour", "Session");
@@ -243,9 +235,8 @@ public class HighLowBreakoutAtrTrailingStopStrategy : Strategy
 			_prevClose = candle.ClosePrice;
 			return;
 		}
-
-		var allowLong = Direction != TradeDirection.ShortOnly;
-		var allowShort = Direction != TradeDirection.LongOnly;
+	 var allowLong = Direction is null || Direction == Sides.Buy;
+	var allowShort = Direction is null || Direction == Sides.Sell;
 
 		var stopDistance = atr * AtrMultiplier;
 		var riskAmount = AccountSize * (RiskPerTrade / 100m);

--- a/API/0983_Liquidity_Breakout/CS/LiquidityBreakoutStrategy.cs
+++ b/API/0983_Liquidity_Breakout/CS/LiquidityBreakoutStrategy.cs
@@ -15,9 +15,9 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class LiquidityBreakoutStrategy : Strategy
 {
-	private readonly StrategyParam<int> _pivotLength;
-	private readonly StrategyParam<TradeDirections> _tradeDirection;
-	private readonly StrategyParam<StopLossModes> _stopLossMode;
+private readonly StrategyParam<int> _pivotLength;
+private readonly StrategyParam<Sides?> _direction;
+private readonly StrategyParam<StopLossModes> _stopLossMode;
 	private readonly StrategyParam<decimal> _fixedPercentage;
 	private readonly StrategyParam<int> _superTrendPeriod;
 	private readonly StrategyParam<decimal> _superTrendMultiplier;
@@ -31,25 +31,17 @@ public class LiquidityBreakoutStrategy : Strategy
 	private decimal _prevLow;
 	private bool _initialized;
 
-	/// <summary>Allowed trade direction.</summary>
-	public enum TradeDirections
-	{
-		Long,
-		Short,
-		Both,
-	}
-
-	/// <summary>Stop loss calculation mode.</summary>
-	public enum StopLossModes
+/// <summary>Stop loss calculation mode.</summary>
+public enum StopLossModes
 	{
 		SuperTrend,
 		FixedPercentage,
 		None,
 	}
 
-	public int PivotLength { get => _pivotLength.Value; set => _pivotLength.Value = value; }
-	public TradeDirections TradeDirection { get => _tradeDirection.Value; set => _tradeDirection.Value = value; }
-	public StopLossModes StopLoss { get => _stopLossMode.Value; set => _stopLossMode.Value = value; }
+public int PivotLength { get => _pivotLength.Value; set => _pivotLength.Value = value; }
+public Sides? Direction { get => _direction.Value; set => _direction.Value = value; }
+public StopLossModes StopLoss { get => _stopLossMode.Value; set => _stopLossMode.Value = value; }
 	public decimal FixedPercentage { get => _fixedPercentage.Value; set => _fixedPercentage.Value = value; }
 	public int SuperTrendPeriod { get => _superTrendPeriod.Value; set => _superTrendPeriod.Value = value; }
 	public decimal SuperTrendMultiplier { get => _superTrendMultiplier.Value; set => _superTrendMultiplier.Value = value; }
@@ -60,9 +52,8 @@ public class LiquidityBreakoutStrategy : Strategy
 		_pivotLength = Param(nameof(PivotLength), 12)
 			.SetGreaterThanZero()
 			.SetDisplay("Contraction Lookback", "Bars for range detection", "General");
-
-		_tradeDirection = Param(nameof(TradeDirection), TradeDirections.Both)
-			.SetDisplay("Trade Direction", "Allowed trade direction", "General");
+	 _direction = Param(nameof(Direction), null)
+	        .SetDisplay("Trade Direction", "Allowed trade direction", "General");
 
 		_stopLossMode = Param(nameof(StopLoss), StopLossModes.SuperTrend)
 			.SetDisplay("Stop Loss Type", "Stop loss mode", "Risk");
@@ -139,9 +130,8 @@ public class LiquidityBreakoutStrategy : Strategy
 			_initialized = true;
 			return;
 		}
-
-		var allowLong = TradeDirection == TradeDirections.Long || TradeDirection == TradeDirections.Both;
-		var allowShort = TradeDirection == TradeDirections.Short || TradeDirection == TradeDirections.Both;
+	 var allowLong = Direction is null || Direction == Sides.Buy;
+	var allowShort = Direction is null || Direction == Sides.Sell;
 
 		var longEntry = allowLong && candle.ClosePrice > _prevHigh;
 		var shortEntry = allowShort && candle.ClosePrice < _prevLow;

--- a/API/1097_Multi_Step_FlexiMA/CS/MultiStepFlexiMaStrategy.cs
+++ b/API/1097_Multi_Step_FlexiMA/CS/MultiStepFlexiMaStrategy.cs
@@ -20,9 +20,9 @@ public class MultiStepFlexiMaStrategy : Strategy
 	private readonly StrategyParam<decimal> _incrementFactor;
 	private readonly StrategyParam<NormalizeMethod> _normalizeMethod;
 	private readonly StrategyParam<int> _superTrendPeriod;
-	private readonly StrategyParam<decimal> _superTrendMultiplier;
-	private readonly StrategyParam<TradeDirection> _direction;
-	private readonly StrategyParam<decimal> _tpLevel1;
+private readonly StrategyParam<decimal> _superTrendMultiplier;
+private readonly StrategyParam<Sides?> _direction;
+private readonly StrategyParam<decimal> _tpLevel1;
 	private readonly StrategyParam<decimal> _tpLevel2;
 	private readonly StrategyParam<decimal> _tpLevel3;
 	private readonly StrategyParam<decimal> _tpPercent1;
@@ -85,7 +85,7 @@ public class MultiStepFlexiMaStrategy : Strategy
 	/// <summary>
 	/// Allowed trade direction.
 	/// </summary>
-	public TradeDirection Direction { get => _direction.Value; set => _direction.Value = value; }
+public Sides? Direction { get => _direction.Value; set => _direction.Value = value; }
 
 	/// <summary>
 	/// Take profit level 1 in percent.
@@ -145,9 +145,8 @@ public class MultiStepFlexiMaStrategy : Strategy
 		_superTrendMultiplier = Param(nameof(SuperTrendMultiplier), 15m)
 		.SetGreaterThanZero()
 		.SetDisplay("SuperTrend Multiplier", "ATR multiplier", "SuperTrend");
-
-		_direction = Param(nameof(Direction), TradeDirection.Both)
-		.SetDisplay("Trade Direction", "Allowed trading direction", "General");
+	 _direction = Param(nameof(Direction), null)
+	        .SetDisplay("Trade Direction", "Allowed trading direction", "General");
 
 		_tpLevel1 = Param(nameof(TakeProfitLevel1), 2m)
 		.SetDisplay("TP Level 1 (%)", "First take profit level", "Risk");
@@ -261,9 +260,8 @@ public class MultiStepFlexiMaStrategy : Strategy
 		var median = (sorted[9] + sorted[10]) / 2m;
 
 		var direction = candle.ClosePrice > superTrendValue ? -1 : 1;
-
-		var allowLong = Direction == TradeDirection.Both || Direction == TradeDirection.Long;
-		var allowShort = Direction == TradeDirection.Both || Direction == TradeDirection.Short;
+	 var allowLong = Direction is null || Direction == Sides.Buy;
+	var allowShort = Direction is null || Direction == Sides.Sell;
 
 		if (allowLong && direction < 0 && median > 0 && Position <= 0)
 		{

--- a/API/1098_Multi_Step_FlexiSuperTrend/CS/MultiStepFlexiSuperTrendStrategy.cs
+++ b/API/1098_Multi_Step_FlexiSuperTrend/CS/MultiStepFlexiSuperTrendStrategy.cs
@@ -16,7 +16,7 @@ public class MultiStepFlexiSuperTrendStrategy : Strategy
 	private readonly StrategyParam<int> _atrPeriod;
 	private readonly StrategyParam<decimal> _atrFactor;
 	private readonly StrategyParam<int> _smaLength;
-	private readonly StrategyParam<TradeDirection> _direction;
+private readonly StrategyParam<Sides?> _direction;
 	private readonly StrategyParam<decimal> _takeProfitLevel1;
 	private readonly StrategyParam<decimal> _takeProfitLevel2;
 	private readonly StrategyParam<decimal> _takeProfitLevel3;
@@ -60,7 +60,7 @@ public class MultiStepFlexiSuperTrendStrategy : Strategy
 	/// <summary>
 	/// Allowed trading direction.
 	/// </summary>
-	public TradeDirection Direction { get => _direction.Value; set => _direction.Value = value; }
+public Sides? Direction { get => _direction.Value; set => _direction.Value = value; }
 
 	/// <summary>
 	/// First take profit level (fraction).
@@ -117,9 +117,8 @@ public class MultiStepFlexiSuperTrendStrategy : Strategy
 			.SetDisplay("SMA Length", "Length of deviation smoothing", "Oscillator")
 			.SetCanOptimize(true)
 			.SetOptimize(5, 20, 5);
-
-		_direction = Param(nameof(Direction), TradeDirection.Both)
-			.SetDisplay("Trade Direction", "Allowed trading direction", "Strategy");
+	 _direction = Param(nameof(Direction), null)
+	        .SetDisplay("Trade Direction", "Allowed trading direction", "Strategy");
 
 		_takeProfitLevel1 = Param(nameof(TakeProfitLevel1), 0.02m)
 			.SetRange(0m, 1m)
@@ -185,9 +184,8 @@ public class MultiStepFlexiSuperTrendStrategy : Strategy
 
 		var osc = smaResult.Value;
 		var direction = candle.ClosePrice > superTrendValue ? -1 : 1;
-
-		var allowLong = Direction == TradeDirection.Both || Direction == TradeDirection.Long;
-		var allowShort = Direction == TradeDirection.Both || Direction == TradeDirection.Short;
+	 var allowLong = Direction is null || Direction == Sides.Buy;
+	var allowShort = Direction is null || Direction == Sides.Sell;
 
 		if (allowLong && direction < 0 && osc > 0 && Position <= 0)
 		{

--- a/API/1099_Multi-Step_Vegas_SuperTrend/CS/MultiStepVegasSuperTrendStrategy.cs
+++ b/API/1099_Multi-Step_Vegas_SuperTrend/CS/MultiStepVegasSuperTrendStrategy.cs
@@ -17,8 +17,8 @@ public class MultiStepVegasSuperTrendStrategy : Strategy
 	private readonly StrategyParam<int> _vegasWindow;
 	private readonly StrategyParam<decimal> _superTrendMultiplier;
 	private readonly StrategyParam<decimal> _volatilityAdjustment;
-	private readonly StrategyParam<MaType> _maType;
-	private readonly StrategyParam<TradeDirection> _direction;
+private readonly StrategyParam<MaType> _maType;
+private readonly StrategyParam<Sides?> _direction;
 	private readonly StrategyParam<bool> _useTakeProfit;
 	private readonly StrategyParam<decimal> _takeProfitPercent1;
 	private readonly StrategyParam<decimal> _takeProfitPercent2;
@@ -66,9 +66,8 @@ public class MultiStepVegasSuperTrendStrategy : Strategy
 
 		_maType = Param(nameof(MaType), MaType.Simple)
 			.SetDisplay("MA Type", "Vegas moving average type", "Parameters");
-
-		_direction = Param(nameof(Direction), TradeDirection.Both)
-			.SetDisplay("Direction", "Trade direction", "Parameters");
+	 _direction = Param(nameof(Direction), null)
+	        .SetDisplay("Direction", "Trade direction", "Parameters");
 
 		_useTakeProfit = Param(nameof(UseTakeProfit), true)
 			.SetDisplay("Use Take Profit", "Enable take profit", "Take Profit");
@@ -102,7 +101,7 @@ public class MultiStepVegasSuperTrendStrategy : Strategy
 	public decimal SuperTrendMultiplier { get => _superTrendMultiplier.Value; set => _superTrendMultiplier.Value = value; }
 	public decimal VolatilityAdjustment { get => _volatilityAdjustment.Value; set => _volatilityAdjustment.Value = value; }
 	public MaType MaType { get => _maType.Value; set => _maType.Value = value; }
-	public TradeDirection Direction { get => _direction.Value; set => _direction.Value = value; }
+public Sides? Direction { get => _direction.Value; set => _direction.Value = value; }
 	public bool UseTakeProfit { get => _useTakeProfit.Value; set => _useTakeProfit.Value = value; }
 	public decimal TakeProfitPercent1 { get => _takeProfitPercent1.Value; set => _takeProfitPercent1.Value = value; }
 	public decimal TakeProfitPercent2 { get => _takeProfitPercent2.Value; set => _takeProfitPercent2.Value = value; }
@@ -160,35 +159,35 @@ public class MultiStepVegasSuperTrendStrategy : Strategy
 			return;
 
 		CancelActiveOrders();
-
-		var volume = Volume + Math.Abs(Position);
-
-		if (_trend == 1)
-		{
-			if (Direction == TradeDirection.Short)
-			{
-				if (Position != 0)
-					ClosePosition();
-			}
-			else
-			{
-				BuyMarket(volume);
-				SetTakeProfits(true, candle.ClosePrice, volume);
-			}
-		}
-		else if (_trend == -1)
-		{
-			if (Direction == TradeDirection.Long)
-			{
-				if (Position != 0)
-					ClosePosition();
-			}
-			else
-			{
-				SellMarket(volume);
-				SetTakeProfits(false, candle.ClosePrice, volume);
-			}
-		}
+	 var volume = Volume + Math.Abs(Position);
+	var allowLong = Direction is null || Direction == Sides.Buy;
+	var allowShort = Direction is null || Direction == Sides.Sell;
+	 if (_trend == 1)
+	{
+	        if (!allowLong)
+	        {
+	                if (Position != 0)
+	                        ClosePosition();
+	        }
+	        else
+	        {
+	                BuyMarket(volume);
+	                SetTakeProfits(true, candle.ClosePrice, volume);
+	        }
+	}
+	else if (_trend == -1)
+	{
+	        if (!allowShort)
+	        {
+	                if (Position != 0)
+	                        ClosePosition();
+	        }
+	        else
+	        {
+	                SellMarket(volume);
+	                SetTakeProfits(false, candle.ClosePrice, volume);
+	        }
+	}
 	}
 
 	private void SetTakeProfits(bool isLong, decimal entryPrice, decimal volume)

--- a/API/1100_Multi_TF_AI_SuperTrend_with_ADX/CS/MultiTfAiSuperTrendWithAdxStrategy.cs
+++ b/API/1100_Multi_TF_AI_SuperTrend_with_ADX/CS/MultiTfAiSuperTrendWithAdxStrategy.cs
@@ -23,8 +23,8 @@ public class MultiTfAiSuperTrendWithAdxStrategy : Strategy
 	private readonly StrategyParam<int> _priceWmaLength2;
 	private readonly StrategyParam<int> _superWmaLength2;
 	private readonly StrategyParam<int> _adxPeriod;
-	private readonly StrategyParam<decimal> _adxThreshold;
-	private readonly StrategyParam<string> _tradeDirection;
+private readonly StrategyParam<decimal> _adxThreshold;
+private readonly StrategyParam<Sides?> _direction;
 
 	private SuperTrend _superTrend1;
 	private SuperTrend _superTrend2;
@@ -46,8 +46,8 @@ public class MultiTfAiSuperTrendWithAdxStrategy : Strategy
 	public int PriceWmaLength2 { get => _priceWmaLength2.Value; set => _priceWmaLength2.Value = value; }
 	public int SuperWmaLength2 { get => _superWmaLength2.Value; set => _superWmaLength2.Value = value; }
 	public int AdxPeriod { get => _adxPeriod.Value; set => _adxPeriod.Value = value; }
-	public decimal AdxThreshold { get => _adxThreshold.Value; set => _adxThreshold.Value = value; }
-	public string TradeDirection { get => _tradeDirection.Value; set => _tradeDirection.Value = value; }
+public decimal AdxThreshold { get => _adxThreshold.Value; set => _adxThreshold.Value = value; }
+public Sides? Direction { get => _direction.Value; set => _direction.Value = value; }
 
 	public MultiTfAiSuperTrendWithAdxStrategy()
 	{
@@ -89,13 +89,11 @@ public class MultiTfAiSuperTrendWithAdxStrategy : Strategy
 		_adxPeriod = Param(nameof(AdxPeriod), 14)
 			.SetGreaterThanZero()
 			.SetDisplay("ADX Period", "Period for ADX", "ADX");
-
-		_adxThreshold = Param(nameof(AdxThreshold), 20m)
-			.SetGreaterThanZero()
-			.SetDisplay("ADX Threshold", "Minimum ADX to trade", "ADX");
-
-		_tradeDirection = Param(nameof(TradeDirection), "Both")
-			.SetDisplay("Direction", "Long/Short/Both", "Trading");
+	 _adxThreshold = Param(nameof(AdxThreshold), 20m)
+	        .SetGreaterThanZero()
+	        .SetDisplay("ADX Threshold", "Minimum ADX to trade", "ADX");
+	 _direction = Param(nameof(Direction), null)
+	        .SetDisplay("Direction", "Long/Short/Both", "Trading");
 	}
 
 	/// <inheritdoc />
@@ -164,12 +162,12 @@ public class MultiTfAiSuperTrendWithAdxStrategy : Strategy
 
 		var longStop = st1 - atr1 * AtrFactor1;
 		var shortStop = st1 + atr1 * AtrFactor1;
-
-		if ((TradeDirection == "Long" || TradeDirection == "Both") && longCond && Position <= 0)
-			BuyMarket();
-
-		if ((TradeDirection == "Short" || TradeDirection == "Both") && shortCond && Position >= 0)
-			SellMarket();
+	 var allowLong = Direction is null || Direction == Sides.Buy;
+	var allowShort = Direction is null || Direction == Sides.Sell;
+	 if (allowLong && longCond && Position <= 0)
+	        BuyMarket();
+	 if (allowShort && shortCond && Position >= 0)
+	        SellMarket();
 
 		if (Position > 0 && (longExit || candle.LowPrice <= longStop))
 			SellMarket();

--- a/API/1114_Negroni_Opening_Range_Strategy/CS/NegroniOpeningRangeStrategy.cs
+++ b/API/1114_Negroni_Opening_Range_Strategy/CS/NegroniOpeningRangeStrategy.cs
@@ -13,9 +13,9 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class NegroniOpeningRangeStrategy : Strategy
 {
-	private readonly StrategyParam<DataType> _candleType;
-	private readonly StrategyParam<int> _maxTradesPerDay;
-	private readonly StrategyParam<TradeDirection> _direction;
+private readonly StrategyParam<DataType> _candleType;
+private readonly StrategyParam<int> _maxTradesPerDay;
+private readonly StrategyParam<Sides?> _direction;
 	private readonly StrategyParam<TimeSpan> _sessionStart;
 	private readonly StrategyParam<TimeSpan> _sessionEnd;
 	private readonly StrategyParam<TimeSpan> _closeTime;
@@ -56,11 +56,11 @@ public class NegroniOpeningRangeStrategy : Strategy
 	/// <summary>
 	/// Trading direction.
 	/// </summary>
-	public TradeDirection Direction
-	{
-		get => _direction.Value;
-		set => _direction.Value = value;
-	}
+public Sides? Direction
+{
+	get => _direction.Value;
+	set => _direction.Value = value;
+}
 
 	/// <summary>
 	/// Start of trading session (UTC).
@@ -145,9 +145,8 @@ public class NegroniOpeningRangeStrategy : Strategy
 		_maxTradesPerDay = Param(nameof(MaxTradesPerDay), 3)
 			.SetGreaterThanZero()
 			.SetDisplay("Max Trades", "Maximum trades per day", "General");
-
-		_direction = Param(nameof(Direction), TradeDirection.Both)
-			.SetDisplay("Direction", "Trading direction", "General");
+	 _direction = Param(nameof(Direction), null)
+	        .SetDisplay("Direction", "Trading direction", "General");
 
 		_sessionStart = Param(nameof(SessionStart), new TimeSpan(9, 30, 0))
 			.SetDisplay("Session Start", "Start time for opening trades", "Time");
@@ -267,18 +266,19 @@ public class NegroniOpeningRangeStrategy : Strategy
 			return;
 
 		var close = candle.ClosePrice;
-
-		if ((Direction == TradeDirection.Long || Direction == TradeDirection.Both) &&
-			Position <= 0 && previousClose <= high.Value && close > high.Value)
-		{
-			BuyMarket(Volume + Math.Abs(Position));
-			_tradesToday++;
-		}
-		else if ((Direction == TradeDirection.Short || Direction == TradeDirection.Both) &&
-			Position >= 0 && previousClose >= low.Value && close < low.Value)
-		{
-			SellMarket(Volume + Math.Abs(Position));
-			_tradesToday++;
-		}
+	 var allowLong = Direction is null || Direction == Sides.Buy;
+	var allowShort = Direction is null || Direction == Sides.Sell;
+	 if (allowLong &&
+	        Position <= 0 && previousClose <= high.Value && close > high.Value)
+	{
+	        BuyMarket(Volume + Math.Abs(Position));
+	        _tradesToday++;
+	}
+	else if (allowShort &&
+	        Position >= 0 && previousClose >= low.Value && close < low.Value)
+	{
+	        SellMarket(Volume + Math.Abs(Position));
+	        _tradesToday++;
+	}
 	}
 }

--- a/API/1131_Obvious_MA/CS/ObviousMaStrategy.cs
+++ b/API/1131_Obvious_MA/CS/ObviousMaStrategy.cs
@@ -18,7 +18,7 @@ public class ObviousMaStrategy : Strategy
 	private readonly StrategyParam<int> _longExitLength;
 	private readonly StrategyParam<int> _shortEntryLength;
 	private readonly StrategyParam<int> _shortExitLength;
-	private readonly StrategyParam<string> _tradeDirection;
+private readonly StrategyParam<Sides?> _direction;
 	private readonly StrategyParam<DataType> _candleType;
 
 	private OnBalanceVolume _obv = null!;
@@ -63,8 +63,8 @@ public class ObviousMaStrategy : Strategy
 			.SetCanOptimize(true)
 			.SetOptimize(100, 500, 10);
 
-		_tradeDirection = Param(nameof(TradeDirection), "Long")
-			.SetDisplay("Direction", "Trading direction: Long or Short", "Parameters");
+_direction = Param(nameof(Direction), Sides.Buy)
+.SetDisplay("Direction", "Trading direction: Long or Short", "Parameters");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(1).TimeFrame())
 			.SetDisplay("Candle Type", "Type of candles for strategy calculation", "Parameters");
@@ -109,11 +109,11 @@ public class ObviousMaStrategy : Strategy
 	/// <summary>
 	/// Trading direction.
 	/// </summary>
-	public string TradeDirection
-	{
-		get => _tradeDirection.Value;
-		set => _tradeDirection.Value = value;
-	}
+public Sides? Direction
+{
+get => _direction.Value;
+set => _direction.Value = value;
+}
 
 	/// <summary>
 	/// Candle type for calculations.
@@ -192,14 +192,14 @@ public class ObviousMaStrategy : Strategy
 		if (!IsFormedAndOnlineAndAllowTrading())
 			return;
 
-		var dir = TradeDirection;
+var dir = Direction;
 
 		if (!_isFirst)
 		{
-			var longCond = _prevObv <= _prevLongEntryMa && obvValue > longEntry && dir != "Short" && Position <= 0;
-			var longExitCond = _prevObv >= _prevLongExitMa && obvValue < longExit && Position > 0;
-			var shortCond = _prevObv >= _prevShortEntryMa && obvValue < shortEntry && dir != "Long" && Position >= 0;
-			var shortExitCond = _prevObv <= _prevShortExitMa && obvValue > shortExit && Position < 0;
+var longCond = _prevObv <= _prevLongEntryMa && obvValue > longEntry && dir != Sides.Sell && Position <= 0;
+var longExitCond = _prevObv >= _prevLongExitMa && obvValue < longExit && Position > 0;
+var shortCond = _prevObv >= _prevShortEntryMa && obvValue < shortEntry && dir != Sides.Buy && Position >= 0;
+var shortExitCond = _prevObv <= _prevShortExitMa && obvValue > shortExit && Position < 0;
 
 			if (longCond)
 				BuyMarket(Volume + Math.Abs(Position));

--- a/API/1154_Parabolic_RSI_Strategy/CS/ParabolicRsiStrategy.cs
+++ b/API/1154_Parabolic_RSI_Strategy/CS/ParabolicRsiStrategy.cs
@@ -14,18 +14,11 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class ParabolicRsiStrategy : Strategy
 {
-	public enum TradeDirections
-	{
-		LongAndShort,
-		LongOnly,
-		ShortOnly
-	}
-
 	private readonly StrategyParam<int> _rsiLength;
 	private readonly StrategyParam<decimal> _sarStart;
 	private readonly StrategyParam<decimal> _sarIncrement;
 	private readonly StrategyParam<decimal> _sarMax;
-	private readonly StrategyParam<TradeDirections> _tradeDirection;
+private readonly StrategyParam<Sides?> _direction;
 	private readonly StrategyParam<bool> _useFilter;
 	private readonly StrategyParam<decimal> _longRsiMin;
 	private readonly StrategyParam<decimal> _shortRsiMax;
@@ -39,7 +32,7 @@ public class ParabolicRsiStrategy : Strategy
 	public decimal SarStart { get => _sarStart.Value; set => _sarStart.Value = value; }
 	public decimal SarIncrement { get => _sarIncrement.Value; set => _sarIncrement.Value = value; }
 	public decimal SarMax { get => _sarMax.Value; set => _sarMax.Value = value; }
-	public TradeDirections TradeDirection { get => _tradeDirection.Value; set => _tradeDirection.Value = value; }
+public Sides? Direction { get => _direction.Value; set => _direction.Value = value; }
 	public bool UseFilter { get => _useFilter.Value; set => _useFilter.Value = value; }
 	public decimal LongRsiMin { get => _longRsiMin.Value; set => _longRsiMin.Value = value; }
 	public decimal ShortRsiMax { get => _shortRsiMax.Value; set => _shortRsiMax.Value = value; }
@@ -63,8 +56,8 @@ public class ParabolicRsiStrategy : Strategy
 			.SetNotNegative()
 			.SetDisplay("SAR Max", "Maximum acceleration", "SAR");
 
-		_tradeDirection = Param(nameof(TradeDirection), TradeDirections.LongAndShort)
-			.SetDisplay("Trade Direction", "Allowed trade direction", "Strategy");
+_direction = Param(nameof(Direction), (Sides?)null)
+.SetDisplay("Trade Direction", "Allowed trade direction", "Strategy");
 
 		_useFilter = Param(nameof(UseFilter), false)
 			.SetDisplay("Use Filter", "Enable RSI filter", "Filter");
@@ -150,34 +143,34 @@ public class ParabolicRsiStrategy : Strategy
 		var sigLong = _isBelow is bool prev1 && !prev1 && isBelow;
 		var sigShort = _isBelow is bool prev2 && prev2 && !isBelow;
 
-		if (sigLong && (!UseFilter || rsiValue >= LongRsiMin))
-		{
-			if (TradeDirection != TradeDirections.ShortOnly)
-			{
-				if (Position < 0)
-					BuyMarket(Math.Abs(Position));
-				if (Position <= 0)
-					BuyMarket(Volume);
-			}
-			else if (Position < 0)
-			{
-				BuyMarket(Math.Abs(Position));
-			}
-		}
-		else if (sigShort && (!UseFilter || rsiValue <= ShortRsiMax))
-		{
-			if (TradeDirection != TradeDirections.LongOnly)
-			{
-				if (Position > 0)
-					SellMarket(Math.Abs(Position));
-				if (Position >= 0)
-					SellMarket(Volume);
-			}
-			else if (Position > 0)
-			{
-				SellMarket(Math.Abs(Position));
-			}
-		}
+if (sigLong && (!UseFilter || rsiValue >= LongRsiMin))
+{
+if (Direction != Sides.Sell)
+{
+if (Position < 0)
+BuyMarket(Math.Abs(Position));
+if (Position <= 0)
+BuyMarket(Volume);
+}
+else if (Position < 0)
+{
+BuyMarket(Math.Abs(Position));
+}
+}
+else if (sigShort && (!UseFilter || rsiValue <= ShortRsiMax))
+{
+if (Direction != Sides.Buy)
+{
+if (Position > 0)
+SellMarket(Math.Abs(Position));
+if (Position >= 0)
+SellMarket(Volume);
+}
+else if (Position > 0)
+{
+SellMarket(Math.Abs(Position));
+}
+}
 
 		_isBelow = isBelow;
 	}

--- a/API/1168_Pivot_Percentile_Trend/CS/PivotPercentileTrendStrategy.cs
+++ b/API/1168_Pivot_Percentile_Trend/CS/PivotPercentileTrendStrategy.cs
@@ -18,7 +18,7 @@ public class PivotPercentileTrendStrategy : Strategy
 	private readonly StrategyParam<int> _percentileLength;
 	private readonly StrategyParam<int> _supertrendLength;
 	private readonly StrategyParam<decimal> _supertrendFactor;
-	private readonly StrategyParam<string> _tradeDirection;
+private readonly StrategyParam<Sides?> _direction;
 	
 	private SuperTrend _supertrend;
 	private int[] _lengths = [];
@@ -66,11 +66,11 @@ public class PivotPercentileTrendStrategy : Strategy
 	/// <summary>
 	/// Allowed trading direction.
 	/// </summary>
-	public string TradeDirection
-	{
-		get => _tradeDirection.Value;
-		set => _tradeDirection.Value = value;
-	}
+public Sides? Direction
+{
+get => _direction.Value;
+set => _direction.Value = value;
+}
 	
 	/// <summary>
 	/// Constructor.
@@ -92,8 +92,8 @@ public class PivotPercentileTrendStrategy : Strategy
 	.SetGreaterThanZero()
 	.SetDisplay("SuperTrend Factor", "Multiplier for SuperTrend", "SuperTrend");
 	
-		_tradeDirection = Param(nameof(TradeDirection), "Both")
-	.SetDisplay("Trading Direction", "Allowed trade direction", "General");
+_direction = Param(nameof(Direction), (Sides?)null)
+.SetDisplay("Trading Direction", "Allowed trade direction", "General");
 	}
 	
 	/// <inheritdoc />
@@ -236,15 +236,18 @@ public class PivotPercentileTrendStrategy : Strategy
 		var enterLong = trendValue > 0 && priceAbove;
 		var enterShort = trendValue < 0 && priceBelow;
 	
-		if ((TradeDirection == "Long" || TradeDirection == "Both") && enterLong && Position <= 0)
-		BuyMarket(Volume + Math.Abs(Position));
-		else if ((TradeDirection == "Short" || TradeDirection == "Both") && enterShort && Position >= 0)
-		SellMarket(Volume + Math.Abs(Position));
-	
-		if ((TradeDirection == "Long" || TradeDirection == "Both") && enterShort && Position > 0)
-		SellMarket(Math.Abs(Position));
-		else if ((TradeDirection == "Short" || TradeDirection == "Both") && enterLong && Position < 0)
-		BuyMarket(Math.Abs(Position));
+var allowLong = Direction is null or Sides.Buy;
+var allowShort = Direction is null or Sides.Sell;
+
+if (allowLong && enterLong && Position <= 0)
+BuyMarket(Volume + Math.Abs(Position));
+else if (allowShort && enterShort && Position >= 0)
+SellMarket(Volume + Math.Abs(Position));
+
+if (allowLong && enterShort && Position > 0)
+SellMarket(Math.Abs(Position));
+else if (allowShort && enterLong && Position < 0)
+BuyMarket(Math.Abs(Position));
 	}
 	
 	private static decimal GetPercentile(Queue<decimal> values, decimal percentile)

--- a/API/1182_PresentTrend/CS/PresentTrendStrategy.cs
+++ b/API/1182_PresentTrend/CS/PresentTrendStrategy.cs
@@ -16,7 +16,7 @@ public class PresentTrendStrategy : Strategy
 	private readonly StrategyParam<int> _length;
 	private readonly StrategyParam<decimal> _multiplier;
 	private readonly StrategyParam<bool> _useRsi;
-	private readonly StrategyParam<string> _tradeDirection;
+private readonly StrategyParam<Sides?> _direction;
 
 	private AverageTrueRange _atr;
 	private RelativeStrengthIndex _rsi;
@@ -45,15 +45,15 @@ public class PresentTrendStrategy : Strategy
 		_useRsi = Param(nameof(UseRsi), false)
 			.SetDisplay("Use RSI", "Use RSI instead of MFI.", "PresentTrend");
 
-		_tradeDirection = Param(nameof(TradeDirection), "Both")
-			.SetDisplay("Trade Direction", "Allowed trade direction (Long/Short/Both).", "PresentTrend");
+_direction = Param(nameof(Direction), (Sides?)null)
+.SetDisplay("Trade Direction", "Allowed trade direction (Long/Short/Both).", "PresentTrend");
 	}
 
 	public DataType CandleType { get => _candleType.Value; set => _candleType.Value = value; }
 	public int Length { get => _length.Value; set => _length.Value = value; }
 	public decimal Multiplier { get => _multiplier.Value; set => _multiplier.Value = value; }
 	public bool UseRsi { get => _useRsi.Value; set => _useRsi.Value = value; }
-	public string TradeDirection { get => _tradeDirection.Value; set => _tradeDirection.Value = value; }
+public Sides? Direction { get => _direction.Value; set => _direction.Value = value; }
 
 	/// <inheritdoc />
 	protected override void OnStarted(DateTimeOffset time)
@@ -110,20 +110,20 @@ public class PresentTrendStrategy : Strategy
 		if (shortSignal)
 			_lastShortIndex = _barIndex;
 
-		if (_trendDirection == 1 && (TradeDirection == "Long" || TradeDirection == "Both"))
+if (_trendDirection == 1 && (Direction is null or Sides.Buy))
 		{
 			if (Position <= 0)
 				BuyMarket();
 		}
-		else if (_trendDirection == -1 && (TradeDirection == "Short" || TradeDirection == "Both"))
+else if (_trendDirection == -1 && (Direction is null or Sides.Sell))
 		{
 			if (Position >= 0)
 				SellMarket();
 		}
 
-		if (TradeDirection == "Long" && _trendDirection == -1 && Position > 0)
+if (Direction == Sides.Buy && _trendDirection == -1 && Position > 0)
 			ClosePosition();
-		else if (TradeDirection == "Short" && _trendDirection == 1 && Position < 0)
+else if (Direction == Sides.Sell && _trendDirection == 1 && Position < 0)
 			ClosePosition();
 
 		_presentTrendPrev = prev;

--- a/API/1183_PresentTrend_RMI_Synergy/CS/PresentTrendRmiSynergyStrategy.cs
+++ b/API/1183_PresentTrend_RMI_Synergy/CS/PresentTrendRmiSynergyStrategy.cs
@@ -16,7 +16,7 @@ public class PresentTrendRmiSynergyStrategy : Strategy
 	private readonly StrategyParam<int> _rmiPeriod;
 	private readonly StrategyParam<int> _superTrendLength;
 	private readonly StrategyParam<decimal> _superTrendMultiplier;
-	private readonly StrategyParam<TradeDirection> _direction;
+private readonly StrategyParam<Sides?> _direction;
 	private readonly StrategyParam<DataType> _candleType;
 
 	private decimal? _stopPrice;
@@ -51,11 +51,11 @@ public class PresentTrendRmiSynergyStrategy : Strategy
 	/// <summary>
 	/// Allowed trading direction
 	/// </summary>
-	public TradeDirection Direction
-	{
-		get => _direction.Value;
-		set => _direction.Value = value;
-	}
+public Sides? Direction
+{
+get => _direction.Value;
+set => _direction.Value = value;
+}
 
 	/// <summary>
 	/// Type of candles used for strategy calculation
@@ -89,8 +89,8 @@ public class PresentTrendRmiSynergyStrategy : Strategy
 			.SetOptimize(2m, 6m, 0.5m)
 			.SetGreaterThanZero();
 
-		_direction = Param(nameof(Direction), TradeDirection.Both)
-			.SetDisplay("Trade Direction", "Allowed trading direction", "General");
+_direction = Param(nameof(Direction), (Sides?)null)
+.SetDisplay("Trade Direction", "Allowed trading direction", "General");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
 			.SetDisplay("Candle Type", "Type of candles to use", "Data");
@@ -151,12 +151,12 @@ public class PresentTrendRmiSynergyStrategy : Strategy
 
 		if (Position == 0)
 		{
-			if ((Direction == TradeDirection.Long || Direction == TradeDirection.Both) && rsiValue > 60m && trendDir == 1)
+if ((Direction is null or Sides.Buy) && rsiValue > 60m && trendDir == 1)
 			{
 				BuyMarket(Volume);
 				_stopPrice = lowerBand;
 			}
-			else if ((Direction == TradeDirection.Short || Direction == TradeDirection.Both) && rsiValue < 40m && trendDir == -1)
+else if ((Direction is null or Sides.Sell) && rsiValue < 40m && trendDir == -1)
 			{
 				SellMarket(Volume);
 				_stopPrice = upperBand;

--- a/API/1257_RMI_Trend_Sync/CS/RmiTrendSyncStrategy.cs
+++ b/API/1257_RMI_Trend_Sync/CS/RmiTrendSyncStrategy.cs
@@ -18,7 +18,7 @@ public class RmiTrendSyncStrategy : Strategy
 	private readonly StrategyParam<decimal> _negativeThreshold;
 	private readonly StrategyParam<int> _superTrendLength;
 	private readonly StrategyParam<decimal> _superTrendMultiplier;
-	private readonly StrategyParam<TradeDirection> _direction;
+private readonly StrategyParam<Sides?> _direction;
 	private readonly StrategyParam<DataType> _candleType;
 
 	private decimal _prevRsiMfi;
@@ -56,7 +56,7 @@ public class RmiTrendSyncStrategy : Strategy
 	/// <summary>
 	/// Allowed direction.
 	/// </summary>
-	public TradeDirection Direction { get => _direction.Value; set => _direction.Value = value; }
+public Sides? Direction { get => _direction.Value; set => _direction.Value = value; }
 
 	/// <summary>
 	/// Type of candles.
@@ -88,8 +88,8 @@ public class RmiTrendSyncStrategy : Strategy
 			.SetDisplay("SuperTrend Mult", "ATR multiplier for SuperTrend", "SuperTrend")
 			.SetGreaterThanZero();
 
-		_direction = Param(nameof(Direction), TradeDirection.Both)
-			.SetDisplay("Trade Direction", "Allowed direction", "General");
+_direction = Param(nameof(Direction), (Sides?)null)
+.SetDisplay("Trade Direction", "Allowed direction", "General");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
 			.SetDisplay("Candle Type", "Type of candles", "General");
@@ -173,12 +173,12 @@ public class RmiTrendSyncStrategy : Strategy
 		var longCondition = positiveMomentum && !_isPositive;
 		var shortCondition = negativeMomentum && !_isNegative;
 
-		if (longCondition && (Direction == TradeDirection.Long || Direction == TradeDirection.Both) && Position <= 0)
+if (longCondition && (Direction is null or Sides.Buy) && Position <= 0)
 		{
 			BuyMarket(Volume + Math.Abs(Position));
 			_stopPrice = st.Value;
 		}
-		else if (shortCondition && (Direction == TradeDirection.Short || Direction == TradeDirection.Both) && Position >= 0)
+else if (shortCondition && (Direction is null or Sides.Sell) && Position >= 0)
 		{
 			SellMarket(Volume + Math.Abs(Position));
 			_stopPrice = st.Value;

--- a/API/1275_RSI_Strategy_With_TP_SL_Lower_TF/CS/RsiStrategyWithTpSlLowerTfStrategy.cs
+++ b/API/1275_RSI_Strategy_With_TP_SL_Lower_TF/CS/RsiStrategyWithTpSlLowerTfStrategy.cs
@@ -19,7 +19,7 @@ public class RsiStrategyWithTpSlLowerTfStrategy : Strategy
 	private readonly StrategyParam<int> _sellLevel;
 	private readonly StrategyParam<decimal> _takeProfitPercent;
 	private readonly StrategyParam<decimal> _stopLossPercent;
-	private readonly StrategyParam<TradeDirection> _direction;
+private readonly StrategyParam<Sides?> _direction;
 
 	private RelativeStrengthIndex _rsi;
 
@@ -56,8 +56,8 @@ public class RsiStrategyWithTpSlLowerTfStrategy : Strategy
 			.SetDisplay("Stop Loss %", "Stop loss percent", "Risk")
 			.SetCanOptimize(true);
 
-		_direction = Param(nameof(Direction), TradeDirection.Both)
-			.SetDisplay("Trade Direction", "Allowed trade direction", "General");
+_direction = Param(nameof(Direction), (Sides?)null)
+.SetDisplay("Trade Direction", "Allowed trade direction", "General");
 	}
 
 	/// <summary>
@@ -93,7 +93,7 @@ public class RsiStrategyWithTpSlLowerTfStrategy : Strategy
 	/// <summary>
 	/// Allowed trade direction.
 	/// </summary>
-	public TradeDirection Direction { get => _direction.Value; set => _direction.Value = value; }
+public Sides? Direction { get => _direction.Value; set => _direction.Value = value; }
 
 	/// <inheritdoc />
 	public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
@@ -139,8 +139,8 @@ public class RsiStrategyWithTpSlLowerTfStrategy : Strategy
 		if (!IsFormedAndOnlineAndAllowTrading())
 			return;
 
-		var allowLong = Direction != TradeDirection.ShortOnly;
-		var allowShort = Direction != TradeDirection.LongOnly;
+var allowLong = Direction != Sides.Sell;
+var allowShort = Direction != Sides.Buy;
 
 		if (allowLong && Position <= 0 && rsiValue < BuyLevel)
 			BuyMarket(Volume);

--- a/API/1346_Strategic_Multi_Step_Supertrend/CS/StrategicMultiStepSupertrendStrategy.cs
+++ b/API/1346_Strategic_Multi_Step_Supertrend/CS/StrategicMultiStepSupertrendStrategy.cs
@@ -23,7 +23,7 @@ public class StrategicMultiStepSupertrendStrategy : Strategy
 	private readonly StrategyParam<decimal> _takeProfitAmount3;
 	private readonly StrategyParam<decimal> _takeProfitAmount4;
 	private readonly StrategyParam<int> _numberOfSteps;
-	private readonly StrategyParam<string> _tradeDirection;
+private readonly StrategyParam<Sides?> _direction;
 	private readonly StrategyParam<int> _atrPeriod1;
 	private readonly StrategyParam<decimal> _factor1;
 	private readonly StrategyParam<int> _atrPeriod2;
@@ -46,7 +46,7 @@ public class StrategicMultiStepSupertrendStrategy : Strategy
 	public decimal TakeProfitAmount3 { get => _takeProfitAmount3.Value; set => _takeProfitAmount3.Value = value; }
 	public decimal TakeProfitAmount4 { get => _takeProfitAmount4.Value; set => _takeProfitAmount4.Value = value; }
 	public int NumberOfSteps { get => _numberOfSteps.Value; set => _numberOfSteps.Value = value; }
-	public string TradeDirection { get => _tradeDirection.Value; set => _tradeDirection.Value = value; }
+public Sides? Direction { get => _direction.Value; set => _direction.Value = value; }
 	public int AtrPeriod1 { get => _atrPeriod1.Value; set => _atrPeriod1.Value = value; }
 	public decimal Factor1 { get => _factor1.Value; set => _factor1.Value = value; }
 	public int AtrPeriod2 { get => _atrPeriod2.Value; set => _atrPeriod2.Value = value; }
@@ -88,8 +88,8 @@ public class StrategicMultiStepSupertrendStrategy : Strategy
 		.SetDisplay("Number of Steps", "Number of take profit steps", "Take Profit Settings")
 		.SetCanOptimize(true);
 		
-		_tradeDirection = Param(nameof(TradeDirection), "Both")
-		.SetDisplay("Trade Direction", "Trade direction (Long/Short/Both)", "Trade Direction");
+_direction = Param(nameof(Direction), (Sides?)null)
+.SetDisplay("Trade Direction", "Trade direction (Long/Short/Both)", "Trade Direction");
 		
 		_atrPeriod1 = Param(nameof(AtrPeriod1), 10)
 		.SetGreaterThanZero()
@@ -157,11 +157,13 @@ public class StrategicMultiStepSupertrendStrategy : Strategy
 		var direction1 = GetDirection(candle, atr1Value, Factor1, ref _prevSupertrend1, ref _prevAbove1);
 		var direction2 = GetDirection(candle, atr2Value, Factor2, ref _prevSupertrend2, ref _prevAbove2);
 		
-		var longCondition = direction1 < 0 && direction2 < 0 && (TradeDirection == "Long" || TradeDirection == "Both");
-		var shortCondition = direction1 > 0 && direction2 > 0 && (TradeDirection == "Short" || TradeDirection == "Both");
-		
-		var longExitCondition = direction1 > 0 && direction2 > 0 && (TradeDirection == "Long" || TradeDirection == "Both");
-		var shortExitCondition = direction1 < 0 && direction2 < 0 && (TradeDirection == "Short" || TradeDirection == "Both");
+var allowLong = Direction is null or Sides.Buy;
+var allowShort = Direction is null or Sides.Sell;
+var longCondition = direction1 < 0 && direction2 < 0 && allowLong;
+var shortCondition = direction1 > 0 && direction2 > 0 && allowShort;
+
+var longExitCondition = direction1 > 0 && direction2 > 0 && allowLong;
+var shortExitCondition = direction1 < 0 && direction2 < 0 && allowShort;
 		
 		if (longCondition && Position <= 0)
 		{

--- a/API/1354_Strategy_Stats_PresentTrading/CS/StrategyStatsPresentTradingStrategy.cs
+++ b/API/1354_Strategy_Stats_PresentTrading/CS/StrategyStatsPresentTradingStrategy.cs
@@ -25,7 +25,7 @@ public class StrategyStatsPresentTradingStrategy : Strategy
 	private readonly StrategyParam<int> _vegasWindow2;
 	private readonly StrategyParam<decimal> _multiplier2;
 	private readonly StrategyParam<decimal> _volatilityAdjustment2;
-	private readonly StrategyParam<string> _tradeDirection;
+private readonly StrategyParam<Sides?> _direction;
 	private readonly StrategyParam<bool> _useHoldDays;
 	private readonly StrategyParam<int> _holdDays;
 	private readonly StrategyParam<string> _tpslCondition;
@@ -90,8 +90,8 @@ public class StrategyStatsPresentTradingStrategy : Strategy
 			Param(nameof(VolatilityAdjustment2), 7m)
 				.SetDisplay("Volatility Adjustment 2", "Volatility factor for second SuperTrend", "SuperTrend 2");
 
-		_tradeDirection =
-			Param(nameof(TradeDirection), "Both").SetDisplay("Trade Direction", "Allowed trading direction", "General");
+_direction =
+Param(nameof(Direction), (Sides?)null).SetDisplay("Trade Direction", "Allowed trading direction", "General");
 
 		_useHoldDays = Param(nameof(UseHoldDays), true).SetDisplay("Use Hold Days", "Enable holding period", "Exits");
 
@@ -173,11 +173,11 @@ public class StrategyStatsPresentTradingStrategy : Strategy
 		set => _volatilityAdjustment2.Value = value;
 	}
 
-	public string TradeDirection
-	{
-		get => _tradeDirection.Value;
-		set => _tradeDirection.Value = value;
-	}
+public Sides? Direction
+{
+get => _direction.Value;
+set => _direction.Value = value;
+}
 
 	public bool UseHoldDays
 	{
@@ -315,8 +315,8 @@ public class StrategyStatsPresentTradingStrategy : Strategy
 		var exitLong = _trend1 == -1 || _trend2 == -1;
 		var exitShort = _trend1 == 1 || _trend2 == 1;
 
-		var allowLong = TradeDirection == "Long" || TradeDirection == "Both";
-		var allowShort = TradeDirection == "Short" || TradeDirection == "Both";
+var allowLong = Direction is null or Sides.Buy;
+var allowShort = Direction is null or Sides.Sell;
 		var now = candle.OpenTime;
 
 				if (UseHoldDays)


### PR DESCRIPTION
## Summary
- replace trade direction strings/enums with nullable `Sides?` across ten more strategies
- filter long and short entries by checking `Sides.Buy`/`Sides.Sell` or allowing both when `null`

## Testing
- `dotnet build` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c4816d16cc8323b06879f9def0f7bc