### PR TITLE
Add strategy parameters for previously hard-coded constants

### DIFF
--- a/API/3032_Color_Schaff_JJRSX_MMRec_Duplex/CS/ColorSchaffJjrsxMmrecDuplexStrategy.cs
+++ b/API/3032_Color_Schaff_JJRSX_MMRec_Duplex/CS/ColorSchaffJjrsxMmrecDuplexStrategy.cs
@@ -15,7 +15,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class ColorSchaffJjrsxMmrecDuplexStrategy : Strategy
 {
-	private const decimal _factor = 0.5m;
+	private readonly StrategyParam<decimal> _factor;
 
 	private readonly StrategyParam<DataType> _longCandleType;
 	private readonly StrategyParam<int> _longTotalTrigger;
@@ -65,6 +65,11 @@ public class ColorSchaffJjrsxMmrecDuplexStrategy : Strategy
 	/// </summary>
 	public ColorSchaffJjrsxMmrecDuplexStrategy()
 	{
+		_factor = Param(nameof(Factor), 0.5m)
+			.SetDisplay("Smoothing Factor", "Multiplier used for trend filtering", "General")
+			.SetRange(0.01m, 5m)
+			.SetCanOptimize(true);
+
 		_longCandleType = Param(nameof(LongCandleType), TimeSpan.FromHours(8).TimeFrame())
 			.SetDisplay("Long Candle", "Time-frame used for the long indicator", "Long")
 			.SetCanOptimize(false);
@@ -180,6 +185,15 @@ public class ColorSchaffJjrsxMmrecDuplexStrategy : Strategy
 
 		_shortPriceType = Param(nameof(ShortAppliedPrice), AppliedPrice.Close)
 			.SetDisplay("Short Applied Price", "Price source for the short indicator", "Short");
+	}
+
+	/// <summary>
+	/// Multiplier applied to smooth the duplex indicators.
+	/// </summary>
+	public decimal Factor
+	{
+		get => _factor.Value;
+		set => _factor.Value = value;
 	}
 
 	/// <summary>
@@ -459,7 +473,7 @@ public class ColorSchaffJjrsxMmrecDuplexStrategy : Strategy
 			SmoothLength = LongSmooth,
 			CycleLength = LongCycleLength,
 			AppliedPrice = LongAppliedPrice,
-			SmoothingFactor = _factor
+			SmoothingFactor = Factor
 		};
 
 		_shortIndicator = new ColorSchaffJjrsxTrendCycleIndicator
@@ -469,7 +483,7 @@ public class ColorSchaffJjrsxMmrecDuplexStrategy : Strategy
 			SmoothLength = ShortSmooth,
 			CycleLength = ShortCycleLength,
 			AppliedPrice = ShortAppliedPrice,
-			SmoothingFactor = _factor
+			SmoothingFactor = Factor
 		};
 
 		var longSubscription = SubscribeCandles(LongCandleType);

--- a/API/3049_Signal_Count_With_Array/CS/SignalCountWithArrayStrategy.cs
+++ b/API/3049_Signal_Count_With_Array/CS/SignalCountWithArrayStrategy.cs
@@ -14,8 +14,8 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class SignalCountWithArrayStrategy : Strategy
 {
-	private const decimal PositiveEmptyValue = 2147483647m;
-	private const decimal NegativeEmptyValue = -2147483646m;
+	private readonly StrategyParam<decimal> _positiveEmptyValue;
+	private readonly StrategyParam<decimal> _negativeEmptyValue;
 
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<int> _channelPeriod;
@@ -57,6 +57,12 @@ public class SignalCountWithArrayStrategy : Strategy
 			.SetGreaterThanZero()
 			.SetDisplay("Gap Count", "Number of offsets evaluated", "Indicator");
 
+		_positiveEmptyValue = Param(nameof(PositiveEmptyValue), 2147483647m)
+			.SetDisplay("Positive Empty Value", "Placeholder for missing positive signals", "Diagnostics");
+
+		_negativeEmptyValue = Param(nameof(NegativeEmptyValue), -2147483646m)
+			.SetDisplay("Negative Empty Value", "Placeholder for missing negative signals", "Diagnostics");
+
 		_logOnEachCandle = Param(nameof(LogOnEachCandle), false)
 			.SetDisplay("Log On Each Candle", "Write diagnostics after every candle", "Diagnostics");
 	}
