### PR TITLE
Add MACD EMA SAR Bollinger BullBear strategy

### DIFF
--- a/API/1653_MACD_EMA_SAR_Bollinger_BullBear/CS/MacdEmaSarBollingerBullBearStrategy.cs
+++ b/API/1653_MACD_EMA_SAR_Bollinger_BullBear/CS/MacdEmaSarBollingerBullBearStrategy.cs
@@ -1,0 +1,275 @@
+using System;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.Messages;
+
+namespace StockSharp.Samples.Strategies;
+
+/// <summary>
+/// Strategy based on MACD, EMA crossover, Bollinger Bands, Parabolic SAR and Bulls/Bears Power.
+/// Trades during a predefined session and allows only one position at a time.
+/// </summary>
+public class MacdEmaSarBollingerBullBearStrategy : Strategy
+{
+	private readonly StrategyParam<int> _macdFast;
+	private readonly StrategyParam<int> _macdSlow;
+	private readonly StrategyParam<int> _macdSignal;
+	private readonly StrategyParam<int> _fastMaPeriod;
+	private readonly StrategyParam<int> _slowMaPeriod;
+	private readonly StrategyParam<int> _powerPeriod;
+	private readonly StrategyParam<decimal> _sarStep;
+	private readonly StrategyParam<decimal> _sarMax;
+	private readonly StrategyParam<int> _bollingerPeriod;
+	private readonly StrategyParam<decimal> _bollingerDeviation;
+	private readonly StrategyParam<TimeSpan> _sessionStart;
+	private readonly StrategyParam<TimeSpan> _sessionEnd;
+	private readonly StrategyParam<DataType> _candleType;
+
+	private decimal _prevBearsPower;
+	private decimal _prevBullsPower;
+	private decimal _prevHigh1;
+	private decimal _prevHigh2;
+	private decimal _prevUpper1;
+	private decimal _prevUpper2;
+	private int _candleCount;
+
+	/// <summary>
+	/// Fast EMA period for MACD.
+	/// </summary>
+	public int MacdFast
+	{
+		get => _macdFast.Value;
+		set => _macdFast.Value = value;
+	}
+
+	/// <summary>
+	/// Slow EMA period for MACD.
+	/// </summary>
+	public int MacdSlow
+	{
+		get => _macdSlow.Value;
+		set => _macdSlow.Value = value;
+	}
+
+	/// <summary>
+	/// Signal line period for MACD.
+	/// </summary>
+	public int MacdSignal
+	{
+		get => _macdSignal.Value;
+		set => _macdSignal.Value = value;
+	}
+
+	/// <summary>
+	/// Period for the fast EMA crossover.
+	/// </summary>
+	public int FastMaPeriod
+	{
+		get => _fastMaPeriod.Value;
+		set => _fastMaPeriod.Value = value;
+	}
+
+	/// <summary>
+	/// Period for the slow EMA crossover.
+	/// </summary>
+	public int SlowMaPeriod
+	{
+		get => _slowMaPeriod.Value;
+		set => _slowMaPeriod.Value = value;
+	}
+
+	/// <summary>
+	/// Period for Bulls and Bears Power indicators.
+	/// </summary>
+	public int PowerPeriod
+	{
+		get => _powerPeriod.Value;
+		set => _powerPeriod.Value = value;
+	}
+
+	/// <summary>
+	/// Parabolic SAR acceleration step.
+	/// </summary>
+	public decimal SarStep
+	{
+		get => _sarStep.Value;
+		set => _sarStep.Value = value;
+	}
+
+	/// <summary>
+	/// Parabolic SAR maximum step.
+	/// </summary>
+	public decimal SarMax
+	{
+		get => _sarMax.Value;
+		set => _sarMax.Value = value;
+	}
+
+	/// <summary>
+	/// Bollinger Bands period.
+	/// </summary>
+	public int BollingerPeriod
+	{
+		get => _bollingerPeriod.Value;
+		set => _bollingerPeriod.Value = value;
+	}
+
+	/// <summary>
+	/// Bollinger Bands deviation multiplier.
+	/// </summary>
+	public decimal BollingerDeviation
+	{
+		get => _bollingerDeviation.Value;
+		set => _bollingerDeviation.Value = value;
+	}
+
+	/// <summary>
+	/// Session start time.
+	/// </summary>
+	public TimeSpan SessionStart
+	{
+		get => _sessionStart.Value;
+		set => _sessionStart.Value = value;
+	}
+
+	/// <summary>
+	/// Session end time.
+	/// </summary>
+	public TimeSpan SessionEnd
+	{
+		get => _sessionEnd.Value;
+		set => _sessionEnd.Value = value;
+	}
+
+	/// <summary>
+	/// Candle type to subscribe.
+	/// </summary>
+	public DataType CandleType
+	{
+		get => _candleType.Value;
+		set => _candleType.Value = value;
+	}
+
+	/// <summary>
+	/// Initialize <see cref="MacdEmaSarBollingerBullBearStrategy"/>.
+	/// </summary>
+	public MacdEmaSarBollingerBullBearStrategy()
+	{
+		_macdFast = Param(nameof(MacdFast), 12).SetDisplay("MACD Fast", "MACD fast EMA period", "MACD");
+		_macdSlow = Param(nameof(MacdSlow), 26).SetDisplay("MACD Slow", "MACD slow EMA period", "MACD");
+		_macdSignal = Param(nameof(MacdSignal), 9).SetDisplay("MACD Signal", "MACD signal line period", "MACD");
+		_fastMaPeriod = Param(nameof(FastMaPeriod), 3).SetDisplay("Fast EMA", "Fast EMA period", "MA");
+		_slowMaPeriod = Param(nameof(SlowMaPeriod), 34).SetDisplay("Slow EMA", "Slow EMA period", "MA");
+		_powerPeriod = Param(nameof(PowerPeriod), 13).SetDisplay("Power Period", "Bulls/Bears Power period", "Power");
+		_sarStep = Param(nameof(SarStep), 0.02m).SetDisplay("SAR Step", "Parabolic SAR step", "SAR");
+		_sarMax = Param(nameof(SarMax), 0.2m).SetDisplay("SAR Max", "Parabolic SAR max", "SAR");
+		_bollingerPeriod = Param(nameof(BollingerPeriod), 20).SetDisplay("BB Period", "Bollinger Bands period", "Bollinger");
+		_bollingerDeviation = Param(nameof(BollingerDeviation), 2m).SetDisplay("BB Deviation", "Bollinger Bands deviation", "Bollinger");
+		_sessionStart = Param(nameof(SessionStart), TimeSpan.FromHours(9)).SetDisplay("Session Start", "Trading session start", "Session");
+		_sessionEnd = Param(nameof(SessionEnd), TimeSpan.FromHours(17)).SetDisplay("Session End", "Trading session end", "Session");
+		_candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromMinutes(15))).SetDisplay("Candle Type", "Type of candles", "Common");
+	}
+
+	/// <inheritdoc />
+	protected override void OnStarted(DateTimeOffset time)
+	{
+		base.OnStarted(time);
+
+		var macd = new MovingAverageConvergenceDivergenceSignal
+		{
+			Macd =
+			{
+				ShortMa = { Length = MacdFast },
+				LongMa = { Length = MacdSlow },
+			},
+			SignalMa = { Length = MacdSignal }
+		};
+
+		var fastMa = new ExponentialMovingAverage { Length = FastMaPeriod };
+		var slowMa = new ExponentialMovingAverage { Length = SlowMaPeriod };
+		var sar = new ParabolicSar { AccelerationStep = SarStep, AccelerationMax = SarMax };
+		var bears = new BearsPower { Length = PowerPeriod };
+		var bulls = new BullsPower { Length = PowerPeriod };
+		var bollinger = new BollingerBands { Length = BollingerPeriod, Width = BollingerDeviation };
+
+		var subscription = SubscribeCandles(CandleType);
+		subscription
+			.BindEx(macd, fastMa, slowMa, sar, bears, bulls, bollinger, ProcessCandle)
+			.Start();
+
+		StartProtection();
+	}
+
+	private void ProcessCandle(
+	ICandleMessage candle,
+	IIndicatorValue macdValue,
+	IIndicatorValue fastMaValue,
+	IIndicatorValue slowMaValue,
+	IIndicatorValue sarValue,
+	IIndicatorValue bearsValue,
+	IIndicatorValue bullsValue,
+	IIndicatorValue bollingerValue)
+	{
+	if (candle.State != CandleStates.Finished)
+	return;
+
+	var time = candle.OpenTime.LocalDateTime.TimeOfDay;
+	var boll = (BollingerBandsValue)bollingerValue;
+	var upperBand = boll.UpBand;
+	var bears = bearsValue.GetValue<decimal>();
+	var bulls = bullsValue.GetValue<decimal>();
+
+	if (time < SessionStart || time >= SessionEnd || !IsFormedAndOnlineAndAllowTrading())
+	{
+	UpdateState(candle, upperBand, bears, bulls);
+	return;
+	}
+
+	var macd = (MovingAverageConvergenceDivergenceSignalValue)macdValue;
+	var macdMain = macd.Macd;
+	var macdSignal = macd.Signal;
+	var emaFast = fastMaValue.GetValue<decimal>();
+	var emaSlow = slowMaValue.GetValue<decimal>();
+	var sar = sarValue.GetValue<decimal>();
+
+	var sellSignal = Position == 0 &&
+	macdMain > macdSignal &&
+	emaFast < emaSlow &&
+	sar > candle.HighPrice &&
+	bears < 0m &&
+	bears > _prevBearsPower;
+
+	var buySignal = Position == 0 &&
+	_candleCount >= 2 &&
+	macdMain < macdSignal &&
+	_prevHigh1 < _prevUpper1 &&
+	_prevHigh2 < _prevUpper2 &&
+	emaFast > emaSlow &&
+	sar < candle.LowPrice &&
+	bulls > 0m &&
+	bulls < _prevBullsPower;
+
+	var volume = Volume + Math.Abs(Position);
+
+	if (sellSignal)
+	SellMarket(volume);
+	else if (buySignal)
+	BuyMarket(volume);
+
+	UpdateState(candle, upperBand, bears, bulls);
+	}
+
+	private void UpdateState(ICandleMessage candle, decimal upperBand, decimal bears, decimal bulls)
+	{
+	_prevBearsPower = bears;
+	_prevBullsPower = bulls;
+
+	_prevHigh2 = _prevHigh1;
+	_prevUpper2 = _prevUpper1;
+	_prevHigh1 = candle.HighPrice;
+	_prevUpper1 = upperBand;
+
+	_candleCount++;
+	}
+}

