### PR TITLE
Expose strategy constants as configurable parameters

### DIFF
--- a/API/3453_Fibonacci_Potential_Entries/CS/FibonacciPotentialEntriesStrategy.cs
+++ b/API/3453_Fibonacci_Potential_Entries/CS/FibonacciPotentialEntriesStrategy.cs
@@ -12,8 +12,8 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class FibonacciPotentialEntriesStrategy : Strategy
 {
-	private const decimal FirstTradeRiskShare = 0.7m;
-	private const decimal SpreadMultiplier = 3m;
+	private readonly StrategyParam<decimal> _firstTradeRiskShare;
+	private readonly StrategyParam<decimal> _spreadMultiplier;
 	
 	private readonly StrategyParam<decimal> _priceOn50Level;
 	private readonly StrategyParam<decimal> _priceOn61Level;
@@ -30,6 +30,24 @@ public class FibonacciPotentialEntriesStrategy : Strategy
 	private bool _ordersPlaced;
 	private bool _targetHandled;
 	
+	/// <summary>
+	/// Share of the total risk allocated to the first trade.
+	/// </summary>
+	public decimal FirstTradeRiskShare
+	{
+		get => _firstTradeRiskShare.Value;
+		set => _firstTradeRiskShare.Value = value;
+	}
+
+	/// <summary>
+	/// Multiplier applied to the spread when calculating stop orders.
+	/// </summary>
+	public decimal SpreadMultiplier
+	{
+		get => _spreadMultiplier.Value;
+		set => _spreadMultiplier.Value = value;
+	}
+
 	/// <summary>
 	/// Price of the 50% Fibonacci retracement level.
 	/// </summary>
@@ -89,6 +107,14 @@ public class FibonacciPotentialEntriesStrategy : Strategy
 	/// </summary>
 	public FibonacciPotentialEntriesStrategy()
 	{
+		_firstTradeRiskShare = Param(nameof(FirstTradeRiskShare), 0.7m)
+			.SetDisplay("First Trade Risk Share", "Portion of the total risk assigned to the first entry.", "Risk Management")
+			.SetGreaterThanZero();
+
+		_spreadMultiplier = Param(nameof(SpreadMultiplier), 3m)
+			.SetDisplay("Spread Multiplier", "Multiplier applied to the spread when placing stop orders.", "Risk Management")
+			.SetGreaterThanZero();
+
 		_priceOn50Level = Param(nameof(PriceOn50Level), 1.08261m)
 			.SetDisplay("50% Level", "Price on the 50% retracement level", "General");
 		

--- a/API/3454_Fibonacci_Potential_Entries/CS/FibonacciPotentialEntriesStrategy.cs
+++ b/API/3454_Fibonacci_Potential_Entries/CS/FibonacciPotentialEntriesStrategy.cs
@@ -13,7 +13,7 @@ using StockSharp.Messages;
 /// </summary>
 public class FibonacciPotentialEntriesStrategy : Strategy
 {
-	private const decimal FirstTradeRiskPercent = 0.7m;
+	private readonly StrategyParam<decimal> _firstTradeRiskPercent;
 
 	private readonly StrategyParam<decimal> _p50Level;
 	private readonly StrategyParam<decimal> _p61Level;
@@ -52,6 +52,15 @@ public class FibonacciPotentialEntriesStrategy : Strategy
 	{
 		Bull = 1,
 		Bear = 2,
+	}
+
+	/// <summary>
+	/// Portion of the total risk allocated to the first trade.
+	/// </summary>
+	public decimal FirstTradeRiskPercent
+	{
+		get => _firstTradeRiskPercent.Value;
+		set => _firstTradeRiskPercent.Value = value;
 	}
 
 	/// <summary>
@@ -113,6 +122,10 @@ public class FibonacciPotentialEntriesStrategy : Strategy
 	/// </summary>
 	public FibonacciPotentialEntriesStrategy()
 	{
+		_firstTradeRiskPercent = Param(nameof(FirstTradeRiskPercent), 0.7m)
+			.SetDisplay("First Trade Risk Percent", "Minimum risk portion allocated to the first entry.", "Risk")
+			.SetGreaterOrEqualThanZero();
+
 		_p50Level = Param(nameof(P50Level), 1.08261m)
 			.SetDisplay("50% Level", "Price level corresponding to the 50% Fibonacci retracement.", "Levels");
 

--- a/API/3467_The_Enchantress/CS/TheEnchantressStrategy.cs
+++ b/API/3467_The_Enchantress/CS/TheEnchantressStrategy.cs
@@ -13,7 +13,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class TheEnchantressStrategy : Strategy
 {
-	private const int PatternLength = 7;
+	private readonly StrategyParam<int> _patternLength;
 
 	private readonly StrategyParam<decimal> _lotSize;
 	private readonly StrategyParam<bool> _useRiskMoneyManagement;
@@ -36,6 +36,11 @@ public class TheEnchantressStrategy : Strategy
 	/// </summary>
 	public TheEnchantressStrategy()
 	{
+		_patternLength = Param(nameof(PatternLength), 7)
+			.SetGreaterThanZero()
+			.SetDisplay("Pattern Length")
+			.SetCanOptimize(true);
+
 		_lotSize = Param(nameof(LotSize), 0.01m)
 			.SetNotNegative()
 			.SetDisplay("Lot Size")
@@ -71,6 +76,15 @@ public class TheEnchantressStrategy : Strategy
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
 			.SetDisplay("Candle Type");
+	}
+
+	/// <summary>
+	/// Number of candles considered when building pattern signatures.
+	/// </summary>
+	public int PatternLength
+	{
+		get => _patternLength.Value;
+		set => _patternLength.Value = value;
 	}
 
 	/// <summary>

--- a/API/3488_MACD_Divergence_RSI/CS/MacdDivergenceRsiStrategy.cs
+++ b/API/3488_MACD_Divergence_RSI/CS/MacdDivergenceRsiStrategy.cs
@@ -46,13 +46,17 @@ public class MacdDivergenceRsiStrategy : Strategy
 	private decimal _pipSize;
 	private decimal _macdThreshold;
 
-	private const int MaxHistory = 600;
+	private readonly StrategyParam<int> _maxHistory;
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="MacdDivergenceRsiStrategy"/> class.
 	/// </summary>
 	public MacdDivergenceRsiStrategy()
 	{
+		_maxHistory = Param(nameof(MaxHistory), 600)
+			.SetGreaterThanZero()
+			.SetDisplay("Max History", "Maximum number of candles retained for divergence checks.", "General");
+
 		_lowerRsiPeriod = Param(nameof(LowerRsiPeriod), 14)
 			.SetGreaterThanZero()
 			.SetDisplay("Lower RSI Period", "Period for the oversold RSI filter (shifted by one bar).", "Signals")
@@ -127,6 +131,15 @@ public class MacdDivergenceRsiStrategy : Strategy
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(1).TimeFrame())
 			.SetDisplay("Candle Type", "Primary timeframe used for all indicator calculations.", "General");
+	}
+
+	/// <summary>
+	/// Maximum number of candles stored for divergence detection.
+	/// </summary>
+	public int MaxHistory
+	{
+		get => _maxHistory.Value;
+		set => _maxHistory.Value = value;
 	}
 
 	/// <summary>

--- a/API/3493_MA_Break/CS/MaBreakStrategy.cs
+++ b/API/3493_MA_Break/CS/MaBreakStrategy.cs
@@ -12,7 +12,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class MaBreakStrategy : Strategy
 {
-	private const decimal DefaultStep = 0.0001m;
+	private readonly StrategyParam<decimal> _priceStepFallback;
 
 	private readonly StrategyParam<int> _fastMa1Period;
 	private readonly StrategyParam<int> _slowMa1Period;
@@ -55,6 +55,10 @@ public class MaBreakStrategy : Strategy
 	/// </summary>
 	public MaBreakStrategy()
 	{
+		_priceStepFallback = Param(nameof(PriceStepFallback), 0.0001m)
+			.SetGreaterThanZero()
+			.SetDisplay("Price Step Fallback", "Price increment used when the instrument does not specify one.", "General");
+
 		_fastMa1Period = Param(nameof(FastMa1Period), 20)
 			.SetDisplay("Fast MA 1", "Fast moving average period used for the first trend filter", "Filters")
 			.SetCanOptimize(true)
@@ -149,6 +153,15 @@ public class MaBreakStrategy : Strategy
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
 			.SetDisplay("Candle Type", "Primary candle series used by the strategy", "General");
+	}
+
+	/// <summary>
+	/// Price step used when the security does not expose one.
+	/// </summary>
+	public decimal PriceStepFallback
+	{
+		get => _priceStepFallback.Value;
+		set => _priceStepFallback.Value = value;
 	}
 
 	/// <summary>
@@ -337,9 +350,9 @@ public class MaBreakStrategy : Strategy
 	{
 		base.OnStarted(time);
 
-		_priceStep = Security?.PriceStep ?? DefaultStep;
+		_priceStep = Security?.PriceStep ?? PriceStepFallback;
 		if (_priceStep <= 0m)
-			_priceStep = DefaultStep;
+			_priceStep = PriceStepFallback;
 
 		_fastMa1 = new ExponentialMovingAverage { Length = FastMa1Period };
 		_slowMa1 = new ExponentialMovingAverage { Length = SlowMa1Period };

--- a/API/3496_StochasticAccelerator/CS/StochasticAcceleratorStrategy.cs
+++ b/API/3496_StochasticAccelerator/CS/StochasticAcceleratorStrategy.cs
@@ -17,7 +17,7 @@ using StockSharp.Messages;
 /// </summary>
 public class StochasticAcceleratorStrategy : Strategy
 {
-	private const decimal Epsilon = 0.000001m; // Same tolerance used by the original expert to avoid equality issues.
+	private readonly StrategyParam<decimal> _epsilon;
 
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<decimal> _tradeVolume;
@@ -56,6 +56,10 @@ public class StochasticAcceleratorStrategy : Strategy
 	/// </summary>
 	public StochasticAcceleratorStrategy()
 	{
+		_epsilon = Param(nameof(Epsilon), 0.000001m)
+			.SetGreaterThanZero()
+			.SetDisplay("Epsilon", "Tolerance applied when comparing oscillator values.", "General");
+
 		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(4).TimeFrame())
 			.SetDisplay("Candle Type", "Primary candle series processed by the strategy.", "General");
 
@@ -142,6 +146,15 @@ public class StochasticAcceleratorStrategy : Strategy
 		_pipSize = 0m;
 		_previousAccelerator = null;
 		_previousAwesome = null;
+	}
+
+	/// <summary>
+	/// Tolerance applied when comparing oscillator values.
+	/// </summary>
+	public decimal Epsilon
+	{
+		get => _epsilon.Value;
+		set => _epsilon.Value = value;
 	}
 
 	/// <summary>

--- a/API/3506_Sample_Check_Pending_Order/CS/SampleCheckPendingOrderStrategy.cs
+++ b/API/3506_Sample_Check_Pending_Order/CS/SampleCheckPendingOrderStrategy.cs
@@ -14,7 +14,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class SampleCheckPendingOrderStrategy : Strategy
 {
-	private const decimal VolumeTolerance = 0.0000001m;
+	private readonly StrategyParam<decimal> _volumeTolerance;
 
 	private readonly StrategyParam<decimal> _orderVolume;
 	private readonly StrategyParam<int> _stopLossPoints;
@@ -39,6 +39,10 @@ public class SampleCheckPendingOrderStrategy : Strategy
 	/// </summary>
 	public SampleCheckPendingOrderStrategy()
 	{
+		_volumeTolerance = Param(nameof(VolumeTolerance), 0.0000001m)
+			.SetGreaterOrEqualThanZero()
+			.SetDisplay("Volume tolerance", "Allowed difference when validating portfolio volume and margin.", "Risk");
+
 		_orderVolume = Param(nameof(OrderVolume), 0.01m)
 		.SetGreaterThanZero()
 		.SetDisplay("Order volume", "Lot size submitted with each pending stop order", "Trading");
@@ -58,6 +62,15 @@ public class SampleCheckPendingOrderStrategy : Strategy
 		_accountLeverage = Param(nameof(AccountLeverage), 100m)
 		.SetGreaterThanZero()
 		.SetDisplay("Account leverage", "Estimated leverage used to approximate margin requirements", "Risk");
+	}
+
+	/// <summary>
+	/// Allowed difference when comparing volumes and margin requirements.
+	/// </summary>
+	public decimal VolumeTolerance
+	{
+		get => _volumeTolerance.Value;
+		set => _volumeTolerance.Value = value;
 	}
 
 	/// <summary>

--- a/API/3528_MA_Grid/CS/MaGridStrategy.cs
+++ b/API/3528_MA_Grid/CS/MaGridStrategy.cs
@@ -15,7 +15,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class MaGridStrategy : Strategy
 {
-	private const decimal VolumeTolerance = 0.0000001m;
+	private readonly StrategyParam<decimal> _volumeTolerance;
 
 	private readonly StrategyParam<int> _maPeriod;
 	private readonly StrategyParam<int> _gridAmount;
@@ -47,6 +47,10 @@ public class MaGridStrategy : Strategy
 	/// </summary>
 	public MaGridStrategy()
 	{
+		_volumeTolerance = Param(nameof(VolumeTolerance), 0.0000001m)
+			.SetGreaterOrEqualThanZero()
+			.SetDisplay("Volume Tolerance", "Small tolerance applied when balancing grid exposure.", "Risk");
+
 		_maPeriod = Param(nameof(MaPeriod), 48)
 		.SetRange(5, 400)
 		.SetDisplay("MA Period", "Exponential moving average length", "Grid")
@@ -69,6 +73,15 @@ public class MaGridStrategy : Strategy
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
 		.SetDisplay("Candle Type", "Primary candle type used by the strategy", "Data");
+	}
+
+	/// <summary>
+	/// Small tolerance used when comparing accumulated exposure.
+	/// </summary>
+	public decimal VolumeTolerance
+	{
+		get => _volumeTolerance.Value;
+		set => _volumeTolerance.Value = value;
 	}
 
 	/// <summary>

--- a/API/3553_OsMA_Four_Colors_Arrow/CS/OsMaFourColorsArrowStrategy.cs
+++ b/API/3553_OsMA_Four_Colors_Arrow/CS/OsMaFourColorsArrowStrategy.cs
@@ -29,7 +29,7 @@ public class OsMaFourColorsArrowStrategy : Strategy
 		Both
 	}
 
-	private const decimal ExposureTolerance = 1e-8m;
+	private readonly StrategyParam<decimal> _exposureTolerance;
 
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<int> _fastPeriod;
@@ -61,6 +61,10 @@ public class OsMaFourColorsArrowStrategy : Strategy
 	/// </summary>
 	public OsMaFourColorsArrowStrategy()
 	{
+		_exposureTolerance = Param(nameof(ExposureTolerance), 1e-8m)
+			.SetGreaterOrEqualThanZero()
+			.SetDisplay("Exposure Tolerance", "Minimal tolerance when comparing aggregated exposure.", "Trading");
+
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
 		.SetDisplay("Candle Type", "Timeframe used for signal generation", "General");
 
@@ -134,6 +138,15 @@ public class OsMaFourColorsArrowStrategy : Strategy
 		.SetGreaterThanZero();
 
 		Volume = TradeVolume;
+	}
+
+	/// <summary>
+	/// Minimal tolerance used when checking aggregated exposure.
+	/// </summary>
+	public decimal ExposureTolerance
+	{
+		get => _exposureTolerance.Value;
+		set => _exposureTolerance.Value = value;
 	}
 
 	/// <summary>

--- a/API/3568_Mean_Reversion/CS/MeanReversionStrategy.cs
+++ b/API/3568_Mean_Reversion/CS/MeanReversionStrategy.cs
@@ -17,9 +17,9 @@ using StockSharp.Messages;
 /// </summary>
 public class MeanReversionStrategy : Strategy
 {
-	private const int MacdFastLength = 12;
-	private const int MacdSlowLength = 26;
-	private const int MacdSignalLength = 9;
+	private readonly StrategyParam<int> _macdFastLength;
+	private readonly StrategyParam<int> _macdSlowLength;
+	private readonly StrategyParam<int> _macdSignalLength;
 
 	private readonly StrategyParam<decimal> _orderVolume;
 	private readonly StrategyParam<DataType> _candleType;
@@ -90,6 +90,21 @@ public class MeanReversionStrategy : Strategy
 		_momentumLength = Param(nameof(MomentumLength), 14)
 		.SetGreaterThanZero()
 		.SetDisplay("Momentum Period", "Period of the momentum indicator on the higher timeframe.", "Signal")
+		.SetCanOptimize(true);
+
+		_macdFastLength = Param(nameof(MacdFastLength), 12)
+		.SetGreaterThanZero()
+		.SetDisplay("MACD Fast Length", "Length of the fast EMA used by the MACD filter.", "Signal")
+		.SetCanOptimize(true);
+
+		_macdSlowLength = Param(nameof(MacdSlowLength), 26)
+		.SetGreaterThanZero()
+		.SetDisplay("MACD Slow Length", "Length of the slow EMA used by the MACD filter.", "Signal")
+		.SetCanOptimize(true);
+
+		_macdSignalLength = Param(nameof(MacdSignalLength), 9)
+		.SetGreaterThanZero()
+		.SetDisplay("MACD Signal Length", "Signal smoothing period for the MACD filter.", "Signal")
 		.SetCanOptimize(true);
 
 		_momentumThreshold = Param(nameof(MomentumThreshold), 0.3m)
@@ -186,6 +201,33 @@ public class MeanReversionStrategy : Strategy
 	{
 		get => _momentumLength.Value;
 		set => _momentumLength.Value = value;
+	}
+
+	/// <summary>
+	/// Number of fast EMA periods used by the MACD component.
+	/// </summary>
+	public int MacdFastLength
+	{
+		get => _macdFastLength.Value;
+		set => _macdFastLength.Value = value;
+	}
+
+	/// <summary>
+	/// Number of slow EMA periods used by the MACD component.
+	/// </summary>
+	public int MacdSlowLength
+	{
+		get => _macdSlowLength.Value;
+		set => _macdSlowLength.Value = value;
+	}
+
+	/// <summary>
+	/// Number of periods used by the MACD signal line.
+	/// </summary>
+	public int MacdSignalLength
+	{
+		get => _macdSignalLength.Value;
+		set => _macdSignalLength.Value = value;
 	}
 
 	/// <summary>

--- a/API/3583_CCI_MACD_Scalper/CS/CciMacdScalperStrategy.cs
+++ b/API/3583_CCI_MACD_Scalper/CS/CciMacdScalperStrategy.cs
@@ -10,7 +10,7 @@ using StockSharp.Messages;
 
 public class CciMacdScalperStrategy : Strategy
 {
-	private const int CooldownBars = 5;
+	private readonly StrategyParam<int> _cooldownBars;
 
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<decimal> _riskPercent;
@@ -47,6 +47,10 @@ public class CciMacdScalperStrategy : Strategy
 
 	public CciMacdScalperStrategy()
 	{
+		_cooldownBars = Param(nameof(CooldownBars), 5)
+			.SetGreaterThanZero()
+			.SetDisplay("Cooldown bars", "Number of completed candles required before reopening trades.", "General");
+
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
 		.SetDisplay("Candle type", "Timeframe processed by the strategy.", "General");
 
@@ -82,6 +86,15 @@ public class CciMacdScalperStrategy : Strategy
 		_trailingStopPoints = Param(nameof(TrailingStopPoints), 100m)
 		.SetNotNegative()
 		.SetDisplay("Trailing points", "Distance in points used when trailing a protective stop.", "Risk");
+	}
+
+	/// <summary>
+	/// Number of completed candles required before a new entry can be opened.
+	/// </summary>
+	public int CooldownBars
+	{
+		get => _cooldownBars.Value;
+		set => _cooldownBars.Value = value;
 	}
 
 	public DataType CandleType

--- a/API/3593_Aussie_Surfer_Ltd/CS/AussieSurferLtdStrategy.cs
+++ b/API/3593_Aussie_Surfer_Ltd/CS/AussieSurferLtdStrategy.cs
@@ -15,7 +15,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class AussieSurferLtdStrategy : Strategy
 {
-	private const decimal Tolerance = 1e-6m;
+	private readonly StrategyParam<decimal> _tolerance;
 
 	private readonly StrategyParam<decimal> _orderVolume;
 	private readonly StrategyParam<int> _stopLossPips;
@@ -44,6 +44,15 @@ public class AussieSurferLtdStrategy : Strategy
 	private decimal? _longTakeProfit;
 	private decimal? _shortStopPrice;
 	private decimal? _shortTakeProfit;
+
+	/// <summary>
+	/// Price tolerance applied when comparing indicator values.
+	/// </summary>
+	public decimal Tolerance
+	{
+		get => _tolerance.Value;
+		set => _tolerance.Value = value;
+	}
 
 	/// <summary>
 	/// Trading volume expressed in lots or contracts.
@@ -122,6 +131,10 @@ public class AussieSurferLtdStrategy : Strategy
 	/// </summary>
 	public AussieSurferLtdStrategy()
 	{
+		_tolerance = Param(nameof(Tolerance), 1e-6m)
+			.SetGreaterOrEqualThanZero()
+			.SetDisplay("Tolerance", "Price tolerance applied when comparing indicator levels.", "Risk");
+
 		_orderVolume = Param(nameof(OrderVolume), 0.30m)
 			.SetGreaterThanZero()
 			.SetDisplay("Order Volume", "Base trade size in lots or contracts", "Trading")

--- a/API/3623_Matrix_Machine_Learning/CS/MatrixMachineLearningStrategy.cs
+++ b/API/3623_Matrix_Machine_Learning/CS/MatrixMachineLearningStrategy.cs
@@ -13,8 +13,8 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class MatrixMachineLearningStrategy : Strategy
 {
-	private const int MaxIterations = 100;
-	private const double Accuracy = 0.00001;
+	private readonly StrategyParam<int> _maxIterations;
+	private readonly StrategyParam<double> _accuracy;
 
 	private readonly StrategyParam<int> _historyDepth;
 	private readonly StrategyParam<int> _forwardDepth;
@@ -73,6 +73,24 @@ public class MatrixMachineLearningStrategy : Strategy
 	}
 
 	/// <summary>
+	/// Maximum number of Hopfield iterations executed per forecast.
+	/// </summary>
+	public int MaxIterations
+	{
+		get => _maxIterations.Value;
+		set => _maxIterations.Value = value;
+	}
+
+	/// <summary>
+	/// Desired accuracy when checking convergence of neuron states.
+	/// </summary>
+	public double Accuracy
+	{
+		get => _accuracy.Value;
+		set => _accuracy.Value = value;
+	}
+
+	/// <summary>
 	/// Enables verbose logging of the neural network state.
 	/// </summary>
 	public bool EnableDebugLog
@@ -86,6 +104,13 @@ public class MatrixMachineLearningStrategy : Strategy
 	/// </summary>
 	public MatrixMachineLearningStrategy()
 	{
+		_maxIterations = Param(nameof(MaxIterations), 100)
+			.SetGreaterThanZero()
+			.SetDisplay("Max Iterations", "Maximum number of Hopfield iterations executed per forecast.", "Machine Learning");
+
+		_accuracy = Param(nameof(Accuracy), 0.00001)
+			.SetDisplay("Accuracy", "Desired accuracy when checking convergence of neuron states.", "Machine Learning");
+
 		_historyDepth = Param(nameof(HistoryDepth), 120)
 			.SetGreaterThanZero()
 			.SetDisplay("History Depth", "Total amount of closes stored for the Hopfield network.", "Machine Learning")


### PR DESCRIPTION
## Summary
- convert the remaining hard-coded risk, tolerance, and indicator constants in the affected strategies into `StrategyParam` fields with public accessors so users can tune them

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7bed493ac83239a52c37b3d80c84d