### PR TITLE
Make indicator constants configurable parameters

### DIFF
--- a/API/4211_Cyclops_CycleIdentifier/CS/CyclopsCycleIdentifierStrategy.cs
+++ b/API/4211_Cyclops_CycleIdentifier/CS/CyclopsCycleIdentifierStrategy.cs
@@ -15,10 +15,8 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class CyclopsCycleIdentifierStrategy : Strategy
 {
-	private const int AverageRangeLength = 250;
-	private const int MinBarsBetweenSignals = 1;
-
 	private readonly StrategyParam<int> _priceActionFilter;
+	private readonly StrategyParam<int> _averageRangeLength;
 	private readonly StrategyParam<int> _length;
 	private readonly StrategyParam<int> _majorCycleStrength;
 	private readonly StrategyParam<bool> _useCycleFilter;
@@ -39,6 +37,7 @@ public class CyclopsCycleIdentifierStrategy : Strategy
 	private readonly StrategyParam<decimal> _takeProfitPips;
 	private readonly StrategyParam<decimal> _stopLossPips;
 	private readonly StrategyParam<DataType> _candleType;
+	private readonly StrategyParam<int> _minBarsBetweenSignals;
 
 	private readonly CycleIdentifierState _cycleState = new();
 
@@ -81,6 +80,10 @@ public class CyclopsCycleIdentifierStrategy : Strategy
 		_priceActionFilter = Param(nameof(PriceActionFilter), 1)
 		.SetRange(1, 100)
 		.SetDisplay("Price Filter", "Smoothed moving average length applied to close price", "Indicator");
+
+		_averageRangeLength = Param(nameof(AverageRangeLength), 250)
+		.SetRange(1, 1000)
+		.SetDisplay("Average Range Length", "Number of candles used to compute the average range", "Indicator");
 
 		_length = Param(nameof(Length), 3)
 		.SetRange(1, 50)
@@ -155,6 +158,10 @@ public class CyclopsCycleIdentifierStrategy : Strategy
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(30).TimeFrame())
 		.SetDisplay("Candle Type", "Primary timeframe that feeds the strategy", "General");
+
+		_minBarsBetweenSignals = Param(nameof(MinBarsBetweenSignals), 1)
+		.SetRange(0, 50)
+		.SetDisplay("Min Bars Between Signals", "Minimum spacing between generated signals", "Indicator");
 	}
 
 
@@ -165,6 +172,15 @@ public class CyclopsCycleIdentifierStrategy : Strategy
 	{
 		get => _priceActionFilter.Value;
 		set => _priceActionFilter.Value = value;
+	}
+
+	/// <summary>
+	/// Number of candles used to compute the average price range.
+	/// </summary>
+	public int AverageRangeLength
+	{
+		get => _averageRangeLength.Value;
+		set => _averageRangeLength.Value = value;
 	}
 
 	/// <summary>
@@ -336,6 +352,15 @@ public class CyclopsCycleIdentifierStrategy : Strategy
 	{
 		get => _stopLossPips.Value;
 		set => _stopLossPips.Value = value;
+	}
+
+	/// <summary>
+	/// Minimum number of bars required between consecutive signals.
+	/// </summary>
+	public int MinBarsBetweenSignals
+	{
+		get => _minBarsBetweenSignals.Value;
+		set => _minBarsBetweenSignals.Value = value;
 	}
 
 	/// <summary>

--- a/API/4216_PSAR_Multi_Timeframe/CS/PsarMultiTimeframeStrategy.cs
+++ b/API/4216_PSAR_Multi_Timeframe/CS/PsarMultiTimeframeStrategy.cs
@@ -14,15 +14,15 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class PsarMultiTimeframeStrategy : Strategy
 {
-	private const decimal SarAcceleration = 0.06m;
-	private const decimal SarAccelerationMax = 0.1m;
-	private const decimal MaximumSarSpreadPoints = 19m;
-
+			
 	private readonly StrategyParam<DataType> _baseCandleType;
 	private readonly StrategyParam<DataType> _fastSarCandleType;
 	private readonly StrategyParam<DataType> _mediumSarCandleType;
 	private readonly StrategyParam<DataType> _slowSarCandleType;
 	private readonly StrategyParam<bool> _enableParabolicFilter;
+	private readonly StrategyParam<decimal> _sarAcceleration;
+	private readonly StrategyParam<decimal> _sarAccelerationMax;
+	private readonly StrategyParam<decimal> _maximumSarSpreadPoints;
 	private readonly StrategyParam<decimal> _takeProfitPoints;
 	private readonly StrategyParam<decimal> _stopLossPoints;
 	private readonly StrategyParam<bool> _useMoneyManagement;
@@ -72,6 +72,18 @@ public class PsarMultiTimeframeStrategy : Strategy
 
 		_enableParabolicFilter = Param(nameof(EnableParabolicFilter), true)
 		.SetDisplay("Enable Multi-timeframe Filter", "Disables trading when set to false", "Signals");
+
+		_sarAcceleration = Param(nameof(SarAcceleration), 0.06m)
+			.SetRange(0m, 1m)
+			.SetDisplay("SAR Acceleration", "Initial acceleration value for Parabolic SAR", "Indicators");
+
+		_sarAccelerationMax = Param(nameof(SarAccelerationMax), 0.1m)
+			.SetRange(0m, 1m)
+			.SetDisplay("SAR Acceleration Max", "Maximum acceleration allowed for Parabolic SAR", "Indicators");
+
+		_maximumSarSpreadPoints = Param(nameof(MaximumSarSpreadPoints), 19m)
+			.SetRange(0m, 1000m)
+			.SetDisplay("Max SAR Spread (points)", "Maximum difference between SAR values to accept a trade", "Indicators");
 
 		_takeProfitPoints = Param(nameof(TakeProfitPoints), 999m)
 		.SetDisplay("Take Profit (points)", "Distance to the target expressed in minimum price increments", "Risk");
@@ -132,6 +144,33 @@ public class PsarMultiTimeframeStrategy : Strategy
 	{
 		get => _enableParabolicFilter.Value;
 		set => _enableParabolicFilter.Value = value;
+	}
+
+	/// <summary>
+	/// Initial acceleration value applied to Parabolic SAR calculations.
+	/// </summary>
+	public decimal SarAcceleration
+	{
+		get => _sarAcceleration.Value;
+		set => _sarAcceleration.Value = value;
+	}
+
+	/// <summary>
+	/// Maximum acceleration value permitted for Parabolic SAR calculations.
+	/// </summary>
+	public decimal SarAccelerationMax
+	{
+		get => _sarAccelerationMax.Value;
+		set => _sarAccelerationMax.Value = value;
+	}
+
+	/// <summary>
+	/// Maximum spread between Parabolic SAR values allowed before skipping signals.
+	/// </summary>
+	public decimal MaximumSarSpreadPoints
+	{
+		get => _maximumSarSpreadPoints.Value;
+		set => _maximumSarSpreadPoints.Value = value;
 	}
 
 	/// <summary>
@@ -582,7 +621,7 @@ public class PsarMultiTimeframeStrategy : Strategy
 		return Orders.Any(o => o.State.IsActive());
 	}
 
