### PR TITLE
Make strategy constants configurable

### DIFF
--- a/API/1655_Input_Resizer/CS/InputResizerStrategy.cs
+++ b/API/1655_Input_Resizer/CS/InputResizerStrategy.cs
@@ -25,6 +25,9 @@ public class InputResizerStrategy : Strategy
 	private readonly StrategyParam<int> _initHeight;
 	private readonly StrategyParam<int> _sleepTime;
 	private readonly StrategyParam<bool> _weekendMode;
+	private readonly StrategyParam<int> _showWindowMaximizeCommand;
+	private readonly StrategyParam<uint> _setWindowPosNoZOrderFlag;
+	private readonly StrategyParam<uint> _setWindowPosNoActivateFlag;
 
 	private readonly Dictionary<string, Rect> _sizes = new();
 	private CancellationTokenSource _cts;
@@ -80,6 +83,21 @@ public class InputResizerStrategy : Strategy
 	public bool WeekendMode { get => _weekendMode.Value; set => _weekendMode.Value = value; }
 
 	/// <summary>
+	/// WinAPI command for maximizing window.
+	/// </summary>
+	public int ShowWindowMaximizeCommand { get => _showWindowMaximizeCommand.Value; set => _showWindowMaximizeCommand.Value = value; }
+
+	/// <summary>
+	/// WinAPI flag to keep Z-order on SetWindowPos.
+	/// </summary>
+	public uint SetWindowPosNoZOrderFlag { get => _setWindowPosNoZOrderFlag.Value; set => _setWindowPosNoZOrderFlag.Value = value; }
+
+	/// <summary>
+	/// WinAPI flag to avoid activation on SetWindowPos.
+	/// </summary>
+	public uint SetWindowPosNoActivateFlag { get => _setWindowPosNoActivateFlag.Value; set => _setWindowPosNoActivateFlag.Value = value; }
+
+	/// <summary>
 	/// Initializes a new instance of <see cref="InputResizerStrategy"/>.
 	/// </summary>
 	public InputResizerStrategy()
@@ -104,6 +122,12 @@ public class InputResizerStrategy : Strategy
 		.SetDisplay("Sleep Time", "Delay in ms between checks", "General");
 		_weekendMode = Param(nameof(WeekendMode), false)
 		.SetDisplay("Weekend Mode", "Run even without market data", "General");
+		_showWindowMaximizeCommand = Param(nameof(ShowWindowMaximizeCommand), 3)
+		.SetDisplay("ShowWindow Maximize", "Command value for window maximization", "WinAPI");
+		_setWindowPosNoZOrderFlag = Param(nameof(SetWindowPosNoZOrderFlag), 0x0004u)
+		.SetDisplay("SWP No ZOrder", "Flag to keep window Z-order", "WinAPI");
+		_setWindowPosNoActivateFlag = Param(nameof(SetWindowPosNoActivateFlag), 0x0010u)
+		.SetDisplay("SWP No Activate", "Flag to prevent activation", "WinAPI");
 	}
 
 	/// <inheritdoc />
@@ -161,14 +185,14 @@ public class InputResizerStrategy : Strategy
 
 		if (RememberSize && _sizes.TryGetValue(key, out var rect))
 		{
-			SetWindowPos(wnd, IntPtr.Zero, rect.Left, rect.Top, rect.Right - rect.Left, rect.Bottom - rect.Top, SWP_NOZORDER | SWP_NOACTIVATE);
+			SetWindowPos(wnd, IntPtr.Zero, rect.Left, rect.Top, rect.Right - rect.Left, rect.Bottom - rect.Top, SetWindowPosNoZOrderFlag | SetWindowPosNoActivateFlag);
 		}
 		else
 		{
 			if (InitMaximized)
-				ShowWindow(wnd, SW_MAXIMIZE);
+				ShowWindow(wnd, ShowWindowMaximizeCommand);
 			else if (InitCustom)
-				SetWindowPos(wnd, IntPtr.Zero, InitX, InitY, InitWidth, InitHeight, SWP_NOZORDER | SWP_NOACTIVATE);
+				SetWindowPos(wnd, IntPtr.Zero, InitX, InitY, InitWidth, InitHeight, SetWindowPosNoZOrderFlag | SetWindowPosNoActivateFlag);
 		}
 
 		if (RememberSize)
@@ -184,9 +208,6 @@ public class InputResizerStrategy : Strategy
 	private const int WS_SIZEBOX = 0x00040000;
 	private const int WS_MINIMIZEBOX = 0x00020000;
 	private const int WS_MAXIMIZEBOX = 0x00010000;
-	private const int SW_MAXIMIZE = 3;
-	private const uint SWP_NOZORDER = 0x0004;
-	private const uint SWP_NOACTIVATE = 0x0010;
 
 	[DllImport("user32.dll")]
 	private static extern IntPtr GetForegroundWindow();


### PR DESCRIPTION
## Summary
- expose WinAPI commands and flags as parameters in the input resizer strategy
- add configurable pattern storage limits with validation in the self-learning experts strategy
- expose Hilbert filter coefficients for the MAMA calculator
- allow configuring DDE window and message codes in the DDE example strategy

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7c4c522088323b67e1e02d5c28b24