### PR TITLE
Make strategy constants configurable parameters

### DIFF
--- a/API/3750_Frank_Ud_Minimal/CS/FrankUdMinimalStrategy.cs
+++ b/API/3750_Frank_Ud_Minimal/CS/FrankUdMinimalStrategy.cs
@@ -14,12 +14,11 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class FrankUdMinimalStrategy : Strategy
 {
-	private const decimal ExtraTakeProfitPips = 25m;
-
 	private readonly StrategyParam<decimal> _takeProfitPips;
 	private readonly StrategyParam<decimal> _reEntryPips;
 	private readonly StrategyParam<decimal> _initialVolume;
 	private readonly StrategyParam<decimal> _minimumFreeMarginRatio;
+	private readonly StrategyParam<decimal> _extraTakeProfitPips;
 
 	private readonly List<PositionEntry> _longEntries = new();
 	private readonly List<PositionEntry> _shortEntries = new();
@@ -53,7 +52,11 @@ public class FrankUdMinimalStrategy : Strategy
 		_minimumFreeMarginRatio = Param(nameof(MinimumFreeMarginRatio), 0.5m)
 		.SetDisplay("Free margin ratio", "Free margin must stay above Balance × Ratio before adding orders.", "Risk")
 		.SetGreaterThanZero();
-	}
+
+		_extraTakeProfitPips = Param(nameof(ExtraTakeProfitPips), 25m)
+		.SetDisplay("Buffer profit (pips)", "Additional pip distance applied when calculating buffered targets.", "Risk")
+		.SetNotNegative();
+}
 
 	/// <summary>
 	/// Profit threshold expressed in pips.
@@ -86,9 +89,18 @@ public class FrankUdMinimalStrategy : Strategy
 	/// Minimal free margin ratio required to send new orders.
 	/// </summary>
 	public decimal MinimumFreeMarginRatio
-	{
+{
 		get => _minimumFreeMarginRatio.Value;
 		set => _minimumFreeMarginRatio.Value = value;
+}
+
+	/// <summary>
+	/// Additional pip buffer added to the take-profit distance.
+	/// </summary>
+	public decimal ExtraTakeProfitPips
+	{
+		get => _extraTakeProfitPips.Value;
+		set => _extraTakeProfitPips.Value = value;
 	}
 
 	/// <inheritdoc />

--- a/API/3755_MACD_Sample/CS/MacdSampleStrategy.cs
+++ b/API/3755_MACD_Sample/CS/MacdSampleStrategy.cs
@@ -13,7 +13,6 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class MacdSampleStrategy : Strategy
 {
-	private const int MinimumHistoryCandles = 100;
 
 	private readonly StrategyParam<int> _fastEmaPeriod;
 	private readonly StrategyParam<int> _slowEmaPeriod;
@@ -24,6 +23,7 @@ public class MacdSampleStrategy : Strategy
 	private readonly StrategyParam<decimal> _takeProfitPoints;
 	private readonly StrategyParam<decimal> _trailingStopPoints;
 	private readonly StrategyParam<DataType> _candleType;
+	private readonly StrategyParam<int> _minimumHistoryCandles;
 
 	private decimal _pointSize;
 	private decimal? _prevMacd;
@@ -113,6 +113,14 @@ public class MacdSampleStrategy : Strategy
 		get => _candleType.Value;
 		set => _candleType.Value = value;
 	}
+	/// <summary>
+	/// Number of finished candles required before the strategy begins trading.
+	/// </summary>
+	public int MinimumHistoryCandles
+	{
+		get => _minimumHistoryCandles.Value;
+		set => _minimumHistoryCandles.Value = value;
+	}
 
 	/// <summary>
 	/// Initialize default parameters for the MACD Sample strategy.
@@ -163,6 +171,9 @@ public class MacdSampleStrategy : Strategy
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
 		.SetDisplay("Candle Type", "Candle type used for analysis", "General");
+		_minimumHistoryCandles = Param(nameof(MinimumHistoryCandles), 100)
+			.SetDisplay("Warm-up candles", "Number of finished candles required before trading starts", "General")
+			.SetGreaterThanZero();
 	}
 
 	/// <inheritdoc />