-	private static ParabolicSar CreateParabolicSar()
+	private ParabolicSar CreateParabolicSar()
 	{
 		return new ParabolicSar
 		{

--- a/API/4221_DVD_100_50_Cent/CS/Dvd10050CentStrategy.cs
+++ b/API/4221_DVD_100_50_Cent/CS/Dvd10050CentStrategy.cs
@@ -13,9 +13,6 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class Dvd10050CentStrategy : Strategy
 {
-	private const int M1HistoryLength = 64;
-	private const int M30HistoryLength = 16;
-	private const int H1HistoryLength = 16;
 
 	private readonly StrategyParam<bool> _accountIsMini;
 	private readonly StrategyParam<bool> _useMoneyManagement;
@@ -31,6 +28,9 @@ public class Dvd10050CentStrategy : Strategy
 	private readonly StrategyParam<decimal> _lowLevel2Pips;
 	private readonly StrategyParam<decimal> _marginCutoff;
 	private readonly StrategyParam<int> _orderExpiryMinutes;
+	private readonly StrategyParam<int> _m1HistoryLength;
+	private readonly StrategyParam<int> _m30HistoryLength;
+	private readonly StrategyParam<int> _h1HistoryLength;
 
 	private SimpleMovingAverage _h1Fast = null!;
 	private SimpleMovingAverage _h1Slow = null!;
@@ -136,6 +136,18 @@ public class Dvd10050CentStrategy : Strategy
 		.SetDisplay("Order Expiry (minutes)", "Lifetime of pending limit orders", "Orders")
 		.SetRange(1, 240)
 		.SetCanOptimize(true);
+
+		_m1HistoryLength = Param(nameof(M1HistoryLength), 64)
+			.SetDisplay("M1 History Length", "Number of M1 candles retained for analysis", "History")
+			.SetRange(1, 500);
+
+		_m30HistoryLength = Param(nameof(M30HistoryLength), 16)
+			.SetDisplay("M30 History Length", "Number of M30 candles retained for analysis", "History")
+			.SetRange(1, 200);
+
+		_h1HistoryLength = Param(nameof(H1HistoryLength), 16)
+			.SetDisplay("H1 History Length", "Number of H1 candles retained for analysis", "History")
+			.SetRange(1, 200);
 	}
 
 	/// <summary>
@@ -262,6 +274,33 @@ public class Dvd10050CentStrategy : Strategy
 	{
 		get => _orderExpiryMinutes.Value;
 		set => _orderExpiryMinutes.Value = value;
+	}
+
+	/// <summary>
+	/// Number of one-minute candles retained for intraday analysis.
+	/// </summary>
+	public int M1HistoryLength
+	{
+		get => _m1HistoryLength.Value;
+		set => _m1HistoryLength.Value = value;
+	}
+
+	/// <summary>
+	/// Number of thirty-minute candles retained for intraday analysis.
+	/// </summary>
+	public int M30HistoryLength
+	{
+		get => _m30HistoryLength.Value;
+		set => _m30HistoryLength.Value = value;
+	}
+
+	/// <summary>
+	/// Number of hourly candles retained for intraday analysis.
+	/// </summary>
+	public int H1HistoryLength
+	{
+		get => _h1HistoryLength.Value;
+		set => _h1HistoryLength.Value = value;
 	}
 
 	/// <inheritdoc />


### PR DESCRIPTION
## Summary
- expose average range lookback and signal spacing in CyclopsCycleIdentifierStrategy as configurable StrategyParam values
- add Parabolic SAR acceleration and spread parameters to PsarMultiTimeframeStrategy
- make per-timeframe history lengths configurable in Dvd10050CentStrategy

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7bf758ea08323b1401e8d6509bb4a