### PR TITLE
Параметризация констант стратегий

### DIFF
--- a/API/2903_Alexav_D1_Profit_GBPUSD/CS/AlexavD1ProfitGbpUsdStrategy.cs
+++ b/API/2903_Alexav_D1_Profit_GBPUSD/CS/AlexavD1ProfitGbpUsdStrategy.cs
@@ -13,7 +13,6 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class AlexavD1ProfitGbpUsdStrategy : Strategy
 {
-	private const int OrdersPerSignal = 4;
 	private static readonly decimal[] TargetSteps = { 1m, 1.5m, 2m, 2.5m };
 
 	private readonly StrategyParam<decimal> _orderVolume;
@@ -27,6 +26,7 @@ public class AlexavD1ProfitGbpUsdStrategy : Strategy
 	private readonly StrategyParam<int> _macdSignalPeriod;
 	private readonly StrategyParam<decimal> _macdDiffBuy;
 	private readonly StrategyParam<decimal> _macdDiffSell;
+	private readonly StrategyParam<int> _ordersPerSignal;
 	private readonly StrategyParam<decimal> _rsiUpperLimit;
 	private readonly StrategyParam<decimal> _rsiUpperLevel;
 	private readonly StrategyParam<decimal> _rsiLowerLevel;
@@ -96,6 +96,10 @@ public class AlexavD1ProfitGbpUsdStrategy : Strategy
 		.SetGreaterThanZero()
 		.SetDisplay("MACD Diff Sell", "Minimum MACD acceleration for sells", "Filters");
 
+		_ordersPerSignal = Param(nameof(OrdersPerSignal), 4)
+		.SetGreaterThanZero()
+		.SetDisplay("Orders Per Signal", "Number of scaling orders per entry", "Trading");
+
 		_rsiUpperLimit = Param(nameof(RsiUpperLimit), 80m)
 		.SetDisplay("RSI Upper Limit", "Maximum RSI allowed for longs", "Filters");
 
@@ -146,6 +150,12 @@ public class AlexavD1ProfitGbpUsdStrategy : Strategy
 	{
 		get => _takeMultiplier.Value;
 		set => _takeMultiplier.Value = value;
+	}
+
+	public int OrdersPerSignal
+	{
+		get => _ordersPerSignal.Value;
+		set => _ordersPerSignal.Value = value;
 	}
 
 	public int MacdFastPeriod

--- a/API/2910_Urdala_Trol/CS/UrdalaTrolStrategy.cs
+++ b/API/2910_Urdala_Trol/CS/UrdalaTrolStrategy.cs
@@ -12,8 +12,6 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class UrdalaTrolStrategy : Strategy
 {
-	private const decimal VolumeTolerance = 0.0000001m;
-
 	private readonly StrategyParam<decimal> _baseVolume;
 	private readonly StrategyParam<int> _minLotsMultiplier;
 	private readonly StrategyParam<decimal> _stopLossPips;
@@ -21,6 +19,7 @@ public class UrdalaTrolStrategy : Strategy
 	private readonly StrategyParam<decimal> _trailingStepPips;
 	private readonly StrategyParam<decimal> _gridStepPips;
 	private readonly StrategyParam<decimal> _minNearestPips;
+	private readonly StrategyParam<decimal> _volumeTolerance;
 
 	private readonly List<PositionItem> _longPositions = new();
 	private readonly List<PositionItem> _shortPositions = new();
@@ -102,6 +101,15 @@ public class UrdalaTrolStrategy : Strategy
 	}
 
 	/// <summary>
+	/// Tolerance used when comparing order volumes.
+	/// </summary>
+	public decimal VolumeTolerance
+	{
+		get => _volumeTolerance.Value;
+		set => _volumeTolerance.Value = value;
+	}
+
+	/// <summary>
 	/// Initializes the strategy parameters.
 	/// </summary>
 	public UrdalaTrolStrategy()
@@ -128,6 +136,10 @@ public class UrdalaTrolStrategy : Strategy
 
 		_minNearestPips = Param(nameof(MinNearestPips), 3m)
 			.SetDisplay("Min Nearest (pips)", "Minimal distance to existing trades after a stop", "Trading");
+
+		_volumeTolerance = Param(nameof(VolumeTolerance), 0.0000001m)
+			.SetGreaterThanZero()
+			.SetDisplay("Volume Tolerance", "Tolerance when comparing order volumes", "Trading");
 	}
 
 	/// <inheritdoc />