--- a/API/3767_Zs1_Forex_Instruments/CS/Zs1ForexInstrumentsStrategy.cs
+++ b/API/3767_Zs1_Forex_Instruments/CS/Zs1ForexInstrumentsStrategy.cs
@@ -15,7 +15,6 @@ using StockSharp.Messages;
 /// </summary>
 public class Zs1ForexInstrumentsStrategy : Strategy
 {
-	private const decimal VolumeTolerance = 0.0000001m;
 
 	private static readonly decimal[] TunnelMultipliers =
 	{
@@ -25,6 +24,7 @@ public class Zs1ForexInstrumentsStrategy : Strategy
 	private readonly StrategyParam<decimal> _ordersSpacePips;
 	private readonly StrategyParam<int> _pkPips;
 	private readonly StrategyParam<decimal> _initialVolume;
+	private readonly StrategyParam<decimal> _volumeTolerance;
 
 	private readonly Dictionary<Order, OrderIntent> _orderIntents = new();
 	private readonly List<Entry> _longEntries = new();
@@ -91,6 +91,14 @@ public class Zs1ForexInstrumentsStrategy : Strategy
 		get => _initialVolume.Value;
 		set => _initialVolume.Value = value;
 	}
+	/// <summary>
+	/// Allowed difference used when comparing position volumes.
+	/// </summary>
+	public decimal VolumeTolerance
+	{
+		get => _volumeTolerance.Value;
+		set => _volumeTolerance.Value = value;
+	}
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="Zs1ForexInstrumentsStrategy"/> class.
@@ -112,6 +120,9 @@ public class Zs1ForexInstrumentsStrategy : Strategy
 			.SetDisplay("Initial Volume", "Base volume for the hedge orders.", "Trading")
 			.SetCanOptimize(true)
 			.SetOptimize(0.01m, 1m, 0.01m);
+		_volumeTolerance = Param(nameof(VolumeTolerance), 0.0000001m)
+			.SetDisplay("Volume tolerance", "Allowed difference when comparing cumulative volumes.", "Trading")
+			.SetNotNegative();
 	}
 
 	/// <inheritdoc />

--- a/API/3774_Time_Based_Range_Breakout/CS/TimeBasedRangeBreakoutStrategy.cs
+++ b/API/3774_Time_Based_Range_Breakout/CS/TimeBasedRangeBreakoutStrategy.cs
@@ -13,7 +13,6 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class TimeBasedRangeBreakoutStrategy : Strategy
 {
-	private const int LastOpenHour = 23;
 
 	private readonly StrategyParam<int> _checkHour;
 	private readonly StrategyParam<int> _checkMinute;
@@ -25,6 +24,7 @@ public class TimeBasedRangeBreakoutStrategy : Strategy
 	private readonly StrategyParam<int> _closeMode;
 	private readonly StrategyParam<int> _tradesPerDay;
 	private readonly StrategyParam<DataType> _candleType;
+	private readonly StrategyParam<int> _lastOpenHour;
 
 	private readonly Queue<decimal> _rangeHistory = new();
 	private readonly Queue<decimal> _closeDiffHistory = new();
@@ -131,6 +131,14 @@ public class TimeBasedRangeBreakoutStrategy : Strategy
 		get => _candleType.Value;
 		set => _candleType.Value = value;
 	}
+	/// <summary>
+	/// Last hour of the day when breakout orders are allowed to remain open.
+	/// </summary>
+	public int LastOpenHour
+	{
+		get => _lastOpenHour.Value;
+		set => _lastOpenHour.Value = value;
+	}
 
 	/// <summary>
 	/// Initializes strategy parameters.
@@ -185,6 +193,9 @@ public class TimeBasedRangeBreakoutStrategy : Strategy
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
 		.SetDisplay("Candle Type", "Primary candle series used by the strategy", "Data");
+		_lastOpenHour = Param(nameof(LastOpenHour), 23)
+			.SetDisplay("Last Open Hour", "Hour after which new trades are not opened", "Schedule")
+			.SetRange(0, 23);
 	}
 
 	/// <inheritdoc />

--- a/API/3794_OverHedge_V2/CS/OverHedgeV2Strategy.cs
+++ b/API/3794_OverHedge_V2/CS/OverHedgeV2Strategy.cs
@@ -15,7 +15,6 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class OverHedgeV2Strategy : Strategy
 {
-	private const decimal VolumeTolerance = 1e-6m;
 
 	private readonly StrategyParam<decimal> _baseVolume;
 	private readonly StrategyParam<decimal> _hedgeMultiplier;
@@ -25,6 +24,7 @@ public class OverHedgeV2Strategy : Strategy
 	private readonly StrategyParam<int> _emaLongPeriod;
 	private readonly StrategyParam<bool> _shutdownGrid;
 	private readonly StrategyParam<DataType> _candleType;
+	private readonly StrategyParam<decimal> _volumeTolerance;
 
 	private readonly HashSet<Order> _activeEntryOrders = new();
 	private readonly HashSet<Order> _activeExitOrders = new();
@@ -94,6 +94,9 @@ public class OverHedgeV2Strategy : Strategy
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(1).TimeFrame())
 		.SetDisplay("Candle Type", "Timeframe used to calculate the EMA filters.", "Indicators");
