### PR TITLE
Add strategy parameters for configurable thresholds

### DIFF
--- a/API/4049_Hans123Trader/CS/Hans123TraderStrategy.cs
+++ b/API/4049_Hans123Trader/CS/Hans123TraderStrategy.cs
@@ -14,9 +14,6 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class Hans123TraderStrategy : Strategy
 {
-	private const int RangeLength = 80;
-	private const decimal BreakoutOffsetPoints = 5m;
-
 	private readonly StrategyParam<int> _beginSession1;
 	private readonly StrategyParam<int> _endSession1;
 	private readonly StrategyParam<int> _beginSession2;
@@ -24,6 +21,8 @@ public class Hans123TraderStrategy : Strategy
 	private readonly StrategyParam<decimal> _trailingStopPoints;
 	private readonly StrategyParam<decimal> _takeProfitPoints;
 	private readonly StrategyParam<decimal> _initialStopLossPoints;
+	private readonly StrategyParam<int> _rangeLength;
+	private readonly StrategyParam<decimal> _breakoutOffsetPoints;
 	private readonly StrategyParam<DataType> _candleType;
 
 	private Highest _highest = null!;
@@ -118,45 +117,73 @@ public class Hans123TraderStrategy : Strategy
 	}
 
 	/// <summary>
+	/// Number of candles analysed when computing the breakout range.
+	/// </summary>
+	public int RangeLength
+	{
+		get => _rangeLength.Value;
+		set => _rangeLength.Value = value;
+	}
+
+	/// <summary>
+	/// Distance in points between the range extremes and the breakout stop orders.
+	/// </summary>
+	public decimal BreakoutOffsetPoints
+	{
+		get => _breakoutOffsetPoints.Value;
+		set => _breakoutOffsetPoints.Value = value;
+	}
+
+	/// <summary>
 	/// Initializes a new instance of the <see cref="Hans123TraderStrategy"/> class.
 	/// </summary>
 	public Hans123TraderStrategy()
 	{
+		_rangeLength = Param(nameof(RangeLength), 80)
+			.SetDisplay("Range Length", "Number of candles used to compute the breakout range", "Breakout")
+			.SetGreaterThanZero()
+			.SetCanOptimize(true);
+
+		_breakoutOffsetPoints = Param(nameof(BreakoutOffsetPoints), 5m)
+			.SetDisplay("Breakout Offset", "Distance in points added above/below the range for stop orders", "Breakout")
+			.SetNotNegative()
+			.SetCanOptimize(true);
+
 		_beginSession1 = Param(nameof(BeginSession1), 6)
-		.SetDisplay("Begin Session 1", "First monitoring window start hour", "Time")
-		.SetCanOptimize(true);
+			.SetDisplay("Begin Session 1", "First monitoring window start hour", "Time")
+			.SetCanOptimize(true);
 
 		_endSession1 = Param(nameof(EndSession1), 10)
-		.SetDisplay("End Session 1", "Hour when first breakout orders are armed", "Time")
-		.SetCanOptimize(true);
+			.SetDisplay("End Session 1", "Hour when first breakout orders are armed", "Time")
+			.SetCanOptimize(true);
 
 		_beginSession2 = Param(nameof(BeginSession2), 10)
-		.SetDisplay("Begin Session 2", "Second monitoring window start hour", "Time")
-		.SetCanOptimize(true);
+			.SetDisplay("Begin Session 2", "Second monitoring window start hour", "Time")
+			.SetCanOptimize(true);
 
 		_endSession2 = Param(nameof(EndSession2), 14)
-		.SetDisplay("End Session 2", "Hour when second breakout orders are armed", "Time")
-		.SetCanOptimize(true);
+			.SetDisplay("End Session 2", "Hour when second breakout orders are armed", "Time")
+			.SetCanOptimize(true);
 
 		_trailingStopPoints = Param(nameof(TrailingStop), 0m)
-		.SetDisplay("Trailing Stop", "Trailing stop distance in points", "Risk")
-		.SetCanOptimize(true);
+			.SetDisplay("Trailing Stop", "Trailing stop distance in points", "Risk")
+			.SetCanOptimize(true);
 
 		_takeProfitPoints = Param(nameof(TakeProfit), 0m)
-		.SetDisplay("Take Profit", "Take-profit distance in points", "Risk")
-		.SetCanOptimize(true);
+			.SetDisplay("Take Profit", "Take-profit distance in points", "Risk")
+			.SetCanOptimize(true);
 
 		_initialStopLossPoints = Param(nameof(InitialStopLoss), 40m)
-		.SetDisplay("Initial Stop Loss", "Initial stop-loss distance in points", "Risk")
-		.SetCanOptimize(true);
+			.SetDisplay("Initial Stop Loss", "Initial stop-loss distance in points", "Risk")
+			.SetCanOptimize(true);
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
-		.SetDisplay("Candle Type", "Candle series for range detection", "Data");
+			.SetDisplay("Candle Type", "Candle series for range detection", "Data");
 
 		Volume = 1m;
 	}
 
