### PR TITLE
Add Binary Wave StdDev strategy

### DIFF
--- a/API/2243_Binary_Wave_StDev/CS/BinaryWaveStdDevStrategy.cs
+++ b/API/2243_Binary_Wave_StDev/CS/BinaryWaveStdDevStrategy.cs
@@ -1,0 +1,315 @@
+using System;
+using System.Collections.Generic;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
+namespace StockSharp.Samples.Strategies;
+
+/// <summary>
+/// Binary Wave Standard Deviation strategy.
+/// Combines multiple indicators with weights and uses volatility filter based on standard deviation.
+/// </summary>
+public class BinaryWaveStdDevStrategy : Strategy
+{
+	private readonly StrategyParam<decimal> _weightMa;
+	private readonly StrategyParam<decimal> _weightMacd;
+	private readonly StrategyParam<decimal> _weightCci;
+	private readonly StrategyParam<decimal> _weightMomentum;
+	private readonly StrategyParam<decimal> _weightRsi;
+	private readonly StrategyParam<decimal> _weightAdx;
+	private readonly StrategyParam<int> _maPeriod;
+	private readonly StrategyParam<int> _fastMacd;
+	private readonly StrategyParam<int> _slowMacd;
+	private readonly StrategyParam<int> _signalMacd;
+	private readonly StrategyParam<int> _cciPeriod;
+	private readonly StrategyParam<int> _momentumPeriod;
+	private readonly StrategyParam<int> _rsiPeriod;
+	private readonly StrategyParam<int> _adxPeriod;
+	private readonly StrategyParam<int> _stdDevPeriod;
+	private readonly StrategyParam<decimal> _entryVolatility;
+	private readonly StrategyParam<decimal> _exitVolatility;
+	private readonly StrategyParam<decimal> _stopLossPoints;
+	private readonly StrategyParam<decimal> _takeProfitPoints;
+	private readonly StrategyParam<bool> _useStopLoss;
+	private readonly StrategyParam<bool> _useTakeProfit;
+	private readonly StrategyParam<DataType> _candleType;
+
+	/// <summary>
+	/// Weight for moving average signal.
+	/// </summary>
+	public decimal WeightMa { get => _weightMa.Value; set => _weightMa.Value = value; }
+
+	/// <summary>
+	/// Weight for MACD histogram signal.
+	/// </summary>
+	public decimal WeightMacd { get => _weightMacd.Value; set => _weightMacd.Value = value; }
+
+	/// <summary>
+	/// Weight for CCI signal.
+	/// </summary>
+	public decimal WeightCci { get => _weightCci.Value; set => _weightCci.Value = value; }
+
+	/// <summary>
+	/// Weight for Momentum signal.
+	/// </summary>
+	public decimal WeightMomentum { get => _weightMomentum.Value; set => _weightMomentum.Value = value; }
+
+	/// <summary>
+	/// Weight for RSI signal.
+	/// </summary>
+	public decimal WeightRsi { get => _weightRsi.Value; set => _weightRsi.Value = value; }
+
+	/// <summary>
+	/// Weight for ADX trend direction.
+	/// </summary>
+	public decimal WeightAdx { get => _weightAdx.Value; set => _weightAdx.Value = value; }
+
+	/// <summary>
+	/// Moving average period.
+	/// </summary>
+	public int MaPeriod { get => _maPeriod.Value; set => _maPeriod.Value = value; }
+
+	/// <summary>
+	/// Fast MACD EMA length.
+	/// </summary>
+	public int FastMacd { get => _fastMacd.Value; set => _fastMacd.Value = value; }
+
+	/// <summary>
+	/// Slow MACD EMA length.
+	/// </summary>
+	public int SlowMacd { get => _slowMacd.Value; set => _slowMacd.Value = value; }
+
+	/// <summary>
+	/// MACD signal line length.
+	/// </summary>
+	public int SignalMacd { get => _signalMacd.Value; set => _signalMacd.Value = value; }
+
+	/// <summary>
+	/// CCI lookback period.
+	/// </summary>
+	public int CciPeriod { get => _cciPeriod.Value; set => _cciPeriod.Value = value; }
+
+	/// <summary>
+	/// Momentum length.
+	/// </summary>
+	public int MomentumPeriod { get => _momentumPeriod.Value; set => _momentumPeriod.Value = value; }
+
+	/// <summary>
+	/// RSI length.
+	/// </summary>
+	public int RsiPeriod { get => _rsiPeriod.Value; set => _rsiPeriod.Value = value; }
+
+	/// <summary>
+	/// ADX length.
+	/// </summary>
+	public int AdxPeriod { get => _adxPeriod.Value; set => _adxPeriod.Value = value; }
+
+	/// <summary>
+	/// Standard deviation length.
+	/// </summary>
+	public int StdDevPeriod { get => _stdDevPeriod.Value; set => _stdDevPeriod.Value = value; }
+
+	/// <summary>
+	/// Entry volatility threshold.
+	/// </summary>
+	public decimal EntryVolatility { get => _entryVolatility.Value; set => _entryVolatility.Value = value; }
+
+	/// <summary>
+	/// Exit volatility threshold.
+	/// </summary>
+	public decimal ExitVolatility { get => _exitVolatility.Value; set => _exitVolatility.Value = value; }
+
+	/// <summary>
+	/// Stop loss in points.
+	/// </summary>
+	public decimal StopLossPoints { get => _stopLossPoints.Value; set => _stopLossPoints.Value = value; }
+
+	/// <summary>
+	/// Take profit in points.
+	/// </summary>
+	public decimal TakeProfitPoints { get => _takeProfitPoints.Value; set => _takeProfitPoints.Value = value; }
+
+	/// <summary>
+	/// Enable stop loss.
+	/// </summary>
+	public bool UseStopLoss { get => _useStopLoss.Value; set => _useStopLoss.Value = value; }
+
+	/// <summary>
+	/// Enable take profit.
+	/// </summary>
+	public bool UseTakeProfit { get => _useTakeProfit.Value; set => _useTakeProfit.Value = value; }
+
+	/// <summary>
+	/// Candle type to process.
+	/// </summary>
+	public DataType CandleType { get => _candleType.Value; set => _candleType.Value = value; }
+
+	public BinaryWaveStdDevStrategy()
+	{
+		_weightMa = Param(nameof(WeightMa), 1m)
+			.SetDisplay("MA Weight", "Weight for moving average direction", "Weights");
+		_weightMacd = Param(nameof(WeightMacd), 1m)
+			.SetDisplay("MACD Weight", "Weight for MACD histogram", "Weights");
+		_weightCci = Param(nameof(WeightCci), 1m)
+			.SetDisplay("CCI Weight", "Weight for CCI direction", "Weights");
+		_weightMomentum = Param(nameof(WeightMomentum), 1m)
+			.SetDisplay("Momentum Weight", "Weight for momentum", "Weights");
+		_weightRsi = Param(nameof(WeightRsi), 1m)
+			.SetDisplay("RSI Weight", "Weight for RSI", "Weights");
+		_weightAdx = Param(nameof(WeightAdx), 1m)
+			.SetDisplay("ADX Weight", "Weight for ADX trend", "Weights");
+
+		_maPeriod = Param(nameof(MaPeriod), 13)
+			.SetDisplay("MA Period", "Moving average period", "Indicators")
+			.SetCanOptimize(true);
+		_fastMacd = Param(nameof(FastMacd), 12)
+			.SetDisplay("Fast MACD", "Fast EMA length", "Indicators")
+			.SetCanOptimize(true);
+		_slowMacd = Param(nameof(SlowMacd), 26)
+			.SetDisplay("Slow MACD", "Slow EMA length", "Indicators")
+			.SetCanOptimize(true);
+		_signalMacd = Param(nameof(SignalMacd), 9)
+			.SetDisplay("MACD Signal", "Signal line length", "Indicators")
+			.SetCanOptimize(true);
+		_cciPeriod = Param(nameof(CciPeriod), 14)
+			.SetDisplay("CCI Period", "Lookback period for CCI", "Indicators")
+			.SetCanOptimize(true);
+		_momentumPeriod = Param(nameof(MomentumPeriod), 14)
+			.SetDisplay("Momentum Period", "Lookback for momentum", "Indicators")
+			.SetCanOptimize(true);
+		_rsiPeriod = Param(nameof(RsiPeriod), 14)
+			.SetDisplay("RSI Period", "Lookback for RSI", "Indicators")
+			.SetCanOptimize(true);
+		_adxPeriod = Param(nameof(AdxPeriod), 14)
+			.SetDisplay("ADX Period", "Lookback for ADX", "Indicators")
+			.SetCanOptimize(true);
+		_stdDevPeriod = Param(nameof(StdDevPeriod), 9)
+			.SetDisplay("StdDev Period", "Length of standard deviation", "Indicators")
+			.SetCanOptimize(true);
+
+		_entryVolatility = Param(nameof(EntryVolatility), 1.5m)
+			.SetDisplay("Entry Volatility", "Minimum standard deviation to enter", "Risk Management")
+			.SetCanOptimize(true);
+		_exitVolatility = Param(nameof(ExitVolatility), 1m)
+			.SetDisplay("Exit Volatility", "Standard deviation threshold to exit", "Risk Management")
+			.SetCanOptimize(true);
+		_stopLossPoints = Param(nameof(StopLossPoints), 1000m)
+			.SetDisplay("Stop Loss", "Stop loss in points", "Risk Management")
+			.SetCanOptimize(true);
+		_takeProfitPoints = Param(nameof(TakeProfitPoints), 2000m)
+			.SetDisplay("Take Profit", "Take profit in points", "Risk Management")
+			.SetCanOptimize(true);
+		_useStopLoss = Param(nameof(UseStopLoss), false)
+			.SetDisplay("Use Stop Loss", "Enable stop loss", "Risk Management");
+		_useTakeProfit = Param(nameof(UseTakeProfit), false)
+			.SetDisplay("Use Take Profit", "Enable take profit", "Risk Management");
+		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(4).TimeFrame())
+			.SetDisplay("Candle Type", "Timeframe for candles", "General");
+	}
+
+	/// <inheritdoc />
+	public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
+	{
+		return [(Security, CandleType)];
+	}
+
+	/// <inheritdoc />
+	protected override void OnStarted(DateTimeOffset time)
+	{
+		base.OnStarted(time);
+
+		StartProtection(
+			useMarketOrders: true,
+			takeProfit: UseTakeProfit ? new Unit(TakeProfitPoints, UnitTypes.Absolute) : null,
+			stopLoss: UseStopLoss ? new Unit(StopLossPoints, UnitTypes.Absolute) : null);
+
+		var ema = new ExponentialMovingAverage { Length = MaPeriod };
+		var macd = new MovingAverageConvergenceDivergence
+		{
+			ShortLength = FastMacd,
+			LongLength = SlowMacd,
+			SignalLength = SignalMacd
+		};
+		var cci = new CommodityChannelIndex { Length = CciPeriod };
+		var momentum = new Momentum { Length = MomentumPeriod };
+		var rsi = new RelativeStrengthIndex { Length = RsiPeriod };
+		var adx = new AverageDirectionalIndex { Length = AdxPeriod };
+		var stdDev = new StandardDeviation { Length = StdDevPeriod };
+
+		var subscription = SubscribeCandles(CandleType);
+		subscription
+			.BindEx(ema, macd, cci, momentum, rsi, adx, stdDev, ProcessCandle)
+			.Start();
+
+		var area = CreateChartArea();
+		if (area != null)
+		{
+			DrawCandles(area, subscription);
+			DrawIndicator(area, ema);
+			DrawIndicator(area, cci);
+			DrawIndicator(area, rsi);
+			DrawOwnTrades(area);
+
+			var volArea = CreateChartArea();
+			if (volArea != null)
+			{
+				DrawIndicator(volArea, stdDev);
+			}
+		}
+	}
+
+	private void ProcessCandle(
+		ICandleMessage candle,
+		IIndicatorValue emaValue,
+		IIndicatorValue macdValue,
+		IIndicatorValue cciValue,
+		IIndicatorValue momentumValue,
+		IIndicatorValue rsiValue,
+		IIndicatorValue adxValue,
+		IIndicatorValue stdDevValue)
+	{
+		if (candle.State != CandleStates.Finished)
+			return;
+
+		var ema = emaValue.ToDecimal();
+		var macd = (MovingAverageConvergenceDivergenceValue)macdValue;
+		var cci = cciValue.ToDecimal();
+		var momentum = momentumValue.ToDecimal();
+		var rsi = rsiValue.ToDecimal();
+		var adx = (AverageDirectionalIndexValue)adxValue;
+		var std = stdDevValue.ToDecimal();
+
+		var score = 0m;
+		score += candle.ClosePrice > ema ? WeightMa : -WeightMa;
+		score += macd.Histogram > 0 ? WeightMacd : -WeightMacd;
+		score += cci > 0 ? WeightCci : -WeightCci;
+		score += momentum > 0 ? WeightMomentum : -WeightMomentum;
+		score += rsi > 50 ? WeightRsi : -WeightRsi;
+		score += adx.Dx.Plus > adx.Dx.Minus ? WeightAdx : -WeightAdx;
+
+		if (!IsFormedAndOnlineAndAllowTrading())
+			return;
+
+		if (std >= EntryVolatility)
+		{
+			if (score > 0 && Position <= 0)
+				BuyMarket(Volume + Math.Abs(Position));
+			else if (score < 0 && Position >= 0)
+				SellMarket(Volume + Math.Abs(Position));
+		}
+
+		if (std <= ExitVolatility && Position != 0)
+		{
+			if (Position > 0)
+				SellMarket(Position);
+			else
+				BuyMarket(-Position);
+		}
+	}
+}
+