--- a/API/2953_Freeman/CS/FreemanStrategy.cs
+++ b/API/2953_Freeman/CS/FreemanStrategy.cs
@@ -10,13 +10,12 @@ namespace StockSharp.Samples.Strategies;
 
 public class FreemanStrategy : Strategy
 {
-	private const int FilterRsiPeriod = 14;
-
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<DataType> _filterCandleType;
 	private readonly StrategyParam<int> _firstMaPeriod;
 	private readonly StrategyParam<int> _secondMaPeriod;
 	private readonly StrategyParam<int> _filterMaPeriod;
+	private readonly StrategyParam<int> _filterRsiPeriod;
 	private readonly StrategyParam<MovingAverageTypeEnum> _maType;
 	private readonly StrategyParam<int> _rsiFirstPeriod;
 	private readonly StrategyParam<int> _rsiSecondPeriod;
@@ -108,6 +107,15 @@ public class FreemanStrategy : Strategy
 	{
 		get => _filterMaPeriod.Value;
 		set => _filterMaPeriod.Value = value;
+	}
+
+	/// <summary>
+	/// Period of the RSI filter applied on the higher timeframe.
+	/// </summary>
+	public int FilterRsiPeriod
+	{
+		get => _filterRsiPeriod.Value;
+		set => _filterRsiPeriod.Value = value;
 	}
 
 	/// <summary>
@@ -318,6 +326,10 @@ public class FreemanStrategy : Strategy
 		_filterMaPeriod = Param(nameof(FilterMaPeriod), 20)
 			.SetGreaterThanZero()
 			.SetDisplay("Filter MA Period", "Period of the higher timeframe moving average", "Indicators");
+
+		_filterRsiPeriod = Param(nameof(FilterRsiPeriod), 14)
+			.SetGreaterThanZero()
+			.SetDisplay("Filter RSI Period", "Period of the higher timeframe RSI filter", "Indicators");
 
 		_maType = Param(nameof(MaType), MovingAverageTypeEnum.Simple)
 			.SetDisplay("MA Type", "Type of moving averages", "Indicators");

--- a/API/2958_Dematus/CS/DematusStrategy.cs
+++ b/API/2958_Dematus/CS/DematusStrategy.cs
@@ -12,9 +12,6 @@ using StockSharp.Messages;
 /// </summary>
 public class DematusStrategy : Strategy
 {
-	private const decimal OversoldLevel = 0.3m;
-	private const decimal OverboughtLevel = 0.7m;
-
 	private readonly StrategyParam<decimal> _initialVolume;
 	private readonly StrategyParam<decimal> _stopLossPips;
 	private readonly StrategyParam<decimal> _trailingStopPips;
@@ -25,6 +22,8 @@ public class DematusStrategy : Strategy
 	private readonly StrategyParam<decimal> _trailingStartEquity;
 	private readonly StrategyParam<int> _demarkerLength;
 	private readonly StrategyParam<decimal> _volumeMultiplier;
+	private readonly StrategyParam<decimal> _oversoldLevel;
+	private readonly StrategyParam<decimal> _overboughtLevel;
 	private readonly StrategyParam<bool> _resetEntryPrice;
 	private readonly StrategyParam<DataType> _candleType;
 
@@ -139,6 +138,24 @@ public class DematusStrategy : Strategy
 	}
 
 	/// <summary>
+	/// Oversold level used for DeMarker crossovers.
+	/// </summary>
+	public decimal OversoldLevel
+	{
+		get => _oversoldLevel.Value;
+		set => _oversoldLevel.Value = value;
+	}
+
+	/// <summary>
+	/// Overbought level used for DeMarker crossovers.
+	/// </summary>
+	public decimal OverboughtLevel
+	{
+		get => _overboughtLevel.Value;
+		set => _overboughtLevel.Value = value;
+	}
+
+	/// <summary>
 	/// Reset the last entry price after exits when enabled.
 	/// </summary>
 	public bool ResetEntryPrice
@@ -202,6 +219,14 @@ public class DematusStrategy : Strategy
 		_volumeMultiplier = Param(nameof(VolumeMultiplier), 2m)
 		.SetGreaterOrEqual(1m)
 		.SetDisplay("Volume Multiplier", "Multiplier applied to the last executed volume.", "Trading");
+
+		_oversoldLevel = Param(nameof(OversoldLevel), 0.3m)
+		.SetRange(0m, 1m)
+		.SetDisplay("Oversold Level", "Oversold threshold for DeMarker crossovers.", "Signals");
+
+		_overboughtLevel = Param(nameof(OverboughtLevel), 0.7m)
+		.SetRange(0m, 1m)
+		.SetDisplay("Overbought Level", "Overbought threshold for DeMarker crossovers.", "Signals");
 
 		_resetEntryPrice = Param(nameof(ResetEntryPrice), false)
 		.SetDisplay("Reset Entry Price", "Reset the last entry price whenever an exit happens.", "Trading");

--- a/API/2963_Expert_Ichimoku/CS/ExpertIchimokuStrategy.cs
+++ b/API/2963_Expert_Ichimoku/CS/ExpertIchimokuStrategy.cs
@@ -16,8 +16,6 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class ExpertIchimokuStrategy : Strategy
 {
-	private const int HistoryCapacity = 64;
-
 	private readonly StrategyParam<int> _tenkanPeriod;
 	private readonly StrategyParam<int> _kijunPeriod;
 	private readonly StrategyParam<int> _senkouSpanBPeriod;
@@ -28,6 +26,7 @@ public class ExpertIchimokuStrategy : Strategy
 	private readonly StrategyParam<int> _maxPositions;
 	private readonly StrategyParam<bool> _useMartingale;
 	private readonly StrategyParam<DataType> _candleType;
+	private readonly StrategyParam<int> _historyCapacity;
 
 	private Ichimoku _ichimoku;
 
@@ -128,6 +127,15 @@ public class ExpertIchimokuStrategy : Strategy
 	}
 
 	/// <summary>
+	/// Maximum number of historical values retained for Ichimoku components.
+	/// </summary>
+	public int HistoryCapacity
+	{
+		get => _historyCapacity.Value;
+		set => _historyCapacity.Value = Math.Max(1, value);
+	}
+
+	/// <summary>
 	/// Candle type used for calculations.
 	/// </summary>
 	public DataType CandleType
@@ -184,6 +192,10 @@ public class ExpertIchimokuStrategy : Strategy
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(1).TimeFrame())
 			.SetDisplay("Candle Type", "Timeframe used for calculations", "General");
