### PR TITLE
Expose strategy constants as configurable parameters

### DIFF
--- a/API/3636_MartinGale_Breakout/CS/MartinGaleBreakoutStrategy.cs
+++ b/API/3636_MartinGale_Breakout/CS/MartinGaleBreakoutStrategy.cs
@@ -12,7 +12,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class MartinGaleBreakoutStrategy : Strategy
 {
-	private const int RequiredHistory = 11;
+	private readonly StrategyParam<int> _requiredHistory;
 
 	private readonly StrategyParam<int> _takeProfitPoints;
 	private readonly StrategyParam<decimal> _balancePercentageAvailable;
@@ -35,6 +35,10 @@ public class MartinGaleBreakoutStrategy : Strategy
 	/// </summary>
 	public MartinGaleBreakoutStrategy()
 	{
+		_requiredHistory = Param(nameof(RequiredHistory), 11)
+			.SetDisplay("Required History", "Number of finished candles kept for breakout evaluation", "General")
+			.SetGreaterThanZero();
+
 		_takeProfitPoints = Param(nameof(TakeProfitPoints), 50)
 			.SetDisplay("Take Profit Points", "Base take-profit distance in price points", "Risk")
 			.SetGreaterThanZero();
@@ -129,6 +133,15 @@ public class MartinGaleBreakoutStrategy : Strategy
 	{
 		get => _candleType.Value;
 		set => _candleType.Value = value;
+	}
+
+	/// <summary>
+	/// Gets or sets the number of finished candles stored for breakout evaluation.
+	/// </summary>
+	public int RequiredHistory
+	{
+		get => _requiredHistory.Value;
+		set => _requiredHistory.Value = value;
 	}
 
 	/// <inheritdoc />

--- a/API/3638_Donchian_Scalper/CS/DonchianScalperStrategy.cs
+++ b/API/3638_Donchian_Scalper/CS/DonchianScalperStrategy.cs
@@ -26,6 +26,7 @@ public class DonchianScalperStrategy : Strategy
 	private readonly StrategyParam<int> _cooldownBars;
 	private readonly StrategyParam<int> _atrPeriod;
 	private readonly StrategyParam<decimal> _atrMultiplier;
+	private readonly StrategyParam<decimal> _priceToleranceMultiplier;
 
 	private DonchianChannels _donchian = null!;
 	private ExponentialMovingAverage _ema = null!;
@@ -46,8 +47,6 @@ public class DonchianScalperStrategy : Strategy
 	private decimal _lastAtr;
 	private int _barsSinceExit = int.MaxValue;
 	private decimal _previousPosition;
-
-	private const decimal PriceToleranceMultiplier = 0.5m;
 
 	/// <summary>
 	/// Determines how the strategy manages profitable positions.
@@ -168,6 +167,15 @@ public class DonchianScalperStrategy : Strategy
 	}
 
 	/// <summary>
+	/// Multiplier applied to the instrument point size to derive price tolerance when adjusting orders.
+	/// </summary>
+	public decimal PriceToleranceMultiplier
+	{
+		get => _priceToleranceMultiplier.Value;
+		set => _priceToleranceMultiplier.Value = value;
+	}
+
+	/// <summary>
 	/// Initializes the Donchian scalper strategy.
 	/// </summary>
 	public DonchianScalperStrategy()
@@ -220,6 +228,12 @@ public class DonchianScalperStrategy : Strategy
 		.SetDisplay("ATR Multiplier", "Multiplier applied to the ATR based trailing stop", "Indicators")
 		.SetCanOptimize(true)
 		.SetOptimize(0.5m, 5m, 0.5m);
+
+		_priceToleranceMultiplier = Param(nameof(PriceToleranceMultiplier), 0.5m)
+			.SetDisplay("Price Tolerance Multiplier", "Multiplier applied to point size when reconciling order prices", "Orders")
+			.SetGreaterThanZero()
+			.SetCanOptimize(true)
+			.SetOptimize(0.1m, 2m, 0.1m);
 	}
 
 	/// <inheritdoc />