--- a/API/2243_Binary_Wave_StDev/README.md
+++ b/API/2243_Binary_Wave_StDev/README.md
@@ -1,0 +1,49 @@
+# Binary Wave StdDev Strategy
+[Русский](README_ru.md) | [中文](README_cn.md)
+
+Strategy that sums signals from MA, MACD, CCI, Momentum, RSI and ADX using configurable weights.
+Trades in direction of cumulative score when volatility measured by standard deviation exceeds a threshold.
+Optional stop loss and take profit in points.
+
+## Details
+
+- **Entry Criteria**:
+  - Long: score > 0 and StdDev >= EntryVolatility
+  - Short: score < 0 and StdDev >= EntryVolatility
+- **Exit Criteria**:
+  - Volatility falls below ExitVolatility
+- **Stops**: Optional via `UseStopLoss` and `UseTakeProfit`
+- **Default Values**:
+  - `WeightMa` = 1
+  - `WeightMacd` = 1
+  - `WeightCci` = 1
+  - `WeightMomentum` = 1
+  - `WeightRsi` = 1
+  - `WeightAdx` = 1
+  - `MaPeriod` = 13
+  - `FastMacd` = 12
+  - `SlowMacd` = 26
+  - `SignalMacd` = 9
+  - `CciPeriod` = 14
+  - `MomentumPeriod` = 14
+  - `RsiPeriod` = 14
+  - `AdxPeriod` = 14
+  - `StdDevPeriod` = 9
+  - `EntryVolatility` = 1.5
+  - `ExitVolatility` = 1
+  - `StopLossPoints` = 1000
+  - `TakeProfitPoints` = 2000
+  - `UseStopLoss` = false
+  - `UseTakeProfit` = false
+  - `CandleType` = TimeSpan.FromHours(4).TimeFrame()
+- **Filters**:
+  - Category: Trend following
+  - Direction: Both
+  - Indicators: MA, MACD, CCI, Momentum, RSI, ADX, StandardDeviation
+  - Stops: Optional
+  - Complexity: Medium
+  - Timeframe: Mid-term
+  - Seasonality: No
+  - Neural Networks: No
+  - Divergence: No
+  - Risk Level: Medium

