### PR TITLE
Expose strategy limits as parameters

### DIFF
--- a/API/3104_MA_MACD_Position_Averaging/CS/MaMacdPositionAveragingStrategy.cs
+++ b/API/3104_MA_MACD_Position_Averaging/CS/MaMacdPositionAveragingStrategy.cs
@@ -14,8 +14,6 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class MaMacdPositionAveragingStrategy : Strategy
 {
-	private const int BufferCapacity = 512;
-
 	private sealed class PositionLeg
 	{
 		public bool IsLong;
@@ -46,6 +44,7 @@ public class MaMacdPositionAveragingStrategy : Strategy
 	private readonly StrategyParam<AppliedPriceType> _macdAppliedPrice;
 	private readonly StrategyParam<decimal> _macdRatio;
 	private readonly StrategyParam<DataType> _candleType;
+	private readonly StrategyParam<int> _bufferCapacity;
 
 	private LengthIndicator<decimal> _ma = null!;
 	private MovingAverageConvergenceDivergence _macd = null!;
@@ -233,6 +232,15 @@ public class MaMacdPositionAveragingStrategy : Strategy
 	}
 
 	/// <summary>
+	/// Maximum amount of indicator history retained for internal buffers.
+	/// </summary>
+	public int BufferCapacity
+	{
+		get => _bufferCapacity.Value;
+		set => _bufferCapacity.Value = value;
+	}
+
+	/// <summary>
 	/// Initializes a new instance of the strategy.
 	/// </summary>
 	public MaMacdPositionAveragingStrategy()
@@ -318,6 +326,10 @@ public class MaMacdPositionAveragingStrategy : Strategy
 			.SetGreaterThanZero()
 			.SetCanOptimize(true)
 			.SetDisplay("MACD Ratio", "Required MACD main/signal ratio", "Signals");
+
+		_bufferCapacity = Param(nameof(BufferCapacity), 512)
+			.SetGreaterThanZero()
+			.SetDisplay("Buffer Capacity", "Maximum history size for internal buffers", "Advanced");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(1).TimeFrame())
 			.SetDisplay("Candle Type", "Timeframe used for calculations", "General");
@@ -711,7 +723,7 @@ public class MaMacdPositionAveragingStrategy : Strategy
 		_legs.Clear();
 	}
 
-	private static void PushValue<T>(List<T> buffer, T value)
+	private void PushValue<T>(List<T> buffer, T value)
 	{
 		buffer.Add(value);
 

--- a/API/3108_Bago_EA/CS/BagoEaStrategy.cs
+++ b/API/3108_Bago_EA/CS/BagoEaStrategy.cs
@@ -15,9 +15,6 @@ using StockSharp.Messages;
 /// </summary>
 public class BagoEaStrategy : Strategy
 {
-	private const int HistoryLimit = 300;
-	private const decimal FiftyLevel = 50m;
-
 	private readonly StrategyParam<decimal> _tradeVolume;
 	private readonly StrategyParam<decimal> _stopLossPips;
 	private readonly StrategyParam<decimal> _stopLossToFiboPips;
@@ -41,6 +38,8 @@ public class BagoEaStrategy : Strategy
 	private readonly StrategyParam<int> _rsiPeriod;
 	private readonly StrategyParam<AppliedPriceType> _rsiAppliedPrice;
 	private readonly StrategyParam<DataType> _candleType;
+	private readonly StrategyParam<int> _historyLimit;
+	private readonly StrategyParam<decimal> _fiftyLevel;
 
 	private LengthIndicator<decimal> _fastMa = null!;
 	private LengthIndicator<decimal> _slowMa = null!;
@@ -164,8 +163,15 @@ public class BagoEaStrategy : Strategy
 		_rsiAppliedPrice = Param(nameof(RsiAppliedPrice), AppliedPriceType.Close)
 		.SetDisplay("RSI Price", "Applied price for RSI", "Indicator");
 
+		_fiftyLevel = Param(nameof(FiftyLevel), 50m)
+		.SetDisplay("RSI Mid Level", "Neutral RSI threshold", "Indicator");
+
 		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(1).TimeFrame())
 		.SetDisplay("Candle Type", "Working timeframe", "General");
+
+		_historyLimit = Param(nameof(HistoryLimit), 300)
+		.SetGreaterThanZero()
+		.SetDisplay("History Limit", "Maximum stored bars for signal validation", "Advanced");
 	}
 
 /// <summary>
