### PR TITLE
Expose strategy constants as configurable parameters

### DIFF
--- a/API/3865_AK47_A1/CS/AK47A1Strategy.cs
+++ b/API/3865_AK47_A1/CS/AK47A1Strategy.cs
@@ -13,17 +13,17 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class AK47A1Strategy : Strategy
 {
-	private const int JawLength = 13;
-	private const int JawShift = 8;
-	private const int TeethLength = 8;
-	private const int TeethShift = 5;
-	private const int LipsLength = 5;
-	private const int LipsShift = 3;
-	private const int FractalWindow = 5;
-	private const int FractalLookback = 3;
-	private const decimal DemarkerThreshold = 0.5m;
-	private const decimal WprLowerBound = 0.25m;
-	private const decimal WprUpperBound = 0.75m;
+	private readonly StrategyParam<int> _jawLength;
+	private readonly StrategyParam<int> _jawShift;
+	private readonly StrategyParam<int> _teethLength;
+	private readonly StrategyParam<int> _teethShift;
+	private readonly StrategyParam<int> _lipsLength;
+	private readonly StrategyParam<int> _lipsShift;
+	private readonly StrategyParam<int> _fractalWindow;
+	private readonly StrategyParam<int> _fractalLookback;
+	private readonly StrategyParam<decimal> _demarkerThreshold;
+	private readonly StrategyParam<decimal> _wprLowerBound;
+	private readonly StrategyParam<decimal> _wprUpperBound;
 
 	private readonly StrategyParam<decimal> _spanGatorPoints;
 	private readonly StrategyParam<decimal> _takeProfitPoints;
@@ -57,6 +57,105 @@ public class AK47A1Strategy : Strategy
 	private decimal? _longTargetPrice;
 	private decimal? _shortStopPrice;
 	private decimal? _shortTargetPrice;
+
+	/// <summary>
+	/// Length of the Alligator jaw moving average.
+	/// </summary>
+	public int JawLength
+	{
+		get => _jawLength.Value;
+		set => _jawLength.Value = value;
+	}
+
+	/// <summary>
+	/// Shift applied to the Alligator jaw line.
+	/// </summary>
+	public int JawShift
+	{
+		get => _jawShift.Value;
+		set => _jawShift.Value = value;
+	}
+
+	/// <summary>
+	/// Length of the Alligator teeth moving average.
+	/// </summary>
+	public int TeethLength
+	{
+		get => _teethLength.Value;
+		set => _teethLength.Value = value;
+	}
+
+	/// <summary>
+	/// Shift applied to the Alligator teeth line.
+	/// </summary>
+	public int TeethShift
+	{
+		get => _teethShift.Value;
+		set => _teethShift.Value = value;
+	}
+
+	/// <summary>
+	/// Length of the Alligator lips moving average.
+	/// </summary>
+	public int LipsLength
+	{
+		get => _lipsLength.Value;
+		set => _lipsLength.Value = value;
+	}
+
+	/// <summary>
+	/// Shift applied to the Alligator lips line.
+	/// </summary>
+	public int LipsShift
+	{
+		get => _lipsShift.Value;
+		set => _lipsShift.Value = value;
+	}
+
+	/// <summary>
+	/// Number of candles used to detect fractal formations.
+	/// </summary>
+	public int FractalWindow
+	{
+		get => _fractalWindow.Value;
+		set => _fractalWindow.Value = value;
+	}
+
+	/// <summary>
+	/// Maximum age for a detected fractal to remain valid.
+	/// </summary>
+	public int FractalLookback
+	{
+		get => _fractalLookback.Value;
+		set => _fractalLookback.Value = value;
+	}
+
+	/// <summary>
+	/// Minimum DeMarker value required for long entries.
+	/// </summary>
+	public decimal DemarkerThreshold
+	{
+		get => _demarkerThreshold.Value;
+		set => _demarkerThreshold.Value = value;
+	}
+
+	/// <summary>
+	/// Lower bound of the Williams %R filter range.
+	/// </summary>
+	public decimal WprLowerBound
+	{
+		get => _wprLowerBound.Value;
+		set => _wprLowerBound.Value = value;
+	}
+
+	/// <summary>
+	/// Upper bound of the Williams %R filter range.
+	/// </summary>
+	public decimal WprUpperBound
+	{
+		get => _wprUpperBound.Value;
+		set => _wprUpperBound.Value = value;
+	}
 
 	/// <summary>
 	/// Required Alligator mouth width in points.
@@ -108,6 +207,72 @@ public class AK47A1Strategy : Strategy
 	/// </summary>
 	public AK47A1Strategy()
 	{
+		_jawLength = Param(nameof(JawLength), 13)
+		.SetGreaterThanZero()
+		.SetDisplay("Jaw Length", "Length of the Alligator jaw line", "Alligator")
+		.SetCanOptimize(true)
+		.SetOptimize(5, 40, 1);
+
+		_jawShift = Param(nameof(JawShift), 8)
+		.SetGreaterThanOrEqualTo(0)
+		.SetDisplay("Jaw Shift", "Shift applied to the Alligator jaw line", "Alligator")
+		.SetCanOptimize(true)
+		.SetOptimize(0, 16, 1);
+
+		_teethLength = Param(nameof(TeethLength), 8)
+		.SetGreaterThanZero()
+		.SetDisplay("Teeth Length", "Length of the Alligator teeth line", "Alligator")
+		.SetCanOptimize(true)
+		.SetOptimize(5, 30, 1);
+
+		_teethShift = Param(nameof(TeethShift), 5)
+		.SetGreaterThanOrEqualTo(0)
+		.SetDisplay("Teeth Shift", "Shift applied to the Alligator teeth line", "Alligator")
+		.SetCanOptimize(true)
+		.SetOptimize(0, 16, 1);
+
+		_lipsLength = Param(nameof(LipsLength), 5)
+		.SetGreaterThanZero()
+		.SetDisplay("Lips Length", "Length of the Alligator lips line", "Alligator")
+		.SetCanOptimize(true)
+		.SetOptimize(3, 20, 1);
+
+		_lipsShift = Param(nameof(LipsShift), 3)
+		.SetGreaterThanOrEqualTo(0)
+		.SetDisplay("Lips Shift", "Shift applied to the Alligator lips line", "Alligator")
+		.SetCanOptimize(true)
+		.SetOptimize(0, 10, 1);
+
+		_fractalWindow = Param(nameof(FractalWindow), 5)
+		.SetGreaterThanZero()
+		.SetDisplay("Fractal Window", "Number of candles for fractal detection", "Fractals")
+		.SetCanOptimize(true)
+		.SetOptimize(3, 9, 2);
+
+		_fractalLookback = Param(nameof(FractalLookback), 3)
+		.SetGreaterThanZero()
+		.SetDisplay("Fractal Lookback", "Maximum age of a detected fractal", "Fractals")
+		.SetCanOptimize(true)
+		.SetOptimize(1, 6, 1);
+
+		_demarkerThreshold = Param(nameof(DemarkerThreshold), 0.5m)
+		.SetGreaterThanOrEqualTo(0m)
+		.SetDisplay("DeMarker Threshold", "Minimum value for long setups", "Filters")
+		.SetCanOptimize(true)
+		.SetOptimize(0m, 1m, 0.05m);
+
+		_wprLowerBound = Param(nameof(WprLowerBound), 0.25m)
+		.SetGreaterThanOrEqualTo(0m)
+		.SetDisplay("WPR Lower", "Lower Williams %R filter bound", "Filters")
+		.SetCanOptimize(true)
+		.SetOptimize(0m, 0.5m, 0.05m);
+
+		_wprUpperBound = Param(nameof(WprUpperBound), 0.75m)
+		.SetGreaterThanOrEqualTo(0m)
+		.SetDisplay("WPR Upper", "Upper Williams %R filter bound", "Filters")
+		.SetCanOptimize(true)
+		.SetOptimize(0.5m, 1m, 0.05m);
+
 		_spanGatorPoints = Param(nameof(SpanGatorPoints), 0.5m)
 		.SetGreaterThanOrEqualTo(0m)
 		.SetDisplay("Alligator Span", "Required gap between Alligator lines", "Alligator")

--- a/API/3884_Otkat_Sys/CS/OtkatSysStrategy.cs
+++ b/API/3884_Otkat_Sys/CS/OtkatSysStrategy.cs
@@ -13,7 +13,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class OtkatSysStrategy : Strategy
 {
-	private const decimal LongExtraTakeProfit = 3m;
+	private readonly StrategyParam<decimal> _longExtraTakeProfit;
 
 	private readonly StrategyParam<DataType> _entryCandleType;
 	private readonly StrategyParam<DataType> _dailyCandleType;
@@ -56,6 +56,15 @@ public class OtkatSysStrategy : Strategy
 	{
 		get => _takeProfit.Value;
 		set => _takeProfit.Value = value;
+	}
+
+	/// <summary>
+	/// Extra take profit points added to long positions.
+	/// </summary>
+	public decimal LongExtraTakeProfit
+	{
+		get => _longExtraTakeProfit.Value;
+		set => _longExtraTakeProfit.Value = value;
 	}
 
 	/// <summary>
@@ -113,6 +122,12 @@ public class OtkatSysStrategy : Strategy
 
 		_dailyCandleType = Param(nameof(DailyCandleType), TimeSpan.FromDays(1).TimeFrame())
 			.SetDisplay("Daily Candles", "Session statistics timeframe", "General");
+
+		_longExtraTakeProfit = Param(nameof(LongExtraTakeProfit), 3m)
+		.SetGreaterThanOrEqualTo(0m)
+		.SetDisplay("Long Bonus Take Profit", "Additional points added to long take profit", "Risk")
+		.SetCanOptimize(true)
+		.SetOptimize(0m, 10m, 0.5m);
 
 		_takeProfit = Param(nameof(TakeProfit), 5m)
 			.SetGreaterThanZero()

--- a/API/3885_Weekly_Rebound_Corridor/CS/WeeklyReboundCorridorStrategy.cs
+++ b/API/3885_Weekly_Rebound_Corridor/CS/WeeklyReboundCorridorStrategy.cs
@@ -11,7 +11,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class WeeklyReboundCorridorStrategy : Strategy
 {
-	private const decimal AdditionalBuyTakeProfitPoints = 3m;
+	private readonly StrategyParam<decimal> _additionalBuyTakeProfitPoints;
 
 	private readonly StrategyParam<decimal> _takeProfitPoints;
 	private readonly StrategyParam<decimal> _stopLossPoints;
@@ -46,6 +46,15 @@ public class WeeklyReboundCorridorStrategy : Strategy
 	{
 		get => _stopLossPoints.Value;
 		set => _stopLossPoints.Value = value;
+	}
+
+	/// <summary>
+	/// Additional take-profit points added when buying.
+	/// </summary>
+	public decimal AdditionalBuyTakeProfitPoints
+	{
+		get => _additionalBuyTakeProfitPoints.Value;
+		set => _additionalBuyTakeProfitPoints.Value = value;
 	}
 
 	/// <summary>
@@ -89,6 +98,12 @@ public class WeeklyReboundCorridorStrategy : Strategy
 	/// </summary>
 	public WeeklyReboundCorridorStrategy()
 	{
+		_additionalBuyTakeProfitPoints = Param(nameof(AdditionalBuyTakeProfitPoints), 3m)
+		.SetGreaterThanOrEqualTo(0m)
+		.SetDisplay("Buy Bonus Take Profit", "Additional points added to long take profits", "Risk Management")
+		.SetCanOptimize(true)
+		.SetOptimize(0m, 10m, 0.5m);
+
 		_takeProfitPoints = Param(nameof(TakeProfitPoints), 5m)
 		.SetGreaterThanZero()
 		.SetDisplay("Take Profit", "Take-profit size in points", "Risk Management")

--- a/API/3887_Double_Up/CS/DoubleUpStrategy.cs
+++ b/API/3887_Double_Up/CS/DoubleUpStrategy.cs
@@ -12,7 +12,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class DoubleUpStrategy : Strategy
 {
-private const decimal MacdScale = 1_000_000m;
+private readonly StrategyParam<decimal> _macdScale;
 
 private readonly StrategyParam<int> _cciPeriod;
 private readonly StrategyParam<decimal> _threshold;
@@ -61,6 +61,15 @@ public decimal Threshold
 {
 get => _threshold.Value;
 set => _threshold.Value = value;
+}
+
+/// <summary>
+/// Scaling factor applied to the MACD indicator output.
+/// </summary>
+public decimal MacdScale
+{
+get => _macdScale.Value;
+set => _macdScale.Value = value;
 }
 
 /// <summary>
@@ -137,6 +146,7 @@ set => _candleType.Value = value;
 
 public DoubleUpStrategy()
 {
+_macdScale = Param(nameof(MacdScale), 1_000_000m).SetDisplay("MACD Scale").SetCanOptimize(true);
 _cciPeriod = Param(nameof(CciPeriod), 8).SetDisplay("CCI Period").SetCanOptimize(true);
 _threshold = Param(nameof(Threshold), 230m).SetDisplay("Threshold").SetCanOptimize(true);
 _macdFastPeriod = Param(nameof(MacdFastPeriod), 13).SetDisplay("MACD Fast").SetCanOptimize(true);

--- a/API/3891_SilverTrendV3/CS/SilverTrendV3Strategy.cs
+++ b/API/3891_SilverTrendV3/CS/SilverTrendV3Strategy.cs
@@ -12,10 +12,10 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class SilverTrendV3Strategy : Strategy
 {
-	private const int SilverTrendLookback = 350;
-	private const int SilverTrendWindow = 9;
-	private const int DefaultRisk = 3;
-	private const int JtpoDefaultLength = 14;
+	private readonly StrategyParam<int> _silverTrendLookback;
+	private readonly StrategyParam<int> _silverTrendWindow;
+	private readonly StrategyParam<int> _defaultRisk;
+	private readonly StrategyParam<int> _jtpoLength;
 
 	private readonly StrategyParam<decimal> _trailingStopPoints;
 	private readonly StrategyParam<decimal> _takeProfitPoints;
@@ -38,6 +38,42 @@ public class SilverTrendV3Strategy : Strategy
 	private decimal? _longEntryPrice;
 	private decimal? _shortEntryPrice;
 
+
+	/// <summary>
+	/// Number of candles used for SilverTrend calculations.
+	/// </summary>
+	public int SilverTrendLookback
+	{
+		get => _silverTrendLookback.Value;
+		set => _silverTrendLookback.Value = value;
+	}
+
+	/// <summary>
+	/// Window size used to compute SilverTrend extrema.
+	/// </summary>
+	public int SilverTrendWindow
+	{
+		get => _silverTrendWindow.Value;
+		set => _silverTrendWindow.Value = value;
+	}
+
+	/// <summary>
+	/// Risk coefficient applied in SilverTrend formulas.
+	/// </summary>
+	public int DefaultRisk
+	{
+		get => _defaultRisk.Value;
+		set => _defaultRisk.Value = value;
+	}
+
+	/// <summary>
+	/// Length parameter used in the J_TPO filter.
+	/// </summary>
+	public int JtpoDefaultLength
+	{
+		get => _jtpoLength.Value;
+		set => _jtpoLength.Value = value;
+	}
 
 	/// <summary>
 	/// Trailing stop distance expressed in points.
@@ -89,6 +125,30 @@ public class SilverTrendV3Strategy : Strategy
 	/// </summary>
 	public SilverTrendV3Strategy()
 	{
+
+		_silverTrendLookback = Param(nameof(SilverTrendLookback), 350)
+		.SetGreaterThanZero()
+		.SetDisplay("SilverTrend Lookback", "Number of candles for SilverTrend calculations", "SilverTrend")
+		.SetCanOptimize(true)
+		.SetOptimize(100, 600, 50);
+
+		_silverTrendWindow = Param(nameof(SilverTrendWindow), 9)
+		.SetGreaterThanZero()
+		.SetDisplay("SilverTrend Window", "Sliding window size for extrema", "SilverTrend")
+		.SetCanOptimize(true)
+		.SetOptimize(3, 21, 2);
+
+		_defaultRisk = Param(nameof(DefaultRisk), 3)
+		.SetGreaterThanOrEqualTo(0)
+		.SetDisplay("Risk Coefficient", "Risk coefficient used in SilverTrend", "SilverTrend")
+		.SetCanOptimize(true)
+		.SetOptimize(0, 10, 1);
+
+		_jtpoLength = Param(nameof(JtpoDefaultLength), 14)
+		.SetGreaterThanZero()
+		.SetDisplay("J TPO Length", "Lookback for J_TPO filter", "SilverTrend")
+		.SetCanOptimize(true)
+		.SetOptimize(5, 40, 1);
 
 		_trailingStopPoints = Param(nameof(TrailingStopPoints), 0m)
 		.SetGreaterThanOrEqual(0m)


### PR DESCRIPTION
## Summary
- convert the Alligator, fractal, and oscillator thresholds in AK47A1Strategy into editable strategy parameters
- add configurable long bonus take-profit offsets for OtkatSysStrategy and WeeklyReboundCorridorStrategy
- expose the MACD scaling factor and SilverTrend calculation lengths as strategy parameters

## Testing
- dotnet build AlgoTrading.sln *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7bf0af54083238a313a599e0eaaad