--- a/API/1653_MACD_EMA_SAR_Bollinger_BullBear/README.md
+++ b/API/1653_MACD_EMA_SAR_Bollinger_BullBear/README.md
@@ -1,0 +1,39 @@
+# MACD EMA SAR Bollinger BullBear Strategy
+[Русский](README_ru.md) | [中文](README_cn.md)
+
+Combines MACD, EMA crossover, Parabolic SAR, Bollinger Bands, and Bulls/Bears Power indicators. Trades only during active hours.
+
+## Details
+
+- **Entry Criteria**:
+  - **Long**: MACD < Signal, last two highs below upper Bollinger Band, EMA3 > EMA34, SAR below price, Bulls Power > 0 and decreasing.
+  - **Short**: MACD > Signal, EMA3 < EMA34, SAR above price, Bears Power < 0 and increasing.
+- **Long/Short**: Both directions.
+- **Exit Criteria**:
+  - No dedicated exit rules; position closes on opposite signal.
+- **Stops**: None.
+- **Default Values**:
+  - `MACD Fast` = 12
+  - `MACD Slow` = 26
+  - `MACD Signal` = 9
+  - `Fast EMA Period` = 3
+  - `Slow EMA Period` = 34
+  - `Power Period` = 13
+  - `SAR Step` = 0.02
+  - `SAR Max` = 0.2
+  - `Bollinger Period` = 20
+  - `Bollinger Deviation` = 2.0
+  - `Candle Type` = 15-minute
+  - `Session Start` = 09:00
+  - `Session End` = 17:00
+- **Filters**:
+  - Category: Trend Following
+  - Direction: Both
+  - Indicators: Multiple
+  - Stops: No
+  - Complexity: Intermediate
+  - Timeframe: Intraday
+  - Seasonality: No
+  - Neural networks: No
+  - Divergence: No
+  - Risk level: Medium