+		_volumeTolerance = Param(nameof(VolumeTolerance), 1e-6m)
+			.SetDisplay("Volume tolerance", "Threshold used when checking exposure neutrality.", "Trading")
+			.SetNotNegative();
 	}
 
 	/// <summary>
@@ -166,6 +169,14 @@ public class OverHedgeV2Strategy : Strategy
 	{
 		get => _candleType.Value;
 		set => _candleType.Value = value;
+	}
+	/// <summary>
+	/// Minimum volume difference treated as zero when comparing exposures.
+	/// </summary>
+	public decimal VolumeTolerance
+	{
+		get => _volumeTolerance.Value;
+		set => _volumeTolerance.Value = value;
 	}
 
 	/// <inheritdoc />

--- a/API/3802_BollTrade_Bollinger_Reversion/CS/BollTradeBollingerReversionStrategy.cs
+++ b/API/3802_BollTrade_Bollinger_Reversion/CS/BollTradeBollingerReversionStrategy.cs
@@ -13,7 +13,6 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class BollTradeBollingerReversionStrategy : Strategy
 {
-	private const decimal MaxVolume = 500m;
 
 	private readonly StrategyParam<decimal> _takeProfit;
 	private readonly StrategyParam<decimal> _stopLoss;
@@ -23,6 +22,7 @@ public class BollTradeBollingerReversionStrategy : Strategy
 	private readonly StrategyParam<decimal> _lots;
 	private readonly StrategyParam<bool> _lotIncrease;
 	private readonly StrategyParam<DataType> _candleType;
+	private readonly StrategyParam<decimal> _maxVolume;
 
 	private decimal _lotBaseline;
 	private decimal _pipSize;
@@ -102,6 +102,14 @@ public class BollTradeBollingerReversionStrategy : Strategy
 		get => _candleType.Value;
 		set => _candleType.Value = value;
 	}
+	/// <summary>
+	/// Maximum volume allowed when scaling trades.
+	/// </summary>
+	public decimal MaxVolume
+	{
+		get => _maxVolume.Value;
+		set => _maxVolume.Value = value;
+	}
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="BollTradeBollingerReversionStrategy"/> class.
@@ -142,6 +150,9 @@ public class BollTradeBollingerReversionStrategy : Strategy
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
 			.SetDisplay("Candle Type", "Primary timeframe for signals.", "General");
+		_maxVolume = Param(nameof(MaxVolume), 500m)
+			.SetDisplay("Max Volume", "Upper cap applied after balance-based scaling.", "Money Management")
+			.SetGreaterThanZero();
 	}
 
 	/// <inheritdoc />

--- a/API/3818_Bago_EA/CS/BagoEaClassicStrategy.cs
+++ b/API/3818_Bago_EA/CS/BagoEaClassicStrategy.cs
@@ -15,8 +15,6 @@ using StockSharp.Messages;
 /// </summary>
 public class BagoEaClassicStrategy : Strategy
 {
-	private const int HistoryLimit = 300;
-	private const decimal FiftyLevel = 50m;
 
 	private readonly StrategyParam<decimal> _tradeVolume;
 	private readonly StrategyParam<decimal> _stopLossPips;
@@ -41,6 +39,8 @@ public class BagoEaClassicStrategy : Strategy
 	private readonly StrategyParam<int> _rsiPeriod;
 	private readonly StrategyParam<AppliedPriceType> _rsiAppliedPrice;
 	private readonly StrategyParam<DataType> _candleType;
+	private readonly StrategyParam<int> _historyLimit;
+	private readonly StrategyParam<decimal> _fiftyLevel;
 
 	private LengthIndicator<decimal> _fastMa = null!;
 	private LengthIndicator<decimal> _slowMa = null!;
@@ -166,6 +166,12 @@ public class BagoEaClassicStrategy : Strategy
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(1).TimeFrame())
 		.SetDisplay("Candle Type", "Working timeframe", "General");