@@ -367,12 +373,30 @@ public AppliedPriceType RsiAppliedPrice
 }
 
 /// <summary>
+/// Neutral RSI threshold defining the bullish/bearish boundary.
+/// </summary>
+public decimal FiftyLevel
+{
+	get => _fiftyLevel.Value;
+	set => _fiftyLevel.Value = value;
+}
+
+/// <summary>
 /// Candle data type used for calculations.
 /// </summary>
 public DataType CandleType
 {
 	get => _candleType.Value;
 	set => _candleType.Value = value;
+}
+
+/// <summary>
+/// Maximum number of historical bars cached for indicator comparisons.
+/// </summary>
+public int HistoryLimit
+{
+	get => _historyLimit.Value;
+	set => _historyLimit.Value = value;
 }
 
 /// <inheritdoc />

--- a/API/3110_BitexOneMarketMaker/CS/BitexOneMarketMakerStrategy.cs
+++ b/API/3110_BitexOneMarketMaker/CS/BitexOneMarketMakerStrategy.cs
@@ -12,14 +12,13 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class BitexOneMarketMakerStrategy : Strategy
 {
-	private const decimal PriceToleranceRatio = 0.0005m;
-	private const decimal VolumeTolerance = 0.0000001m;
-
 	private readonly StrategyParam<decimal> _maxVolumePerLevel;
 	private readonly StrategyParam<decimal> _shiftCoefficient;
 	private readonly StrategyParam<int> _levelCount;
 	private readonly StrategyParam<LeadPriceSource> _priceSource;
 	private readonly StrategyParam<Security> _leadSecurityParam;
+	private readonly StrategyParam<decimal> _priceToleranceRatio;
+	private readonly StrategyParam<decimal> _volumeTolerance;
 
 	private Order[] _buyOrders = Array.Empty<Order>();
 	private Order[] _sellOrders = Array.Empty<Order>();
@@ -82,6 +81,24 @@ public class BitexOneMarketMakerStrategy : Strategy
 	}
 
 	/// <summary>
+	/// Maximum allowed deviation between desired and actual price as a fraction of price step.
+	/// </summary>
+	public decimal PriceToleranceRatio
+	{
+		get => _priceToleranceRatio.Value;
+		set => _priceToleranceRatio.Value = value;
+	}
+
+	/// <summary>
+	/// Minimum volume difference treated as negligible when comparing order sizes.
+	/// </summary>
+	public decimal VolumeTolerance
+	{
+		get => _volumeTolerance.Value;
+		set => _volumeTolerance.Value = value;
+	}
+
+	/// <summary>
 	/// Initializes a new instance of <see cref="BitexOneMarketMakerStrategy"/>.
 	/// </summary>
 	public BitexOneMarketMakerStrategy()
@@ -107,6 +124,14 @@ public class BitexOneMarketMakerStrategy : Strategy
 
 		_leadSecurityParam = Param<Security>(nameof(LeadSecurity))
 		.SetDisplay("Lead Security", "Instrument that supplies mark or index prices when needed.", "General");
+
+		_priceToleranceRatio = Param(nameof(PriceToleranceRatio), 0.0005m)
+		.SetGreaterThanZero()
+		.SetDisplay("Price Tolerance", "Allowed deviation ratio when matching resting quotes.", "Orders");
+
+		_volumeTolerance = Param(nameof(VolumeTolerance), 0.0000001m)
+		.SetGreaterThanZero()
+		.SetDisplay("Volume Tolerance", "Minimum difference ignored when comparing order volumes.", "Orders");
 	}
 
 	/// <inheritdoc />

