### PR TITLE
Convert strategy constants into configurable parameters

### DIFF
--- a/API/3947_Macd_Pattern_Trader_v01/CS/MacdPatternTraderV01Strategy.cs
+++ b/API/3947_Macd_Pattern_Trader_v01/CS/MacdPatternTraderV01Strategy.cs
@@ -13,11 +13,10 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class MacdPatternTraderV01Strategy : Strategy
 {
-	private const int HistoryLimit = 1000;
-
 	private readonly StrategyParam<int> _stopLossBars;
 	private readonly StrategyParam<int> _takeProfitBars;
 	private readonly StrategyParam<int> _offsetPoints;
+	private readonly StrategyParam<int> _historyLimit;
 	private readonly StrategyParam<int> _macdFastPeriod;
 	private readonly StrategyParam<int> _macdSlowPeriod;
 	private readonly StrategyParam<int> _macdSignalPeriod;
@@ -71,6 +70,11 @@ public class MacdPatternTraderV01Strategy : Strategy
 	/// Offset in points added to the calculated stop level.
 	/// </summary>
 	public int OffsetPoints { get => _offsetPoints.Value; set => _offsetPoints.Value = value; }
+
+	/// <summary>
+	/// Number of historical candles stored for swing detection.
+	/// </summary>
+	public int HistoryLimit { get => _historyLimit.Value; set => _historyLimit.Value = value; }
 
 	/// <summary>
 	/// Fast EMA period for the MACD indicator.
@@ -150,6 +154,10 @@ public class MacdPatternTraderV01Strategy : Strategy
 		_offsetPoints = Param(nameof(OffsetPoints), 10)
 		.SetGreaterThanZero()
 		.SetDisplay("Stop Offset", "Additional points added to the stop-loss", "Risk");
+
+		_historyLimit = Param(nameof(HistoryLimit), 1000)
+		.SetGreaterThanZero()
+		.SetDisplay("History Limit", "Number of recent candles stored for swing detection", "Risk");
 
 		_macdFastPeriod = Param(nameof(MacdFastPeriod), 5)
 		.SetGreaterThanZero()

--- a/API/3949_Macd_Pattern_Trader_V02/CS/MacdPatternTraderV02Strategy.cs
+++ b/API/3949_Macd_Pattern_Trader_V02/CS/MacdPatternTraderV02Strategy.cs
@@ -17,9 +17,8 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class MacdPatternTraderV02Strategy : Strategy
 {
-	private const decimal ProfitThresholdPoints = 5m;
-	private const int MaxHistory = 1024;
-
+	private readonly StrategyParam<decimal> _profitThresholdPoints;
+	private readonly StrategyParam<int> _maxHistory;
 	private readonly StrategyParam<int> _stopLossBars;
 	private readonly StrategyParam<int> _takeProfitBars;
 	private readonly StrategyParam<int> _offsetPoints;
@@ -97,6 +96,15 @@ public class MacdPatternTraderV02Strategy : Strategy
 	{
 		get => _offsetPoints.Value;
 		set => _offsetPoints.Value = value;
+	}
+
+	/// <summary>
+	/// Minimal profit in points required before partial exits are considered.
+	/// </summary>
+	public decimal ProfitThresholdPoints
+	{
+		get => _profitThresholdPoints.Value;
+		set => _profitThresholdPoints.Value = value;
 	}
 
 	/// <summary>
@@ -190,6 +198,15 @@ public class MacdPatternTraderV02Strategy : Strategy
 	}
 
 	/// <summary>
+	/// Maximum number of finished candles stored in the sliding history window.
+	/// </summary>
+	public int MaxHistory
+	{
+		get => _maxHistory.Value;
+		set => _maxHistory.Value = value;
+	}
+
+	/// <summary>
 	/// Initializes a new instance of the <see cref="MacdPatternTraderV02Strategy"/> class.
 	/// </summary>
 	public MacdPatternTraderV02Strategy()
@@ -205,6 +222,10 @@ public class MacdPatternTraderV02Strategy : Strategy
 		_offsetPoints = Param(nameof(OffsetPoints), 10)
 			.SetGreaterThanZero()
 			.SetDisplay("Offset Points", "Additional protective offset in points", "Risk");
+
+		_profitThresholdPoints = Param(nameof(ProfitThresholdPoints), 5m)
+			.SetGreaterThanZero()
+			.SetDisplay("Profit Threshold Points", "Minimal profit in points before partial exits", "Risk");
 
 		_fastEmaPeriod = Param(nameof(FastEmaPeriod), 5)
 			.SetGreaterThanZero()
@@ -242,6 +263,10 @@ public class MacdPatternTraderV02Strategy : Strategy
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(1).TimeFrame())
 			.SetDisplay("Candle Type", "Candle type used for indicators", "General");