+
+		_historyCapacity = Param(nameof(HistoryCapacity), 64)
+			.SetGreaterThanZero()
+			.SetDisplay("History Capacity", "Maximum stored Ichimoku history size", "General");
 	}
 
 	/// <inheritdoc />
@@ -477,10 +489,11 @@ public class ExpertIchimokuStrategy : Strategy
 		_takeProfitPrice = null;
 	}
 
-	private static void AddToHistory(List<decimal> history, decimal value)
+	private void AddToHistory(List<decimal> history, decimal value)
 	{
 		history.Add(value);
-		if (history.Count > HistoryCapacity)
+		var capacity = HistoryCapacity;
+		if (history.Count > capacity)
 			history.RemoveAt(0);
 	}
 


### PR DESCRIPTION
## Изменения
- Заменил жёстко заданные размеры буферов и пороги в ExpSinewave2X2Strategy на параметры стратегии и обновил связанные индикаторы.
- Добавил параметры для OrdersPerSignal, коэффициентов BrainTrend и допусков объёма/цветов в других стратегиях из списка.
- Ввёл настраиваемую ёмкость историй для XPeriodCandleSystemTmPlus и ExpertIchimoku.

## Тестирование
- ⚠️ `dotnet build -c Release` (команда недоступна в окружении)


------
https://chatgpt.com/codex/tasks/task_e_68d7be61ff808323acc9e86b90e74b9d