@@ -89,6 +95,18 @@ public class SignalCountWithArrayStrategy : Strategy
 	{
 		get => _gapCount.Value;
 		set => _gapCount.Value = value;
+	}
+
+	public decimal PositiveEmptyValue
+	{
+		get => _positiveEmptyValue.Value;
+		set => _positiveEmptyValue.Value = value;
+	}
+
+	public decimal NegativeEmptyValue
+	{
+		get => _negativeEmptyValue.Value;
+		set => _negativeEmptyValue.Value = value;
 	}
 
 	public bool LogOnEachCandle

--- a/API/3051_Exp_Skyscraper_Fix_ColorAML/CS/ExpSkyscraperFixColorAmlStrategy.cs
+++ b/API/3051_Exp_Skyscraper_Fix_ColorAML/CS/ExpSkyscraperFixColorAmlStrategy.cs
@@ -15,8 +15,8 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class ExpSkyscraperFixColorAmlStrategy : Strategy
 {
-	private const int SkyscraperAtrPeriod = 15;
-	private const int MaxHistory = 512;
+	private readonly StrategyParam<int> _skyscraperAtrPeriod;
+	private readonly StrategyParam<int> _maxHistory;
 
 	private readonly StrategyParam<DataType> _skyscraperCandleType;
 	private readonly StrategyParam<bool> _skyscraperEnableLongEntry;
@@ -57,6 +57,16 @@ public class ExpSkyscraperFixColorAmlStrategy : Strategy
 	/// </summary>
 	public ExpSkyscraperFixColorAmlStrategy()
 	{
+		_skyscraperAtrPeriod = Param(nameof(SkyscraperAtrPeriod), 15)
+			.SetGreaterThanZero()
+			.SetDisplay("Skyscraper ATR Period", "ATR period used for Skyscraper calculations", "Skyscraper")
+			.SetCanOptimize(true)
+			.SetOptimize(5, 40, 1);
+
+		_maxHistory = Param(nameof(MaxHistory), 512)
+			.SetGreaterThanZero()
+			.SetDisplay("Max History", "Maximum number of historical candles stored", "General");
+
 	_skyscraperCandleType = Param(nameof(SkyscraperCandleType), TimeSpan.FromHours(4).TimeFrame())
 	.SetDisplay("Skyscraper Timeframe", "Timeframe used for the Skyscraper Fix module", "Skyscraper");
 
@@ -203,6 +213,15 @@ public class ExpSkyscraperFixColorAmlStrategy : Strategy
 	{
 	get => _skyscraperLength.Value;
 	set => _skyscraperLength.Value = value;
+	}
+
+	/// <summary>
+	/// ATR period used for Skyscraper historical smoothing.
+	/// </summary>
+	public int SkyscraperAtrPeriod
+	{
+	get => _skyscraperAtrPeriod.Value;
+	set => _skyscraperAtrPeriod.Value = value;
 	}
 
 	/// <summary>
@@ -365,6 +384,15 @@ public class ExpSkyscraperFixColorAmlStrategy : Strategy
 	{
 	get => _colorAmlTakeProfit.Value;
 	set => _colorAmlTakeProfit.Value = value;
+	}
+
+	/// <summary>
+	/// Maximum number of historical candles stored for pattern analysis.
+	/// </summary>
+	public int MaxHistory
+	{
+	get => _maxHistory.Value;
+	set => _maxHistory.Value = value;
 	}
 
 	/// <inheritdoc />

--- a/API/3059_Volatility_HFT_EA/CS/VolatilityHftEaStrategy.cs
+++ b/API/3059_Volatility_HFT_EA/CS/VolatilityHftEaStrategy.cs
@@ -15,7 +15,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class VolatilityHftEaStrategy : Strategy
 {
-	private const int MinimumBars = 60;
+	private readonly StrategyParam<int> _minimumBars;
 
 	private readonly StrategyParam<decimal> _orderVolume;
 	private readonly StrategyParam<int> _fastMaLength;
@@ -36,6 +36,10 @@ public class VolatilityHftEaStrategy : Strategy
 
 	public VolatilityHftEaStrategy()
 	{
+		_minimumBars = Param(nameof(MinimumBars), 60)
+			.SetGreaterThanZero()
+			.SetDisplay("Minimum Bars", "Minimum completed candles before signal evaluation", "Signal");
+
 		_orderVolume = Param(nameof(OrderVolume), 1m)
 			.SetGreaterThanZero()
 			.SetDisplay("Order Volume", "Volume applied to market orders", "Trading");
@@ -78,6 +82,12 @@ public class VolatilityHftEaStrategy : Strategy
 	{
 		get => _maDifferencePips.Value;
 		set => _maDifferencePips.Value = value;
+	}
+
+	public int MinimumBars
+	{
+		get => _minimumBars.Value;
+		set => _minimumBars.Value = value;
 	}
 
 	public DataType CandleType

--- a/API/3067_Exp_Hans_Indicator_Cloud_System_Tm_Plus/CS/ExpHansIndicatorCloudSystemTmPlusStrategy.cs
+++ b/API/3067_Exp_Hans_Indicator_Cloud_System_Tm_Plus/CS/ExpHansIndicatorCloudSystemTmPlusStrategy.cs
@@ -12,7 +12,7 @@ using StockSharp.Messages;
 /// </summary>
 public class ExpHansIndicatorCloudSystemTmPlusStrategy : Strategy
 {
-	private const int MaxHistory = 1024;
+	private readonly StrategyParam<int> _maxHistory;
 
 	private static readonly TimeSpan Session1Start = TimeSpan.FromHours(4);
 	private static readonly TimeSpan Session1End = TimeSpan.FromHours(8);
@@ -199,10 +199,23 @@ public class ExpHansIndicatorCloudSystemTmPlusStrategy : Strategy
 	}
 
 	/// <summary>
+	/// Maximum number of Hans color samples preserved for decision making.
+	/// </summary>
+	public int MaxHistory
+	{
+		get => _maxHistory.Value;
+		set => _maxHistory.Value = value;
+	}
+
+	/// <summary>
 	/// Initialize the strategy parameters with defaults matching the MQL5 inputs.
 	/// </summary>
 	public ExpHansIndicatorCloudSystemTmPlusStrategy()
 	{
+		_maxHistory = Param(nameof(MaxHistory), 1024)
+			.SetGreaterThanZero()
+			.SetDisplay("Max History", "Maximum number of Hans color entries stored", "Indicator");
+
 		_moneyManagement = Param(nameof(MoneyManagement), 0.1m)
 		.SetDisplay("Money Management", "Portion of the base volume traded per entry", "Risk");
 

--- a/API/3071_Vortex_Indicator_Duplex/CS/VortexIndicatorDuplexStrategy.cs
+++ b/API/3071_Vortex_Indicator_Duplex/CS/VortexIndicatorDuplexStrategy.cs
@@ -45,13 +45,17 @@ public class VortexIndicatorDuplexStrategy : Strategy
 	private decimal? _longTakeProfitPrice;
 	private decimal? _shortTakeProfitPrice;
 
-	private const int MaxHistoryLength = 512;
+	private readonly StrategyParam<int> _maxHistoryLength;
 
 	/// <summary>
 	/// Initializes parameters for the duplex Vortex strategy.
 	/// </summary>
 	public VortexIndicatorDuplexStrategy()
 	{
+		_maxHistoryLength = Param(nameof(MaxHistoryLength), 512)
+			.SetGreaterThanZero()
+			.SetDisplay("Max History Length", "Maximum stored Vortex samples per direction.", "General");
+
 		_longCandleType = Param(nameof(LongCandleType), TimeSpan.FromHours(4).TimeFrame())
 			.SetDisplay("Long Candle Type", "Timeframe used for long-side Vortex calculations.", "General");
 
@@ -242,6 +246,16 @@ public class VortexIndicatorDuplexStrategy : Strategy
 		get => _tradeVolume.Value;
 		set => _tradeVolume.Value = value;
 	}
+
+	/// <summary>
+	/// Maximum number of stored Vortex samples per signal stream.
+	/// </summary>
+	public int MaxHistoryLength
+	{
+		get => _maxHistoryLength.Value;
+		set => _maxHistoryLength.Value = value;
+	}
+
 	/// <inheritdoc />
 	public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
 	{

--- a/API/3086_Tunnel_Gen4/CS/TunnelGen4Strategy.cs
+++ b/API/3086_Tunnel_Gen4/CS/TunnelGen4Strategy.cs
@@ -15,7 +15,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class TunnelGen4Strategy : Strategy
 {
-	private const decimal VolumeTolerance = 0.0000001m;
+	private readonly StrategyParam<decimal> _volumeTolerance;
 
 	private readonly StrategyParam<decimal> _startVolume;
 	private readonly StrategyParam<decimal> _stepPips;
@@ -64,10 +64,23 @@ public class TunnelGen4Strategy : Strategy
 	}
 
 	/// <summary>
+	/// Maximum allowed difference when comparing exposure volumes.
+	/// </summary>
+	public decimal VolumeTolerance
+	{
+		get => _volumeTolerance.Value;
+		set => _volumeTolerance.Value = value;
+	}
+
+	/// <summary>
 	/// Initialize strategy parameters.
 	/// </summary>
 	public TunnelGen4Strategy()
 	{
+		_volumeTolerance = Param(nameof(VolumeTolerance), 0.0000001m)
+			.SetNotNegative()
+			.SetDisplay("Volume Tolerance", "Tolerance when comparing exposure volumes", "Trading");
+
 		_startVolume = Param(nameof(StartVolume), 1m)
 		.SetGreaterThanZero()
 		.SetDisplay("Start Volume", "Initial hedge volume", "Trading")

--- a/API/3087_RSI_RFTL/CS/RsiRftlStrategy.cs
+++ b/API/3087_RSI_RFTL/CS/RsiRftlStrategy.cs
@@ -33,13 +33,17 @@ public class RsiRftlStrategy : Strategy
 	private decimal? _longTrailingStop;
 	private decimal? _shortTrailingStop;
 
-	private const int MaxHistoryLength = 600;
+	private readonly StrategyParam<int> _maxHistoryLength;
 
 	/// <summary>
 	/// Initializes a new instance of the strategy.
 	/// </summary>
 	public RsiRftlStrategy()
 	{
+		_maxHistoryLength = Param(nameof(MaxHistoryLength), 600)
+			.SetGreaterThanZero()
+			.SetDisplay("Max History Length", "Maximum stored RSI/RFTL samples", "Indicator");
+
 		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(1).TimeFrame())
 			.SetDisplay("Candle Type", "Primary timeframe used for calculations", "General");
 
@@ -132,6 +136,15 @@ public class RsiRftlStrategy : Strategy
 	{
 		get => _trailingStepPips.Value;
 		set => _trailingStepPips.Value = value;
+	}
+
+	/// <summary>
+	/// Maximum stored samples for historical calculations.
+	/// </summary>
+	public int MaxHistoryLength
+	{
+		get => _maxHistoryLength.Value;
+		set => _maxHistoryLength.Value = value;
 	}
 
 	/// <inheritdoc />

--- a/API/3089_ScalpWiz_9001/CS/ScalpWiz9001Strategy.cs
+++ b/API/3089_ScalpWiz_9001/CS/ScalpWiz9001Strategy.cs
@@ -14,7 +14,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class ScalpWiz9001Strategy : Strategy
 {
-	private const int LevelCount = 4;
+	private readonly StrategyParam<int> _levelCount;
 
 	private enum VolumeMode
 	{
@@ -31,8 +31,8 @@ public class ScalpWiz9001Strategy : Strategy
 	private readonly StrategyParam<decimal> _trailingStepPips;
 	private readonly StrategyParam<int> _expirationMinutes;
 	private readonly StrategyParam<VolumeMode> _volumeMode;
-	private readonly StrategyParam<decimal>[] _levelValues = new StrategyParam<decimal>[LevelCount];
-	private readonly StrategyParam<decimal>[] _levelPips = new StrategyParam<decimal>[LevelCount];
+	private readonly StrategyParam<decimal>[] _levelValues;
+	private readonly StrategyParam<decimal>[] _levelPips;
 
 	private decimal _pipSize;
 	private decimal _tickSize;
@@ -53,6 +53,11 @@ public class ScalpWiz9001Strategy : Strategy
 	/// </summary>
 	public ScalpWiz9001Strategy()
 	{
+		const int levelSlots = 4;
+
+		_levelValues = new StrategyParam<decimal>[levelSlots];
+		_levelPips = new StrategyParam<decimal>[levelSlots];
+
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(1).TimeFrame())
 			.SetDisplay("Candle Type", "Timeframe used for Bollinger calculations", "General");
 
@@ -86,6 +91,10 @@ public class ScalpWiz9001Strategy : Strategy
 
 		_volumeMode = Param(nameof(ManagementMode), VolumeMode.RiskPercent)
 			.SetDisplay("Management Mode", "Interpretation of level values (fixed lot or risk percent)", "Money Management");
+
+		_levelCount = Param(nameof(LevelCount), levelSlots)
+			.SetRange(1, levelSlots)
+			.SetDisplay("Level Count", "Number of active breakout layers", "Money Management");
 
 		_levelValues[0] = Param(nameof(Level0Value), 1m)
 			.SetNotNegative()
@@ -190,6 +199,15 @@ public class ScalpWiz9001Strategy : Strategy
 	{
 		get => _expirationMinutes.Value;
 		set => _expirationMinutes.Value = value;
+	}
+
+	/// <summary>
+	/// Number of breakout layers actively managed by the strategy.
+	/// </summary>
+	public int LevelCount
+	{
+		get => _levelCount.Value;
+		set => _levelCount.Value = value;
 	}
 
 	/// <summary>

--- a/API/3092_FxNode_Safe_Tunnel/CS/FxNodeSafeTunnelStrategy.cs
+++ b/API/3092_FxNode_Safe_Tunnel/CS/FxNodeSafeTunnelStrategy.cs
@@ -14,7 +14,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class FxNodeSafeTunnelStrategy : Strategy
 {
-	private const decimal AtrMultiplier = 10m;
+	private readonly StrategyParam<decimal> _atrMultiplier;
 
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<TrendPreference> _trendPreference;
@@ -138,6 +138,10 @@ public class FxNodeSafeTunnelStrategy : Strategy
 		_atrPeriod = Param(nameof(AtrPeriod), 14)
 		.SetGreaterThanZero()
 		.SetDisplay("ATR Period", "Average True Range lookback", "Indicators");
+
+		_atrMultiplier = Param(nameof(AtrMultiplier), 10m)
+		.SetGreaterThanZero()
+		.SetDisplay("ATR Multiplier", "Multiplier applied to ATR distance filters", "Indicators");
 
 		_zigZagDepth = Param(nameof(ZigZagDepth), 5)
 		.SetGreaterThanZero()
@@ -325,6 +329,15 @@ public class FxNodeSafeTunnelStrategy : Strategy
 	{
 		get => _atrPeriod.Value;
 		set => _atrPeriod.Value = value;
+	}
+
+	/// <summary>
+	/// Multiplier applied to ATR-derived distance filters.
+	/// </summary>
+	public decimal AtrMultiplier
+	{
+		get => _atrMultiplier.Value;
+		set => _atrMultiplier.Value = value;
 	}
 
 	/// <summary>

--- a/API/3098_Doubler/CS/DoublerStrategy.cs
+++ b/API/3098_Doubler/CS/DoublerStrategy.cs
@@ -14,7 +14,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class DoublerStrategy : Strategy
 {
-	private const decimal VolumeTolerance = 0.0000001m;
+	private readonly StrategyParam<decimal> _volumeTolerance;
 
 	private readonly StrategyParam<decimal> _orderVolume;
 	private readonly StrategyParam<decimal> _stopLossPips;
@@ -97,10 +97,23 @@ public class DoublerStrategy : Strategy
 	}
 
 	/// <summary>
+	/// Maximum allowed volume mismatch between hedge legs.
+	/// </summary>
+	public decimal VolumeTolerance
+	{
+		get => _volumeTolerance.Value;
+		set => _volumeTolerance.Value = value;
+	}
+
+	/// <summary>
 	/// Initializes strategy parameters.
 	/// </summary>
 	public DoublerStrategy()
 	{
+		_volumeTolerance = Param(nameof(VolumeTolerance), 0.0000001m)
+			.SetNotNegative()
+			.SetDisplay("Volume Tolerance", "Tolerance used when comparing hedge legs", "Trading");
+
 		_orderVolume = Param(nameof(OrderVolume), 1m)
 			.SetGreaterThanZero()
 			.SetDisplay("Order Volume", "Volume for each hedge leg", "Trading")

--- a/API/3101_5Min_Scalping/CS/FiveMinScalpingStrategy.cs
+++ b/API/3101_5Min_Scalping/CS/FiveMinScalpingStrategy.cs
@@ -15,12 +15,12 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class FiveMinScalpingStrategy : Strategy
 {
-	private const int ScalperLookback = 20;
-	private const int BreakoutWindow = 5;
-	private const int MomentumHistorySize = 3;
-	private const int FastTrendLength = 8;
-	private const int MiddleTrendLength = 13;
-	private const int SlowTrendLength = 21;
+	private readonly StrategyParam<int> _scalperLookback;
+	private readonly StrategyParam<int> _breakoutWindow;
+	private readonly StrategyParam<int> _momentumHistorySize;
+	private readonly StrategyParam<int> _fastTrendLength;
+	private readonly StrategyParam<int> _middleTrendLength;
+	private readonly StrategyParam<int> _slowTrendLength;
 
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<DataType> _momentumCandleType;
@@ -52,7 +52,7 @@ public class FiveMinScalpingStrategy : Strategy
 	private readonly List<decimal> _slowTrendHistory = new();
 	private readonly List<decimal> _highHistory = new();
 	private readonly List<decimal> _lowHistory = new();
-	private readonly List<decimal> _momentumDeviationHistory = new(MomentumHistorySize);
+	private readonly List<decimal> _momentumDeviationHistory = new();
 
 	private bool _momentumReady;
 	private bool _hasMacroMacd;
@@ -70,6 +70,30 @@ public class FiveMinScalpingStrategy : Strategy
 	/// </summary>
 	public FiveMinScalpingStrategy()
 	{
+		_scalperLookback = Param(nameof(ScalperLookback), 20)
+			.SetGreaterThanZero()
+			.SetDisplay("Scalper Lookback", "Candles considered when searching for breakouts", "Trend");
+
+		_breakoutWindow = Param(nameof(BreakoutWindow), 5)
+			.SetGreaterThanZero()
+			.SetDisplay("Breakout Window", "Window used to track recent highs and lows", "Trend");
+
+		_momentumHistorySize = Param(nameof(MomentumHistorySize), 3)
+			.SetGreaterThanZero()
+			.SetDisplay("Momentum History Size", "Number of deviations stored for momentum confirmation", "Filters");
+
+		_fastTrendLength = Param(nameof(FastTrendLength), 8)
+			.SetGreaterThanZero()
+			.SetDisplay("Fast Trend Length", "LWMA length for the fastest trend filter", "Trend");
+
+		_middleTrendLength = Param(nameof(MiddleTrendLength), 13)
+			.SetGreaterThanZero()
+			.SetDisplay("Middle Trend Length", "LWMA length for the mid-term trend filter", "Trend");
+
+		_slowTrendLength = Param(nameof(SlowTrendLength), 21)
+			.SetGreaterThanZero()
+			.SetDisplay("Slow Trend Length", "LWMA length for the slow trend filter", "Trend");
+
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
 			.SetDisplay("Signal Timeframe", "Primary timeframe used for entry signals", "General");
 
@@ -282,6 +306,60 @@ public class FiveMinScalpingStrategy : Strategy
 	{
 		get => _tradeVolume.Value;
 		set => _tradeVolume.Value = value;
+	}
+
+	/// <summary>
+	/// Number of candles considered for breakout detection.
+	/// </summary>
+	public int ScalperLookback
+	{
+		get => _scalperLookback.Value;
+		set => _scalperLookback.Value = value;
+	}
+
+	/// <summary>
+	/// Window length used when computing recent highs and lows.
+	/// </summary>
+	public int BreakoutWindow
+	{
+		get => _breakoutWindow.Value;
+		set => _breakoutWindow.Value = value;
+	}
+
+	/// <summary>
+	/// Stored deviations for momentum confirmation.
+	/// </summary>
+	public int MomentumHistorySize
+	{
+		get => _momentumHistorySize.Value;
+		set => _momentumHistorySize.Value = value;
+	}
+
+	/// <summary>
+	/// Length of the fastest trend LWMA.
+	/// </summary>
+	public int FastTrendLength
+	{
+		get => _fastTrendLength.Value;
+		set => _fastTrendLength.Value = value;
+	}
+
+	/// <summary>
+	/// Length of the middle trend LWMA.
+	/// </summary>
+	public int MiddleTrendLength
+	{
+		get => _middleTrendLength.Value;
+		set => _middleTrendLength.Value = value;
+	}
+
+	/// <summary>
+	/// Length of the slow trend LWMA.
+	/// </summary>
+	public int SlowTrendLength
+	{
+		get => _slowTrendLength.Value;
+		set => _slowTrendLength.Value = value;
 	}
 
 	/// <inheritdoc />


### PR DESCRIPTION
## Summary
- replace fixed constants with `StrategyParam` definitions across the updated strategies so their smoothing factors, history windows, volume tolerances, and level counts can be tuned by users
- update each strategy to consume the new parameters when configuring indicators, trimming history, and validating trade signals

## Testing
- dotnet build AlgoTrading.sln *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d7be8623648323b82506496715da7b