+		_historyLimit = Param(nameof(HistoryLimit), 300)
+			.SetDisplay("History Limit", "Maximum number of cached indicator values", "General")
+			.SetGreaterThanZero();
+		_fiftyLevel = Param(nameof(FiftyLevel), 50m)
+			.SetDisplay("RSI Middle", "Neutral RSI level separating long and short signals", "Indicators")
+			.SetNotNegative();
 	}
 
 /// <summary>
@@ -374,6 +380,22 @@ public DataType CandleType
 	get => _candleType.Value;
 	set => _candleType.Value = value;
 }
+	/// <summary>
+	/// Maximum number of cached history items used by the strategy.
+	/// </summary>
+	public int HistoryLimit
+	{
+		get => _historyLimit.Value;
+		set => _historyLimit.Value = value;
+	}
+	/// <summary>
+	/// RSI neutral level separating bullish and bearish regimes.
+	/// </summary>
+	public decimal FiftyLevel
+	{
+		get => _fiftyLevel.Value;
+		set => _fiftyLevel.Value = value;
+	}
 
 /// <inheritdoc />
 public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()

--- a/API/3822_BreakOut15/CS/BreakOut15Strategy.cs
+++ b/API/3822_BreakOut15/CS/BreakOut15Strategy.cs
@@ -36,6 +36,7 @@ public class BreakOut15Strategy : Strategy
 	private readonly StrategyParam<MovingAverageMethod> _slowMethod;
 	private readonly StrategyParam<int> _slowPeriod;
 	private readonly StrategyParam<int> _slowShift;
+	private readonly StrategyParam<int> _signalBarShift;
 	private readonly StrategyParam<AppliedPrice> _slowPriceType;
 	private readonly StrategyParam<decimal> _breakoutLevelPips;
 	private readonly StrategyParam<bool> _useTimeLimit;
@@ -60,7 +61,6 @@ public class BreakOut15Strategy : Strategy
 	private decimal? _longEntryPrice;
 	private decimal? _shortEntryPrice;
 
-	private const int SignalBarShift = 1;
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="BreakOut15Strategy"/> class.
@@ -137,6 +137,9 @@ public class BreakOut15Strategy : Strategy
 
 		_slowShift = Param(nameof(SlowShift), 0)
 			.SetDisplay("Slow MA Shift", "Bar shift applied to the slow average", "Indicators");
+		_signalBarShift = Param(nameof(SignalBarShift), 1)
+			.SetDisplay("Signal Bar Shift", "Offset applied when evaluating breakout signals", "Indicators")
+			.SetNotNegative();
 
 		_slowPriceType = Param(nameof(SlowPriceType), AppliedPrice.Close)
 			.SetDisplay("Slow MA Price", "Applied price for the slow average", "Indicators");
@@ -363,6 +366,14 @@ public class BreakOut15Strategy : Strategy
 	{
 		get => _slowShift.Value;
 		set => _slowShift.Value = Math.Max(0, value);
+	}
+	/// <summary>
+	/// Additional bar shift applied when reading indicator values.
+	/// </summary>
+	public int SignalBarShift
+	{
+		get => _signalBarShift.Value;
+		set => _signalBarShift.Value = value;
 	}
 
 	/// <summary>