--- a/API/2243_Binary_Wave_StDev/README_cn.md
+++ b/API/2243_Binary_Wave_StDev/README_cn.md
@@ -1,0 +1,49 @@
+# Binary Wave StdDev 策略
+[English](README.md) | [Русский](README_ru.md)
+
+该策略对 MA、MACD、CCI、动量、RSI 和 ADX 的信号按权重求和。
+当标准差表示的波动率超过阈值时，按累计得分的方向开仓。
+可选的止损和止盈以点为单位。
+
+## 细节
+
+- **入场条件**：
+  - 多头：得分 > 0 且 StdDev >= EntryVolatility
+  - 空头：得分 < 0 且 StdDev >= EntryVolatility
+- **出场条件**：
+  - 波动率下降到 ExitVolatility 以下
+- **止损/止盈**：通过 `UseStopLoss` 和 `UseTakeProfit` 可选
+- **默认值**：
+  - `WeightMa` = 1
+  - `WeightMacd` = 1
+  - `WeightCci` = 1
+  - `WeightMomentum` = 1
+  - `WeightRsi` = 1
+  - `WeightAdx` = 1
+  - `MaPeriod` = 13
+  - `FastMacd` = 12
+  - `SlowMacd` = 26
+  - `SignalMacd` = 9
+  - `CciPeriod` = 14
+  - `MomentumPeriod` = 14
+  - `RsiPeriod` = 14
+  - `AdxPeriod` = 14
+  - `StdDevPeriod` = 9
+  - `EntryVolatility` = 1.5
+  - `ExitVolatility` = 1
+  - `StopLossPoints` = 1000
+  - `TakeProfitPoints` = 2000
+  - `UseStopLoss` = false
+  - `UseTakeProfit` = false
+  - `CandleType` = TimeSpan.FromHours(4).TimeFrame()
+- **过滤**：
+  - 类别：趋势跟随
+  - 方向：双向
+  - 指标：MA、MACD、CCI、Momentum、RSI、ADX、StandardDeviation
+  - 止损：可选
+  - 复杂度：中
+  - 时间框架：中期
+  - 季节性：无
+  - 神经网络：无
+  - 背离：无
+  - 风险等级：中

