### PR TITLE
Expose strategy constants as configurable parameters

### DIFF
--- a/API/2657_OzFx_Accelerator_Stochastic/CS/OzFxAcceleratorStochasticStrategy.cs
+++ b/API/2657_OzFx_Accelerator_Stochastic/CS/OzFxAcceleratorStochasticStrategy.cs
@@ -16,7 +16,7 @@ using StockSharp.Messages;
 /// </summary>
 public class OzFxAcceleratorStochasticStrategy : Strategy
 {
-	private const int MaxLayers = 5;
+	private readonly StrategyParam<int> _maxLayers;
 
 	private readonly StrategyParam<decimal> _orderVolume;
 	private readonly StrategyParam<decimal> _stopLossPips;
@@ -61,6 +61,15 @@ public class OzFxAcceleratorStochasticStrategy : Strategy
 		public decimal? StopPrice;
 		public decimal? TakeProfitPrice;
 		public int Layer;
+	}
+
+	/// <summary>
+	/// Maximum number of layered positions.
+	/// </summary>
+	public int MaxLayers
+	{
+		get => _maxLayers.Value;
+		set => _maxLayers.Value = value;
 	}
 
 	/// <summary>
@@ -158,6 +167,10 @@ public class OzFxAcceleratorStochasticStrategy : Strategy
 	/// </summary>
 	public OzFxAcceleratorStochasticStrategy()
 	{
+		_maxLayers = Param(nameof(MaxLayers), 5)
+			.SetGreaterThanZero()
+			.SetDisplay("Max Layers", "Maximum number of layered positions", "Risk");
+
 		_orderVolume = Param(nameof(OrderVolume), 0.1m)
 			.SetGreaterThanZero()
 			.SetDisplay("Volume", "Order volume for each layer", "Trading");

--- a/API/2664_Stopreversal_Trailing_Strategy/CS/StopreversalTrailingStrategy.cs
+++ b/API/2664_Stopreversal_Trailing_Strategy/CS/StopreversalTrailingStrategy.cs
@@ -13,7 +13,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class StopreversalTrailingStrategy : Strategy
 {
-	private const int AtrPeriod = 15;
+	private readonly StrategyParam<int> _atrPeriod;
 
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<int> _stopLossSteps;
@@ -43,8 +43,11 @@ public class StopreversalTrailingStrategy : Strategy
 	public StopreversalTrailingStrategy()
 	{
 		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(4).TimeFrame())
-		.SetDisplay("Candle Type", "Stopreversal timeframe", "General");
+			.SetDisplay("Candle Type", "Stopreversal timeframe", "General");
 
+		_atrPeriod = Param(nameof(AtrPeriod), 15)
+			.SetGreaterThanZero()
+			.SetDisplay("ATR Period", "ATR lookback for trailing stop", "Indicator");
 
 		_stopLossSteps = Param(nameof(StopLossSteps), 1000)
 		.SetNotNegative()
@@ -91,6 +94,14 @@ public class StopreversalTrailingStrategy : Strategy
 		set => _candleType.Value = value;
 	}
 
+	/// <summary>
+	/// ATR period used for the trailing stop calculation.
+	/// </summary>
+	public int AtrPeriod
+	{
+		get => _atrPeriod.Value;
+		set => _atrPeriod.Value = value;
+	}
 
 	/// <summary>
 	/// Stop loss distance measured in price steps.

--- a/API/2669_ChaosTraderLite/CS/ChaosTraderLiteStrategy.cs
+++ b/API/2669_ChaosTraderLite/CS/ChaosTraderLiteStrategy.cs
@@ -14,8 +14,8 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class ChaosTraderLiteStrategy : Strategy
 {
-	private const int LipsShift = 3;
-	private const int TeethShift = 5;
+	private readonly StrategyParam<int> _lipsShift;
+	private readonly StrategyParam<int> _teethShift;
 
 	private readonly StrategyParam<int> _magnitudePips;
 	private readonly StrategyParam<bool> _useFirstWiseMan;
@@ -63,6 +63,24 @@ public class ChaosTraderLiteStrategy : Strategy
 	}
 
 	/// <summary>
+	/// Number of candles used to shift the Alligator lips line.
+	/// </summary>
+	public int LipsShift
+	{
+		get => _lipsShift.Value;
+		set => _lipsShift.Value = value;
+	}
+
+	/// <summary>
+	/// Number of candles used to shift the Alligator teeth line.
+	/// </summary>
+	public int TeethShift
+	{
+		get => _teethShift.Value;
+		set => _teethShift.Value = value;
+	}
+
+	/// <summary>
 	/// Enable the first wise man divergent bar setup.
 	/// </summary>
 	public bool UseFirstWiseMan
@@ -107,6 +125,14 @@ public class ChaosTraderLiteStrategy : Strategy
 		_magnitudePips = Param(nameof(MagnitudePips), 10)
 			.SetGreaterThanZero()
 			.SetDisplay("Magnitude", "Distance from lips in pips", "General");
+
+		_lipsShift = Param(nameof(LipsShift), 3)
+			.SetNotNegative()
+			.SetDisplay("Lips Shift", "Shift applied to Alligator lips", "Alligator");
+
+		_teethShift = Param(nameof(TeethShift), 5)
+			.SetNotNegative()
+			.SetDisplay("Teeth Shift", "Shift applied to Alligator teeth", "Alligator");
 
 		_useFirstWiseMan = Param(nameof(UseFirstWiseMan), true)
 			.SetDisplay("First Wise Man", "Enable divergent bar setup", "General");

--- a/API/2677_II_Outbreak/CS/IiOutbreakStrategy.cs
+++ b/API/2677_II_Outbreak/CS/IiOutbreakStrategy.cs
@@ -14,7 +14,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class IiOutbreakStrategy : Strategy
 {
-	private const decimal _epsilon = 0.0000000001m;
+	private readonly StrategyParam<decimal> _epsilonTolerance;
 
 	private readonly StrategyParam<decimal> _spreadThreshold;
 	private readonly StrategyParam<decimal> _trailStopPoints;
@@ -63,6 +63,15 @@ public class IiOutbreakStrategy : Strategy
 	{
 		get => _spreadThreshold.Value;
 		set => _spreadThreshold.Value = value;
+	}
+
+	/// <summary>
+	/// Minimum acceleration threshold treated as zero when evaluating timing signals.
+	/// </summary>
+	public decimal EpsilonTolerance
+	{
+		get => _epsilonTolerance.Value;
+		set => _epsilonTolerance.Value = value;
 	}
 
 	/// <summary>
@@ -145,6 +154,10 @@ public class IiOutbreakStrategy : Strategy
 		_commission = Param(nameof(Commission), 4m)
 			.SetGreaterThanOrEqual(0m)
 			.SetDisplay("Commission", "Round lot commission used for stop offset", "Risk Management");
+
+		_epsilonTolerance = Param(nameof(EpsilonTolerance), 0.0000000001m)
+			.SetGreaterThanOrEqual(0m)
+			.SetDisplay("Epsilon", "Minimum acceleration threshold", "Filters");
 
 		_spreadThreshold = Param(nameof(SpreadThreshold), 6m)
 			.SetGreaterThanOrEqual(0m)
@@ -675,7 +688,7 @@ public class IiOutbreakStrategy : Strategy
 					j = 0;
 			}
 
-			if (j > 6 && amov > _epsilon)
+			if (j > 6 && amov > EpsilonTolerance)
 			{
 				tval = 50m * (dmov / amov + 1m);
 				if (tval > 100m)


### PR DESCRIPTION
## Summary
- replace hard-coded layer, ATR, alligator shift, and epsilon tolerances with configurable strategy parameters across the affected strategies
- expose the new parameters via properties so they can be tuned from the UI and persist existing behavior by keeping prior defaults

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7cd02fa588323b9234cc273eb846d