### PR TITLE
Expose configurable strategy parameters

### DIFF
--- a/API/4096_STO_M5xM15xM30/CS/StoM5xM15xM30Strategy.cs
+++ b/API/4096_STO_M5xM15xM30/CS/StoM5xM15xM30Strategy.cs
@@ -13,8 +13,8 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class StoM5xM15xM30Strategy : Strategy
 {
-	private const int SignalPeriod = 3;
-	private const int SlowingPeriod = 3;
+	private readonly StrategyParam<int> _signalPeriod;
+	private readonly StrategyParam<int> _slowingPeriod;
 
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<DataType> _middleCandleType;
@@ -65,6 +65,14 @@ public class StoM5xM15xM30Strategy : Strategy
 
 		_slowCandleType = Param(nameof(SlowCandleType), TimeSpan.FromMinutes(30).TimeFrame())
 			.SetDisplay("Slow Timeframe", "Third timeframe that validates the trend", "General");
+
+		_signalPeriod = Param(nameof(SignalPeriod), 3)
+			.SetGreaterThanZero()
+			.SetDisplay("Signal Period", "Length of the %D smoothing average", "Indicators");
+
+		_slowingPeriod = Param(nameof(SlowingPeriod), 3)
+			.SetGreaterThanZero()
+			.SetDisplay("Slowing Period", "Length of the %K smoothing average", "Indicators");
 
 		_fastKPeriod = Param(nameof(FastKPeriod), 5)
 			.SetGreaterThanZero()
@@ -124,6 +132,24 @@ public class StoM5xM15xM30Strategy : Strategy
 	{
 		get => _slowCandleType.Value;
 		set => _slowCandleType.Value = value;
+	}
+
+	/// <summary>
+	/// Length of the %D smoothing average.
+	/// </summary>
+	public int SignalPeriod
+	{
+		get => _signalPeriod.Value;
+		set => _signalPeriod.Value = value;
+	}
+
+	/// <summary>
+	/// Length of the %K smoothing average.
+	/// </summary>
+	public int SlowingPeriod
+	{
+		get => _slowingPeriod.Value;
+		set => _slowingPeriod.Value = value;
 	}
 
 	/// <summary>
@@ -483,7 +509,7 @@ public class StoM5xM15xM30Strategy : Strategy
 		_previousClose = candle.ClosePrice;
 	}
 