--- a/API/3669_Get_Last_Nth_Closed_Trade/CS/GetLastNthClosedTradeStrategy.cs
+++ b/API/3669_Get_Last_Nth_Closed_Trade/CS/GetLastNthClosedTradeStrategy.cs
@@ -14,8 +14,6 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class GetLastNthClosedTradeStrategy : Strategy
 {
-	private const int MaxStoredTrades = 100;
-
 	private sealed class TradeDetail
 	{
 		public required string Symbol { get; init; }
@@ -62,6 +60,7 @@ public class GetLastNthClosedTradeStrategy : Strategy
 	private readonly StrategyParam<string> _strategyIdFilter;
 	private readonly StrategyParam<bool> _enableSecurityFilter;
 	private readonly StrategyParam<int> _tradeIndex;
+	private readonly StrategyParam<int> _maxStoredTrades;
 
 	private readonly List<ClosedTradeInfo> _closedTrades = new();
 	private PositionRecord _openRecord;
@@ -105,6 +104,15 @@ public class GetLastNthClosedTradeStrategy : Strategy
 	}
 
 	/// <summary>
+	/// Gets or sets the maximum number of closed trades retained for reporting.
+	/// </summary>
+	public int MaxStoredTrades
+	{
+		get => _maxStoredTrades.Value;
+		set => _maxStoredTrades.Value = value;
+	}
+
+	/// <summary>
 	/// Initializes a new instance of the <see cref="GetLastNthClosedTradeStrategy"/> class.
 	/// </summary>
 	public GetLastNthClosedTradeStrategy()
@@ -121,6 +129,10 @@ public class GetLastNthClosedTradeStrategy : Strategy
 		_tradeIndex = Param(nameof(TradeIndex), 0)
 		.SetDisplay("Trade Index", "Zero-based index of the closed trade snapshot", "General")
 		.SetCanOptimize(true);
+
+		_maxStoredTrades = Param(nameof(MaxStoredTrades), 100)
+		.SetDisplay("Max Stored Trades", "Maximum number of closed trades kept in memory", "General")
+		.SetGreaterThanZero();
 	}
 
 	/// <inheritdoc />

--- a/API/3680_Neural_Network_ATR/CS/NeuralNetworkAtrStrategy.cs
+++ b/API/3680_Neural_Network_ATR/CS/NeuralNetworkAtrStrategy.cs
@@ -16,10 +16,6 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class NeuralNetworkAtrStrategy : Strategy
 {
-	private const int InputSize = 5;
-	private const decimal MinimumLearningRate = 0.0001m;
-	private const decimal FeatureClamp = 1m;
-
 	private readonly StrategyParam<decimal> _maxRiskPerTrade;
 	private readonly StrategyParam<decimal> _dailyLossLimit;
 	private readonly StrategyParam<decimal> _totalLossLimit;
@@ -33,6 +29,9 @@ public class NeuralNetworkAtrStrategy : Strategy
 	private readonly StrategyParam<decimal> _maxSpreadPoints;
 	private readonly StrategyParam<decimal> _riskRewardRatio;
 	private readonly StrategyParam<int> _fallbackStopLossPoints;
+	private readonly StrategyParam<int> _inputSize;
+	private readonly StrategyParam<decimal> _minimumLearningRate;
+	private readonly StrategyParam<decimal> _featureClamp;
 
 	private decimal _accountEquityAtStart;
 	private decimal _dailyEquityAtStart;
@@ -173,6 +172,33 @@ public class NeuralNetworkAtrStrategy : Strategy
 	}
 
 	/// <summary>
+	/// Number of input features processed by the neural layer.
+	/// </summary>
+	public int InputSize
+	{
+		get => _inputSize.Value;
+		set => _inputSize.Value = value;
+	}
+
+	/// <summary>
+	/// Minimum learning rate applied when adapting the network weights.
+	/// </summary>
+	public decimal MinimumLearningRate
+	{
+		get => _minimumLearningRate.Value;
+		set => _minimumLearningRate.Value = value;
+	}
+
+	/// <summary>
+	/// Absolute value used to clamp normalized features.
+	/// </summary>
+	public decimal FeatureClamp
+	{
+		get => _featureClamp.Value;
+		set => _featureClamp.Value = value;
+	}
+
+	/// <summary>
 	/// Constructor.
 	/// </summary>
 	public NeuralNetworkAtrStrategy()
@@ -249,6 +275,20 @@ public class NeuralNetworkAtrStrategy : Strategy
 		.SetDisplay("Fallback Stop", "Stop distance when ATR is not formed", "Risk Management")
 		.SetCanOptimize(true)
 		.SetOptimize(30, 100, 10);
+
+		_inputSize = Param(nameof(InputSize), 5)
+		.SetGreaterThanZero()
+		.SetDisplay("Input Size", "Number of features processed by the neural layer", "Neural Network")
+		.SetCanOptimize(true)
+		.SetOptimize(3, 9, 2);
+
+		_minimumLearningRate = Param(nameof(MinimumLearningRate), 0.0001m)
+		.SetGreaterThanZero()
+		.SetDisplay("Min Learning Rate", "Lower bound applied when adapting learning rate", "Neural Network");
+
+		_featureClamp = Param(nameof(FeatureClamp), 1m)
+		.SetGreaterThanZero()
+		.SetDisplay("Feature Clamp", "Absolute value used to clamp normalized features", "Neural Network");
 	}
 
 	/// <inheritdoc />