+
+		_maxHistory = Param(nameof(MaxHistory), 1024)
+			.SetGreaterThanZero()
+			.SetDisplay("History Limit", "Maximum candles stored for pattern recognition", "General");
 	}
 
 	/// <inheritdoc />

--- a/API/3962_Momo_Trades_V3/CS/MomoTradesV3Strategy.cs
+++ b/API/3962_Momo_Trades_V3/CS/MomoTradesV3Strategy.cs
@@ -17,8 +17,6 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class MomoTradesV3Strategy : Strategy
 {
-	private const decimal MacdZeroTolerance = 1e-8m;
-
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<int> _emaPeriod;
 	private readonly StrategyParam<int> _emaShift;
@@ -26,6 +24,7 @@ public class MomoTradesV3Strategy : Strategy
 	private readonly StrategyParam<int> _macdSlow;
 	private readonly StrategyParam<int> _macdSignal;
 	private readonly StrategyParam<int> _macdShift;
+	private readonly StrategyParam<decimal> _macdZeroTolerance;
 	private readonly StrategyParam<decimal> _priceShiftPoints;
 	private readonly StrategyParam<decimal> _tradeVolume;
 	private readonly StrategyParam<decimal> _riskFraction;
@@ -105,6 +104,15 @@ public class MomoTradesV3Strategy : Strategy
 	{
 		get => _macdShift.Value;
 		set => _macdShift.Value = value;
+	}
+
+	/// <summary>
+	/// Absolute tolerance used to treat MACD values as neutral.
+	/// </summary>
+	public decimal MacdZeroTolerance
+	{
+		get => _macdZeroTolerance.Value;
+		set => _macdZeroTolerance.Value = value;
 	}
 
 	/// <summary>
@@ -219,6 +227,10 @@ public class MomoTradesV3Strategy : Strategy
 		_macdShift = Param(nameof(MacdShift), 1)
 		.SetGreaterThanZero()
 		.SetDisplay("MACD Shift", "Extra displacement for MACD history", "Indicators");
+		_macdZeroTolerance = Param(nameof(MacdZeroTolerance), 1e-8m)
+			.SetGreaterThanZero()
+			.SetDisplay("MACD Zero Tolerance", "Absolute tolerance for flat MACD detection", "Indicators");
+
 
 		_priceShiftPoints = Param(nameof(PriceShiftPoints), 10m)
 		.SetDisplay("Price Shift", "Required price offset from EMA in MetaTrader points", "Signals");

--- a/API/3972_Macd_Pattern_Trader_All_v001/CS/MacdPatternTraderAllV001Strategy.cs
+++ b/API/3972_Macd_Pattern_Trader_All_v001/CS/MacdPatternTraderAllV001Strategy.cs
@@ -15,11 +15,6 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class MacdPatternTraderAllV001Strategy : Strategy
 {
-	private const int MacdHistoryLength = 3;
-	private const int CandleHistoryLimit = 1000;
-	private const decimal MinPartialVolume = 0.01m;
-	private const decimal ProfitThreshold = 5m;
-
 	private readonly StrategyParam<bool> _pattern1Enabled;
 	private readonly StrategyParam<int> _pattern1StopLossBars;
 	private readonly StrategyParam<int> _pattern1TakeProfitBars;
@@ -95,6 +90,10 @@ public class MacdPatternTraderAllV001Strategy : Strategy
 	private readonly StrategyParam<TimeSpan> _stopTime;
 	private readonly StrategyParam<bool> _useMartingale;
 	private readonly StrategyParam<DataType> _candleType;
+	private readonly StrategyParam<int> _macdHistoryLength;
+	private readonly StrategyParam<int> _candleHistoryLimit;
+	private readonly StrategyParam<decimal> _minPartialVolume;
+	private readonly StrategyParam<decimal> _profitThreshold;
 
 	private MovingAverageConvergenceDivergenceSignal _macd1 = null!;
 	private MovingAverageConvergenceDivergenceSignal _macd2 = null!;
@@ -783,6 +782,42 @@ public class MacdPatternTraderAllV001Strategy : Strategy
 		get => _candleType.Value;
 		set => _candleType.Value = value;
 	}
+	/// <summary>
+	/// Number of MACD values cached per pattern for hook detection.
+	/// </summary>
+	public int MacdHistoryLength
+	{
+		get => _macdHistoryLength.Value;
+		set => _macdHistoryLength.Value = value;
+	}
+
+	/// <summary>
+	/// Maximum number of finished candles stored for trailing calculations.
+	/// </summary>
+	public int CandleHistoryLimit
+	{
+		get => _candleHistoryLimit.Value;
+		set => _candleHistoryLimit.Value = value;
+	}
+
+	/// <summary>
+	/// Minimal volume allowed when performing partial exits.
+	/// </summary>
+	public decimal MinPartialVolume
+	{
+		get => _minPartialVolume.Value;
+		set => _minPartialVolume.Value = value;
+	}
+
+	/// <summary>
+	/// Minimal floating profit required before partial exits can trigger.
+	/// </summary>
+	public decimal ProfitThreshold
+	{
+		get => _profitThreshold.Value;
+		set => _profitThreshold.Value = value;
+	}
+
 
 	/// <summary>
 	/// Constructor.
@@ -971,6 +1006,21 @@ public class MacdPatternTraderAllV001Strategy : Strategy
 			.SetDisplay("Martingale", "Enable martingale volume adjustment", "Risk");
 		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(1).TimeFrame())
 			.SetDisplay("Candle Type", "Type of candles used for analysis", "General");
