### PR TITLE
Make strategy constants configurable via parameters

### DIFF
--- a/API/1283_RTB_Momentum_Breakout/CS/RtbMomentumBreakoutStrategy.cs
+++ b/API/1283_RTB_Momentum_Breakout/CS/RtbMomentumBreakoutStrategy.cs
@@ -13,7 +13,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class RtbMomentumBreakoutStrategy : Strategy
 {
-	private const int MaxLookback = 100;
+        private readonly StrategyParam<int> _maxLookback;
 
 	private readonly StrategyParam<int> _emaFastLen;
 	private readonly StrategyParam<int> _emaSlowLen;
@@ -32,6 +32,7 @@ public class RtbMomentumBreakoutStrategy : Strategy
 	private decimal? _prevResistance;
 	private decimal? _prevSupport;
 
+public int MaxLookback { get => _maxLookback.Value; set => _maxLookback.Value = value; }
 public int EmaFastLength { get => _emaFastLen.Value; set => _emaFastLen.Value = value; }
 public int EmaSlowLength { get => _emaSlowLen.Value; set => _emaSlowLen.Value = value; }
 public int RsiLength { get => _rsiLen.Value; set => _rsiLen.Value = value; }
@@ -45,8 +46,12 @@ public DataType CandleType { get => _candleType.Value; set => _candleType.Value 
 
 public RtbMomentumBreakoutStrategy()
 {
-	_emaFastLen = Param(nameof(EmaFastLength), 20);
-	_emaSlowLen = Param(nameof(EmaSlowLength), 50);
+		_maxLookback = Param(nameof(MaxLookback), 100)
+			.SetGreaterThanZero()
+			.SetDisplay("Max Lookback", "Bars used for trailing highs and lows", "Breakout");
+
+        _emaFastLen = Param(nameof(EmaFastLength), 20);
+        _emaSlowLen = Param(nameof(EmaSlowLength), 50);
 	_rsiLen = Param(nameof(RsiLength), 14);
 	_rsiOb = Param(nameof(RsiOverbought), 70);
 	_rsiOs = Param(nameof(RsiOversold), 30);

--- a/API/1290_Scalping_Strategy_By_TradingConToto/CS/ScalpingStrategyByTradingConTotoStrategy.cs
+++ b/API/1290_Scalping_Strategy_By_TradingConToto/CS/ScalpingStrategyByTradingConTotoStrategy.cs
@@ -11,7 +11,7 @@ using StockSharp.Messages;
 
 public class ScalpingStrategyByTradingConTotoStrategy : Strategy
 {
-	private const int RightBars = 10;
+	private readonly StrategyParam<int> _rightBars;
 
 	private readonly StrategyParam<int> _pivot;
 	private readonly StrategyParam<decimal> _pips;
@@ -41,7 +41,8 @@ public class ScalpingStrategyByTradingConTotoStrategy : Strategy
 	private decimal _prevFast;
 	private decimal _prevSlow;
 
-	public int Pivot { get => _pivot.Value; set => _pivot.Value = value; }
+	public int RightBars { get => _rightBars.Value; set => _rightBars.Value = value; }
+        public int Pivot { get => _pivot.Value; set => _pivot.Value = value; }
 	public decimal Pips { get => _pips.Value; set => _pips.Value = value; }
 	public decimal Spread { get => _spread.Value; set => _spread.Value = value; }
 	public string Session { get => _session.Value; set => _session.Value = value; }
@@ -51,6 +52,10 @@ public class ScalpingStrategyByTradingConTotoStrategy : Strategy
 
 	public ScalpingStrategyByTradingConTotoStrategy()
 	{
+		_rightBars = Param(nameof(RightBars), 10)
+			.SetGreaterThanZero()
+			.SetDisplay("Right Bars", "Right bars for pivot detection", "Parameters");
+
 		_pivot = Param(nameof(Pivot), 16)
 			.SetGreaterThanZero()
 			.SetDisplay("Pivot", "Left bars for pivot detection", "Parameters");

--- a/API/1655_Input_Resizer/CS/InputResizerStrategy.cs
+++ b/API/1655_Input_Resizer/CS/InputResizerStrategy.cs
@@ -25,6 +25,10 @@ public class InputResizerStrategy : Strategy
 	private readonly StrategyParam<int> _initHeight;
 	private readonly StrategyParam<int> _sleepTime;
 	private readonly StrategyParam<bool> _weekendMode;
+	private readonly StrategyParam<int> _gwlStyle;
+	private readonly StrategyParam<int> _wsSizeBox;
+	private readonly StrategyParam<int> _wsMinimizeBox;
+	private readonly StrategyParam<int> _wsMaximizeBox;
 
 	private readonly Dictionary<string, Rect> _sizes = new();
 	private CancellationTokenSource _cts;
@@ -78,6 +82,25 @@ public class InputResizerStrategy : Strategy
 	/// Run without market data.
 	/// </summary>
 	public bool WeekendMode { get => _weekendMode.Value; set => _weekendMode.Value = value; }
+	/// <summary>
+	/// Index used to retrieve window styles.
+	/// </summary>
+	public int GwlStyle { get => _gwlStyle.Value; set => _gwlStyle.Value = value; }
+
+	/// <summary>
+	/// Flag enabling resizable borders.
+	/// </summary>
+	public int WsSizeBox { get => _wsSizeBox.Value; set => _wsSizeBox.Value = value; }
+
+	/// <summary>
+	/// Flag enabling minimize button.
+	/// </summary>
+	public int WsMinimizeBox { get => _wsMinimizeBox.Value; set => _wsMinimizeBox.Value = value; }
+
+	/// <summary>
+	/// Flag enabling maximize button.
+	/// </summary>
+	public int WsMaximizeBox { get => _wsMaximizeBox.Value; set => _wsMaximizeBox.Value = value; }
 
 	/// <summary>
 	/// Initializes a new instance of <see cref="InputResizerStrategy"/>.
@@ -103,8 +126,20 @@ public class InputResizerStrategy : Strategy
 		_sleepTime = Param(nameof(SleepTime), 300)
 		.SetDisplay("Sleep Time", "Delay in ms between checks", "General");
 		_weekendMode = Param(nameof(WeekendMode), false)
-		.SetDisplay("Weekend Mode", "Run even without market data", "General");
-	}
+			.SetDisplay("Weekend Mode", "Run even without market data", "General");
+
+		_gwlStyle = Param(nameof(GwlStyle), -16)
+			.SetDisplay("GWL Style", "Index used in GetWindowLong", "WinAPI");
+
+		_wsSizeBox = Param(nameof(WsSizeBox), 0x00040000)
+			.SetDisplay("WS SIZEBOX", "Resizable border flag", "WinAPI");
+
+		_wsMinimizeBox = Param(nameof(WsMinimizeBox), 0x00020000)
+			.SetDisplay("WS MINIMIZEBOX", "Minimize button flag", "WinAPI");
+
+		_wsMaximizeBox = Param(nameof(WsMaximizeBox), 0x00010000)
+			.SetDisplay("WS MAXIMIZEBOX", "Maximize button flag", "WinAPI");
+}
 
 	/// <inheritdoc />
 	protected override void OnStarted(DateTimeOffset time)
@@ -151,9 +186,9 @@ public class InputResizerStrategy : Strategy
 
 	private void ProcessWindow(IntPtr wnd)
 	{
-		var style = GetWindowLong(wnd, GWL_STYLE);
-		style |= WS_SIZEBOX | WS_MAXIMIZEBOX | WS_MINIMIZEBOX;
-		SetWindowLong(wnd, GWL_STYLE, style);
+		var style = GetWindowLong(wnd, GwlStyle);
+		style |= WsSizeBox | WsMaximizeBox | WsMinimizeBox;
+		SetWindowLong(wnd, GwlStyle, style);
 
 		var sb = new StringBuilder(256);
 		GetWindowText(wnd, sb, sb.Capacity);
@@ -180,10 +215,6 @@ public class InputResizerStrategy : Strategy
 
 	#region WinAPI
 
-	private const int GWL_STYLE = -16;
-	private const int WS_SIZEBOX = 0x00040000;
-	private const int WS_MINIMIZEBOX = 0x00020000;
-	private const int WS_MAXIMIZEBOX = 0x00010000;
 	private const int SW_MAXIMIZE = 3;
 	private const uint SWP_NOZORDER = 0x0004;
 	private const uint SWP_NOACTIVATE = 0x0010;


### PR DESCRIPTION
## Summary
- replace hard-coded divergence pivot bounds with configurable strategy parameters
- expose max lookback, right bar, correlation length, and WinAPI flags as strategy parameters
- document the new parameters for the UI and keep existing strategy logic intact

## Testing
- Not run (dotnet CLI is unavailable in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68d7c4b7c51c83238208b9c308fea75a