--- a/API/1653_MACD_EMA_SAR_Bollinger_BullBear/README_cn.md
+++ b/API/1653_MACD_EMA_SAR_Bollinger_BullBear/README_cn.md
@@ -1,0 +1,39 @@
+# MACD EMA SAR Bollinger BullBear 策略
+[English](README.md) | [Русский](README_ru.md)
+
+结合 MACD、EMA 交叉、Parabolic SAR、布林带以及 Bulls/Bears Power 指标，仅在活跃时段进行交易。
+
+## 细节
+
+- **入场条件**：
+  - **多头**：MACD < Signal，前两个最高价低于上轨，EMA3 > EMA34，SAR 在价格下方，Bulls Power > 0 且下降。
+  - **空头**：MACD > Signal，EMA3 < EMA34，SAR 在价格上方，Bears Power < 0 且上升。
+- **多空方向**：双向。
+- **出场条件**：
+  - 无固定退出规则；遇到相反信号时平仓。
+- **止损**：无。
+- **默认值**：
+  - `MACD Fast` = 12
+  - `MACD Slow` = 26
+  - `MACD Signal` = 9
+  - `Fast EMA Period` = 3
+  - `Slow EMA Period` = 34
+  - `Power Period` = 13
+  - `SAR Step` = 0.02
+  - `SAR Max` = 0.2
+  - `Bollinger Period` = 20
+  - `Bollinger Deviation` = 2.0
+  - `Candle Type` = 15 分钟
+  - `Session Start` = 09:00
+  - `Session End` = 17:00
+- **筛选**：
+  - 类别: Trend Following
+  - 方向: 双向
+  - 指标: 多个
+  - 止损: 无
+  - 复杂度: 中等
+  - 时间框架: 日内
+  - 季节性: 无
+  - 神经网络: 无
+  - 背离: 无
+  - 风险等级: 中等

