### PR TITLE
Make strategy limits configurable via parameters

### DIFF
--- a/API/2614_Bollinger_Bands_N_Positions/CS/BollingerBandsNPositionsStrategy.cs
+++ b/API/2614_Bollinger_Bands_N_Positions/CS/BollingerBandsNPositionsStrategy.cs
@@ -13,7 +13,7 @@ using StockSharp.Messages;
 /// </summary>
 public class BollingerBandsNPositionsStrategy : Strategy
 {
-	private const decimal VolumeTolerance = 0.00000001m;
+	private readonly StrategyParam<decimal> _volumeTolerance;
 
 	private readonly StrategyParam<int> _maxPositions;
 	private readonly StrategyParam<int> _bollingerPeriod;
@@ -93,6 +93,15 @@ public class BollingerBandsNPositionsStrategy : Strategy
 	}
 
 	/// <summary>
+	/// Net position magnitude treated as flat.
+	/// </summary>
+	public decimal VolumeTolerance
+	{
+		get => _volumeTolerance.Value;
+		set => _volumeTolerance.Value = value;
+	}
+
+	/// <summary>
 	/// Candle type used for signal calculations.
 	/// </summary>
 	public DataType CandleType
@@ -133,6 +142,10 @@ public class BollingerBandsNPositionsStrategy : Strategy
 		_trailingStepPips = Param(nameof(TrailingStepPips), 5m)
 		.SetNotNegative()
 		.SetDisplay("Trailing Step (pips)", "Trailing adjustment increment", "Risk");
+
+		_volumeTolerance = Param(nameof(VolumeTolerance), 0.00000001m)
+		.SetNotNegative()
+		.SetDisplay("Volume Tolerance", "Minimum net position magnitude treated as flat", "Risk");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(1).TimeFrame())
 		.SetDisplay("Candle Type", "Source candles", "General");