-	private static StochasticOscillator CreateStochastic(int kLength)
+	private StochasticOscillator CreateStochastic(int kLength)
 	{
 		// Configure the oscillator with matching smoothing constants from the MT4 script.
 		return new StochasticOscillator

--- a/API/4119_Champion/CS/ChampionStrategy.cs
+++ b/API/4119_Champion/CS/ChampionStrategy.cs
@@ -15,7 +15,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class ChampionStrategy : Strategy
 {
-	private const int PendingOrderCount = 3;
+	private readonly StrategyParam<int> _pendingOrderCount;
 
 	private readonly StrategyParam<int> _takeProfitPoints;
 	private readonly StrategyParam<int> _stopLossPoints;
@@ -78,6 +78,10 @@ public class ChampionStrategy : Strategy
 		_repriceDistancePoints = Param(nameof(RepriceDistancePoints), 20m)
 		.SetGreaterThanZero()
 		.SetDisplay("Reprice Distance (points)", "Distance that triggers stop order repricing when the spread widens.", "Orders");
+
+		_pendingOrderCount = Param(nameof(PendingOrderCount), 3)
+		.SetGreaterThanZero()
+		.SetDisplay("Pending Orders", "Number of stop entries placed after each signal.", "Orders");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
 		.SetDisplay("Candle Type", "Time-frame used to calculate the RSI signal.", "Data");
@@ -159,6 +163,15 @@ public class ChampionStrategy : Strategy
 	{
 		get => _candleType.Value;
 		set => _candleType.Value = value;
+	}
+
+	/// <summary>
+	/// Number of stop entries placed after each RSI signal.
+	/// </summary>
+	public int PendingOrderCount
+	{
+		get => _pendingOrderCount.Value;
+		set => _pendingOrderCount.Value = value;
 	}
 
 	/// <inheritdoc />

--- a/API/4144_SendCloseOrder/CS/SendCloseOrderStrategy.cs
+++ b/API/4144_SendCloseOrder/CS/SendCloseOrderStrategy.cs
@@ -14,10 +14,10 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class SendCloseOrderStrategy : Strategy
 {
-	private const decimal CloseOffsetPoints = 15m;
-	private const decimal VolumeTolerance = 0.0000001m;
-	private const int MaxStoredFractals = 64;
-	private const decimal DefaultPriceStep = 0.0001m;
+	private readonly StrategyParam<decimal> _closeOffsetPoints;
+	private readonly StrategyParam<decimal> _volumeTolerance;
+	private readonly StrategyParam<int> _maxStoredFractals;
+	private readonly StrategyParam<decimal> _defaultPriceStep;
 
 	private readonly StrategyParam<bool> _enableSellLine;
 	private readonly StrategyParam<bool> _enableBuyLine;
@@ -129,6 +129,22 @@ public class SendCloseOrderStrategy : Strategy
 			.SetGreaterThanZero()
 			.SetDisplay("Trade Volume", "Volume per individual entry.", "Trading");
 
+		_closeOffsetPoints = Param(nameof(CloseOffsetPoints), 15m)
+			.SetNotNegative()
+			.SetDisplay("Close Offset", "Offset in points added when projecting close lines.", "Lines");
+
+		_volumeTolerance = Param(nameof(VolumeTolerance), 0.0000001m)
+			.SetNotNegative()
+			.SetDisplay("Volume Tolerance", "Tolerance when comparing calculated volume against broker limits.", "Trading");
+
+		_maxStoredFractals = Param(nameof(MaxStoredFractals), 64)
+			.SetGreaterThanZero()
+			.SetDisplay("Fractal Cache", "Maximum number of historical fractal points kept for trendline construction.", "Lines");
+
+		_defaultPriceStep = Param(nameof(DefaultPriceStep), 0.0001m)
+			.SetGreaterThanZero()
+			.SetDisplay("Price Step Fallback", "Fallback price step used when the security does not provide one.", "Trading");
+
 		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(1).TimeFrame())
 			.SetDisplay("Candle Type", "Candle series used for fractal detection.", "Data");
 	}
@@ -185,6 +201,42 @@ public class SendCloseOrderStrategy : Strategy
 	{
 		get => _tradeVolume.Value;
 		set => _tradeVolume.Value = value;
+	}
+
+	/// <summary>
+	/// Offset in points applied when drawing the close lines.
+	/// </summary>
+	public decimal CloseOffsetPoints
+	{
+		get => _closeOffsetPoints.Value;
+		set => _closeOffsetPoints.Value = value;
+	}
+
+	/// <summary>
+	/// Tolerance when comparing calculated volume with broker limits.
+	/// </summary>
+	public decimal VolumeTolerance
+	{
+		get => _volumeTolerance.Value;
+		set => _volumeTolerance.Value = value;
+	}
+
+	/// <summary>
+	/// Maximum number of stored fractals used to build trendlines.
+	/// </summary>
+	public int MaxStoredFractals
+	{
+		get => _maxStoredFractals.Value;
+		set => _maxStoredFractals.Value = value;
+	}
+
+	/// <summary>
+	/// Fallback price step used when the security does not define one.
+	/// </summary>
+	public decimal DefaultPriceStep
+	{
+		get => _defaultPriceStep.Value;
+		set => _defaultPriceStep.Value = value;
 	}
 
 	/// <summary>


### PR DESCRIPTION
## Summary
- replace hard-coded stochastic smoothing periods in `StoM5xM15xM30Strategy` with strategy parameters and expose matching properties
- add an epsilon strategy parameter to `JMasterRsxStrategy` and wire it through the nested RSX indicator
- convert various constants across EliteEfiboTrader, Champion, ComFracti, and SendCloseOrder strategies into configurable `StrategyParam` values, updating related helpers and usages

## Testing
- `dotnet build AlgoTrading.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d7bf4df3508323b9e9efc1cdbb2d18