### PR TITLE
Use IsEmpty extension for string checks

### DIFF
--- a/API/1075_Motion/CS/MotionStrategy.cs
+++ b/API/1075_Motion/CS/MotionStrategy.cs
@@ -88,7 +88,7 @@ public class MotionStrategy : Strategy
 			return;
 
 		var text = Text;
-		if (string.IsNullOrEmpty(text))
+		if (text.IsEmpty())
 			return;
 
 		var step = Step;

--- a/API/1609_Session_Input_Parser/CS/SessionInputParserStrategy.cs
+++ b/API/1609_Session_Input_Parser/CS/SessionInputParserStrategy.cs
@@ -78,7 +78,7 @@ public class SessionInputParserStrategy : Strategy
 		var mEnd = int.Parse(endStr.Substring(2, 2));
 
 		int[] weekdays = Array.Empty<int>();
-		if (!string.IsNullOrEmpty(weekdaysPart))
+		if (!weekdaysPart.IsEmpty())
 			weekdays = weekdaysPart.Select(c => int.Parse(c.ToString())).ToArray();
 
 		return (hStart, mStart, hEnd, mEnd, weekdays);

--- a/API/1645_Price_Quotes_By_Email/CS/PriceQuotesByEmailStrategy.cs
+++ b/API/1645_Price_Quotes_By_Email/CS/PriceQuotesByEmailStrategy.cs
@@ -209,7 +209,7 @@ public class PriceQuotesByEmailStrategy : Strategy
 	        sb.AppendLine($"{pair.Key.Id}: {last} ({change:+0.##;-0.##;0}%)");
 	    }
 
-	    if (string.IsNullOrEmpty(SmtpHost) || string.IsNullOrEmpty(EmailFrom) || string.IsNullOrEmpty(EmailTo))
+	    if (SmtpHost.IsEmpty() || EmailFrom.IsEmpty() || EmailTo.IsEmpty())
 	        return;
 
 	    using var message = new MailMessage(EmailFrom, EmailTo)

--- a/API/1674_Shuriken_Lite/CS/ShurikenLiteStrategy.cs
+++ b/API/1674_Shuriken_Lite/CS/ShurikenLiteStrategy.cs
@@ -62,7 +62,7 @@ public class ShurikenLiteStrategy : Strategy
 			return;
 
 		var comment = order.Comment;
-		if (string.IsNullOrEmpty(comment))
+		if (comment.IsEmpty())
 			return;
 
 		if (!int.TryParse(comment, out var magic))

--- a/API/2553_Order_Notify/CS/OrderNotifyStrategy.cs
+++ b/API/2553_Order_Notify/CS/OrderNotifyStrategy.cs
@@ -292,7 +292,7 @@ public class OrderNotifyStrategy : Strategy
 				DeliveryMethod = SmtpDeliveryMethod.Network
 			};
 
-			if (!string.IsNullOrEmpty(SmtpUser))
+			if (!SmtpUser.IsEmpty())
 			{
 				client.Credentials = new NetworkCredential(SmtpUser, SmtpPassword ?? string.Empty);
 			}

--- a/API/2587_List_Positions/CS/ListPositionsStrategy.cs
+++ b/API/2587_List_Positions/CS/ListPositionsStrategy.cs
@@ -129,10 +129,10 @@ public class ListPositionsStrategy : Strategy
 				if (selectionMode == PositionSelectionMode.CurrentSymbol && currentSecurity != null && !Equals(position.Security, currentSecurity))
 					continue;
 
-				if (!string.IsNullOrEmpty(filter))
+				if (!filter.IsEmpty())
 				{
 					var strategyId = TryGetStrategyId(position);
-					if (!string.IsNullOrEmpty(strategyId) && strategyId.EqualsIgnoreCase(filter))
+					if (!strategyId.IsEmpty() && strategyId.EqualsIgnoreCase(filter))
 						continue;
 				}
 

--- a/API/2627_EES_Hedger/CS/EesHedgerStrategy.cs
+++ b/API/2627_EES_Hedger/CS/EesHedgerStrategy.cs
@@ -204,14 +204,14 @@ public class EesHedgerStrategy : Strategy
 		if (trade.Order.TransactionId != 0 && _ownOrderTransactions.Contains(trade.Order.TransactionId))
 		return;
 
-		if (!string.IsNullOrEmpty(HedgerOrderComment))
+		if (!HedgerOrderComment.IsEmpty())
 		{
 			var hedgeComment = trade.Order.Comment ?? string.Empty;
 			if (hedgeComment.Equals(HedgerOrderComment, StringComparison.InvariantCultureIgnoreCase))
 				return;
 		}
 