--- a/API/3846_Graal_Fractal_Channel/CS/GraalFractalChannelStrategy.cs
+++ b/API/3846_Graal_Fractal_Channel/CS/GraalFractalChannelStrategy.cs
@@ -16,7 +16,6 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class GraalFractalChannelStrategy : Strategy
 {
-	private const int DefaultSignalAge = 3;
 
 	private readonly StrategyParam<decimal> _orderVolume;
 	private readonly StrategyParam<decimal> _stopLossPips;
@@ -125,7 +124,7 @@ public class GraalFractalChannelStrategy : Strategy
 		_singlePosition = Param(nameof(SinglePosition), false)
 			.SetDisplay("Single Position Mode", "Block additional entries while already holding exposure in that direction.", "Orders");
 
-		_signalAgeLimit = Param(nameof(SignalAgeLimit), DefaultSignalAge)
+		_signalAgeLimit = Param(nameof(SignalAgeLimit), 3)
 			.SetDisplay("Signal Age (bars)", "Maximum number of new bars during which a fractal signal remains valid.", "Orders")
 			.SetGreaterThanZero();
 

--- a/API/3853_Ema_Cross_Contest_Hedged/CS/EmaCrossContestHedgedStrategy.cs
+++ b/API/3853_Ema_Cross_Contest_Hedged/CS/EmaCrossContestHedgedStrategy.cs
@@ -12,10 +12,6 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class EmaCrossContestHedgedStrategy : Strategy
 {
-	private const int MacdFastLength = 4;
-	private const int MacdSlowLength = 24;
-	private const int MacdSignalLength = 12;
-	private const int PendingOrderCount = 4;
 
 	private readonly StrategyParam<decimal> _orderVolume;
 	private readonly StrategyParam<int> _takeProfitPips;
@@ -27,8 +23,12 @@ public class EmaCrossContestHedgedStrategy : Strategy
 	private readonly StrategyParam<int> _pendingExpirationSeconds;
 	private readonly StrategyParam<int> _shortEmaLength;
 	private readonly StrategyParam<int> _longEmaLength;
+	private readonly StrategyParam<int> _macdFastLength;
+	private readonly StrategyParam<int> _macdSlowLength;
+	private readonly StrategyParam<int> _macdSignalLength;
 	private readonly StrategyParam<int> _signalBarShift;
 	private readonly StrategyParam<DataType> _candleType;
+	private readonly StrategyParam<int> _pendingOrderCount;
 
 	private decimal? _shortEmaCurrent;
 	private decimal? _shortEmaPrevious;
@@ -115,11 +115,43 @@ public class EmaCrossContestHedgedStrategy : Strategy
 		get => _longEmaLength.Value;
 		set => _longEmaLength.Value = value;
 	}
+	/// <summary>
+	/// Fast MACD EMA length.
+	/// </summary>
+	public int MacdFastLength
+	{
+		get => _macdFastLength.Value;
+		set => _macdFastLength.Value = value;
+	}
+	/// <summary>
+	/// Slow MACD EMA length.
+	/// </summary>
+	public int MacdSlowLength
+	{
+		get => _macdSlowLength.Value;
+		set => _macdSlowLength.Value = value;
+	}
+	/// <summary>
+	/// MACD signal line smoothing length.
+	/// </summary>
+	public int MacdSignalLength
+	{
+		get => _macdSignalLength.Value;
+		set => _macdSignalLength.Value = value;
+	}
 
 	public int SignalBarShift
 	{
 		get => _signalBarShift.Value;
 		set => _signalBarShift.Value = value;
+	}
+	/// <summary>
+	/// Number of layered pending hedge orders per side.
+	/// </summary>
+	public int PendingOrderCount
+	{
+		get => _pendingOrderCount.Value;
+		set => _pendingOrderCount.Value = value;
 	}
 
 	public DataType CandleType
@@ -154,10 +186,22 @@ public class EmaCrossContestHedgedStrategy : Strategy
 
 		_pendingExpirationSeconds = Param(nameof(PendingExpirationSeconds), 7200)
 		.SetDisplay("Expiration (s)", "Pending order lifetime in seconds", "Orders");
+		_pendingOrderCount = Param(nameof(PendingOrderCount), 4)
+			.SetDisplay("Pending Orders", "Number of layered pending hedges per side", "Orders")
+			.SetGreaterThanZero();
 
 		_shortEmaLength = Param(nameof(ShortEmaLength), 4)
 		.SetGreaterThanZero()
 		.SetDisplay("Short EMA", "Fast EMA length", "Indicators");
+		_macdFastLength = Param(nameof(MacdFastLength), 4)
+			.SetGreaterThanZero()
+			.SetDisplay("MACD Fast", "Fast EMA length used inside MACD", "Indicators");
+		_macdSlowLength = Param(nameof(MacdSlowLength), 24)
+			.SetGreaterThanZero()
+			.SetDisplay("MACD Slow", "Slow EMA length used inside MACD", "Indicators");
+		_macdSignalLength = Param(nameof(MacdSignalLength), 12)
+			.SetGreaterThanZero()
+			.SetDisplay("MACD Signal", "Signal line smoothing length", "Indicators");
 
 		_longEmaLength = Param(nameof(LongEmaLength), 24)
 		.SetGreaterThanZero()


### PR DESCRIPTION
## Summary
- replace the hard-coded take-profit buffer in Frank Ud Minimal with a strategy parameter
- expose the listed tolerance, history-length, scheduling, and MACD configuration constants across the affected strategies as `StrategyParam` values so they can be tuned from the UI

## Testing
- `dotnet build AlgoTrading.sln` *(fails: `dotnet` command not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7bef7fed48323b1b1ca20197268a3