### PR TITLE
Make tuning constants configurable via strategy parameters

### DIFF
--- a/API/2710_VR_Overturn/CS/VrOverturnStrategy.cs
+++ b/API/2710_VR_Overturn/CS/VrOverturnStrategy.cs
@@ -14,7 +14,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class VrOverturnStrategy : Strategy
 {
-	private const decimal VolumeEpsilon = 1e-6m;
+	private readonly StrategyParam<decimal> _volumeEpsilon;
 
 	private enum InitialDirection
 	{
@@ -67,31 +67,44 @@ public class VrOverturnStrategy : Strategy
 	/// </summary>
 	public VrOverturnStrategy()
 	{
+		_volumeEpsilon = Param(nameof(VolumeEpsilon), 1e-6m)
+			.SetGreaterThan(0m)
+			.SetDisplay("Volume Epsilon", "Minimum volume threshold to treat position as flat", "Risk");
+
 		_initialDirection = Param(nameof(FirstPositionDirection), InitialDirection.Buy)
-		.SetDisplay("Initial Direction", "Direction of the very first trade", "Trading");
+			.SetDisplay("Initial Direction", "Direction of the very first trade", "Trading");
 
 		_tradeMode = Param(nameof(Mode), TradeMode.Martingale)
-		.SetDisplay("Trading Mode", "Choose martingale or anti-martingale sizing", "Trading");
+			.SetDisplay("Trading Mode", "Choose martingale or anti-martingale sizing", "Trading");
 
 		_baseVolume = Param(nameof(BaseVolume), 0.1m)
-		.SetGreaterThanZero()
-		.SetDisplay("Base Volume", "Initial order size", "Risk")
-		.SetCanOptimize(true);
+			.SetGreaterThanZero()
+			.SetDisplay("Base Volume", "Initial order size", "Risk")
+			.SetCanOptimize(true);
 
 		_stopLossPips = Param(nameof(StopLossPips), 30)
-		.SetGreaterThanZero()
-		.SetDisplay("Stop Loss (pips)", "Distance to stop loss in pips", "Risk")
-		.SetCanOptimize(true);
+			.SetGreaterThanZero()
+			.SetDisplay("Stop Loss (pips)", "Distance to stop loss in pips", "Risk")
+			.SetCanOptimize(true);
 
 		_takeProfitPips = Param(nameof(TakeProfitPips), 90)
-		.SetGreaterThanZero()
-		.SetDisplay("Take Profit (pips)", "Distance to take profit in pips", "Risk")
-		.SetCanOptimize(true);
+			.SetGreaterThanZero()
+			.SetDisplay("Take Profit (pips)", "Distance to take profit in pips", "Risk")
+			.SetCanOptimize(true);
 
 		_lotMultiplier = Param(nameof(LotMultiplier), 1.6m)
-		.SetGreaterThanZero()
-		.SetDisplay("Lot Multiplier", "Multiplier applied after losses or wins", "Risk")
-		.SetCanOptimize(true);
+			.SetGreaterThanZero()
+			.SetDisplay("Lot Multiplier", "Multiplier applied after losses or wins", "Risk")
+			.SetCanOptimize(true);
+	}
+
+	/// <summary>
+	/// Volume tolerance used to consider a position fully closed.
+	/// </summary>
+	public decimal VolumeEpsilon
+	{
+		get => _volumeEpsilon.Value;
+		set => _volumeEpsilon.Value = value;
 	}
 
 	/// <summary>

--- a/API/2714_Billy_Expert/CS/BillyExpertStrategy.cs
+++ b/API/2714_Billy_Expert/CS/BillyExpertStrategy.cs
@@ -14,7 +14,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class BillyExpertStrategy : Strategy
 {
-	private const decimal VolumeTolerance = 0.0000001m;
+	private readonly StrategyParam<decimal> _volumeTolerance;
 
 	private readonly StrategyParam<decimal> _tradeVolume;
 	private readonly StrategyParam<int> _stopLossPips;
@@ -54,6 +54,15 @@ public class BillyExpertStrategy : Strategy
 	private bool _slowHasPrevious;
 
 	private decimal _pipSize;
+
+	/// <summary>
+	/// Volume tolerance used to compare accumulated volumes.
+	/// </summary>
+	public decimal VolumeTolerance
+	{
+		get => _volumeTolerance.Value;
+		set => _volumeTolerance.Value = value;
+	}
 
 	/// <summary>
 	/// Trade volume used for each entry.
@@ -123,6 +132,10 @@ public class BillyExpertStrategy : Strategy
 	/// </summary>
 	public BillyExpertStrategy()
 	{
+		_volumeTolerance = Param(nameof(VolumeTolerance), 0.0000001m)
+			.SetGreaterThan(0m)
+			.SetDisplay("Volume Tolerance", "Tolerance for comparing volume sums", "Risk");
+
 		_tradeVolume = Param(nameof(TradeVolume), 0.01m)
 		.SetGreaterThanZero()
 		.SetDisplay("Trade Volume", "Order size for each entry", "General");

--- a/API/2769_EMA_Cross_Contest_Hedged/CS/EmaCrossContestHedgedStrategy.cs
+++ b/API/2769_EMA_Cross_Contest_Hedged/CS/EmaCrossContestHedgedStrategy.cs
@@ -20,10 +20,10 @@ public class EmaCrossContestHedgedStrategy : Strategy
 		Previous
 	}
 
-	private const int PendingOrderCount = 4;
-	private const int MacdFastLength = 4;
-	private const int MacdSlowLength = 24;
-	private const int MacdSignalLength = 12;
+	private readonly StrategyParam<int> _pendingOrderCount;
+	private readonly StrategyParam<int> _macdFastLength;
+	private readonly StrategyParam<int> _macdSlowLength;
+	private readonly StrategyParam<int> _macdSignalLength;
 
 	private readonly StrategyParam<decimal> _orderVolume;
 	private readonly StrategyParam<int> _stopLossPips;
@@ -113,10 +113,46 @@ public class EmaCrossContestHedgedStrategy : Strategy
 		set => _useMacdFilter.Value = value;
 	}
 
+	/// <summary>
+	/// Number of pending stop orders per direction.
+	/// </summary>
+	public int PendingOrderCount
+	{
+		get => _pendingOrderCount.Value;
+		set => _pendingOrderCount.Value = value;
+	}
+
 	public int PendingExpirationSeconds
 	{
 		get => _pendingExpirationSeconds.Value;
 		set => _pendingExpirationSeconds.Value = value;
+	}
+
+	/// <summary>
+	/// Fast moving average length for the MACD filter.
+	/// </summary>
+	public int MacdFastLength
+	{
+		get => _macdFastLength.Value;
+		set => _macdFastLength.Value = value;
+	}
+
+	/// <summary>
+	/// Slow moving average length for the MACD filter.
+	/// </summary>
+	public int MacdSlowLength
+	{
+		get => _macdSlowLength.Value;
+		set => _macdSlowLength.Value = value;
+	}
+
+	/// <summary>
+	/// Signal moving average length for the MACD filter.
+	/// </summary>
+	public int MacdSignalLength
+	{
+		get => _macdSignalLength.Value;
+		set => _macdSignalLength.Value = value;
 	}
 
 	public int ShortMaPeriod
@@ -170,8 +206,24 @@ public class EmaCrossContestHedgedStrategy : Strategy
 		_useMacdFilter = Param(nameof(UseMacdFilter), false)
 			.SetDisplay("Use MACD", "Require MACD confirmation", "Filters");
 
+		_pendingOrderCount = Param(nameof(PendingOrderCount), 4)
+			.SetGreaterThanZero()
+			.SetDisplay("Pending Orders", "Pending stop orders per side", "Orders");
+
 		_pendingExpirationSeconds = Param(nameof(PendingExpirationSeconds), 65535)
 			.SetDisplay("Pending Expiration (s)", "Lifetime of hedging stop orders in seconds", "Orders");
+
+		_macdFastLength = Param(nameof(MacdFastLength), 4)
+			.SetGreaterThanZero()
+			.SetDisplay("MACD Fast Length", "Fast EMA length for MACD", "Indicators");
+
+		_macdSlowLength = Param(nameof(MacdSlowLength), 24)
+			.SetGreaterThanZero()
+			.SetDisplay("MACD Slow Length", "Slow EMA length for MACD", "Indicators");
+
+		_macdSignalLength = Param(nameof(MacdSignalLength), 12)
+			.SetGreaterThanZero()
+			.SetDisplay("MACD Signal Length", "Signal EMA length for MACD", "Indicators");
 
 		_shortMaPeriod = Param(nameof(ShortMaPeriod), 4)
 			.SetGreaterThanZero()

--- a/API/2771_Trailing_Stop_And_Take/CS/TrailingStopAndTakeStrategy.cs
+++ b/API/2771_Trailing_Stop_And_Take/CS/TrailingStopAndTakeStrategy.cs
@@ -19,7 +19,7 @@ public enum TrailingPositionType
 /// </summary>
 public class TrailingStopAndTakeStrategy : Strategy
 {
-	private const decimal Epsilon = 0.0000001m;
+	private readonly StrategyParam<decimal> _epsilon;
 
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<TrailingPositionType> _positionType;
@@ -75,6 +75,10 @@ public class TrailingStopAndTakeStrategy : Strategy
 		_trailingStepPoints = Param(nameof(TrailingStepPoints), 10m)
 			.SetRange(0m, 1000m)
 			.SetDisplay("Trailing Step", "Minimum movement required before adjusting targets", "Risk");
+
+		_epsilon = Param(nameof(Epsilon), 0.0000001m)
+			.SetGreaterThan(0m)
+			.SetDisplay("Trailing Epsilon", "Minimum trailing step size", "Risk");
 
 		_allowTrailingLoss = Param(nameof(AllowTrailingLoss), false)
 			.SetDisplay("Trail In Loss", "Allow trailing while position is not yet profitable", "Risk");
@@ -151,6 +155,15 @@ public class TrailingStopAndTakeStrategy : Strategy
 		get => _trailingStepPoints.Value;
 		set => _trailingStepPoints.Value = value;
 	}
+	/// <summary>
+	/// Minimum trailing step size used as a floor.
+	/// </summary>
+	public decimal Epsilon
+	{
+		get => _epsilon.Value;
+		set => _epsilon.Value = value;
+	}
+
 
 	/// <summary>
 	/// Enables trailing adjustments while the position remains in the loss zone.

--- a/API/2773_Channels_Envelope_Cross/CS/ChannelsEnvelopeCrossStrategy.cs
+++ b/API/2773_Channels_Envelope_Cross/CS/ChannelsEnvelopeCrossStrategy.cs
@@ -15,9 +15,9 @@ using StockSharp.Messages;
 /// </summary>
 public class ChannelsEnvelopeCrossStrategy : Strategy
 {
-	private const decimal Envelope003 = 0.3m / 100m;
-	private const decimal Envelope007 = 0.7m / 100m;
-	private const decimal Envelope010 = 1.0m / 100m;
+	private readonly StrategyParam<decimal> _envelope003;
+	private readonly StrategyParam<decimal> _envelope007;
+	private readonly StrategyParam<decimal> _envelope010;
 
 	private readonly StrategyParam<decimal> _orderVolume;
 	private readonly StrategyParam<bool> _useTradeHours;
@@ -160,6 +160,33 @@ public class ChannelsEnvelopeCrossStrategy : Strategy
 	}
 
 	/// <summary>
+	/// Percentage width for the 0.3% envelope band.
+	/// </summary>
+	public decimal Envelope003
+	{
+		get => _envelope003.Value;
+		set => _envelope003.Value = value;
+	}
+
+	/// <summary>
+	/// Percentage width for the 0.7% envelope band.
+	/// </summary>
+	public decimal Envelope007
+	{
+		get => _envelope007.Value;
+		set => _envelope007.Value = value;
+	}
+
+	/// <summary>
+	/// Percentage width for the 1.0% envelope band.
+	/// </summary>
+	public decimal Envelope010
+	{
+		get => _envelope010.Value;
+		set => _envelope010.Value = value;
+	}
+
+	/// <summary>
 	/// Initializes a new instance of <see cref="ChannelsEnvelopeCrossStrategy"/>.
 	/// </summary>
 	public ChannelsEnvelopeCrossStrategy()
@@ -197,6 +224,18 @@ public class ChannelsEnvelopeCrossStrategy : Strategy
 
 		_trailingStepPips = Param(nameof(TrailingStepPips), 1)
 		.SetDisplay("Trailing Step (pips)", "Minimum increment for trailing stop", "Risk");
+
+		_envelope003 = Param(nameof(Envelope003), 0.3m / 100m)
+			.SetGreaterThan(0m)
+			.SetDisplay("Envelope 0.3%", "Width of the 0.3% envelope", "Indicators");
+
+		_envelope007 = Param(nameof(Envelope007), 0.7m / 100m)
+			.SetGreaterThan(0m)
+			.SetDisplay("Envelope 0.7%", "Width of the 0.7% envelope", "Indicators");
+
+		_envelope010 = Param(nameof(Envelope010), 1.0m / 100m)
+			.SetGreaterThan(0m)
+			.SetDisplay("Envelope 1.0%", "Width of the 1.0% envelope", "Indicators");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(1).TimeFrame())
 		.SetDisplay("Candle Type", "Time frame used for calculations", "General");

--- a/API/2781_Open_Time_Two_Sessions/CS/OpenTimeTwoStrategy.cs
+++ b/API/2781_Open_Time_Two_Sessions/CS/OpenTimeTwoStrategy.cs
@@ -13,7 +13,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class OpenTimeTwoStrategy : Strategy
 {
-	private const int SecondsInDay = 24 * 60 * 60;
+	private readonly StrategyParam<int> _secondsInDay;
 
 	private readonly StrategyParam<bool> _useClosingWindowOne;
 	private readonly StrategyParam<TimeSpan> _closeWindowOneStart;
@@ -190,6 +190,15 @@ public class OpenTimeTwoStrategy : Strategy
 	}
 
 	/// <summary>
+	/// Total number of seconds considered a full trading day.
+	/// </summary>
+	public int SecondsInDay
+	{
+		get => _secondsInDay.Value;
+		set => _secondsInDay.Value = value;
+	}
+
+	/// <summary>
 	/// Trade direction for interval one (true for buy, false for sell).
 	/// </summary>
 	public bool IntervalOneBuy
@@ -325,6 +334,10 @@ public class OpenTimeTwoStrategy : Strategy
 		_duration = Param(nameof(Duration), TimeSpan.FromSeconds(30))
 			.SetDisplay("Window Duration", "Extra duration added to opening/closing windows", "Opening")
 			.SetRange(TimeSpan.Zero, TimeSpan.FromHours(1));
+
+		_secondsInDay = Param(nameof(SecondsInDay), 24 * 60 * 60)
+			.SetGreaterThanZero()
+			.SetDisplay("Seconds In Day", "Total number of seconds in a trading day", "Opening");
 
 		_intervalOneBuy = Param(nameof(IntervalOneBuy), true)
 			.SetDisplay("Direction #1", "Trade direction for interval #1 (Buy=true)", "Opening")

--- a/API/2794_Aeron_JJN_Scalper_EA/CS/AeronJjnScalperEaStrategy.cs
+++ b/API/2794_Aeron_JJN_Scalper_EA/CS/AeronJjnScalperEaStrategy.cs
@@ -13,8 +13,8 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class AeronJjnScalperEaStrategy : Strategy
 {
-	private const int AtrLength = 8;
-	private const int HistoryDepth = 120;
+	private readonly StrategyParam<int> _atrLength;
+	private readonly StrategyParam<int> _historyDepth;
 
 	private readonly StrategyParam<decimal> _trailingStopPips;
 	private readonly StrategyParam<decimal> _trailingStepPips;
@@ -103,6 +103,24 @@ public class AeronJjnScalperEaStrategy : Strategy
 	}
 
 	/// <summary>
+	/// ATR indicator period used to evaluate volatility.
+	/// </summary>
+	public int AtrLength
+	{
+		get => _atrLength.Value;
+		set => _atrLength.Value = value;
+	}
+
+	/// <summary>
+	/// Maximum number of stored candle snapshots for pattern checks.
+	/// </summary>
+	public int HistoryDepth
+	{
+		get => _historyDepth.Value;
+		set => _historyDepth.Value = value;
+	}
+
+	/// <summary>
 	/// Create strategy instance.
 	/// </summary>
 	public AeronJjnScalperEaStrategy()
@@ -124,6 +142,14 @@ public class AeronJjnScalperEaStrategy : Strategy
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(1).TimeFrame())
 		.SetDisplay("Candle Type");