--- a/API/2625_VLT_Trader/CS/VltTraderStrategy.cs
+++ b/API/2625_VLT_Trader/CS/VltTraderStrategy.cs
@@ -13,7 +13,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class VltTraderStrategy : Strategy
 {
-	private const decimal BreakoutBufferPips = 10m;
+	private readonly StrategyParam<decimal> _breakoutBufferPips;
 
 	private readonly StrategyParam<decimal> _takeProfitPips;
 	private readonly StrategyParam<decimal> _stopLossPips;
@@ -59,6 +59,12 @@ public class VltTraderStrategy : Strategy
 			.SetCanOptimize(true)
 			.SetOptimize(5m, 30m, 5m);
 
+		_breakoutBufferPips = Param(nameof(BreakoutBufferPips), 10m)
+			.SetNotNegative()
+			.SetDisplay("Breakout Buffer (pips)", "Additional distance added to breakout entries", "Signals")
+			.SetCanOptimize(true)
+			.SetOptimize(0m, 30m, 5m);
+
 		_maxCandleSizePips = Param(nameof(MaxCandleSizePips), 100m)
 			.SetGreaterThanZero()
 			.SetDisplay("Max Candle Size (pips)", "Largest candle range considered for comparison", "Signals")
@@ -91,6 +97,15 @@ public class VltTraderStrategy : Strategy
 	{
 		get => _stopLossPips.Value;
 		set => _stopLossPips.Value = value;
+	}
+
+	/// <summary>
+	/// Additional breakout buffer applied on both sides of the price range.
+	/// </summary>
+	public decimal BreakoutBufferPips
+	{
+		get => _breakoutBufferPips.Value;
+		set => _breakoutBufferPips.Value = value;
 	}
 
 	/// <summary>

--- a/API/2641_EurUsd_Session_Breakout/CS/EurUsdSessionBreakoutStrategy.cs
+++ b/API/2641_EurUsd_Session_Breakout/CS/EurUsdSessionBreakoutStrategy.cs
@@ -13,7 +13,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class EurUsdSessionBreakoutStrategy : Strategy
 {
-	private const int EuSessionLengthBars = 24;
+	private readonly StrategyParam<int> _euSessionLengthBars;
 
 	// Strategy parameters
 	private readonly StrategyParam<int> _startHourEuSession;
@@ -82,6 +82,11 @@ public class EurUsdSessionBreakoutStrategy : Strategy
 			.SetDisplay("Breakout Buffer (points)", "Extra points added to the breakout trigger", "Entries")
 			.SetCanOptimize(true);
 
+		_euSessionLengthBars = Param(nameof(EuSessionLengthBars), 24)
+			.SetRange(1, 72)
+			.SetDisplay("EU Session Length (bars)", "Number of bars representing the EU session range", "Schedule")
+			.SetCanOptimize(true);
+
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
 			.SetDisplay("Candle Type", "Candle type used for calculations", "General");
 	}
@@ -132,6 +137,24 @@ public class EurUsdSessionBreakoutStrategy : Strategy
 	{
 		get => _breakoutBufferPoints.Value;
 		set => _breakoutBufferPoints.Value = value;
+	}
+
+	public int EuSessionLengthBars
+	{
+		get => _euSessionLengthBars.Value;
+		set
+		{
+			_euSessionLengthBars.Value = value;
+			if (_highest != null)
+			{
+				_highest.Length = value;
+			}
+
+			if (_lowest != null)
+			{
+				_lowest.Length = value;
+			}
+		}
 	}
 
 	public DataType CandleType

--- a/API/2651_AFStar/CS/AfStarStrategy.cs
+++ b/API/2651_AFStar/CS/AfStarStrategy.cs
@@ -15,8 +15,8 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class AfStarStrategy : Strategy
 {
-	private const int RangeLength = 10;
-	private const int MaxHistory = 512;
+	private readonly StrategyParam<int> _rangeLength;
+	private readonly StrategyParam<int> _maxHistory;
 
 	private readonly StrategyParam<decimal> _orderVolume;
 	private readonly StrategyParam<DataType> _candleType;
@@ -94,6 +94,14 @@ public class AfStarStrategy : Strategy
 		_stepRisk = Param(nameof(StepRisk), 0.5m)
 		.SetGreaterThanZero()
 		.SetDisplay("Risk Step", "Increment for risk parameter", "Williams %R");
+
+		_rangeLength = Param(nameof(RangeLength), 10)
+		.SetRange(1, 200, 1)
+		.SetDisplay("Range Length", "Bars used to compute the average range filter", "Indicator");
+
+		_maxHistory = Param(nameof(MaxHistory), 512)
+		.SetRange(10, 5000, 1)
+		.SetDisplay("Max History", "Maximum candles stored for calculations", "General");
 
 		_signalBar = Param(nameof(SignalBar), 1)
 		.SetRange(0, 10, 1)
@@ -208,6 +216,28 @@ public class AfStarStrategy : Strategy
 	{
 		get => _stepRisk.Value;
 		set => _stepRisk.Value = value;
+	}
+
+	/// <summary>
+	/// Number of bars used to calculate the average range filter.
+	/// </summary>
+	public int RangeLength
+	{
+		get => _rangeLength.Value;
+		set => _rangeLength.Value = value;
+	}
+
+	/// <summary>
+	/// Maximum number of stored candles for calculations.
+	/// </summary>
+	public int MaxHistory
+	{
+		get => _maxHistory.Value;
+		set
+		{
+			_maxHistory.Value = value;
+			TrimHistory();
+		}
 	}
 
 	/// <summary>
@@ -349,6 +379,19 @@ public class AfStarStrategy : Strategy
 				var activeSignal = _signalQueue.Dequeue();
 				ExecuteSignal(activeSignal, candle);
 			}
+		}
+	}
+
+	private void TrimHistory()
+	{
+		while (_candles.Count > MaxHistory)
+		{
+			_candles.RemoveAt(0);
+		}
+
+		while (_value2History.Count > MaxHistory)
+		{
+			_value2History.RemoveAt(0);
 		}
 	}
 


### PR DESCRIPTION
## Summary
- expose hedge panel slot capacity as a configurable strategy parameter and auto-initialize slot settings
- add strategy parameters for volume tolerance, color history length, breakout buffers, EU session window, and AFStar history/range limits
- ensure runtime changes to new parameters resize associated caches where required

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d7ccf68e388323baff864ff02603e5