-	/// <inheritdoc />
+/// <inheritdoc />
 	public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
 	{
 		return [(Security, CandleType)];

--- a/API/4051_Profit_Hunter_HSI_with_Fibonacci/CS/ProfitHunterHsiWithFibonacciStrategy.cs
+++ b/API/4051_Profit_Hunter_HSI_with_Fibonacci/CS/ProfitHunterHsiWithFibonacciStrategy.cs
@@ -22,7 +22,7 @@ public class ProfitHunterHsiWithFibonacciStrategy : Strategy
 		60m, 80m, 100m, 120m, 140m, 160m, 180m, 200m, 220m, 240m, 260m
 	};
 
-	private const decimal TrailingBuffer = 5m;
+	private readonly StrategyParam<decimal> _trailingBuffer;
 
 	private readonly StrategyParam<int> _numBars;
 	private readonly StrategyParam<int> _maPeriod;
@@ -109,6 +109,11 @@ public class ProfitHunterHsiWithFibonacciStrategy : Strategy
 		.SetCanOptimize(true);
 
 
+		_trailingBuffer = Param(nameof(TrailingBuffer), 5m)
+			.SetNotNegative()
+			.SetDisplay("Trailing Buffer", "Pip buffer subtracted from trailing thresholds", "Risk")
+			.SetCanOptimize(true);
+
 		ResetInternalState();
 	}
 
@@ -155,6 +160,15 @@ public class ProfitHunterHsiWithFibonacciStrategy : Strategy
 	{
 		get => _daysBackForLow.Value;
 		set => _daysBackForLow.Value = value;
+	}
+
+	/// <summary>
+	/// Additional pip buffer applied when trailing stop-loss orders.
+	/// </summary>
+	public decimal TrailingBuffer
+	{
+		get => _trailingBuffer.Value;
+		set => _trailingBuffer.Value = value;
 	}
 
 