--- a/API/3690_Close_Agent/CS/CloseAgentStrategy.cs
+++ b/API/3690_Close_Agent/CS/CloseAgentStrategy.cs
@@ -53,16 +53,15 @@ public enum CloseAgentOperationMode
 /// </summary>
 public class CloseAgentStrategy : Strategy
 {
-	private const int RsiLength = 13;
-	private const int BollingerLength = 21;
-	private const decimal RsiOverbought = 70m;
-	private const decimal RsiOversold = 30m;
-
 	private readonly StrategyParam<CloseAgentMode> _closeMode;
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<CloseAgentOperationMode> _operationMode;
 	private readonly StrategyParam<decimal> _closeAllTarget;
 	private readonly StrategyParam<bool> _enableAlerts;
+	private readonly StrategyParam<int> _rsiLength;
+	private readonly StrategyParam<int> _bollingerLength;
+	private readonly StrategyParam<decimal> _rsiOverbought;
+	private readonly StrategyParam<decimal> _rsiOversold;
 
 	private RelativeStrengthIndex _rsi;
 	private BollingerBands _bands;
@@ -117,6 +116,42 @@ public class CloseAgentStrategy : Strategy
 	}
 
 	/// <summary>
+	/// Length of the RSI indicator.
+	/// </summary>
+	public int RsiLength
+	{
+		get => _rsiLength.Value;
+		set => _rsiLength.Value = value;
+	}
+
+	/// <summary>
+	/// Length of the Bollinger Bands indicator.
+	/// </summary>
+	public int BollingerLength
+	{
+		get => _bollingerLength.Value;
+		set => _bollingerLength.Value = value;
+	}
+
+	/// <summary>
+	/// RSI threshold that marks overbought conditions.
+	/// </summary>
+	public decimal RsiOverbought
+	{
+		get => _rsiOverbought.Value;
+		set => _rsiOverbought.Value = value;
+	}
+
+	/// <summary>
+	/// RSI threshold that marks oversold conditions.
+	/// </summary>
+	public decimal RsiOversold
+	{
+		get => _rsiOversold.Value;
+		set => _rsiOversold.Value = value;
+	}
+
+	/// <summary>
 	/// Initializes parameters with defaults inspired by the original MQL script.
 	/// </summary>
 	public CloseAgentStrategy()
@@ -136,6 +171,22 @@ public class CloseAgentStrategy : Strategy
 
 		_enableAlerts = Param(nameof(EnableAlerts), true)
 		.SetDisplay("Enable Alerts", "Log a message whenever a position is closed", "Notifications");
+
+		_rsiLength = Param(nameof(RsiLength), 13)
+		.SetGreaterThanZero()
+		.SetDisplay("RSI Length", "Lookback period for the RSI indicator", "Indicators");
+
+		_bollingerLength = Param(nameof(BollingerLength), 21)
+		.SetGreaterThanZero()
+		.SetDisplay("Bollinger Length", "Lookback period for Bollinger Bands", "Indicators");
+
+		_rsiOverbought = Param(nameof(RsiOverbought), 70m)
+		.SetRange(0m, 100m)
+		.SetDisplay("RSI Overbought", "Threshold that triggers closing longs when exceeded", "Signals");
+
+		_rsiOversold = Param(nameof(RsiOversold), 30m)
+		.SetRange(0m, 100m)
+		.SetDisplay("RSI Oversold", "Threshold that triggers closing shorts when crossed", "Signals");
 	}
 
 	/// <inheritdoc />