+
+		_atrLength = Param(nameof(AtrLength), 8)
+			.SetGreaterThanZero()
+			.SetDisplay("ATR Length", "ATR indicator period", "Indicators");
+
+		_historyDepth = Param(nameof(HistoryDepth), 120)
+			.SetGreaterThanZero()
+			.SetDisplay("History Depth", "Number of candles stored for patterns", "Indicators");
 
 		Volume = 0.1m;
 	}

--- a/API/2830_BSS_Triple_EMA_Separation/CS/BssTripleEmaSeparationStrategy.cs
+++ b/API/2830_BSS_Triple_EMA_Separation/CS/BssTripleEmaSeparationStrategy.cs
@@ -19,7 +19,7 @@ public enum MaMethod
 public class BssTripleEmaSeparationStrategy : Strategy
 {
 	// Small epsilon used to compare decimal volumes without floating point noise.
-	private const decimal VolumeTolerance = 1e-8m;
+	private readonly StrategyParam<decimal> _volumeTolerance;
 
 	// User configurable parameters.
 	private readonly StrategyParam<decimal> _orderVolume;
@@ -41,6 +41,15 @@ public class BssTripleEmaSeparationStrategy : Strategy
 
 	// Timestamp of the last position entry used to enforce the pause between trades.
 	private DateTimeOffset? _lastEntryTime;
+
+	/// <summary>
+	/// Tolerance used when comparing accumulated volume values.
+	/// </summary>
+	public decimal VolumeTolerance
+	{
+		get => _volumeTolerance.Value;
+		set => _volumeTolerance.Value = value;
+	}
 
 	public decimal OrderVolume
 	{
@@ -110,6 +119,10 @@ public class BssTripleEmaSeparationStrategy : Strategy
 
 	public BssTripleEmaSeparationStrategy()
 	{
+		_volumeTolerance = Param(nameof(VolumeTolerance), 1e-8m)
+			.SetGreaterThan(0m)
+			.SetDisplay("Volume Tolerance", "Tolerance when comparing volume values", "Risk");
+
 		_orderVolume = Param(nameof(OrderVolume), 0.1m)
 			.SetGreaterThanZero()
 			.SetDisplay("Order Volume", "Volume used for each entry order", "Trading");

--- a/API/2865_Night_Flat_Trade/CS/NightFlatTradeStrategy.cs
+++ b/API/2865_Night_Flat_Trade/CS/NightFlatTradeStrategy.cs
@@ -13,7 +13,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class NightFlatTradeStrategy : Strategy
 {
-	private const int RangeLength = 3;
+	private readonly StrategyParam<int> _rangeLength;
 
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<decimal> _takeProfitPips;
@@ -73,6 +73,15 @@ public class NightFlatTradeStrategy : Strategy
 		set => _openHour.Value = value;
 	}
 
+	/// <summary>
+	/// Number of candles used to form the overnight range.
+	/// </summary>
+	public int RangeLength
+	{
+		get => _rangeLength.Value;
+		set => _rangeLength.Value = value;
+	}
+
 	public NightFlatTradeStrategy()
 	{
 		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(1).TimeFrame())
@@ -102,6 +111,10 @@ public class NightFlatTradeStrategy : Strategy
 			.SetRange(0, 23)
 			.SetDisplay("Open Hour", "Hour (exchange time) when entries become active", "Schedule");
 	}
+
+		_rangeLength = Param(nameof(RangeLength), 3)
+			.SetGreaterThanZero()
+			.SetDisplay("Range Length", "Number of candles composing the range", "Setup");
 
 	public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
 	{

--- a/API/2867_MACD_and_SAR/CS/MacdAndSarStrategy.cs
+++ b/API/2867_MACD_and_SAR/CS/MacdAndSarStrategy.cs
@@ -14,7 +14,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class MacdAndSarStrategy : Strategy
 {
-	private const decimal VolumeTolerance = 0.0000001m;
+	private readonly StrategyParam<decimal> _volumeTolerance;
 
 	private readonly StrategyParam<decimal> _tradeVolume;
 	private readonly StrategyParam<int> _maxPositions;
@@ -33,6 +33,15 @@ public class MacdAndSarStrategy : Strategy
 
 	private MovingAverageConvergenceDivergenceSignal _macd = null!;
 	private ParabolicSar _parabolicSar = null!;
+
+	/// <summary>
+	/// Tolerance used when comparing cumulative position volumes.
+	/// </summary>
+	public decimal VolumeTolerance
+	{
+		get => _volumeTolerance.Value;
+		set => _volumeTolerance.Value = value;
+	}
 
 	/// <summary>
 	/// Volume per individual trade.
@@ -167,6 +176,10 @@ public class MacdAndSarStrategy : Strategy
 	/// </summary>
 	public MacdAndSarStrategy()
 	{
+		_volumeTolerance = Param(nameof(VolumeTolerance), 0.0000001m)
+			.SetGreaterThan(0m)
+			.SetDisplay("Volume Tolerance", "Tolerance when stacking positions", "Risk");
+
 		_tradeVolume = Param(nameof(TradeVolume), 0.1m)
 			.SetGreaterThanZero()
 			.SetDisplay("Trade Volume", "Volume per trade", "Trading");


### PR DESCRIPTION
## Summary
- expose volume tolerances and epsilon thresholds as configurable StrategyParam values across several strategies
- add StrategyParam controls for indicator window and period settings such as MACD lengths, zigzag window size, and range lengths
- allow BrainTrend2 indicators to inherit Dartp and Cecf values from strategy parameters instead of internal constants

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7be53e5588323ba01579bb092c630