-		if (!string.IsNullOrEmpty(OriginalOrderComment))
+		if (!OriginalOrderComment.IsEmpty())
 		{
 		var comment = trade.Order.Comment ?? string.Empty;
 		if (!comment.Equals(OriginalOrderComment, StringComparison.InvariantCultureIgnoreCase))

--- a/API/2709_Risk_Fixed_Margin/CS/RiskFixedMarginStrategy.cs
+++ b/API/2709_Risk_Fixed_Margin/CS/RiskFixedMarginStrategy.cs
@@ -81,7 +81,7 @@ public class RiskFixedMarginStrategy : Strategy
 			return;
 
 		var status = BuildStatusMessage();
-		if (string.IsNullOrEmpty(status) || status == _lastStatus)
+		if (status.IsEmpty() || status == _lastStatus)
 			return;
 
 		_lastStatus = status;

--- a/API/2729_Show_Pips/CS/ShowPipsStrategy.cs
+++ b/API/2729_Show_Pips/CS/ShowPipsStrategy.cs
@@ -250,7 +250,7 @@ public class ShowPipsStrategy : Strategy
 	private void UpdateDisplay()
 	{
 		var text = BuildStatusText();
-		if (string.IsNullOrEmpty(text))
+		if (text.IsEmpty())
 			return;
 
 		switch (ShowType)
@@ -308,7 +308,7 @@ public class ShowPipsStrategy : Strategy
 		if (ShowSpread)
 		{
 			var spreadText = BuildSpreadText();
-			if (!string.IsNullOrEmpty(spreadText))
+			if (!spreadText.IsEmpty())
 			{
 				blocks.Add(spreadText);
 			}
@@ -317,7 +317,7 @@ public class ShowPipsStrategy : Strategy
 		if (ShowTime)
 		{
 			var timeText = BuildCountdownText();
-			if (!string.IsNullOrEmpty(timeText))
+			if (!timeText.IsEmpty())
 			{
 				blocks.Add(timeText);
 			}

--- a/API/2808_Multi_Pair_Closer/CS/MultiPairCloserStrategy.cs
+++ b/API/2808_Multi_Pair_Closer/CS/MultiPairCloserStrategy.cs
@@ -143,7 +143,7 @@ public class MultiPairCloserStrategy : Strategy
 		var raw = WatchedSymbols ?? string.Empty;
 		var tokens = raw.Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries)
 			.Select(t => t.Trim())
-			.Where(t => !string.IsNullOrEmpty(t))
+			.Where(t => !t.IsEmpty())
 			.ToArray();
 
 		if (tokens.Length == 0)

--- a/API/2977_ColorXPWMA_Digit_MTF/CS/ColorXpWmaDigitMultiTimeframeStrategy.cs
+++ b/API/2977_ColorXPWMA_Digit_MTF/CS/ColorXpWmaDigitMultiTimeframeStrategy.cs
@@ -169,7 +169,7 @@ public class ColorXpWmaDigitMultiTimeframeStrategy : Strategy
 		base.OnNewMyTrade(trade);
 
 		var comment = trade.Order.Comment;
-		if (string.IsNullOrEmpty(comment))
+		if (comment.IsEmpty())
 		return;
 
 		if (!TryParseComment(comment, out var processor, out var action))

--- a/API/3253_MultiTrader_Currency_Strength/CS/MultiTraderStrategy.cs
+++ b/API/3253_MultiTrader_Currency_Strength/CS/MultiTraderStrategy.cs
@@ -267,7 +267,7 @@ _canonicalToSecurity.Clear();
 foreach (var security in securities)
 {
 var canonical = GetCanonicalPair(security.Code);
-if (string.IsNullOrEmpty(canonical))
+if (canonical.IsEmpty())
 {
 LogWarning($"Unable to determine canonical code for security '{security.Id}'.");
 continue;
@@ -445,15 +445,15 @@ SellMarket(orderVolume, security);
 
 private string GetCanonicalPair(string code)
 {
-if (string.IsNullOrEmpty(code))
+if (code.IsEmpty())
 return string.Empty;
 
 var trimmed = code;
 
-if (!string.IsNullOrEmpty(SymbolPrefix) && trimmed.StartsWith(SymbolPrefix, StringComparison.OrdinalIgnoreCase))
+if (!SymbolPrefix.IsEmpty() && trimmed.StartsWith(SymbolPrefix, StringComparison.OrdinalIgnoreCase))
 trimmed = trimmed[SymbolPrefix.Length..];
 
-if (!string.IsNullOrEmpty(SymbolSuffix) && trimmed.EndsWith(SymbolSuffix, StringComparison.OrdinalIgnoreCase))
+if (!SymbolSuffix.IsEmpty() && trimmed.EndsWith(SymbolSuffix, StringComparison.OrdinalIgnoreCase))
 trimmed = trimmed[..^SymbolSuffix.Length];
 
 return trimmed.ToUpperInvariant();

--- a/API/3294_HistoryInfoEA/CS/HistoryInfoEaStrategy.cs
+++ b/API/3294_HistoryInfoEA/CS/HistoryInfoEaStrategy.cs
@@ -151,9 +151,9 @@ public class HistoryInfoEaStrategy : Strategy
 
 		return FilterType switch
 		{
-			HistoryInfoFilterType.CountByUserOrderId => !string.IsNullOrEmpty(MagicNumber) && order.UserOrderId.EqualsIgnoreCase(MagicNumber),
-			HistoryInfoFilterType.CountByComment => !string.IsNullOrEmpty(OrderComment) && order.Comment != null && order.Comment.StartsWith(OrderComment, StringComparison.Ordinal),
-			HistoryInfoFilterType.CountBySecurity => !string.IsNullOrEmpty(SecurityId) && order.Security?.Id != null && order.Security.Id.EqualsIgnoreCase(SecurityId),
+			HistoryInfoFilterType.CountByUserOrderId => !MagicNumber.IsEmpty() && order.UserOrderId.EqualsIgnoreCase(MagicNumber),
+			HistoryInfoFilterType.CountByComment => !OrderComment.IsEmpty() && order.Comment != null && order.Comment.StartsWith(OrderComment, StringComparison.Ordinal),
+			HistoryInfoFilterType.CountBySecurity => !SecurityId.IsEmpty() && order.Security?.Id != null && order.Security.Id.EqualsIgnoreCase(SecurityId),
 			_ => false
 		};
 	}

--- a/API/3325_ReversingMartingale/CS/ReversingMartingaleStrategy.cs
+++ b/API/3325_ReversingMartingale/CS/ReversingMartingaleStrategy.cs
@@ -207,7 +207,7 @@ public class ReversingMartingaleStrategy : Strategy
 		else
 			order = SellMarket(volume);
 
-		if (order != null && !string.IsNullOrEmpty(OrderComment))
+		if (order != null && !OrderComment.IsEmpty())
 			order.Comment = OrderComment;
 	}
 

--- a/API/3354_Couple_Hedge/CS/CoupleHedgeStrategy.cs
+++ b/API/3354_Couple_Hedge/CS/CoupleHedgeStrategy.cs
@@ -884,7 +884,7 @@ public class CoupleHedgeStrategy : Strategy
 
 	private Security LookupSecurity(string id)
 	{
-		if (string.IsNullOrEmpty(id))
+		if (id.IsEmpty())
 		return null;
 
 		var provider = SecurityProvider;

--- a/API/3384_Refresh28ChartsV3/CS/Refresh28ChartsV3Strategy.cs
+++ b/API/3384_Refresh28ChartsV3/CS/Refresh28ChartsV3Strategy.cs
@@ -144,7 +144,7 @@ public class Refresh28ChartsV3Strategy : Strategy
 		var raw = Symbols ?? string.Empty;
 		var tokens = raw.Split(new[] { ',', ';', '\n', '\r', '\t' }, StringSplitOptions.RemoveEmptyEntries)
 			.Select(t => t.Trim())
-			.Where(t => !string.IsNullOrEmpty(t))
+			.Where(t => !t.IsEmpty())
 			.Distinct(StringComparer.OrdinalIgnoreCase)
 			.ToArray();
 

--- a/API/3418_Galender/CS/GalenderStrategy.cs
+++ b/API/3418_Galender/CS/GalenderStrategy.cs
@@ -139,7 +139,7 @@ public class GalenderStrategy : Strategy
 
 		var text = ((news.Headline ?? string.Empty) + " " + (news.Story ?? string.Empty)).Trim();
 
-		if (string.IsNullOrEmpty(text))
+		if (text.IsEmpty())
 		{
 			return;
 		}

--- a/API/3472_Close_Orders/CS/CloseOrdersStrategy.cs
+++ b/API/3472_Close_Orders/CS/CloseOrdersStrategy.cs
@@ -130,7 +130,7 @@ public class CloseOrdersStrategy : Strategy
 			return 0m;
 
 		var magic = MagicNumber;
-		var filterEnabled = !string.IsNullOrEmpty(magic);
+		var filterEnabled = !magic.IsEmpty();
 
 		if (!filterEnabled && portfolio.CurrentProfit is decimal currentProfit)
 			return currentProfit;
@@ -160,7 +160,7 @@ public class CloseOrdersStrategy : Strategy
 	private void CancelMatchingOrders()
 	{
 		var magic = MagicNumber;
-		var filterEnabled = !string.IsNullOrEmpty(magic);
+		var filterEnabled = !magic.IsEmpty();
 
 		var snapshot = new List<Order>(ActiveOrders);
 		foreach (var order in snapshot)
@@ -179,7 +179,7 @@ public class CloseOrdersStrategy : Strategy
 			return;
 
 		var magic = MagicNumber;
-		var filterEnabled = !string.IsNullOrEmpty(magic);
+		var filterEnabled = !magic.IsEmpty();
 
 		foreach (var position in portfolio.Positions)
 		{
@@ -211,7 +211,7 @@ public class CloseOrdersStrategy : Strategy
 			return false;
 
 		var magic = MagicNumber;
-		var filterEnabled = !string.IsNullOrEmpty(magic);
+		var filterEnabled = !magic.IsEmpty();
 
 		foreach (var position in portfolio.Positions)
 		{
@@ -228,7 +228,7 @@ public class CloseOrdersStrategy : Strategy
 
 	private static bool MatchesMagicNumber(Position position, string magicNumber)
 	{
-		if (string.IsNullOrEmpty(magicNumber))
+		if (magicNumber.IsEmpty())
 			return true;
 
 		var value = position.StrategyId;

--- a/API/3525_Close_All_Control/CS/CloseAllControlStrategy.cs
+++ b/API/3525_Close_All_Control/CS/CloseAllControlStrategy.cs
@@ -290,10 +290,10 @@ public class CloseAllControlStrategy : Strategy
 	{
 		var filter = (OrderComment ?? string.Empty).Trim();
 
-		if (string.IsNullOrEmpty(filter))
+		if (filter.IsEmpty())
 			return true;
 
-		if (string.IsNullOrEmpty(comment))
+		if (comment.IsEmpty())
 			return false;
 
 		return comment.Trim().IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0;
@@ -303,7 +303,7 @@ public class CloseAllControlStrategy : Strategy
 	{
 		var filter = (CurrencyId ?? string.Empty).Trim();
 
-		if (string.IsNullOrEmpty(filter))
+		if (filter.IsEmpty())
 		{
 			if (!requireCurrency)
 				return true;
@@ -328,7 +328,7 @@ public class CloseAllControlStrategy : Strategy
 		if (order.Id != null && MatchesIdentifier(order.Id.ToString() ?? string.Empty))
 			return true;
 
-		if (!string.IsNullOrEmpty(order.UserOrderId) && MatchesIdentifier(order.UserOrderId))
+		if (!order.UserOrderId.IsEmpty() && MatchesIdentifier(order.UserOrderId))
 			return true;
 
 		return MatchesIdentifier(TryGetStrategyId(order));
@@ -346,7 +346,7 @@ public class CloseAllControlStrategy : Strategy
 		if (target <= 0)
 			return false;
 
-		if (string.IsNullOrEmpty(value))
+		if (value.IsEmpty())
 			return false;
 
 		if (long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))

--- a/API/3526_Close_All_MT5/CS/CloseAllMt5Strategy.cs
+++ b/API/3526_Close_All_MT5/CS/CloseAllMt5Strategy.cs
@@ -300,7 +300,7 @@ public class CloseAllMt5Strategy : Strategy
 			return true;
 
 		var strategyId = TryGetStrategyId(position);
-		if (!string.IsNullOrEmpty(strategyId) && strategyId.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0)
+		if (!strategyId.IsEmpty() && strategyId.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0)
 			return true;
 
 		return false;
@@ -495,7 +495,7 @@ public class CloseAllMt5Strategy : Strategy
 					return false;
 
 				var strategyId = TryGetStrategyId(position);
-				if (string.IsNullOrEmpty(strategyId))
+				if (strategyId.IsEmpty())
 					return false;
 
 				var magic = MagicNumber.ToString(CultureInfo.InvariantCulture);
@@ -508,7 +508,7 @@ public class CloseAllMt5Strategy : Strategy
 					return false;
 
 				var positionId = position.Id;
-				if (string.IsNullOrEmpty(positionId))
+				if (positionId.IsEmpty())
 					return false;
 
 				var ticket = TicketNumber.ToString(CultureInfo.InvariantCulture);

--- a/API/3540_Simple_Profit_By_Periods_Panel_2_Extended/CS/SimpleProfitByPeriodsPanel2ExtendedStrategy.cs
+++ b/API/3540_Simple_Profit_By_Periods_Panel_2_Extended/CS/SimpleProfitByPeriodsPanel2ExtendedStrategy.cs
@@ -146,7 +146,7 @@ public class SimpleProfitByPeriodsPanel2ExtendedStrategy : Strategy
 		var monthPercent = CalculatePercent(currentBalance, currentBalance - monthProfit);
 		
 		var currency = Portfolio?.Currency ?? Security?.Currency ?? string.Empty;
-		var currencyPrefix = string.IsNullOrEmpty(currency) ? string.Empty : currency + " ";
+		var currencyPrefix = currency.IsEmpty() ? string.Empty : currency + " ";
 		
 		Comment = string.Join(Environment.NewLine,
 			FormatProfitLine("Daily", currencyPrefix, dayProfit, dayPercent),

--- a/API/3565_News_Template_Universal/CS/NewsTemplateUniversalStrategy.cs
+++ b/API/3565_News_Template_Universal/CS/NewsTemplateUniversalStrategy.cs
@@ -280,10 +280,10 @@ public class NewsTemplateUniversalStrategy : Strategy
 		var headline = news.Headline ?? string.Empty;
 		var story = news.Story ?? string.Empty;
 
-		if (string.IsNullOrEmpty(headline))
+		if (headline.IsEmpty())
 		return story;
 
-		if (string.IsNullOrEmpty(story))
+		if (story.IsEmpty())
 		return headline;
 
 		return $"{headline} - {story}";

--- a/API/3574_LazyBot_V1/CS/LazyBotV1Strategy.cs
+++ b/API/3574_LazyBot_V1/CS/LazyBotV1Strategy.cs
@@ -473,7 +473,7 @@ public class LazyBotV1Strategy : Strategy
 	{
 		var symbol = Security?.Id ?? string.Empty;
 		var barsInfo = signalDate.ToString("yyyyMMdd");
-		return string.IsNullOrEmpty(symbol)
+		return symbol.IsEmpty()
 		? BotName
 		: $"{BotName};{symbol};{barsInfo}";
 	}

--- a/API/3579_XP_Trade_Manager_Grid/CS/XpTradeManagerGridStrategy.cs
+++ b/API/3579_XP_Trade_Manager_Grid/CS/XpTradeManagerGridStrategy.cs
@@ -896,7 +896,7 @@ entries.Add(entry);
 private static int? ExtractStage(string comment)
 {
 var digits = new string(comment.Where(char.IsDigit).ToArray());
-if (string.IsNullOrEmpty(digits))
+if (digits.IsEmpty())
 return null;
 
 if (int.TryParse(digits, NumberStyles.Integer, CultureInfo.InvariantCulture, out var stage))

--- a/API/3615_Check_Open_Orders/CS/CheckOpenOrdersStrategy.cs
+++ b/API/3615_Check_Open_Orders/CS/CheckOpenOrdersStrategy.cs
@@ -253,7 +253,7 @@ public class CheckOpenOrdersStrategy : Strategy
 
 	private void UpdateStatusMessage()
 	{
-		if (string.IsNullOrEmpty(_modeDescription))
+		if (_modeDescription.IsEmpty())
 		return;
 
 		var hasOpenOrders = HasOpenOrders();

--- a/API/3667_Get_Last_Nth_Close_Trade/CS/GetLastNthCloseTradeStrategy.cs
+++ b/API/3667_Get_Last_Nth_Close_Trade/CS/GetLastNthCloseTradeStrategy.cs
@@ -190,7 +190,7 @@ public class GetLastNthCloseTradeStrategy : Strategy
 		if (EnableMagicNumber)
 		{
 			var comment = order.Comment?.Trim();
-			if (string.IsNullOrEmpty(comment))
+			if (comment.IsEmpty())
 			return false;
 
 			if (!long.TryParse(comment, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))

--- a/API/3668_Get_Last_Nth_Open_Trade/CS/Get_Last_Nth_Open_TradeStrategy.cs
+++ b/API/3668_Get_Last_Nth_Open_Trade/CS/Get_Last_Nth_Open_TradeStrategy.cs
@@ -143,7 +143,7 @@ public class Get_Last_Nth_Open_TradeStrategy : Strategy
 				if (EnableMagicNumber)
 				{
 					var strategyId = TryGetStrategyId(position);
-					if (string.IsNullOrEmpty(strategyId))
+					if (strategyId.IsEmpty())
 						continue;
 
 					if (!strategyId.EqualsIgnoreCase(MagicNumber))
@@ -183,7 +183,7 @@ public class Get_Last_Nth_Open_TradeStrategy : Strategy
 			builder.AppendLine($"LastChangeTime: {selected.LastChangeTime:yyyy-MM-dd HH:mm:ss}");
 
 			var strategyIdText = TryGetStrategyId(selected);
-			if (!string.IsNullOrEmpty(strategyIdText))
+			if (!strategyIdText.IsEmpty())
 				builder.AppendLine($"StrategyId: {strategyIdText}");
 
 			LogInfo(builder.ToString().TrimEnd());

--- a/API/3669_Get_Last_Nth_Closed_Trade/CS/GetLastNthClosedTradeStrategy.cs
+++ b/API/3669_Get_Last_Nth_Closed_Trade/CS/GetLastNthClosedTradeStrategy.cs
@@ -183,7 +183,7 @@ public class GetLastNthClosedTradeStrategy : Strategy
 		{
 		var filter = StrategyIdFilter;
 		var orderStrategyId = trade.Order.StrategyId;
-		var target = string.IsNullOrEmpty(filter) ? Id.ToString() : filter;
+		var target = filter.IsEmpty() ? Id.ToString() : filter;
 
 		if (!orderStrategyId.EqualsIgnoreCase(target))
 		return false;

--- a/API/3690_Close_Agent/CS/CloseAgentStrategy.cs
+++ b/API/3690_Close_Agent/CS/CloseAgentStrategy.cs
@@ -322,12 +322,12 @@ public class CloseAgentStrategy : Strategy
 			case CloseAgentMode.Auto:
 			{
 				var strategyId = TryGetStrategyId(position);
-				return !string.IsNullOrEmpty(strategyId) && strategyId.EqualsIgnoreCase(Id);
+				return !strategyId.IsEmpty() && strategyId.EqualsIgnoreCase(Id);
 			}
 			case CloseAgentMode.Manual:
 			{
 				var strategyId = TryGetStrategyId(position);
-				return string.IsNullOrEmpty(strategyId) || !strategyId.EqualsIgnoreCase(Id);
+				return strategyId.IsEmpty() || !strategyId.EqualsIgnoreCase(Id);
 			}
 			default:
 				return true;

--- a/API/3697_Symbol_Swap/CS/SymbolSwapStrategy.cs
+++ b/API/3697_Symbol_Swap/CS/SymbolSwapStrategy.cs
@@ -160,7 +160,7 @@ public class SymbolSwapStrategy : Strategy
 
 	private void TryApplyPendingSecurity()
 	{
-		if (string.IsNullOrEmpty(_pendingSecurityId))
+		if (_pendingSecurityId.IsEmpty())
 			return;
 
 		var candidate = SecurityProvider?.LookupById(_pendingSecurityId);
@@ -239,7 +239,7 @@ public class SymbolSwapStrategy : Strategy
 	private void UpdatePanel()
 	{
 		var text = BuildPanelText();
-		if (string.IsNullOrEmpty(text))
+		if (text.IsEmpty())
 			return;
 
 		switch (OutputMode)
@@ -281,7 +281,7 @@ public class SymbolSwapStrategy : Strategy
 		builder.AppendLine(GetTimeFrameName());
 
 		builder.Append("Symbol: ");
-		builder.AppendLine(!string.IsNullOrEmpty(security.Code) ? security.Code : security.Id);
+		builder.AppendLine(!security.Code.IsEmpty() ? security.Code : security.Id);
 
 		builder.Append("Close Price: ");
 		builder.AppendLine(FormatDecimal(_lastClose));

--- a/API/3698_Symbol_Swap_Panel/CS/SymbolSwapPanelStrategy.cs
+++ b/API/3698_Symbol_Swap_Panel/CS/SymbolSwapPanelStrategy.cs
@@ -181,7 +181,7 @@ public class SymbolSwapPanelStrategy : Strategy
 		if (!requested)
 			return;
 
-		if (string.IsNullOrEmpty(target))
+		if (target.IsEmpty())
 		{
 			LogWarning("Swap requested but the target security ID is empty.");
 

--- a/API/3705_Magic_Number_Wise_EA_Profit_Loss_Dashboard/CS/MagicNumberWiseEaProfitLossDashboardStrategy.cs
+++ b/API/3705_Magic_Number_Wise_EA_Profit_Loss_Dashboard/CS/MagicNumberWiseEaProfitLossDashboardStrategy.cs
@@ -132,7 +132,7 @@ public class MagicNumberWiseEaProfitLossDashboardStrategy : Strategy
 		{
 			var summary = GetOrCreateSummary(identifier);
 
-			if (!string.IsNullOrEmpty(comment) && string.IsNullOrEmpty(summary.Comment))
+			if (!comment.IsEmpty() && summary.Comment.IsEmpty())
 				summary.Comment = comment;
 
 			UpdateSymbol(summary, symbol);
@@ -154,9 +154,9 @@ public class MagicNumberWiseEaProfitLossDashboardStrategy : Strategy
 			summary.DealCount++;
 			summary.ClosedPnL += trade.PnL;
 
-			if (GroupByComment && string.IsNullOrEmpty(summary.Comment))
+			if (GroupByComment && summary.Comment.IsEmpty())
 				summary.Comment = identifier;
-			else if (!string.IsNullOrEmpty(comment) && string.IsNullOrEmpty(summary.Comment))
+			else if (!comment.IsEmpty() && summary.Comment.IsEmpty())
 				summary.Comment = comment;
 
 			UpdateSymbol(summary, tradeSecurity);
@@ -188,8 +188,8 @@ public class MagicNumberWiseEaProfitLossDashboardStrategy : Strategy
 			foreach (var snapshot in snapshots)
 			{
 				var floatingText = snapshot.HasFloating ? snapshot.FloatingPnL.ToString("0.##") : "-";
-				var symbol = string.IsNullOrEmpty(snapshot.Symbol) ? "-" : snapshot.Symbol;
-				var comment = string.IsNullOrEmpty(snapshot.Comment) ? "-" : snapshot.Comment;
+				var symbol = snapshot.Symbol.IsEmpty() ? "-" : snapshot.Symbol;
+				var comment = snapshot.Comment.IsEmpty() ? "-" : snapshot.Comment;
 
 				builder.AppendLine(string.Format(
 					"{0,-10} | {1,5} | {2,11:0.##} | {3,12} | {4,-12} | {5}",
@@ -256,7 +256,7 @@ public class MagicNumberWiseEaProfitLossDashboardStrategy : Strategy
 		foreach (var position in portfolio.Positions)
 		{
 			var symbol = position.Security?.Id;
-			if (string.IsNullOrEmpty(symbol))
+			if (symbol.IsEmpty())
 				continue;
 
 			if (!_symbolMap.TryGetValue(symbol, out var summary))
@@ -280,10 +280,10 @@ public class MagicNumberWiseEaProfitLossDashboardStrategy : Strategy
 
 	private void UpdateSymbol(Summary summary, string symbol)
 	{
-		if (string.IsNullOrEmpty(symbol))
+		if (symbol.IsEmpty())
 			return;
 
-		if (!string.IsNullOrEmpty(summary.Symbol))
+		if (!summary.Symbol.IsEmpty())
 		{
 			if (summary.Symbol.EqualsIgnoreCase(symbol))
 				return;
@@ -305,18 +305,18 @@ public class MagicNumberWiseEaProfitLossDashboardStrategy : Strategy
 
 		if (GroupByComment)
 		{
-			if (!string.IsNullOrEmpty(comment))
+			if (!comment.IsEmpty())
 				return comment;
 
-			if (!string.IsNullOrEmpty(userOrderId))
+			if (!userOrderId.IsEmpty())
 				return userOrderId;
 		}
 		else
 		{
-			if (!string.IsNullOrEmpty(userOrderId))
+			if (!userOrderId.IsEmpty())
 				return userOrderId;
 
-			if (!string.IsNullOrEmpty(comment))
+			if (!comment.IsEmpty())
 				return comment;
 		}
 

--- a/API/3726_Auto_Close_On_Profit_Loss/CS/AutoCloseOnProfitLossStrategy.cs
+++ b/API/3726_Auto_Close_On_Profit_Loss/CS/AutoCloseOnProfitLossStrategy.cs
@@ -179,7 +179,7 @@ public class AutoCloseOnProfitLossStrategy : Strategy
 
 	private void TriggerCloseAll()
 	{
-		if (ShowAlerts && !string.IsNullOrEmpty(_pendingReason))
+		if (ShowAlerts && !_pendingReason.IsEmpty())
 			LogInfo($"Closing all positions. Reason: {_pendingReason}.");
 
 		_closeAllRequested = true;

--- a/API/3759_DAlembert_Exposure_Balancer/CS/DAlembertExposureBalancerStrategy.cs
+++ b/API/3759_DAlembert_Exposure_Balancer/CS/DAlembertExposureBalancerStrategy.cs
@@ -571,7 +571,7 @@ public class DAlembertExposureBalancerStrategy : Strategy
 	private static (string Base, string Quote) ExtractCurrencies(Security security)
 	{
 		var code = security?.Code;
-		if (string.IsNullOrEmpty(code) || code.Length < 6)
+		if (code.IsEmpty() || code.Length < 6)
 		return (null, null);
 
 		var baseCurrency = code.Substring(0, 3);

--- a/API/3980_EES_Hedger/CS/EesHedgerAdvancedStrategy.cs
+++ b/API/3980_EES_Hedger/CS/EesHedgerAdvancedStrategy.cs
@@ -216,14 +216,14 @@ public class EesHedgerAdvancedStrategy : Strategy
 		if (trade.Order.TransactionId != 0 && _ownOrderTransactions.Contains(trade.Order.TransactionId))
 		return;
 
-		if (!string.IsNullOrEmpty(HedgerOrderComment))
+		if (!HedgerOrderComment.IsEmpty())
 		{
 			var hedgeComment = trade.Order.Comment ?? string.Empty;
 			if (hedgeComment.Equals(HedgerOrderComment, StringComparison.InvariantCultureIgnoreCase))
 			return;
 		}
 
-		if (!string.IsNullOrEmpty(OriginalOrderComment))
+		if (!OriginalOrderComment.IsEmpty())
 		{
 			var comment = trade.Order.Comment ?? string.Empty;
 			if (!comment.Equals(OriginalOrderComment, StringComparison.InvariantCultureIgnoreCase))

--- a/API/4146_Trade_Arbitrage/CS/TradeArbitrageStrategy.cs
+++ b/API/4146_Trade_Arbitrage/CS/TradeArbitrageStrategy.cs
@@ -692,12 +692,12 @@ private bool TryComputeVariantQuotes(Variant variant, out decimal bid, out decim
 						if (provider == null)
 						throw new InvalidOperationException("Security provider is not configured.");
 
-						if (string.IsNullOrEmpty(SymbolSuffix) && Security?.Code is string code && code.Length > 6)
-						{
-							var suffix = code.Substring(6);
-							if (!string.IsNullOrEmpty(suffix))
-							SymbolSuffix = suffix;
-						}
+if (SymbolSuffix.IsEmpty() && Security?.Code is string code && code.Length > 6)
+{
+var suffix = code.Substring(6);
+if (!suffix.IsEmpty())
+SymbolSuffix = suffix;
+}
 
 						var resolved = new Dictionary<string, Security>(StringComparer.OrdinalIgnoreCase);
 
@@ -805,7 +805,7 @@ private Security ResolveSecurity(ISecurityProvider provider, string symbol)
 {
 	Security security = null;
 
-	if (!string.IsNullOrEmpty(SymbolSuffix))
+	if (!SymbolSuffix.IsEmpty())
 	{
 		security = provider.LookupById(symbol + SymbolSuffix);
 	}

--- a/API/4193_EA_MA_Email/CS/EaMaEmailStrategy.cs
+++ b/API/4193_EA_MA_Email/CS/EaMaEmailStrategy.cs
@@ -276,7 +276,7 @@ public class EaMaEmailStrategy : Strategy
 	private void LogAlert(string fastLabel, string slowLabel, string direction, ICandleMessage candle)
 	{
 		var securityId = Security?.Id ?? "Unknown";
-		var period = string.IsNullOrEmpty(_periodDescription) ? CandleType.ToString() : _periodDescription;
+		var period = _periodDescription.IsEmpty() ? CandleType.ToString() : _periodDescription;
 		var subject = $"{securityId} {fastLabel}{direction}{slowLabel} {period}";
 		var body = $"Date and Time: {candle.CloseTime:yyyy-MM-dd HH:mm:ss}; Instrument: {securityId}; Close: {candle.ClosePrice:0.#####}";
 

--- a/API/4198_AutoMagiCal/CS/AutoMagiCalStrategy.cs
+++ b/API/4198_AutoMagiCal/CS/AutoMagiCalStrategy.cs
@@ -44,7 +44,7 @@ public class AutoMagiCalStrategy : Strategy
 	{
 		var symbol = Security?.Id ?? Security?.Code;
 
-		if (string.IsNullOrEmpty(symbol))
+		if (symbol.IsEmpty())
 		{
 			LogError("Security is not assigned. Unable to generate magic number.");
 			return;

--- a/API/4206_MACDNotSoSample/CS/MacdNotSoSampleStrategy.cs
+++ b/API/4206_MACDNotSoSample/CS/MacdNotSoSampleStrategy.cs
@@ -185,7 +185,7 @@ public class MacdNotSoSampleStrategy : Strategy
 		Volume = TradeVolume; // Align helper order volume with the configured trade size.
 
 		var requiredCode = RequiredSecurityCode;
-		if (!string.IsNullOrEmpty(requiredCode) && Security?.Code is string code && !code.EqualsIgnoreCase(requiredCode))
+		if (!requiredCode.IsEmpty() && Security?.Code is string code && !code.EqualsIgnoreCase(requiredCode))
 		{
 			LogWarning($"Configured security {code} does not match required code {requiredCode}. Strategy will stop to mimic MetaTrader checks.");
 			Stop();

--- a/API/4207_Rich_Kohonen_Map/CS/RichKohonenMapStrategy.cs
+++ b/API/4207_Rich_Kohonen_Map/CS/RichKohonenMapStrategy.cs
@@ -443,7 +443,7 @@ public class RichKohonenMapStrategy : Strategy
 		try
 		{
 			var directory = Path.GetDirectoryName(path);
-			if (!string.IsNullOrEmpty(directory))
+			if (!directory.IsEmpty())
 				Directory.CreateDirectory(directory);
 
 			using var stream = File.Open(path, FileMode.Create, FileAccess.Write, FileShare.None);


### PR DESCRIPTION
## Summary
- replace `string.IsNullOrEmpty` calls with the `IsEmpty` extension across the affected strategies to align with the shared helper usage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7ad9892ec8323beb086c067faf8f6