--- a/API/3725_RiskManagementATR/CS/RiskManagementAtrStrategy.cs
+++ b/API/3725_RiskManagementATR/CS/RiskManagementAtrStrategy.cs
@@ -10,15 +10,14 @@ using StockSharp.Messages;
 
 public class RiskManagementAtrStrategy : Strategy
 {
-	private const int FastMaPeriod = 10;
-	private const int SlowMaPeriod = 20;
-
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<int> _atrPeriod;
 	private readonly StrategyParam<decimal> _atrMultiplier;
 	private readonly StrategyParam<decimal> _riskPercentage;
 	private readonly StrategyParam<bool> _useAtrStopLoss;
 	private readonly StrategyParam<int> _fixedStopLossPoints;
+	private readonly StrategyParam<int> _fastMaPeriod;
+	private readonly StrategyParam<int> _slowMaPeriod;
 
 	private AverageTrueRange _atr;
 	private SimpleMovingAverage _fastMovingAverage;
@@ -51,6 +50,14 @@ public class RiskManagementAtrStrategy : Strategy
 		_fixedStopLossPoints = Param(nameof(FixedStopLossPoints), 50)
 			.SetGreaterThanZero()
 			.SetDisplay("Fixed stop (points)", "Stop-loss distance expressed in price steps when ATR mode is disabled.", "Risk");
+
+		_fastMaPeriod = Param(nameof(FastMaPeriod), 10)
+			.SetGreaterThanZero()
+			.SetDisplay("Fast MA period", "Length of the fast moving average used for signals.", "Indicators");
+
+		_slowMaPeriod = Param(nameof(SlowMaPeriod), 20)
+			.SetGreaterThanZero()
+			.SetDisplay("Slow MA period", "Length of the slow moving average used for signals.", "Indicators");
 	}
 
 	public DataType CandleType
@@ -87,6 +94,18 @@ public class RiskManagementAtrStrategy : Strategy
 	{
 		get => _fixedStopLossPoints.Value;
 		set => _fixedStopLossPoints.Value = value;
+	}
+
+	public int FastMaPeriod
+	{
+		get => _fastMaPeriod.Value;
+		set => _fastMaPeriod.Value = value;
+	}
+
+	public int SlowMaPeriod
+	{
+		get => _slowMaPeriod.Value;
+		set => _slowMaPeriod.Value = value;
 	}
 
 	/// <inheritdoc />

--- a/API/3736_Tuyul_Uncensored/CS/TuyulUncensoredStrategy.cs
+++ b/API/3736_Tuyul_Uncensored/CS/TuyulUncensoredStrategy.cs
@@ -14,8 +14,6 @@ using StockSharp.Messages;
 /// </summary>
 public class TuyulUncensoredStrategy : Strategy
 {
-private const decimal FibLevel = 0.57m;
-
 private readonly StrategyParam<decimal> _volume;
 private readonly StrategyParam<decimal> _takeProfitMultiplier;
 private readonly StrategyParam<int> _zigZagDepth;
@@ -30,6 +28,7 @@ private readonly StrategyParam<bool> _allowWednesday;
 private readonly StrategyParam<bool> _allowThursday;
 private readonly StrategyParam<bool> _allowFriday;
 private readonly StrategyParam<DataType> _candleType;
+private readonly StrategyParam<decimal> _fibLevel;
 
 private readonly List<(DateTimeOffset Time, decimal Price)> _pivots = new();
 
@@ -107,6 +106,10 @@ _allowFriday = Param(nameof(AllowFriday), true)
 
 _candleType = Param(nameof(CandleType), TimeSpan.FromHours(1).TimeFrame())
 .SetDisplay("Candle Type", "Type of candles used for analysis", "General");
+
+_fibLevel = Param(nameof(FibLevel), 0.57m)
+.SetDisplay("Fibonacci Level", "Retracement level used to position pending orders", "Trading")
+.SetRange(0m, 1m);
 }
 
 /// <summary>
@@ -233,6 +236,15 @@ public DataType CandleType
 {
 get => _candleType.Value;
 set => _candleType.Value = value;
+}
+
+/// <summary>
+/// Fibonacci retracement level used to place pending orders.
+/// </summary>
+public decimal FibLevel
+{
+get => _fibLevel.Value;
+set => _fibLevel.Value = value;
 }
 
 /// <inheritdoc />

--- a/API/3739_Pending_Tread/CS/PendingTreadStrategy.cs
+++ b/API/3739_Pending_Tread/CS/PendingTreadStrategy.cs
@@ -14,9 +14,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class PendingTreadStrategy : Strategy
 {
-	private const int OrdersPerSide = 10;
 	private static readonly TimeSpan SubmissionThrottle = TimeSpan.FromSeconds(5);
-	private const string CommentPrefix = "PendingTread";
 
 	/// <summary>
 	/// Order direction used for a pending grid.
@@ -45,6 +43,8 @@ public class PendingTreadStrategy : Strategy
 	private readonly StrategyParam<decimal> _minimumEquity;
 	private readonly StrategyParam<bool> _enableEquityGuard;
 	private readonly StrategyParam<decimal> _maxLossPercent;
+	private readonly StrategyParam<int> _ordersPerSide;
+	private readonly StrategyParam<string> _commentPrefix;
 
 	private decimal _pointSize;
 	private decimal _pipDistance;
@@ -160,6 +160,24 @@ public class PendingTreadStrategy : Strategy
 	}
 
 	/// <summary>