--- a/API/4062_ESmartTralling/CS/ESmartTrallingStrategy.cs
+++ b/API/4062_ESmartTralling/CS/ESmartTrallingStrategy.cs
@@ -11,7 +11,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class ESmartTrallingStrategy : Strategy
 {
-	private const decimal DefaultPartialStep = 0.1m;
+	private readonly StrategyParam<decimal> _defaultPartialStep;
 
 	private readonly StrategyParam<bool> _useCloseOneThird;
 	private readonly StrategyParam<decimal> _levelProfit1;
@@ -73,6 +73,10 @@ public class ESmartTrallingStrategy : Strategy
 		_trailingStep = Param(nameof(TrailingStep), 5m)
 		.SetDisplay("Trailing Step (points)", "Additional favorable movement required before moving the trailing stop again", "Trailing")
 		.SetCanOptimize(true);
+
+		_defaultPartialStep = Param(nameof(DefaultPartialStep), 0.1m)
+		.SetGreaterThanZero()
+		.SetDisplay("Default Volume Step", "Fallback volume increment used when the security lacks a volume step", "General");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
 		.SetDisplay("Candle Type", "Candle type providing price updates for the trailing logic", "General");
@@ -157,6 +161,15 @@ public class ESmartTrallingStrategy : Strategy
 	{
 		get => _trailingStep.Value;
 		set => _trailingStep.Value = value;
+	}
+
+	/// <summary>
+	/// Default volume step used when the security does not define one.
+	/// </summary>
+	public decimal DefaultPartialStep
+	{
+		get => _defaultPartialStep.Value;
+		set => _defaultPartialStep.Value = value;
 	}
 
 	/// <summary>

--- a/API/4070_Very_Blondie_System/CS/VeryBlondieSystemStrategy.cs
+++ b/API/4070_Very_Blondie_System/CS/VeryBlondieSystemStrategy.cs
@@ -15,7 +15,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class VeryBlondieSystemStrategy : Strategy
 {
-	private const int GridOrderCount = 4;
+	private readonly StrategyParam<int> _gridOrderCount;
 
 	private readonly StrategyParam<int> _periodLength;
 	private readonly StrategyParam<decimal> _limitPoints;
@@ -60,6 +60,10 @@ public class VeryBlondieSystemStrategy : Strategy
 		.SetDisplay("Grid Step", "Distance in points between consecutive limit orders", "Orders")
 		.SetRange(0m, 100_000m)
 		.SetCanOptimize(true);
+
+		_gridOrderCount = Param(nameof(GridOrderCount), 4)
+		.SetGreaterThanZero()
+		.SetDisplay("Grid Orders", "Number of layered limit orders per side", "Orders");
 
 		_profitTarget = Param(nameof(ProfitTarget), 40m)
 		.SetDisplay("Profit Target", "Floating profit target in account currency", "Risk")
@@ -131,6 +135,15 @@ public class VeryBlondieSystemStrategy : Strategy
 	{
 		get => _pointValue.Value;
 		set => _pointValue.Value = value;
+	}
+
+	/// <summary>
+	/// Number of grid orders placed on each side of the market.
+	/// </summary>
+	public int GridOrderCount
+	{
+		get => _gridOrderCount.Value;
+		set => _gridOrderCount.Value = value;
 	}
 
 	/// <summary>

--- a/API/4075_Stairs/CS/StairsStrategy.cs
+++ b/API/4075_Stairs/CS/StairsStrategy.cs
@@ -15,7 +15,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class StairsStrategy : Strategy
 {
-	private const decimal VolumeEpsilon = 1e-6m;
+	private readonly StrategyParam<decimal> _volumeEpsilon;
 
 	private readonly StrategyParam<int> _channelSteps;
 	private readonly StrategyParam<int> _profitSteps;
@@ -81,6 +81,15 @@ public class StairsStrategy : Strategy
 	}
 
 	/// <summary>
+	/// Minimum volume threshold that treats values as zero when closing orders.
+	/// </summary>
+	public decimal VolumeEpsilon
+	{
+	get => _volumeEpsilon.Value;
+	set => _volumeEpsilon.Value = value;
+	}
+
+	/// <summary>
 	/// Candle type used for trade management.
 	/// </summary>
 	public DataType CandleType
@@ -112,6 +121,10 @@ public class StairsStrategy : Strategy
 	_baseVolume = Param(nameof(BaseVolume), 0.1m)
 	.SetGreaterThanZero()
 	.SetDisplay("Base Volume", "Initial volume submitted to the grid", "Position Sizing");
+
+	_volumeEpsilon = Param(nameof(VolumeEpsilon), 1e-6m)
+	.SetGreaterThanZero()
+	.SetDisplay("Volume Epsilon", "Volumes below this threshold are treated as zero", "Position Sizing");
 
 	_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(1).TimeFrame())
 	.SetDisplay("Candle Type", "Primary timeframe used to supervise the grid", "General");

--- a/API/4090_Multi_Stoch/CS/YtgMultiStochStrategy.cs
+++ b/API/4090_Multi_Stoch/CS/YtgMultiStochStrategy.cs
@@ -30,8 +30,8 @@ public class YtgMultiStochStrategy : Strategy
 
 	private readonly List<SymbolContext> _contexts = new();
 
-	private const decimal OversoldLevel = 20m;
-	private const decimal OverboughtLevel = 80m;
+	private readonly StrategyParam<decimal> _oversoldLevel;
+	private readonly StrategyParam<decimal> _overboughtLevel;
 
 	/// <summary>
 	/// Initializes a new instance of <see cref="YtgMultiStochStrategy"/>.
@@ -73,6 +73,14 @@ public class YtgMultiStochStrategy : Strategy
 		_takeProfitPips = Param(nameof(TakeProfitPips), 10m)
 			.SetRange(0m, 1000m)
 			.SetDisplay("Take Profit (pips)", "Take-profit distance expressed in pips", "Risk Management");
+
+		_oversoldLevel = Param(nameof(OversoldLevel), 20m)
+			.SetRange(0m, 100m)
+			.SetDisplay("Oversold Level", "Stochastic threshold that enables long trades", "Signals");
+
+		_overboughtLevel = Param(nameof(OverboughtLevel), 80m)
+			.SetRange(0m, 100m)
+			.SetDisplay("Overbought Level", "Stochastic threshold that enables short trades", "Signals");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(30).TimeFrame())
 			.SetDisplay("Candle Type", "Timeframe used to calculate signals", "General");
@@ -175,6 +183,24 @@ public class YtgMultiStochStrategy : Strategy
 	{
 		get => _takeProfitPips.Value;
 		set => _takeProfitPips.Value = value;
+	}
+
+	/// <summary>
+	/// Stochastic oversold threshold used to trigger long entries.
+	/// </summary>
+	public decimal OversoldLevel
+	{
+		get => _oversoldLevel.Value;
+		set => _oversoldLevel.Value = value;
+	}
+
+	/// <summary>
+	/// Stochastic overbought threshold used to trigger short entries.
+	/// </summary>
+	public decimal OverboughtLevel
+	{
+		get => _overboughtLevel.Value;
+		set => _overboughtLevel.Value = value;
 	}
 
 	/// <summary>


### PR DESCRIPTION
## Summary
- add configurable range length and breakout offset parameters to Hans123Trader
- expose trailing buffer, grid order count, volume epsilon, stochastic thresholds, and Laguerre/SilverTrend constants as strategy parameters across affected strategies
- replace hardcoded classifier dimensions in StatEuclideanMetricStrategy with parameters and resize logic

## Testing
- dotnet build AlgoTrading.sln *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7bf3f551883239cc3db07e4454175