+		_macdHistoryLength = Param(nameof(MacdHistoryLength), 3)
+			.SetGreaterThanZero()
+			.SetDisplay("MACD History", "Number of MACD values cached per pattern", "General");
+
+		_candleHistoryLimit = Param(nameof(CandleHistoryLimit), 1000)
+			.SetGreaterThanZero()
+			.SetDisplay("Candle History", "Maximum stored candles for trailing logic", "General");
+
+		_minPartialVolume = Param(nameof(MinPartialVolume), 0.01m)
+			.SetGreaterThanZero()
+			.SetDisplay("Min Partial Volume", "Lowest allowed volume for partial exits", "General");
+
+		_profitThreshold = Param(nameof(ProfitThreshold), 5m)
+			.SetGreaterThanZero()
+			.SetDisplay("Profit Threshold", "Minimal floating profit before partial exits", "General");
 	}
 
 	/// <inheritdoc />

--- a/API/3981_Trend_RDS/CS/TrendRdsStrategy.cs
+++ b/API/3981_Trend_RDS/CS/TrendRdsStrategy.cs
@@ -14,7 +14,6 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class TrendRdsStrategy : Strategy
 {
-	private const int MaxPatternDepth = 100;
 	private static readonly TimeSpan SignalWindow = TimeSpan.FromMinutes(10);
 	private static readonly TimeSpan CloseWindow = TimeSpan.FromMinutes(15);
 
@@ -28,8 +27,9 @@ public class TrendRdsStrategy : Strategy
 	private readonly StrategyParam<decimal> _trailingStepPips;
 	private readonly StrategyParam<decimal> _breakEvenPips;
 	private readonly StrategyParam<DataType> _candleType;
+	private readonly StrategyParam<int> _maxPatternDepth;
 
-	private readonly List<(decimal High, decimal Low)> _recentExtremes = new(MaxPatternDepth + 2);
+	private readonly List<(decimal High, decimal Low)> _recentExtremes;
 
 	private decimal _pipSize;
 	private decimal _previousPosition;
@@ -128,6 +128,15 @@ public class TrendRdsStrategy : Strategy
 	}
 
 	/// <summary>