+	/// Maximum number of pending orders maintained on each side of the market.
+	/// </summary>
+	public int OrdersPerSide
+	{
+		get => _ordersPerSide.Value;
+		set => _ordersPerSide.Value = value;
+	}
+
+	/// <summary>
+	/// Prefix used when tagging orders created by the strategy.
+	/// </summary>
+	public string CommentPrefix
+	{
+		get => _commentPrefix.Value;
+		set => _commentPrefix.Value = value;
+	}
+
+	/// <summary>
 	/// Initializes a new instance of the <see cref="PendingTreadStrategy"/> class.
 	/// </summary>
 	public PendingTreadStrategy()
@@ -201,6 +219,13 @@ public class PendingTreadStrategy : Strategy
 		_maxLossPercent = Param(nameof(MaxLossPercent), 20m)
 		.SetNotNegative()
 		.SetDisplay("Max Loss Percent", "Drawdown percentage that triggers the equity guard.", "Protection");
+
+		_ordersPerSide = Param(nameof(OrdersPerSide), 10)
+		.SetGreaterThanZero()
+		.SetDisplay("Orders Per Side", "Maximum number of pending orders maintained on each side", "Orders");
+
+		_commentPrefix = Param(nameof(CommentPrefix), "PendingTread")
+		.SetDisplay("Comment Prefix", "Text added to order comments for identification", "Orders");
 	}
 
 	/// <inheritdoc />
@@ -500,7 +525,7 @@ public class PendingTreadStrategy : Strategy
 		return $"{BuildCommentPrefix(aboveMarket)}|{direction}";
 	}
 
-	private static string BuildCommentPrefix(bool aboveMarket)
+	private string BuildCommentPrefix(bool aboveMarket)
 	{
 		return $"{CommentPrefix}|{(aboveMarket ? "Above" : "Below")}";
 	}

--- a/API/3744_Build_Your_Grid/CS/BuildYourGridStrategy.cs
+++ b/API/3744_Build_Your_Grid/CS/BuildYourGridStrategy.cs
@@ -151,6 +151,7 @@ public class BuildYourGridStrategy : Strategy
 	private readonly StrategyParam<decimal> _maxMultiplierLot;
 	private readonly StrategyParam<int> _maxOrders;
 	private readonly StrategyParam<decimal> _maxSpread;
+	private readonly StrategyParam<decimal> _volumeTolerance;
 
 	private readonly List<PositionEntry> _buyEntries = new();
 	private readonly List<PositionEntry> _sellEntries = new();
@@ -167,8 +168,6 @@ public class BuildYourGridStrategy : Strategy
 	private decimal _lastSellVolume;
 	private decimal _lastBuyPrice;
 	private decimal _lastSellPrice;
-
-	private const decimal VolumeTolerance = 0.0000001m;
 
 	/// <summary>
 	/// Initializes default parameters mirroring the MetaTrader expert advisor inputs.
@@ -255,6 +254,9 @@ public class BuildYourGridStrategy : Strategy
 		_maxSpread = Param(nameof(MaxSpread), 0m)
 		.SetNotNegative()
 		.SetDisplay("Max Spread", "Maximum accepted bid/ask spread in pips (0 = ignore).", "Filters");
+		_volumeTolerance = Param(nameof(VolumeTolerance), 0.0000001m)
+			.SetGreaterThanZero()
+			.SetDisplay("Volume Tolerance", "Minimum difference to consider volumes equal when balancing hedge trades.", "Orders");
 	}
 
 	/// <summary>
@@ -435,6 +437,12 @@ public class BuildYourGridStrategy : Strategy
 	{
 		get => _maxSpread.Value;
 		set => _maxSpread.Value = value;
+	}
+
+	public decimal VolumeTolerance
+	{
+		get => _volumeTolerance.Value;
+		set => _volumeTolerance.Value = value;
 	}
 
 	/// <inheritdoc />


### PR DESCRIPTION
## Summary
- convert the breakout history length in MartinGaleBreakoutStrategy into a configurable parameter
- expose price tolerance, trade history size, and neural-network tuning values as strategy parameters across DonchianScalper, GetLastNthClosedTrade, and NeuralNetworkAtr strategies
- add user-settable indicator lengths, Fibonacci level, order limits, comment prefix, and volume tolerance parameters to CloseAgent, TuyulUncensored, PendingTread, and BuildYourGrid strategies

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7bee78c1883238b176a5671a265f7