--- a/API/1653_MACD_EMA_SAR_Bollinger_BullBear/README_ru.md
+++ b/API/1653_MACD_EMA_SAR_Bollinger_BullBear/README_ru.md
@@ -1,0 +1,39 @@
+# Стратегия MACD EMA SAR Bollinger BullBear
+[English](README.md) | [中文](README_cn.md)
+
+Объединяет индикаторы MACD, пересечение EMA, Parabolic SAR, полосы Боллинджера и Bulls/Bears Power. Торгует только в активные часы.
+
+## Детали
+
+- **Условия входа**:
+  - **Long**: MACD < Signal, два предыдущих максимума ниже верхней полосы Боллинджера, EMA3 > EMA34, SAR ниже цены, Bulls Power > 0 и снижается.
+  - **Short**: MACD > Signal, EMA3 < EMA34, SAR выше цены, Bears Power < 0 и растёт.
+- **Long/Short**: Оба направления.
+- **Условия выхода**:
+  - Нет специальных правил выхода; позиция закрывается по противоположному сигналу.
+- **Стопы**: Отсутствуют.
+- **Значения по умолчанию**:
+  - `MACD Fast` = 12
+  - `MACD Slow` = 26
+  - `MACD Signal` = 9
+  - `Fast EMA Period` = 3
+  - `Slow EMA Period` = 34
+  - `Power Period` = 13
+  - `SAR Step` = 0.02
+  - `SAR Max` = 0.2
+  - `Bollinger Period` = 20
+  - `Bollinger Deviation` = 2.0
+  - `Candle Type` = 15 минут
+  - `Session Start` = 09:00
+  - `Session End` = 17:00
+- **Фильтры**:
+  - Категория: Trend Following
+  - Направление: Оба
+  - Индикаторы: Несколько
+  - Стопы: Нет
+  - Сложность: Средняя
+  - Таймфрейм: Внутридневной
+  - Сезонность: Нет
+  - Нейросети: Нет
+  - Дивергенция: Нет
+  - Уровень риска: Средний


### PR DESCRIPTION
## Summary
- port MQL strategy 10311 to C# using MACD, EMA crossover, SAR, Bollinger Bands and Bulls/Bears Power
- document strategy behavior in English, Russian and Chinese

## Testing
- `dotnet build -c Release` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c5935e072883238674ecb9ee0a8f7f