+	/// Maximum number of swings tracked when validating the pattern.
+	/// </summary>
+	public int MaxPatternDepth
+	{
+		get => _maxPatternDepth.Value;
+		set => _maxPatternDepth.Value = value;
+	}
+
+	/// <summary>
 	/// Initializes a new instance of the <see cref="TrendRdsStrategy"/> class.
 	/// </summary>
 	public TrendRdsStrategy()
@@ -173,6 +182,11 @@ public class TrendRdsStrategy : Strategy
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
 			.SetDisplay("Candle Type", "Working timeframe", "General");
+		_maxPatternDepth = Param(nameof(MaxPatternDepth), 100)
+			.SetGreaterThanZero()
+			.SetDisplay("Max Pattern Depth", "Maximum candles tracked for pattern detection", "General");
+
+		_recentExtremes = new List<(decimal High, decimal Low)>(MaxPatternDepth + 2);
 	}
 
 	/// <inheritdoc />

--- a/API/3996_Open_Close/CS/OpenCloseStrategy.cs
+++ b/API/3996_Open_Close/CS/OpenCloseStrategy.cs
@@ -13,11 +13,10 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class OpenCloseStrategy : Strategy
 {
-	private const decimal MinimumVolume = 0.1m;
-
 	private readonly StrategyParam<decimal> _initialVolume;
 	private readonly StrategyParam<decimal> _maximumRisk;
 	private readonly StrategyParam<decimal> _decreaseFactor;
+	private readonly StrategyParam<decimal> _minimumVolume;
 	private readonly StrategyParam<DataType> _candleType;
 
 	private bool _hasPreviousCandle;
@@ -39,6 +38,10 @@ public class OpenCloseStrategy : Strategy
 
 		_decreaseFactor = Param(nameof(DecreaseFactor), 100m)
 			.SetDisplay("Decrease Factor", "Lot reduction factor applied after consecutive losing trades.", "Risk");
+
+		_minimumVolume = Param(nameof(MinimumVolume), 0.1m)
+			.SetGreaterThanZero()
+			.SetDisplay("Minimum Volume", "Lower bound for trade volume calculations.", "Risk");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
 			.SetDisplay("Candle Type", "Time-frame used to evaluate the open/close pattern.", "Data");
@@ -70,6 +73,15 @@ public class OpenCloseStrategy : Strategy
 		get => _decreaseFactor.Value;
 		set => _decreaseFactor.Value = value;
 	}
+	/// <summary>
+	/// Minimal volume allowed for any generated order.
+	/// </summary>
+	public decimal MinimumVolume
+	{
+		get => _minimumVolume.Value;
+		set => _minimumVolume.Value = value;
+	}
+
 
 	/// <summary>
 	/// Candle series used to evaluate the pattern.