--- a/API/2243_Binary_Wave_StDev/README_ru.md
+++ b/API/2243_Binary_Wave_StDev/README_ru.md
@@ -1,0 +1,49 @@
+# Стратегия Binary Wave StdDev
+[English](README.md) | [中文](README_cn.md)
+
+Стратегия суммирует сигналы от MA, MACD, CCI, Momentum, RSI и ADX с настраиваемыми весами.
+Сделки открываются по направлению итогового балла, если волатильность (стандартное отклонение) превышает порог.
+Стоп‑лосс и тейк‑профит в пунктах по желанию.
+
+## Детали
+
+- **Условия входа**:
+  - Лонг: балл > 0 и StdDev >= EntryVolatility
+  - Шорт: балл < 0 и StdDev >= EntryVolatility
+- **Условия выхода**:
+  - Волатильность падает ниже ExitVolatility
+- **Стопы**: опционально через `UseStopLoss` и `UseTakeProfit`
+- **Значения по умолчанию**:
+  - `WeightMa` = 1
+  - `WeightMacd` = 1
+  - `WeightCci` = 1
+  - `WeightMomentum` = 1
+  - `WeightRsi` = 1
+  - `WeightAdx` = 1
+  - `MaPeriod` = 13
+  - `FastMacd` = 12
+  - `SlowMacd` = 26
+  - `SignalMacd` = 9
+  - `CciPeriod` = 14
+  - `MomentumPeriod` = 14
+  - `RsiPeriod` = 14
+  - `AdxPeriod` = 14
+  - `StdDevPeriod` = 9
+  - `EntryVolatility` = 1.5
+  - `ExitVolatility` = 1
+  - `StopLossPoints` = 1000
+  - `TakeProfitPoints` = 2000
+  - `UseStopLoss` = false
+  - `UseTakeProfit` = false
+  - `CandleType` = TimeSpan.FromHours(4).TimeFrame()
+- **Фильтры**:
+  - Категория: Следование тренду
+  - Направление: Обе стороны
+  - Индикаторы: MA, MACD, CCI, Momentum, RSI, ADX, StandardDeviation
+  - Стопы: Опционально
+  - Сложность: Средняя
+  - Таймфрейм: Среднесрочный
+  - Сезонность: Нет
+  - Нейросети: Нет
+  - Дивергенция: Нет
+  - Уровень риска: Средний


### PR DESCRIPTION
## Summary
- add BinaryWaveStdDevStrategy combining multiple indicators with standard deviation volatility filter
- document strategy usage and parameters in English, Russian and Chinese

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c719e0b2d483238f3c3bb5f1771031