--- a/API/3119_Exp_XFisher_org_v1/CS/ExpXFisherOrgV1Strategy.cs
+++ b/API/3119_Exp_XFisher_org_v1/CS/ExpXFisherOrgV1Strategy.cs
@@ -46,8 +46,6 @@ public enum XfisherAppliedPrice
 /// </summary>
 public class ExpXFisherOrgV1Strategy : Strategy
 {
-	private const int MaxHistory = 1024;
-
 	private readonly StrategyParam<decimal> _orderVolume;
 	private readonly StrategyParam<bool> _buyOpen;
 	private readonly StrategyParam<bool> _sellOpen;
@@ -60,6 +58,7 @@ public class ExpXFisherOrgV1Strategy : Strategy
 	private readonly StrategyParam<XfisherSmoothingMethod> _smoothingMethod;
 	private readonly StrategyParam<XfisherAppliedPrice> _priceType;
 	private readonly StrategyParam<DataType> _candleType;
+	private readonly StrategyParam<int> _maxHistory;
 
 	private XFisherOrgIndicator _indicator = null!;
 	private readonly List<decimal> _fisherHistory = new();
@@ -173,6 +172,15 @@ public class ExpXFisherOrgV1Strategy : Strategy
 	}
 
 	/// <summary>
+	/// Maximum number of Fisher readings cached for reversal detection.
+	/// </summary>
+	public int MaxHistory
+	{
+		get => _maxHistory.Value;
+		set => _maxHistory.Value = value;
+	}
+
+	/// <summary>
 	/// Initializes a new instance of <see cref="ExpXFisherOrgV1Strategy"/>.
 	/// </summary>
 	public ExpXFisherOrgV1Strategy()
@@ -222,6 +230,10 @@ public class ExpXFisherOrgV1Strategy : Strategy
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(4).TimeFrame())
 			.SetDisplay("Candle Type", "Type of candles used for calculations", "General");
+
+		_maxHistory = Param(nameof(MaxHistory), 1024)
+			.SetGreaterThanZero()
+			.SetDisplay("History Size", "Maximum number of cached Fisher values", "Advanced");
 	}
 
 	/// <inheritdoc />