--- a/API/4025_DayTrading/CS/DayTradingStrategy.cs
+++ b/API/4025_DayTrading/CS/DayTradingStrategy.cs
@@ -14,10 +14,6 @@ using StockSharp.Messages;
 /// </summary>
 public class DayTradingStrategy : Strategy
 {
-	private const decimal MomentumNeutralLevel = 100m;
-	private const decimal StochasticBuyThreshold = 35m;
-	private const decimal StochasticSellThreshold = 60m;
-
 	private readonly StrategyParam<decimal> _lotSize;
 	private readonly StrategyParam<decimal> _trailingStopPoints;
 	private readonly StrategyParam<decimal> _takeProfitPoints;
@@ -30,7 +26,10 @@ public class DayTradingStrategy : Strategy
 	private readonly StrategyParam<int> _stochasticLength;
 	private readonly StrategyParam<int> _stochasticSignal;
 	private readonly StrategyParam<int> _stochasticSlow;
+	private readonly StrategyParam<decimal> _stochasticBuyThreshold;
+	private readonly StrategyParam<decimal> _stochasticSellThreshold;
 	private readonly StrategyParam<int> _momentumPeriod;
+	private readonly StrategyParam<decimal> _momentumNeutralLevel;
 	private readonly StrategyParam<decimal> _sarAcceleration;
 	private readonly StrategyParam<decimal> _sarStep;
 	private readonly StrategyParam<decimal> _sarMaximum;
@@ -110,10 +109,22 @@ public class DayTradingStrategy : Strategy
 			.SetGreaterThanZero()
 			.SetDisplay("Stochastic Slowing", "Final smoothing applied to %K", "Indicators")
 			.SetCanOptimize(true);
+		_stochasticBuyThreshold = Param(nameof(StochasticBuyThreshold), 35m)
+			.SetDisplay("Stochastic Buy", "Oversold %K threshold for long entries", "Indicators")
+			.SetCanOptimize(true);
+
+		_stochasticSellThreshold = Param(nameof(StochasticSellThreshold), 60m)
+			.SetDisplay("Stochastic Sell", "Overbought %K threshold for short entries", "Indicators")
+			.SetCanOptimize(true);
+
 
 		_momentumPeriod = Param(nameof(MomentumPeriod), 14)
 			.SetGreaterThanZero()
 			.SetDisplay("Momentum Period", "Number of candles used for Momentum", "Indicators")
+			.SetCanOptimize(true);
+
+		_momentumNeutralLevel = Param(nameof(MomentumNeutralLevel), 100m)
+			.SetDisplay("Momentum Neutral", "Neutral momentum value used for signal confirmation", "Indicators")
 			.SetCanOptimize(true);
 
 		_sarAcceleration = Param(nameof(SarAcceleration), 0.02m)
@@ -241,12 +252,39 @@ public class DayTradingStrategy : Strategy
 	}
 
 	/// <summary>
+	/// Stochastic %K level that qualifies oversold conditions.
+	/// </summary>
+	public decimal StochasticBuyThreshold
+	{
+		get => _stochasticBuyThreshold.Value;
+		set => _stochasticBuyThreshold.Value = value;
+	}
+
+	/// <summary>
+	/// Stochastic %K level that qualifies overbought conditions.
+	/// </summary>
+	public decimal StochasticSellThreshold
+	{
+		get => _stochasticSellThreshold.Value;
+		set => _stochasticSellThreshold.Value = value;
+	}
+
+	/// <summary>
 	/// Number of candles used for Momentum.
 	/// </summary>
 	public int MomentumPeriod
 	{
 		get => _momentumPeriod.Value;
 		set => _momentumPeriod.Value = value;
+	}
+
+	/// <summary>
+	/// Momentum value considered neutral for trend confirmation.
+	/// </summary>
+	public decimal MomentumNeutralLevel
+	{
+		get => _momentumNeutralLevel.Value;
+		set => _momentumNeutralLevel.Value = value;
 	}
 
 	/// <summary>


### PR DESCRIPTION
## Summary
- expose the candle history limit in MacdPatternTraderV01 as a configurable strategy parameter
- turn MACD thresholds, history sizes, and minimum exit volumes into strategy parameters across the MACD-based strategies
- add parameter support for TrendRds, OpenClose, and DayTrading thresholds so they can be tuned from the UI

## Testing
- not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d7bf30a40c8323b698b0189d16cb29