### PR TITLE
Expose strategy constants as parameters

### DIFF
--- a/API/3233_Auto_Adjusting/CS/AutoAdjustingStrategy.cs
+++ b/API/3233_Auto_Adjusting/CS/AutoAdjustingStrategy.cs
@@ -16,13 +16,13 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class AutoAdjustingStrategy : Strategy
 {
-	private const int FastEmaLength = 6;
-	private const int MiddleEmaLength = 14;
-	private const int SlowEmaLength = 26;
-	private const int MomentumLength = 14;
-	private const int MomentumSamples = 3;
 	private static readonly DataType DefaultMacroType = TimeSpan.FromDays(30).TimeFrame();
 
+	private readonly StrategyParam<int> _fastEmaLength;
+	private readonly StrategyParam<int> _middleEmaLength;
+	private readonly StrategyParam<int> _slowEmaLength;
+	private readonly StrategyParam<int> _momentumLength;
+	private readonly StrategyParam<int> _momentumSamples;
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<DataType> _momentumCandleType;
 	private readonly StrategyParam<DataType> _macroCandleType;
@@ -54,6 +54,26 @@ public class AutoAdjustingStrategy : Strategy
 	{
 		var defaultFrame = TimeSpan.FromHours(1);
 		var defaultMomentum = GetDefaultMomentumFrame(defaultFrame);
+
+		_fastEmaLength = Param(nameof(FastEmaLength), 6)
+			.SetGreaterThanZero()
+			.SetDisplay("Fast EMA", "Length of the fast EMA in the stack", "Signals");
+
+		_middleEmaLength = Param(nameof(MiddleEmaLength), 14)
+			.SetGreaterThanZero()
+			.SetDisplay("Middle EMA", "Length of the middle EMA in the stack", "Signals");
+
+		_slowEmaLength = Param(nameof(SlowEmaLength), 26)
+			.SetGreaterThanZero()
+			.SetDisplay("Slow EMA", "Length of the slow EMA in the stack", "Signals");
+
+		_momentumLength = Param(nameof(MomentumLength), 14)
+			.SetGreaterThanZero()
+			.SetDisplay("Momentum Length", "Lookback for the momentum indicator", "Signals");
+
+		_momentumSamples = Param(nameof(MomentumSamples), 3)
+			.SetGreaterThanZero()
+			.SetDisplay("Momentum Samples", "Number of higher timeframe momentum values required", "Signals");
 
 		_candleType = Param(nameof(CandleType), defaultFrame.TimeFrame())
 			.SetDisplay("Candle Type", "Primary timeframe used for the EMA stack", "General");
@@ -99,6 +119,51 @@ public class AutoAdjustingStrategy : Strategy
 	{
 		get => _candleType.Value;
 		set => _candleType.Value = value;
+	}
+
+	/// <summary>
+	/// Length of the fast EMA in the stack.
+	/// </summary>
+	public int FastEmaLength
+	{
+		get => _fastEmaLength.Value;
+		set => _fastEmaLength.Value = value;
+	}
+
+	/// <summary>
+	/// Length of the middle EMA in the stack.
+	/// </summary>
+	public int MiddleEmaLength
+	{
+		get => _middleEmaLength.Value;
+		set => _middleEmaLength.Value = value;
+	}
+
+	/// <summary>
+	/// Length of the slow EMA in the stack.
+	/// </summary>
+	public int SlowEmaLength
+	{
+		get => _slowEmaLength.Value;
+		set => _slowEmaLength.Value = value;
+	}
+
+	/// <summary>
+	/// Lookback for the momentum indicator.
+	/// </summary>
+	public int MomentumLength
+	{
+		get => _momentumLength.Value;
+		set => _momentumLength.Value = value;
+	}
+
+	/// <summary>
+	/// Number of higher timeframe momentum values required.
+	/// </summary>
+	public int MomentumSamples
+	{
+		get => _momentumSamples.Value;
+		set => _momentumSamples.Value = value;
 	}
 
 	/// <summary>

--- a/API/3238_JK_Synchro/CS/JkSynchroStrategy.cs
+++ b/API/3238_JK_Synchro/CS/JkSynchroStrategy.cs
@@ -15,7 +15,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class JkSynchroStrategy : Strategy
 {
-	private const decimal VolumeTolerance = 1e-8m;
+	private readonly StrategyParam<decimal> _volumeTolerance;
 
 	private readonly StrategyParam<decimal> _orderVolume;
 	private readonly StrategyParam<int> _maxPositions;
@@ -52,6 +52,15 @@ public class JkSynchroStrategy : Strategy
 	{
 		get => _orderVolume.Value;
 		set => _orderVolume.Value = value;
+	}
+
+	/// <summary>
+	/// Minimum absolute position size treated as non-zero.
+	/// </summary>
+	public decimal VolumeTolerance
+	{
+		get => _volumeTolerance.Value;
+		set => _volumeTolerance.Value = value;
 	}
 
 	/// <summary>
@@ -149,6 +158,10 @@ public class JkSynchroStrategy : Strategy
 	/// </summary>
 	public JkSynchroStrategy()
 	{
+	_volumeTolerance = Param(nameof(VolumeTolerance), 1e-8m)
+	.SetGreaterThanOrEqualZero()
+	.SetDisplay("Volume Tolerance", "Threshold below which positions are considered flat", "Risk");
+
 	_orderVolume = Param(nameof(OrderVolume), 0.1m)
 	.SetGreaterThanZero()
 	.SetDisplay("Order Volume", "Volume placed with every market order", "Trading")

--- a/API/3242_Day_Trading/CS/DayTradingStrategy.cs
+++ b/API/3242_Day_Trading/CS/DayTradingStrategy.cs
@@ -13,7 +13,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class DayTradingStrategy : Strategy
 {
-	private const int PullbackLookback = 3;
+	private readonly StrategyParam<int> _pullbackLookback;
 
 	private readonly Queue<bool> _pullbackBelowMa20 = new();
 	private readonly Queue<bool> _pullbackAboveMa20 = new();
@@ -44,6 +44,10 @@ public class DayTradingStrategy : Strategy
 	/// </summary>
 	public DayTradingStrategy()
 	{
+
+		_pullbackLookback = Param(nameof(PullbackLookback), 3)
+			.SetGreaterThanZero()
+			.SetDisplay("Pullback Lookback", "Candles stored for recent pullback checks", "Trend");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
 			.SetDisplay("Candle Type", "Primary timeframe", "General");
@@ -146,6 +150,15 @@ public class DayTradingStrategy : Strategy
 	{
 		get => _maxPositions.Value;
 		set => _maxPositions.Value = value;
+	}
+
+	/// <summary>
+	/// Number of candles tracked for pullback evaluation.
+	/// </summary>
+	public int PullbackLookback
+	{
+		get => _pullbackLookback.Value;
+		set => _pullbackLookback.Value = value;
 	}
 
 	/// <inheritdoc />

--- a/API/3243_JBrainTrend1Stop/CS/JBrainTrend1StopStrategy.cs
+++ b/API/3243_JBrainTrend1Stop/CS/JBrainTrend1StopStrategy.cs
@@ -15,10 +15,10 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class JBrainTrend1StopStrategy : Strategy
 {
-	private const decimal RangeDivisor = 2.3m;
-	private const decimal RangeMultiplier = 1.5m;
-	private const decimal UpperThreshold = 53m;
-	private const decimal LowerThreshold = 47m;
+	private readonly StrategyParam<decimal> _rangeDivisor;
+	private readonly StrategyParam<decimal> _rangeMultiplier;
+	private readonly StrategyParam<decimal> _upperThreshold;
+	private readonly StrategyParam<decimal> _lowerThreshold;
 
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<int> _atrPeriod;
@@ -102,10 +102,44 @@ public class JBrainTrend1StopStrategy : Strategy
 	public bool SellClose { get => _sellClose.Value; set => _sellClose.Value = value; }
 
 	/// <summary>
+	/// Divisor applied to ATR when calculating the trailing range.
+	/// </summary>
+	public decimal RangeDivisor { get => _rangeDivisor.Value; set => _rangeDivisor.Value = value; }
+
+	/// <summary>
+	/// Multiplier applied to the calculated trailing range.
+	/// </summary>
+	public decimal RangeMultiplier { get => _rangeMultiplier.Value; set => _rangeMultiplier.Value = value; }
+
+	/// <summary>
+	/// Upper threshold of the BrainTrend oscillator.
+	/// </summary>
+	public decimal UpperThreshold { get => _upperThreshold.Value; set => _upperThreshold.Value = value; }
+
+	/// <summary>
+	/// Lower threshold of the BrainTrend oscillator.
+	/// </summary>
+	public decimal LowerThreshold { get => _lowerThreshold.Value; set => _lowerThreshold.Value = value; }
+
+	/// <summary>
 	/// Initializes a new instance of the <see cref="JBrainTrend1StopStrategy"/> class.
 	/// </summary>
 	public JBrainTrend1StopStrategy()
 	{
+		_rangeDivisor = Param(nameof(RangeDivisor), 2.3m)
+			.SetGreaterThanZero()
+			.SetDisplay("Range Divisor", "Divisor applied to ATR when calculating the trail range", "Indicator");
+
+		_rangeMultiplier = Param(nameof(RangeMultiplier), 1.5m)
+			.SetGreaterThanZero()
+			.SetDisplay("Range Multiplier", "Multiplier applied to the calculated range", "Indicator");
+
+		_upperThreshold = Param(nameof(UpperThreshold), 53m)
+			.SetDisplay("Upper Threshold", "BrainTrend oscillator upper threshold", "Indicator");
+
+		_lowerThreshold = Param(nameof(LowerThreshold), 47m)
+			.SetDisplay("Lower Threshold", "BrainTrend oscillator lower threshold", "Indicator");
+
 		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(4).TimeFrame())
 			.SetDisplay("Candle Type", "Time frame used for indicator calculations", "General");
 

--- a/API/3256_FiboChannel_Line/CS/FiboChannelLineStrategy.cs
+++ b/API/3256_FiboChannel_Line/CS/FiboChannelLineStrategy.cs
@@ -15,7 +15,7 @@ using StockSharp.Messages;
 /// </summary>
 public class FiboChannelLineStrategy : Strategy
 {
-private const int MomentumSampleSize = 3;
+private readonly StrategyParam<int> _momentumSampleSize;
 
 private readonly StrategyParam<DataType> _candleType;
 private readonly StrategyParam<int> _fastMaPeriod;
@@ -64,6 +64,10 @@ _momentumPeriod = Param(nameof(MomentumPeriod), 14)
 .SetDisplay("Momentum Period", "Number of bars for the momentum oscillator.", "Momentum")
 .SetCanOptimize(true)
 .SetOptimize(5, 30, 1);
+
+_momentumSampleSize = Param(nameof(MomentumSampleSize), 3)
+.SetGreaterThanZero()
+.SetDisplay("Momentum Samples", "Number of recent momentum readings stored.", "Momentum");
 
 _momentumThreshold = Param(nameof(MomentumThreshold), 0.3m)
 .SetGreaterThanZero()
@@ -156,6 +160,15 @@ public decimal MomentumThreshold
 {
 get => _momentumThreshold.Value;
 set => _momentumThreshold.Value = value;
+}
+
+/// <summary>
+/// Number of recent momentum values kept for confirmation.
+/// </summary>
+public int MomentumSampleSize
+{
+get => _momentumSampleSize.Value;
+set => _momentumSampleSize.Value = value;
 }
 
 /// <summary>

--- a/API/3288_Williams_AO_AC/CS/WilliamsAoAcStrategy.cs
+++ b/API/3288_Williams_AO_AC/CS/WilliamsAoAcStrategy.cs
@@ -14,7 +14,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class WilliamsAoAcStrategy : Strategy
 {
-	private const int AcceleratorSmoothingPeriod = 5;
+	private readonly StrategyParam<int> _acceleratorSmoothingPeriod;
 
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<int> _bollingerPeriod;
@@ -53,6 +53,10 @@ public class WilliamsAoAcStrategy : Strategy
 	/// </summary>
 	public WilliamsAoAcStrategy()
 	{
+		_acceleratorSmoothingPeriod = Param(nameof(AcceleratorSmoothingPeriod), 5)
+			.SetGreaterThanZero()
+			.SetDisplay("AC Smoothing", "Length of the smoothing average for Accelerator Oscillator", "Awesome Oscillator");
+
 		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(1).TimeFrame())
 		.SetDisplay("Candle Type", "Primary candle series used for calculations", "General");
 
@@ -217,6 +221,15 @@ public class WilliamsAoAcStrategy : Strategy
 	{
 		get => _rsiSellThreshold.Value;
 		set => _rsiSellThreshold.Value = value;
+	}
+
+	/// <summary>
+	/// Length of the smoothing average applied to the Accelerator Oscillator.
+	/// </summary>
+	public int AcceleratorSmoothingPeriod
+	{
+		get => _acceleratorSmoothingPeriod.Value;
+		set => _acceleratorSmoothingPeriod.Value = value;
 	}
 
 	/// <summary>

--- a/API/3297_ITrade/CS/ITradeStrategy.cs
+++ b/API/3297_ITrade/CS/ITradeStrategy.cs
@@ -14,8 +14,8 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class ITradeStrategy : Strategy
 {
-	private const int ProfitResetAfterWins = 1;
-	private const int HistoryLimit = 200;
+	private readonly StrategyParam<int> _profitResetAfterWins;
+	private readonly StrategyParam<int> _historyLimit;
 
 	private readonly StrategyParam<decimal> _initialVolume;
 	private readonly StrategyParam<decimal> _martingaleMultiplier;
@@ -57,6 +57,14 @@ public class ITradeStrategy : Strategy
 
 		_baseTradeCount = Param(nameof(BaseTradeCount), 7)
 			.SetDisplay("Base Trade Count", "Number of trades considered part of the initial batch.", "Profit Control")
+			.SetGreaterThanZero();
+
+		_profitResetAfterWins = Param(nameof(ProfitResetAfterWins), 1)
+			.SetDisplay("Profit Reset Wins", "Number of consecutive winning cycles before profit counters reset.", "Profit Control")
+			.SetGreaterThanOrEqualZero();
+
+		_historyLimit = Param(nameof(HistoryLimit), 200)
+			.SetDisplay("History Limit", "Maximum number of closed profit samples retained.", "Profit Control")
 			.SetGreaterThanZero();
 
 		_controlInterval = Param(nameof(ControlInterval), TimeSpan.FromSeconds(1))
@@ -116,6 +124,24 @@ public class ITradeStrategy : Strategy
 	{
 		get => _controlInterval.Value;
 		set => _controlInterval.Value = value;
+	}
+
+	/// <summary>
+	/// Number of consecutive profitable cycles before the profit history resets.
+	/// </summary>
+	public int ProfitResetAfterWins
+	{
+		get => _profitResetAfterWins.Value;
+		set => _profitResetAfterWins.Value = value;
+	}
+
+	/// <summary>
+	/// Maximum number of closed profit samples preserved for averaging.
+	/// </summary>
+	public int HistoryLimit
+	{
+		get => _historyLimit.Value;
+		set => _historyLimit.Value = value;
 	}
 
 	/// <summary>


### PR DESCRIPTION
## Summary
- expose EMA lengths, momentum window and sample count as tunable parameters in AutoAdjustingStrategy
- add user-configurable volume tolerance, pullback lookback and BrainTrend threshold inputs across existing strategies
- surface sample-size, smoothing and history-reset constants as strategy parameters for the remaining converted algorithms

## Testing
- dotnet build AlgoTrading.sln *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d7beabc0c483238c453ec26a836b02