--- a/API/3124_Tengri/CS/TengriStrategy.cs
+++ b/API/3124_Tengri/CS/TengriStrategy.cs
@@ -16,9 +16,6 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class TengriStrategy : Strategy
 {
-	private const decimal RsiUpperThreshold = 70m;
-	private const decimal RsiLowerThreshold = 30m;
-
 	private readonly StrategyParam<DataType> _dealCandleType;
 	private readonly StrategyParam<DataType> _entryCandleType;
 	private readonly StrategyParam<DataType> _scaleCandleType;
@@ -26,6 +23,8 @@ public class TengriStrategy : Strategy
 	private readonly StrategyParam<DataType> _silence1CandleType;
 	private readonly StrategyParam<DataType> _silence2CandleType;
 	private readonly StrategyParam<int> _rsiPeriod;
+	private readonly StrategyParam<decimal> _rsiUpperThreshold;
+	private readonly StrategyParam<decimal> _rsiLowerThreshold;
 	private readonly StrategyParam<int> _silencePeriod1;
 	private readonly StrategyParam<int> _silenceInterpolation1;
 	private readonly StrategyParam<decimal> _silenceLevel1;
@@ -110,6 +109,12 @@ public class TengriStrategy : Strategy
 
 		_rsiPeriod = Param(nameof(RsiPeriod), 14)
 			.SetDisplay("RSI Period", "Lookback period for the RSI filter", "Indicators");
+
+		_rsiUpperThreshold = Param(nameof(RsiUpperThreshold), 70m)
+			.SetDisplay("RSI Overbought", "Upper RSI level blocking additional longs", "Indicators");
+
+		_rsiLowerThreshold = Param(nameof(RsiLowerThreshold), 30m)
+			.SetDisplay("RSI Oversold", "Lower RSI level blocking additional shorts", "Indicators");
 
 		_silencePeriod1 = Param(nameof(SilencePeriod1), 11)
 			.SetDisplay("Silence #1 Period", "ATR length for the first quiet-market detector", "Indicators")
@@ -255,6 +260,24 @@ public class TengriStrategy : Strategy
 	{
 		get => _rsiPeriod.Value;
 		set => _rsiPeriod.Value = value;
+	}
+
+	/// <summary>
+	/// RSI level considered overbought and used to pause new long entries.
+	/// </summary>
+	public decimal RsiUpperThreshold
+	{
+		get => _rsiUpperThreshold.Value;
+		set => _rsiUpperThreshold.Value = value;
+	}
+
+	/// <summary>
+	/// RSI level considered oversold and used to pause new short entries.
+	/// </summary>
+	public decimal RsiLowerThreshold
+	{
+		get => _rsiLowerThreshold.Value;
+		set => _rsiLowerThreshold.Value = value;
 	}
 
 	/// <summary>

--- a/API/3143_Vortex_Indicator_MMRec_Duplex/CS/VortexIndicatorMmrecDuplexStrategy.cs
+++ b/API/3143_Vortex_Indicator_MMRec_Duplex/CS/VortexIndicatorMmrecDuplexStrategy.cs
@@ -14,8 +14,6 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class VortexIndicatorMmrecDuplexStrategy : Strategy
 {
-	private const int MaxHistory = 512;
-
 	private readonly StrategyParam<DataType> _longCandleType;
 	private readonly StrategyParam<DataType> _shortCandleType;
 	private readonly StrategyParam<int> _longLength;
@@ -42,6 +40,7 @@ public class VortexIndicatorMmrecDuplexStrategy : Strategy
 	private readonly StrategyParam<decimal> _shortTakeProfitSteps;
 	private readonly StrategyParam<decimal> _longSlippageSteps;
 	private readonly StrategyParam<decimal> _shortSlippageSteps;
+	private readonly StrategyParam<int> _maxHistory;
 
 	private VortexIndicator _longVortex = null!;
 	private VortexIndicator _shortVortex = null!;
@@ -400,6 +399,15 @@ public class VortexIndicatorMmrecDuplexStrategy : Strategy
 	{
 		get => _shortSlippageSteps.Value;
 		set => _shortSlippageSteps.Value = value;
+	}
+
+	/// <summary>
+	/// Maximum number of indicator points stored for divergence detection.
+	/// </summary>
+	public int MaxHistory
+	{
+		get => _maxHistory.Value;
+		set => _maxHistory.Value = value;
 	}
 
 	/// <inheritdoc />

--- a/API/3153_Puria_Method/CS/PuriaMethodStrategy.cs
+++ b/API/3153_Puria_Method/CS/PuriaMethodStrategy.cs
@@ -14,8 +14,6 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class PuriaMethodStrategy : Strategy
 {
-	private const decimal Epsilon = 0.0000001m;
-
 	private readonly StrategyParam<decimal> _stopLossPips;
 	private readonly StrategyParam<decimal> _takeProfitPips;
 	private readonly StrategyParam<decimal> _trailingStopPips;
@@ -23,6 +21,7 @@ public class PuriaMethodStrategy : Strategy
 	private readonly StrategyParam<decimal> _minProfitStepPips;
 	private readonly StrategyParam<decimal> _minProfitFraction;
 	private readonly StrategyParam<DataType> _candleType;
+	private readonly StrategyParam<decimal> _epsilon;
 
 	private readonly StrategyParam<int> _ma0Period;
 	private readonly StrategyParam<int> _ma0Shift;
@@ -101,6 +100,10 @@ public class PuriaMethodStrategy : Strategy
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(30).TimeFrame())
 			.SetDisplay("Candle Type", "Primary candle series", "Data");
+
+		_epsilon = Param(nameof(Epsilon), 0.0000001m)
+			.SetGreaterThanZero()
+			.SetDisplay("Comparison Tolerance", "Minimum difference considered significant in price/volume checks", "Advanced");
 
 		_ma0Period = Param(nameof(Ma0Period), 69)
 			.SetGreaterThanZero()
@@ -225,6 +228,15 @@ public class PuriaMethodStrategy : Strategy
 	{
 		get => _candleType.Value;
 		set => _candleType.Value = value;
+	}
+
+	/// <summary>
+	/// Numerical tolerance applied when comparing prices and volumes.
+	/// </summary>
+	public decimal Epsilon
+	{
+		get => _epsilon.Value;
+		set => _epsilon.Value = value;
 	}
 
 	/// <summary>

--- a/API/3160_Cidomo/CS/CidomoStrategy.cs
+++ b/API/3160_Cidomo/CS/CidomoStrategy.cs
@@ -15,8 +15,6 @@ using StockSharp.Messages;
 /// </summary>
 public class CidomoStrategy : Strategy
 {
-	private const int TimeWindowSeconds = 30;
-
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<decimal> _stopLossPips;
 	private readonly StrategyParam<decimal> _takeProfitPips;
@@ -30,6 +28,7 @@ public class CidomoStrategy : Strategy
 	private readonly StrategyParam<bool> _useTimeFilter;
 	private readonly StrategyParam<int> _startHour;
 	private readonly StrategyParam<int> _startMinute;
+	private readonly StrategyParam<int> _timeWindowSeconds;
 
 	private Highest _highest = null!;
 	private Lowest _lowest = null!;
@@ -106,6 +105,10 @@ public class CidomoStrategy : Strategy
 		_startMinute = Param(nameof(StartMinute), 58)
 			.SetRange(0, 59)
 			.SetDisplay("Start Minute", "Minute component of the trading window", "Filters");
+
+		_timeWindowSeconds = Param(nameof(TimeWindowSeconds), 30)
+			.SetGreaterThanZero()
+			.SetDisplay("Time Window (sec)", "Tolerance around the candle close for order placement", "Filters");
 	}
 
 	/// <summary>
@@ -223,6 +226,15 @@ public class CidomoStrategy : Strategy
 	{
 		get => _startMinute.Value;
 		set => _startMinute.Value = value;
+	}
+
+	/// <summary>
+	/// Allowed time difference between candle completion and range evaluation in seconds.
+	/// </summary>
+	public int TimeWindowSeconds
+	{
+		get => _timeWindowSeconds.Value;
+		set => _timeWindowSeconds.Value = value;
 	}
 
 	/// <inheritdoc />

--- a/API/3165_Dynamic_Averaging/CS/DynamicAveragingStrategy.cs
+++ b/API/3165_Dynamic_Averaging/CS/DynamicAveragingStrategy.cs
@@ -15,9 +15,6 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class DynamicAveragingStrategy : Strategy
 {
-	private const decimal OversoldLevel = 25m;
-	private const decimal OverboughtLevel = 75m;
-
 	private readonly StrategyParam<decimal> _tradeVolume;
 	private readonly StrategyParam<decimal> _profitTarget;
 	private readonly StrategyParam<int> _slidingWindowDays;
@@ -26,6 +23,8 @@ public class DynamicAveragingStrategy : Strategy
 	private readonly StrategyParam<int> _stochasticSlowPeriod;
 	private readonly StrategyParam<int> _stdDevPeriod;
 	private readonly StrategyParam<DataType> _candleType;
+	private readonly StrategyParam<decimal> _oversoldLevel;
+	private readonly StrategyParam<decimal> _overboughtLevel;
 
 	private StochasticOscillator _stochastic = null!;
 	private StandardDeviation _stdDev = null!;
@@ -109,6 +108,24 @@ public class DynamicAveragingStrategy : Strategy
 	}
 
 	/// <summary>
+	/// Stochastic oversold level triggering long entries.
+	/// </summary>
+	public decimal OversoldLevel
+	{
+		get => _oversoldLevel.Value;
+		set => _oversoldLevel.Value = value;
+	}
+
+	/// <summary>
+	/// Stochastic overbought level triggering short entries.
+	/// </summary>
+	public decimal OverboughtLevel
+	{
+		get => _overboughtLevel.Value;
+		set => _overboughtLevel.Value = value;
+	}
+
+	/// <summary>
 	/// Candle type used for calculations.
 	/// </summary>
 	public DataType CandleType
@@ -149,6 +166,12 @@ public class DynamicAveragingStrategy : Strategy
 		_stdDevPeriod = Param(nameof(StdDevPeriod), 20)
 		.SetDisplay("StdDev Length", "Lookback for the standard deviation filter", "Indicators")
 		.SetGreaterThanZero();
+
+		_oversoldLevel = Param(nameof(OversoldLevel), 25m)
+		.SetDisplay("Oversold Level", "%K threshold for long entries", "Indicators");
+
+		_overboughtLevel = Param(nameof(OverboughtLevel), 75m)
+		.SetDisplay("Overbought Level", "%K threshold for short entries", "Indicators");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
 		.SetDisplay("Candle Type", "Source candles for indicator calculations", "Market Data");

--- a/API/3204_Plateau/CS/PlateauStrategy.cs
+++ b/API/3204_Plateau/CS/PlateauStrategy.cs
@@ -74,8 +74,6 @@ public enum PlateauMovingAverageMethod
 /// </summary>
 public class PlateauStrategy : Strategy
 {
-	private const int HistoryCapacity = 16;
-
 	private readonly StrategyParam<decimal> _stopLossPips;
 	private readonly StrategyParam<decimal> _takeProfitPips;
 	private readonly StrategyParam<decimal> _trailingStopPips;
@@ -95,6 +93,7 @@ public class PlateauStrategy : Strategy
 	private readonly StrategyParam<bool> _closeOpposite;
 	private readonly StrategyParam<bool> _printLog;
 	private readonly StrategyParam<DataType> _candleType;
+	private readonly StrategyParam<int> _historyCapacity;
 
 	private IIndicator _fastMa = null!;
 	private IIndicator _slowMa = null!;
@@ -284,6 +283,15 @@ public class PlateauStrategy : Strategy
 	{
 		get => _candleType.Value;
 		set => _candleType.Value = value;
+	}
+
+	/// <summary>
+	/// Maximum number of historical indicator values retained for signal confirmation.
+	/// </summary>
+	public int HistoryCapacity
+	{
+		get => _historyCapacity.Value;
+		set => _historyCapacity.Value = value;
 	}
 
 	/// <summary>

--- a/API/3210_Back_Kick/CS/BackKickStrategy.cs
+++ b/API/3210_Back_Kick/CS/BackKickStrategy.cs
@@ -13,13 +13,12 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class BackKickStrategy : Strategy
 {
-	private const decimal VolumeTolerance = 0.0000001m;
-
 	private readonly StrategyParam<decimal> _orderVolume;
 	private readonly StrategyParam<int> _stopLossPips;
 	private readonly StrategyParam<int> _takeProfitPips;
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<bool> _logDiagnostics;
+	private readonly StrategyParam<decimal> _volumeTolerance;
 
 	private readonly Dictionary<Order, PendingOrderInfo> _pendingOrders = new();
 
@@ -84,6 +83,15 @@ public class BackKickStrategy : Strategy
 	}
 
 	/// <summary>
+	/// Minimal volume difference treated as meaningful when reconciling hedged orders.
+	/// </summary>
+	public decimal VolumeTolerance
+	{
+		get => _volumeTolerance.Value;
+		set => _volumeTolerance.Value = value;
+	}
+
+	/// <summary>
 	/// Initialize strategy parameters.
 	/// </summary>
 	public BackKickStrategy()
@@ -111,6 +119,10 @@ public class BackKickStrategy : Strategy
 
 		_logDiagnostics = Param(nameof(LogDiagnostics), false)
 		.SetDisplay("Log Diagnostics", "Write detailed fill information", "Logging");
+
+		_volumeTolerance = Param(nameof(VolumeTolerance), 0.0000001m)
+		.SetGreaterThanZero()
+		.SetDisplay("Volume Tolerance", "Minimum difference treated as a volume change", "Trading");
 	}
 
 	/// <inheritdoc />


### PR DESCRIPTION
## Summary
- convert fixed buffer and history limits into configurable strategy parameters across the affected strategies
- expose tolerance and threshold constants (e.g., RSI levels, price/volume tolerances) as user-adjustable parameters

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7be99195c8323943a4e0fd63d9884