### PR TITLE
Expose strategy constants as tunable parameters

### DIFF
--- a/API/3904_OzFx_Simple/CS/OzFxSimpleStrategy.cs
+++ b/API/3904_OzFx_Simple/CS/OzFxSimpleStrategy.cs
@@ -16,12 +16,12 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class OzFxSimpleStrategy : Strategy
 {
-private const int LayersCount = 5;
-private const int AwesomeShortPeriod = 5;
-private const int AwesomeLongPeriod = 34;
-private const int AcceleratorAveragePeriod = 5;
-private const int StochasticKSmooth = 3;
-private const int StochasticDSmooth = 3;
+private readonly StrategyParam<int> _layersCount;
+private readonly StrategyParam<int> _awesomeShortPeriod;
+private readonly StrategyParam<int> _awesomeLongPeriod;
+private readonly StrategyParam<int> _acceleratorAveragePeriod;
+private readonly StrategyParam<int> _stochasticKSmooth;
+private readonly StrategyParam<int> _stochasticDSmooth;
 
 private readonly StrategyParam<decimal> _orderVolume;
 private readonly StrategyParam<decimal> _stopLossPips;
@@ -66,6 +66,57 @@ public int Index;
 /// <summary>
 /// Volume of each submitted market order layer.
 /// </summary>
+public int LayersCount
+{
+get => _layersCount.Value;
+set => _layersCount.Value = value;
+}
+
+/// <summary>
+/// Short period used for the Awesome Oscillator.
+/// </summary>
+public int AwesomeShortPeriod
+{
+get => _awesomeShortPeriod.Value;
+set => _awesomeShortPeriod.Value = value;
+}
+
+/// <summary>
+/// Long period used for the Awesome Oscillator.
+/// </summary>
+public int AwesomeLongPeriod
+{
+get => _awesomeLongPeriod.Value;
+set => _awesomeLongPeriod.Value = value;
+}
+
+/// <summary>
+/// Length of the moving average applied to the accelerator oscillator.
+/// </summary>
+public int AcceleratorAveragePeriod
+{
+get => _acceleratorAveragePeriod.Value;
+set => _acceleratorAveragePeriod.Value = value;
+}
+
+/// <summary>
+/// Smoothing factor of the stochastic %K line.
+/// </summary>
+public int StochasticKSmooth
+{
+get => _stochasticKSmooth.Value;
+set => _stochasticKSmooth.Value = value;
+}
+
+/// <summary>
+/// Smoothing factor of the stochastic %D line.
+/// </summary>
+public int StochasticDSmooth
+{
+get => _stochasticDSmooth.Value;
+set => _stochasticDSmooth.Value = value;
+}
+
 public decimal OrderVolume
 {
 get => _orderVolume.Value;
@@ -122,6 +173,42 @@ set => _candleType.Value = value;
 /// </summary>
 public OzFxSimpleStrategy()
 {
+_layersCount = Param(nameof(LayersCount), 5)
+.SetGreaterThanZero()
+.SetDisplay("Layers", "Number of layered market orders opened per signal.", "Execution")
+.SetCanOptimize(true)
+.SetOptimize(3, 7, 1);
+
+_awesomeShortPeriod = Param(nameof(AwesomeShortPeriod), 5)
+.SetGreaterThanZero()
+.SetDisplay("AO Fast", "Short period of the Awesome Oscillator.", "Indicators")
+.SetCanOptimize(true)
+.SetOptimize(3, 10, 1);
+
+_awesomeLongPeriod = Param(nameof(AwesomeLongPeriod), 34)
+.SetGreaterThanZero()
+.SetDisplay("AO Slow", "Long period of the Awesome Oscillator.", "Indicators")
+.SetCanOptimize(true)
+.SetOptimize(20, 60, 2);
+
+_acceleratorAveragePeriod = Param(nameof(AcceleratorAveragePeriod), 5)
+.SetGreaterThanZero()
+.SetDisplay("Accelerator MA", "Length of the moving average smoothing the accelerator oscillator.", "Indicators")
+.SetCanOptimize(true)
+.SetOptimize(3, 10, 1);
+
+_stochasticKSmooth = Param(nameof(StochasticKSmooth), 3)
+.SetGreaterThanZero()
+.SetDisplay("Stochastic %K Smooth", "Smoothing period applied to %K.", "Indicators")
+.SetCanOptimize(true)
+.SetOptimize(1, 5, 1);
+
+_stochasticDSmooth = Param(nameof(StochasticDSmooth), 3)
+.SetGreaterThanZero()
+.SetDisplay("Stochastic %D Smooth", "Smoothing period applied to %D.", "Indicators")
+.SetCanOptimize(true)
+.SetOptimize(1, 5, 1);
+
 _orderVolume = Param(nameof(OrderVolume), 0.1m)
 .SetGreaterThanZero()
 .SetDisplay("Order Volume", "Lot size per each market order layer.", "Trading")

--- a/API/3908_Five_MA_Multi_Timeframe/CS/FiveMaMultiTimeframeStrategy.cs
+++ b/API/3908_Five_MA_Multi_Timeframe/CS/FiveMaMultiTimeframeStrategy.cs
@@ -14,9 +14,9 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class FiveMaMultiTimeframeStrategy : Strategy
 {
-	private const decimal Weight = 12.5m;
+private readonly StrategyParam<decimal> _weight;
 
-	private readonly StrategyParam<DataType> _candleType;
+private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<DataType> _higherTimeframe1;
 	private readonly StrategyParam<DataType> _higherTimeframe2;
 	private readonly StrategyParam<int> _firstPeriod;
@@ -25,7 +25,7 @@ public class FiveMaMultiTimeframeStrategy : Strategy
 	private readonly StrategyParam<int> _fourthPeriod;
 	private readonly StrategyParam<int> _fifthPeriod;
 	private readonly StrategyParam<int> _openLevel;
-	private readonly StrategyParam<int> _closeLevel;
+private readonly StrategyParam<int> _closeLevel;
 
 	private readonly TimeframeState _primaryState = new(true);
 	private readonly TimeframeState _secondaryState = new(false);
@@ -42,9 +42,13 @@ public class FiveMaMultiTimeframeStrategy : Strategy
 	/// <summary>
 	/// Initializes a new instance of <see cref="FiveMaMultiTimeframeStrategy"/>.
 	/// </summary>
-	public FiveMaMultiTimeframeStrategy()
-	{
-		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
+public FiveMaMultiTimeframeStrategy()
+{
+_weight = Param(nameof(Weight), 12.5m)
+.SetGreaterThanZero()
+.SetDisplay("Weight", "Multiplier applied to the aggregated timeframe score.", "Signals");
+
+_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
 			.SetDisplay("Primary TF", "Primary candle timeframe", "General");
 
 		_higherTimeframe1 = Param(nameof(HigherTimeframe1), TimeSpan.FromHours(1).TimeFrame())
@@ -80,10 +84,19 @@ public class FiveMaMultiTimeframeStrategy : Strategy
 			.SetDisplay("Close Level", "Signal grade required to close opposite trades", "Trading");
 	}
 
-	/// <summary>
-	/// Primary candle type used for signals.
-	/// </summary>
-	public DataType CandleType
+/// <summary>
+/// Scaling multiplier applied to the aggregated score.
+/// </summary>
+public decimal Weight
+{
+get => _weight.Value;
+set => _weight.Value = value;
+}
+
+/// <summary>
+/// Primary candle type used for signals.
+/// </summary>
+public DataType CandleType
 	{
 		get => _candleType.Value;
 		set => _candleType.Value = value;

--- a/API/3927_Hercules/CS/HerculesStrategy.cs
+++ b/API/3927_Hercules/CS/HerculesStrategy.cs
@@ -15,9 +15,9 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class HerculesStrategy : Strategy
 {
-	private const int StopShift = 4;
+private readonly StrategyParam<int> _stopShift;
 
-	private readonly StrategyParam<decimal> _orderVolume;
+private readonly StrategyParam<decimal> _orderVolume;
 	private readonly StrategyParam<bool> _useMoneyManagement;
 	private readonly StrategyParam<decimal> _riskPercent;
 	private readonly StrategyParam<int> _triggerPips;
@@ -69,16 +69,26 @@ public class HerculesStrategy : Strategy
 	private decimal _secondTargetVolume;
 	private bool _firstTargetActive;
 	private bool _secondTargetActive;
-	private decimal _entryPrice;
+private decimal _entryPrice;
 
-	/// <summary>
-	/// Initializes default parameters that mirror the original advisor.
-	/// </summary>
-	public HerculesStrategy()
-	{
-		_orderVolume = Param(nameof(OrderVolume), 0.01m)
-		.SetDisplay("Order Volume", "Volume for each market order", "Trading")
-		.SetCanOptimize(true);
+public int StopShift
+{
+get => _stopShift.Value;
+set => _stopShift.Value = value;
+}
+
+        /// <summary>
+        /// Initializes default parameters that mirror the original advisor.
+        /// </summary>
+public HerculesStrategy()
+{
+_stopShift = Param(nameof(StopShift), 4)
+.SetRange(1, 10)
+.SetDisplay("Stop Shift", "Number of candles used to reference prior highs and lows.", "Risk");
+
+_orderVolume = Param(nameof(OrderVolume), 0.01m)
+.SetDisplay("Order Volume", "Volume for each market order", "Trading")
+.SetCanOptimize(true);
 
 		_useMoneyManagement = Param(nameof(UseMoneyManagement), true)
 		.SetDisplay("Money Management", "Recalculate volume from portfolio balance", "Trading")

--- a/API/3930_One_Two_Three_Pattern/CS/OneTwoThreePatternStrategy.cs
+++ b/API/3930_One_Two_Three_Pattern/CS/OneTwoThreePatternStrategy.cs
@@ -19,8 +19,9 @@ public class OneTwoThreePatternStrategy : Strategy
 	private readonly StrategyParam<decimal> _takeProfitPips;
 	private readonly StrategyParam<decimal> _volumeParam;
 	private readonly StrategyParam<decimal> _trailingStopPips;
-	private readonly StrategyParam<decimal> _trendRatio;
-	private readonly StrategyParam<DataType> _candleType;
+        private readonly StrategyParam<decimal> _trendRatio;
+        private readonly StrategyParam<decimal> _macdEpsilon;
+        private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<int> _macdFast;
 	private readonly StrategyParam<int> _macdSlow;
 	private readonly StrategyParam<int> _macdSignal;
@@ -36,11 +37,9 @@ public class OneTwoThreePatternStrategy : Strategy
 	private decimal? _shortStop;
 	private decimal? _shortTakeProfit;
 	private decimal? _shortEntryPrice;
-	private decimal _pipSize;
+        private decimal _pipSize;
 
-	private const decimal MacdEpsilon = 0.001m;
-
-	/// <summary>
+        /// <summary>
 	/// Take profit distance expressed in MetaTrader points.
 	/// </summary>
 	public decimal TakeProfitPips
@@ -70,11 +69,17 @@ public class OneTwoThreePatternStrategy : Strategy
 	/// <summary>
 	/// Minimum ratio between the previous and current trend lengths.
 	/// </summary>
-	public decimal TrendRatio
-	{
-		get => _trendRatio.Value;
-		set => _trendRatio.Value = value;
-	}
+        public decimal TrendRatio
+        {
+                get => _trendRatio.Value;
+                set => _trendRatio.Value = value;
+        }
+
+        public decimal MacdEpsilon
+        {
+                get => _macdEpsilon.Value;
+                set => _macdEpsilon.Value = value;
+        }
 
 	/// <summary>
 	/// Candle type used for pattern detection.
@@ -141,11 +146,15 @@ public class OneTwoThreePatternStrategy : Strategy
 			.SetCanOptimize(true)
 			.SetOptimize(10m, 60m, 5m);
 
-		_trendRatio = Param(nameof(TrendRatio), 4m)
-			.SetGreaterThanZero()
-			.SetDisplay("Trend Ratio", "Required ratio between previous and current trend lengths.", "Filters")
-			.SetCanOptimize(true)
-			.SetOptimize(2m, 6m, 0.5m);
+                _trendRatio = Param(nameof(TrendRatio), 4m)
+                        .SetGreaterThanZero()
+                        .SetDisplay("Trend Ratio", "Required ratio between previous and current trend lengths.", "Filters")
+                        .SetCanOptimize(true)
+                        .SetOptimize(2m, 6m, 0.5m);
+
+                _macdEpsilon = Param(nameof(MacdEpsilon), 0.001m)
+                        .SetGreaterThanZero()
+                        .SetDisplay("MACD Epsilon", "Small offset used to avoid division by zero in ratio checks.", "Filters");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(1).TimeFrame())
 			.SetDisplay(LocalizedStrings.CandleTypeKey, "Candle series for pattern recognition.", "Data");

--- a/API/3942_FullDamp/CS/FullDampStrategy.cs
+++ b/API/3942_FullDamp/CS/FullDampStrategy.cs
@@ -11,16 +11,16 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class FullDampStrategy : Strategy
 {
-	private const decimal OversoldLevel = 30m;
-	private const decimal OverboughtLevel = 70m;
-	
-	private readonly StrategyParam<DataType> _candleType;
+private readonly StrategyParam<decimal> _oversoldLevel;
+private readonly StrategyParam<decimal> _overboughtLevel;
+
+private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<int> _bollingerPeriod1;
 	private readonly StrategyParam<int> _bollingerPeriod2;
 	private readonly StrategyParam<int> _bollingerPeriod3;
 	private readonly StrategyParam<int> _rsiPeriod;
 	private readonly StrategyParam<int> _lookbackBars;
-	private readonly StrategyParam<int> _stopOffsetPoints;
+private readonly StrategyParam<int> _stopOffsetPoints;
 	
 	private decimal? _wideUpperBand;
 	private decimal? _wideLowerBand;
@@ -107,19 +107,39 @@ public class FullDampStrategy : Strategy
 	/// <summary>
 	/// Offset for stop calculation expressed in instrument points.
 	/// </summary>
-	public int StopOffsetPoints
-	{
-		get => _stopOffsetPoints.Value;
-		set => _stopOffsetPoints.Value = value;
-	}
+public int StopOffsetPoints
+{
+get => _stopOffsetPoints.Value;
+set => _stopOffsetPoints.Value = value;
+}
+
+public decimal OversoldLevel
+{
+get => _oversoldLevel.Value;
+set => _oversoldLevel.Value = value;
+}
+
+public decimal OverboughtLevel
+{
+get => _overboughtLevel.Value;
+set => _overboughtLevel.Value = value;
+}
 	
 	/// <summary>
 	/// Initializes a new instance of <see cref="FullDampStrategy"/>.
 	/// </summary>
 	public FullDampStrategy()
 	{
-		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(1).TimeFrame())
-			.SetDisplay("Candle Type", "Candles for analysis", "General");
+_oversoldLevel = Param(nameof(OversoldLevel), 30m)
+.SetRange(0m, 100m)
+.SetDisplay("Oversold Level", "RSI threshold that marks the oversold region.", "Indicators");
+
+_overboughtLevel = Param(nameof(OverboughtLevel), 70m)
+.SetRange(0m, 100m)
+.SetDisplay("Overbought Level", "RSI threshold that marks the overbought region.", "Indicators");
+
+_candleType = Param(nameof(CandleType), TimeSpan.FromHours(1).TimeFrame())
+.SetDisplay("Candle Type", "Candles for analysis", "General");
 		
 		_bollingerPeriod1 = Param(nameof(BollingerPeriod1), 20)
 			.SetGreaterThanZero()


### PR DESCRIPTION
## Summary
- convert hard-coded OzFx, FiveMA, Elite eFibo, Hercules, OneTwoThree, and Full Damp constants to strategy parameters so they can be adjusted at runtime
- make the FX CHAOS scalp and pyramid fractal trackers honor configurable window sizes by regenerating their stateful helpers when the parameter changes

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d7bf1ef9e08323b357d5095214f273