### PR TITLE
Remove redundant trade price guards

### DIFF
--- a/API/1428_Tick_Chart/CS/TickChartStrategy.cs
+++ b/API/1428_Tick_Chart/CS/TickChartStrategy.cs
@@ -39,7 +39,7 @@ public class TickChartStrategy : Strategy
 
 	private void ProcessTrade(ITickTradeMessage trade)
 	{
-		var price = trade.TradePrice ?? 0m;
+		var price = trade.Price;
 		var vol = trade.Volume ?? 0m;
 
 		if (_count == 0)

--- a/API/1687_Scalping_EA/CS/ScalpingEAStrategy.cs
+++ b/API/1687_Scalping_EA/CS/ScalpingEAStrategy.cs
@@ -77,7 +77,7 @@ public class ScalpingEAStrategy : Strategy
 
 	private void ProcessTrade(ITickTradeMessage trade)
 	{
-		var price = trade.TradePrice ?? 0m;
+		var price = trade.Price;
 		var step = Security.PriceStep ?? 1m;
 
 		if (_buyOrder?.State == OrderStates.Active)

--- a/API/1773_Breakout_04/CS/Breakout04Strategy.cs
+++ b/API/1773_Breakout_04/CS/Breakout04Strategy.cs
@@ -110,7 +110,7 @@ public class Breakout04Strategy : Strategy
 		if (_prevHigh == 0m && _prevLow == 0m)
 			return;
 
-		var price = trade.TradePrice ?? 0m;
+		var price = trade.Price;
 		var step = Security.PriceStep ?? 1m;
 		var stopOffset = StopLoss * step;
 		var takeOffset = TakeProfit * step;

--- a/API/1782_Hedger/CS/HedgerStrategy.cs
+++ b/API/1782_Hedger/CS/HedgerStrategy.cs
@@ -133,7 +133,7 @@ public class HedgerStrategy : Strategy
 		
 	private void ProcessTrade(ITickTradeMessage trade)
 	{
-		var price = trade.TradePrice ?? 0m;
+		var price = trade.Price;
 		
 		PlaceProtectiveOrders();
 		

--- a/API/1795_Close_Positions/CS/ClosePositionsStrategy.cs
+++ b/API/1795_Close_Positions/CS/ClosePositionsStrategy.cs
@@ -17,78 +17,88 @@ public class ClosePositionsStrategy : Strategy
 	private readonly StrategyParam<int> _timeLimit;
 	private readonly StrategyParam<int> _closeHour;
 	private readonly StrategyParam<int> _closeMinute;
-	
+
 	private decimal _entry;
 	private DateTimeOffset _entryTime;
-	
-public int ProfitPips { get => _profitPips.Value; set => _profitPips.Value = value; }
-public int LossPips { get => _lossPips.Value; set => _lossPips.Value = value; }
-public int TimeLimit { get => _timeLimit.Value; set => _timeLimit.Value = value; }
-public int CloseHour { get => _closeHour.Value; set => _closeHour.Value = value; }
-public int CloseMinute { get => _closeMinute.Value; set => _closeMinute.Value = value; }
 
-public ClosePositionsStrategy()
-{
-_profitPips = Param(nameof(ProfitPips), 100);
-_lossPips = Param(nameof(LossPips), -200);
-_timeLimit = Param(nameof(TimeLimit), 60);
-_closeHour = Param(nameof(CloseHour), 15);
-_closeMinute = Param(nameof(CloseMinute), 0);
-}
+	public int ProfitPips { get => _profitPips.Value; set => _profitPips.Value = value; }
+	public int LossPips { get => _lossPips.Value; set => _lossPips.Value = value; }
+	public int TimeLimit { get => _timeLimit.Value; set => _timeLimit.Value = value; }
+	public int CloseHour { get => _closeHour.Value; set => _closeHour.Value = value; }
+	public int CloseMinute { get => _closeMinute.Value; set => _closeMinute.Value = value; }
 
-public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
-=> [(Security, DataType.Ticks)];
+	public ClosePositionsStrategy()
+	{
+		_profitPips = Param(nameof(ProfitPips), 100);
+		_lossPips = Param(nameof(LossPips), -200);
+		_timeLimit = Param(nameof(TimeLimit), 60);
+		_closeHour = Param(nameof(CloseHour), 15);
+		_closeMinute = Param(nameof(CloseMinute), 0);
+	}
 
-/// <inheritdoc />
-protected override void OnStarted(DateTimeOffset time)
-{
-base.OnStarted(time);
-SubscribeTicks().Bind(ProcessTrade).Start();
-}
+	public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
+		=> [(Security, DataType.Ticks)];
 
-private void ProcessTrade(ITickTradeMessage trade)
-{
-var price = trade.TradePrice ?? 0m;
+	/// <inheritdoc />
+	protected override void OnStarted(DateTimeOffset time)
+	{
+		base.OnStarted(time);
+		SubscribeTicks().Bind(ProcessTrade).Start();
+	}
 
-if (Position == 0)
-{
-_entry = 0m;
-_entryTime = default;
-return;
-}
+	private void ProcessTrade(ITickTradeMessage trade)
+	{
+		var price = trade.Price;
 
-if (_entry == 0m)
-{
-_entry = price;
-_entryTime = trade.ServerTime;
-}
+		if (Position == 0)
+		{
+			_entry = 0m;
+			_entryTime = default;
+			return;
+		}
 
-var age = (trade.ServerTime - _entryTime).TotalMinutes;
-var step = Security.PriceStep ?? 1m;
+		if (_entry == 0m)
+		{
+			_entry = price;
+			_entryTime = trade.ServerTime;
+		}
 
-if (trade.ServerTime.Hour >= CloseHour && trade.ServerTime.Minute >= CloseMinute)
-ClosePosition();
-else if (age > TimeLimit)
-ClosePosition();
-else if (Position > 0)
-{
-var diff = price - _entry;
-if (diff >= ProfitPips * step || diff <= LossPips * step)
-ClosePosition();
-}
-else if (Position < 0)
-{
-var diff = _entry - price;
-if (diff >= ProfitPips * step || diff <= LossPips * step)
-ClosePosition();
-}
-}
+		var age = (trade.ServerTime - _entryTime).TotalMinutes;
+		var step = Security.PriceStep ?? 1m;
 
-private void ClosePosition()
-{
-if (Position > 0)
-SellMarket();
-else if (Position < 0)
-BuyMarket();
-}
+		if (trade.ServerTime.Hour >= CloseHour && trade.ServerTime.Minute >= CloseMinute)
+		{
+			ClosePosition();
+		}
+		else if (age > TimeLimit)
+		{
+			ClosePosition();
+		}
+		else if (Position > 0)
+		{
+			var diff = price - _entry;
+
+			if (diff >= ProfitPips * step || diff <= LossPips * step)
+				ClosePosition();
+		}
+		else if (Position < 0)
+		{
+			var diff = _entry - price;
+
+			if (diff >= ProfitPips * step || diff <= LossPips * step)
+				ClosePosition();
+		}
+	}
+
+	private void ClosePosition()
+	{
+		if (Position > 0)
+		{
+			SellMarket();
+		}
+		else if (Position < 0)
+		{
+			BuyMarket();
+		}
+	}
 }

--- a/API/1921_Trailing_Stop_EA/CS/TrailingStopEAStrategy.cs
+++ b/API/1921_Trailing_Stop_EA/CS/TrailingStopEAStrategy.cs
@@ -63,7 +63,7 @@ public class TrailingStopEAStrategy : Strategy
 
 	private void ProcessTrade(ITickTradeMessage trade)
 	{
-		var price = trade.TradePrice ?? 0m;
+		var price = trade.Price;
 
 		if (Position > 0)
 		{

--- a/API/2012_Random_Trader/CS/RandomTraderStrategy.cs
+++ b/API/2012_Random_Trader/CS/RandomTraderStrategy.cs
@@ -76,7 +76,7 @@ public class RandomTraderStrategy : Strategy
 
 	private void ProcessTrade(ITickTradeMessage trade)
 	{
-		var price = trade.TradePrice ?? 0m;
+		var price = trade.Price;
 
 		if (!IsFormedAndOnlineAndAllowTrading())
 			return;

--- a/API/2107_TP_SL_Panel/CS/TpSlPanelStrategy.cs
+++ b/API/2107_TP_SL_Panel/CS/TpSlPanelStrategy.cs
@@ -66,7 +66,7 @@ public class TpSlPanelStrategy : Strategy
 
 	private void ProcessTrade(ITickTradeMessage trade)
 	{
-		var price = trade.TradePrice ?? 0m;
+		var price = trade.Price;
 
 		if (Position == 0)
 			return;

--- a/API/2126_Last_Price/CS/LastPriceStrategy.cs
+++ b/API/2126_Last_Price/CS/LastPriceStrategy.cs
@@ -100,7 +100,7 @@ public class LastPriceStrategy : Strategy
 
 	private void ProcessTrade(ITickTradeMessage trade)
 	{
-		_lastPrice = trade.TradePrice ?? 0m;
+		_lastPrice = trade.Price;
 		_lastVolume = trade.Volume ?? 0m;
 
 		Evaluate(trade.ServerTime);

--- a/API/2174_Hidden_SL/CS/HiddenSlStrategy.cs
+++ b/API/2174_Hidden_SL/CS/HiddenSlStrategy.cs
@@ -41,28 +41,27 @@ public class HiddenSlStrategy : Strategy
 			.Start();
 	}
 
-	private void ProcessTrade(ITickTradeMessage trade)
-	{
-		var price = trade.TradePrice;
-		if (price is null)
-			return;
-
-		var pos = Position;
-		if (pos == 0)
-			return;
-
-		var entryPrice = Position.AveragePrice;
-		if (entryPrice == 0m)
-			return;
-
-		var profit = (price.Value - entryPrice) * pos;
-
-		if (profit >= TakeProfit || profit <= StopLoss)
+		private void ProcessTrade(ITickTradeMessage trade)
 		{
-			if (pos > 0)
-				SellMarket(pos);
-			else
-				BuyMarket(-pos);
+			var price = trade.Price;
+
+			var pos = Position;
+			if (pos == 0)
+				return;
+
+			var entryPrice = Position.AveragePrice;
+			if (entryPrice == 0m)
+				return;
+
+			var profit = (price - entryPrice) * pos;
+
+			if (profit >= TakeProfit || profit <= StopLoss)
+			{
+				if (pos > 0)
+					SellMarket(pos);
+				else
+					BuyMarket(-pos);
+			}
 		}
 	}
 }

--- a/API/2177_Zakryvator/CS/ZakryvatorStrategy.cs
+++ b/API/2177_Zakryvator/CS/ZakryvatorStrategy.cs
@@ -79,7 +79,7 @@ public class ZakryvatorStrategy : Strategy
 		if (Position == 0)
 			return;
 
-		var price = trade.TradePrice ?? 0m;
+		var price = trade.Price;
 		// Calculate unrealized PnL based on current price and average entry price.
 		var openPnL = Position * (price - PositionPrice);
 

--- a/API/2198_Exp_Multic/CS/ExpMulticStrategy.cs
+++ b/API/2198_Exp_Multic/CS/ExpMulticStrategy.cs
@@ -97,7 +97,7 @@ subscription.Bind(trade => ProcessTrade(sec, trade)).Start();
 
 private void ProcessTrade(Security sec, ITickTradeMessage trade)
 {
-_lastPrice[sec] = trade.TradePrice ?? 0m;
+_lastPrice[sec] = trade.Price;
 Process(sec);
 }
 

--- a/API/2248_Exp_To_Close_Profit/CS/ExpToCloseProfitStrategy.cs
+++ b/API/2248_Exp_To_Close_Profit/CS/ExpToCloseProfitStrategy.cs
@@ -46,14 +46,11 @@ public class ExpToCloseProfitStrategy : Strategy
 		StartProtection();
 	}
 
-	private void ProcessTrade(ITickTradeMessage trade)
-	{
-		var price = trade.TradePrice;
+		private void ProcessTrade(ITickTradeMessage trade)
+		{
+			var price = trade.Price;
 
-		if (price is null)
-			return;
-
-		var unrealized = Position * (price.Value - PositionPrice);
+		var unrealized = Position * (price - PositionPrice);
 		var totalProfit = PnL + unrealized;
 
 		LogInfo($"Profit = {totalProfit:0.##}; MaxProfit = {MaxProfit:0.##};");

--- a/API/2306_Cm_Fishing/CS/CmFishingStrategy.cs
+++ b/API/2306_Cm_Fishing/CS/CmFishingStrategy.cs
@@ -152,7 +152,7 @@ public class CmFishingStrategy : Strategy
 		if (!IsFormedAndOnlineAndAllowTrading())
 			return;
 
-		var price = trade.TradePrice ?? 0m;
+		var price = trade.Price;
 		var absPos = Math.Abs(Position);
 
 		if (Buy && Position >= 0m && price <= _level - StepBuy)

--- a/API/2328_Trailing_Master/CS/TrailingMasterStrategy.cs
+++ b/API/2328_Trailing_Master/CS/TrailingMasterStrategy.cs
@@ -120,7 +120,7 @@ public class TrailingMasterStrategy : Strategy
 
 	private void ProcessTrade(ITickTradeMessage trade)
 	{
-		var price = trade.TradePrice ?? 0m;
+		var price = trade.Price;
 		var step = Security.PriceStep ?? 1m;
 
 		if (_entryPrice == 0m && Position != 0)

--- a/API/2445_EliteEFiboTrader/CS/EliteEFiboTraderStrategy.cs
+++ b/API/2445_EliteEFiboTrader/CS/EliteEFiboTraderStrategy.cs
@@ -315,17 +315,16 @@ public class EliteEFiboTraderStrategy : Strategy
 
 	private void ProcessTrade(ITickTradeMessage trade)
 	{
-		if (trade.TradePrice is not decimal price)
-		return;
+		var price = trade.Price;
 
 		if (TradeAgainAfterProfit)
-		_tradeEnabled = true;
+			_tradeEnabled = true;
 
 		UpdateStepSizes();
 		UpdateExecutedEntries();
 
 		if (!_cycleActive && _tradeEnabled && HasValidDirection() && IsFormedAndOnlineAndAllowTrading())
-		TryStartCycle(price);
+			TryStartCycle(price);
 
 		if (Position != 0m)
 		{

--- a/API/2457_Breakdown_Level_Day/CS/BreakdownLevelDayStrategy.cs
+++ b/API/2457_Breakdown_Level_Day/CS/BreakdownLevelDayStrategy.cs
@@ -122,7 +122,7 @@ public class BreakdownLevelDayStrategy : Strategy
 
 	private void ProcessTrade(ITickTradeMessage trade)
 	{
-		var price = trade.TradePrice ?? 0m;
+		var price = trade.Price;
 		var time = trade.ServerTime;
 
 		if (time.Date > _tradeDay)

--- a/API/2486_MoneyFixedRisk/CS/MoneyFixedRiskStrategy.cs
+++ b/API/2486_MoneyFixedRisk/CS/MoneyFixedRiskStrategy.cs
@@ -110,16 +110,14 @@ public class MoneyFixedRiskStrategy : Strategy
 		StartProtection();
 	}
 
-	private void ProcessTrade(ITickTradeMessage trade)
-	{
-		var price = trade.TradePrice;
-		if (price is null || price.Value <= 0m)
-		return;
+		private void ProcessTrade(ITickTradeMessage trade)
+		{
+			var price = trade.Price;
 
 		// Manage existing long position and exit on stop-loss or take-profit.
 		if (Position > 0 && _stopPrice > 0m)
 		{
-			if (price.Value <= _stopPrice || price.Value >= _takeProfitPrice)
+			if (price <= _stopPrice || price >= _takeProfitPrice)
 			{
 				SellMarket(Math.Abs(Position));
 				_stopPrice = 0m;
@@ -148,8 +146,8 @@ public class MoneyFixedRiskStrategy : Strategy
 		// Close short exposure if any and open the long trade sized by risk.
 		BuyMarket(volume + Math.Max(0m, -Position));
 
-		_stopPrice = price.Value - stopDistance;
-		_takeProfitPrice = price.Value + stopDistance;
+		_stopPrice = price - stopDistance;
+		_takeProfitPrice = price + stopDistance;
 	}
 
 	private decimal GetStopDistance()

--- a/API/2497_Trailing_Stop_Manager/CS/TrailingStopManagerStrategy.cs
+++ b/API/2497_Trailing_Stop_Manager/CS/TrailingStopManagerStrategy.cs
@@ -113,32 +113,34 @@ public class TrailingStopManagerStrategy : Strategy
 	}
 
 	/// <inheritdoc />
-	protected override void OnOwnTradeReceived(MyTrade trade)
-	{
-		base.OnOwnTradeReceived(trade);
+		protected override void OnOwnTradeReceived(MyTrade trade)
+		{
+			base.OnOwnTradeReceived(trade);
 
-		var tradePrice = trade.Trade?.Price ?? 0m;
-		if (tradePrice <= 0m)
-			return;
+			if (trade.Trade == null)
+				return;
 
-		// Reset trailing state whenever a new position is opened.
-		if (Position > 0 && trade.Order.Side == Sides.Buy)
-		{
-			_entryPrice = tradePrice;
-			_trailingActive = false;
-			_trailingStopPrice = 0m;
-			_currentDirection = InitialDirection.Long;
-		}
-		else if (Position < 0 && trade.Order.Side == Sides.Sell)
-		{
-			_entryPrice = tradePrice;
-			_trailingActive = false;
-			_trailingStopPrice = 0m;
-			_currentDirection = InitialDirection.Short;
-		}
-		else if (Position == 0)
-		{
-			ResetTrailing();
+			var tradePrice = trade.Trade.Price;
+
+			// Reset trailing state whenever a new position is opened.
+			if (Position > 0 && trade.Order.Side == Sides.Buy)
+			{
+				_entryPrice = tradePrice;
+				_trailingActive = false;
+				_trailingStopPrice = 0m;
+				_currentDirection = InitialDirection.Long;
+			}
+			else if (Position < 0 && trade.Order.Side == Sides.Sell)
+			{
+				_entryPrice = tradePrice;
+				_trailingActive = false;
+				_trailingStopPrice = 0m;
+				_currentDirection = InitialDirection.Short;
+			}
+			else if (Position == 0)
+			{
+				ResetTrailing();
+			}
 		}
 	}
 
@@ -151,11 +153,9 @@ public class TrailingStopManagerStrategy : Strategy
 			ResetTrailing();
 	}
 
-	private void ProcessTrade(ITickTradeMessage trade)
-	{
-		var price = trade.TradePrice;
-		if (price == null || price.Value <= 0m)
-			return;
+		private void ProcessTrade(ITickTradeMessage trade)
+		{
+			var price = trade.Price;
 
 		if (!IsFormedAndOnlineAndAllowTrading())
 			return;
@@ -163,7 +163,7 @@ public class TrailingStopManagerStrategy : Strategy
 		if (_entryPrice <= 0m)
 			return;
 
-		var currentPrice = price.Value;
+		var currentPrice = price;
 
 		if (Position > 0 && _currentDirection == InitialDirection.Long)
 		{

--- a/API/2532_e-Smart_Trailing/CS/ESmartTrailingStrategy.cs
+++ b/API/2532_e-Smart_Trailing/CS/ESmartTrailingStrategy.cs
@@ -81,7 +81,7 @@ public class ESmartTrailingStrategy : Strategy
 
 	private void ProcessTrade(ITickTradeMessage trade)
 	{
-		var tradePrice = trade.TradePrice;
+		var tradePrice = trade.Price;
 
 		if (tradePrice is null)
 			return;

--- a/API/2668_Button_Close_Buy_Sell/CS/ButtonCloseBuySellStrategy.cs
+++ b/API/2668_Button_Close_Buy_Sell/CS/ButtonCloseBuySellStrategy.cs
@@ -124,8 +124,7 @@ public class ButtonCloseBuySellStrategy : Strategy
 	/// <param name="trade">Incoming trade message.</param>
 	private void ProcessTrade(ITickTradeMessage trade)
 	{
-		if (trade.TradePrice is not decimal price)
-			return;
+		var price = trade.Price;
 
 		_lastTradePrice = price;
 		UpdateFloatingProfit();

--- a/API/2701_Jims_Close_Positions/CS/JimsClosePositionsStrategy.cs
+++ b/API/2701_Jims_Close_Positions/CS/JimsClosePositionsStrategy.cs
@@ -123,13 +123,12 @@ public class JimsClosePositionsStrategy : Strategy
 		return false;
 	}
 
-	private void ProcessTrade(ITickTradeMessage trade)
-	{
-		if (trade.TradePrice is not decimal tradePrice)
-			return;
+		private void ProcessTrade(ITickTradeMessage trade)
+		{
+			var tradePrice = trade.Price;
 
-		ProcessPrice(tradePrice);
-	}
+			ProcessPrice(tradePrice);
+		}
 
 	private void ProcessPrice(decimal marketPrice)
 	{

--- a/API/2704_N_Seconds_N_Points/CS/NSecondsNPointsStrategy.cs
+++ b/API/2704_N_Seconds_N_Points/CS/NSecondsNPointsStrategy.cs
@@ -100,14 +100,12 @@ public class NSecondsNPointsStrategy : Strategy
 		return priceStep.Value * adjust;
 	}
 
-	private void ProcessTrade(ITickTradeMessage trade)
-	{
-		var price = trade.TradePrice;
-		if (price == null)
-			return;
+		private void ProcessTrade(ITickTradeMessage trade)
+		{
+			var price = trade.Price;
 
-		_lastPrice = price.Value;
-		_hasLastPrice = true;
+			_lastPrice = price;
+			_hasLastPrice = true;
 	}
 
 	private void ProcessTimer()

--- a/API/2731_Dual_Lot_Step_Hedge/CS/DualLotStepHedgeStrategy.cs
+++ b/API/2731_Dual_Lot_Step_Hedge/CS/DualLotStepHedgeStrategy.cs
@@ -175,7 +175,7 @@ public class DualLotStepHedgeStrategy : Strategy
 		base.OnStarted(time);
 
 		_volumeStep = Security.VolumeStep ?? 0m;
-		if (_volumeStep <= 0m)
+			if (_volumeStep <= 0m)
 		_volumeStep = 1m;
 
 		_maxVolume = LotCheck(_volumeStep * LotMultiplier);
@@ -188,55 +188,54 @@ public class DualLotStepHedgeStrategy : Strategy
 		SubscribeTicks().Bind(ProcessTrade).Start();
 	}
 
-	private void ProcessTrade(ITickTradeMessage trade)
-	{
-		if (trade.TradePrice is not decimal price || price <= 0m)
-		return;
-
-		if (!IsFormedAndOnlineAndAllowTrading())
-		return;
-
-		if (_volumeStep <= 0m)
-		return;
-
-		if (_initialEquity <= 0m)
-		_initialEquity = Portfolio.CurrentValue ?? 0m;
-
-		CheckProtectiveLevels(price);
-
-		if (_longExitInProgress || _shortExitInProgress)
-		return;
-
-		if (CheckProfitTarget())
-		return;
-
-		ResetCurrentVolumeIfNeeded();
-
-		var buyCount = _longVolume > 0m ? 1 : 0;
-		var sellCount = _shortVolume > 0m ? 1 : 0;
-
-		if (buyCount > 1 || sellCount > 1)
+		private void ProcessTrade(ITickTradeMessage trade)
 		{
-			CloseAllPositions();
-			return;
-		}
+			var price = trade.Price;
 
-		if (_longEntryInProgress || _shortEntryInProgress)
-		return;
+			if (!IsFormedAndOnlineAndAllowTrading())
+				return;
 
-		if (buyCount == 0 && sellCount == 0)
-		{
-			TryOpenHedge();
+			if (_volumeStep <= 0m)
+				return;
+
+			if (_initialEquity <= 0m)
+				_initialEquity = Portfolio.CurrentValue ?? 0m;
+
+			CheckProtectiveLevels(price);
+
+			if (_longExitInProgress || _shortExitInProgress)
+				return;
+
+			if (CheckProfitTarget())
+				return;
+
+			ResetCurrentVolumeIfNeeded();
+
+			var buyCount = _longVolume > 0m ? 1 : 0;
+			var sellCount = _shortVolume > 0m ? 1 : 0;
+
+			if (buyCount > 1 || sellCount > 1)
+			{
+				CloseAllPositions();
+				return;
+			}
+
+			if (_longEntryInProgress || _shortEntryInProgress)
+				return;
+
+			if (buyCount == 0 && sellCount == 0)
+			{
+				TryOpenHedge();
+			}
+			else if (buyCount == 1 && sellCount == 0)
+			{
+				OpenShortIfNeeded();
+			}
+			else if (buyCount == 0 && sellCount == 1)
+			{
+				OpenLongIfNeeded();
+			}
 		}
-		else if (buyCount == 1 && sellCount == 0)
-		{
-			OpenShortIfNeeded();
-		}
-		else if (buyCount == 0 && sellCount == 1)
-		{
-			OpenLongIfNeeded();
-		}
-	}
 
 	private bool CheckProfitTarget()
 	{
@@ -503,7 +502,7 @@ public class DualLotStepHedgeStrategy : Strategy
 		if (_longVolume > 0m || _shortVolume > 0m)
 		return;
 
-		if (_longExitInProgress || _shortExitInProgress)
+			if (_longExitInProgress || _shortExitInProgress)
 		return;
 
 		if (_pendingLongEntryVolume > 0m || _pendingShortEntryVolume > 0m)

--- a/API/2838_Breakeven_Trailing_Stop/CS/BreakevenTrailingStopStrategy.cs
+++ b/API/2838_Breakeven_Trailing_Stop/CS/BreakevenTrailingStopStrategy.cs
@@ -105,25 +105,23 @@ public class BreakevenTrailingStopStrategy : Strategy
 			.Start();
 	}
 
-	private void ProcessTrade(ITickTradeMessage trade)
-	{
-		var price = trade.TradePrice;
-		if (price is null || price <= 0m)
-			return;
+		private void ProcessTrade(ITickTradeMessage trade)
+		{
+			var price = trade.Price;
 
-		if (!IsFormedAndOnlineAndAllowTrading())
+			if (!IsFormedAndOnlineAndAllowTrading())
 			return;
 
 		if (EnableDemoEntries)
-			TryCreateDemoEntry(trade, price.Value);
+			TryCreateDemoEntry(trade, price);
 
 		if (TrailingStopPips <= 0m || _pointValue <= 0m || Position == 0)
 			return;
 
 		if (Position > 0)
-			UpdateLongTrailing(price.Value);
+			UpdateLongTrailing(price);
 		else if (Position < 0)
-			UpdateShortTrailing(price.Value);
+			UpdateShortTrailing(price);
 	}
 
 	private void TryCreateDemoEntry(ITickTradeMessage trade, decimal price)

--- a/API/2987_Renko_Chart/CS/RenkoChartStrategy.cs
+++ b/API/2987_Renko_Chart/CS/RenkoChartStrategy.cs
@@ -157,8 +157,7 @@ public class RenkoChartStrategy : Strategy
 
 	private void ProcessTrade(ITickTradeMessage trade)
 	{
-		if (trade.TradePrice is not decimal price)
-		return;
+		var price = trade.Price;
 
 		_lastSourcePrice = price;
 		_lastSourceUpdate = trade.ServerTime;

--- a/API/3028_Previous_Candle_Breakdown/CS/PreviousCandleBreakdownStrategy.cs
+++ b/API/3028_Previous_Candle_Breakdown/CS/PreviousCandleBreakdownStrategy.cs
@@ -272,10 +272,9 @@ public class PreviousCandleBreakdownStrategy : Strategy
 		EvaluateRisk(candle.ClosePrice);
 	}
 
-	private void ProcessTrade(ITickTradeMessage trade)
-	{
-		if (trade.TradePrice is not decimal price || price <= 0m)
-			return;
+		private void ProcessTrade(ITickTradeMessage trade)
+		{
+			var price = trade.Price;
 
 		_lastPrice = price;
 

--- a/API/3082_VR_Steals/CS/VrStealsStrategy.cs
+++ b/API/3082_VR_Steals/CS/VrStealsStrategy.cs
@@ -135,8 +135,7 @@ public class VrStealsStrategy : Strategy
 
 	private void ProcessTrade(ITickTradeMessage trade)
 	{
-		if (trade.TradePrice is not decimal price)
-			return;
+		var price = trade.Price;
 
 		if (Position > 0m)
 		{

--- a/API/3297_ITrade/CS/ITradeStrategy.cs
+++ b/API/3297_ITrade/CS/ITradeStrategy.cs
@@ -243,7 +243,9 @@ public class ITradeStrategy : Strategy
 
 	private void ProcessTrade(ITickTradeMessage trade)
 	{
-		if (trade.TradePrice is decimal price)
+		var price = trade.Price;
+
+		if (price > 0m)
 			_lastTradePrice = price;
 	}
 

--- a/API/3355_VirtPO_TestBed_Scalp/CS/VirtPoTestBedScalpStrategy.cs
+++ b/API/3355_VirtPO_TestBed_Scalp/CS/VirtPoTestBedScalpStrategy.cs
@@ -581,23 +581,21 @@ public class VirtPoTestBedScalpStrategy : Strategy
 			_lastAsk = askPrice;
 	}
 
-	private void ProcessTrade(ITickTradeMessage trade)
-	{
-		var price = trade.TradePrice;
-		if (price is null || price <= 0m)
+		private void ProcessTrade(ITickTradeMessage trade)
+		{
+			var price = trade.Price;
+
+			_lastTradePrice = price;
+
+			if (!TickLevel)
 			return;
 
-		_lastTradePrice = price.Value;
-
-		if (!TickLevel)
-			return;
-
-		var time = trade.ServerTime != default ? trade.ServerTime : trade.LocalTime;
-		if (time == default)
+			var time = trade.ServerTime != default ? trade.ServerTime : trade.LocalTime;
+			if (time == default)
 			time = CurrentTime;
 
-		EvaluatePendingOrders(time, price.Value);
-		UpdateRiskManagement(time, price.Value, price.Value, price.Value);
+			EvaluatePendingOrders(time, price);
+			UpdateRiskManagement(time, price, price, price);
 	}
 
 	private void ProcessCandle(
@@ -695,7 +693,7 @@ public class VirtPoTestBedScalpStrategy : Strategy
 
 		ExpireVirtualOrders(candle.CloseTime);
 
-		if (!TickLevel)
+			if (!TickLevel)
 		{
 			EvaluatePendingOrders(candle.CloseTime, candle.ClosePrice);
 		}

--- a/API/3375_OnTick_Multisymbol/CS/OnTickMultisymbolStrategy.cs
+++ b/API/3375_OnTick_Multisymbol/CS/OnTickMultisymbolStrategy.cs
@@ -134,8 +134,7 @@ public class OnTickMultisymbolStrategy : Strategy
 
 	private void OnTrade(Security security, ITickTradeMessage trade)
 	{
-		if (trade.TradePrice is not decimal price)
-			return;
+		var price = trade.Price;
 
 		var volume = trade.Volume ?? 0m;
 		var time = trade.ServerTime != default ? trade.ServerTime : trade.LocalTime;

--- a/API/3394_Virtual_Profit_Close/CS/VirtualProfitCloseStrategy.cs
+++ b/API/3394_Virtual_Profit_Close/CS/VirtualProfitCloseStrategy.cs
@@ -217,7 +217,7 @@ public class VirtualProfitCloseStrategy : Strategy
 
 	private void ProcessTrade(ITickTradeMessage trade)
 	{
-		var lastPrice = trade.TradePrice;
+		var lastPrice = trade.Price;
 		if (lastPrice is null)
 		return;
 

--- a/API/3474_Daily_Target/CS/DailyTargetStrategy.cs
+++ b/API/3474_Daily_Target/CS/DailyTargetStrategy.cs
@@ -133,9 +133,8 @@ public class DailyTargetStrategy : Strategy
 
 	private void ProcessTrade(ITickTradeMessage trade)
 	{
-		var price = trade.TradePrice;
-		if (price is decimal tradePrice)
-			_lastTradePrice = tradePrice;
+		var price = trade.Price;
+		_lastTradePrice = price;
 
 		EvaluateDailyThresholds();
 	}

--- a/API/3563_Simple_Order_Panel/CS/SimpleOrderPanelStrategy.cs
+++ b/API/3563_Simple_Order_Panel/CS/SimpleOrderPanelStrategy.cs
@@ -880,16 +880,15 @@ public class SimpleOrderPanelStrategy : Strategy
 		}
 
 		CheckPendingOrders();
-		CheckProtectiveLevels();
+			CheckProtectiveLevels();
 	}
 
-	private void ProcessTrade(ITickTradeMessage trade)
-	{
-		if (trade.TradePrice is decimal tradePrice)
+		private void ProcessTrade(ITickTradeMessage trade)
 		{
+			var tradePrice = trade.Price;
+
 			_lastTradePrice = tradePrice;
 			CheckProtectiveLevels();
-		}
 	}
 
 	private void CheckPendingOrders()

--- a/API/3591_Painel/CS/PainelStrategy.cs
+++ b/API/3591_Painel/CS/PainelStrategy.cs
@@ -78,10 +78,10 @@ public class PainelStrategy : Strategy
 	private void ProcessTrade(ITickTradeMessage trade)
 	{
 		// Store the price from the most recent trade to keep the panel accurate.
-		if (trade.TradePrice is decimal price)
-		{
+		var price = trade.Price;
+
+		if (price > 0m)
 			_lastPrice = price;
-		}
 	}
 
 	private void OnTimer(DateTimeOffset time)

--- a/API/3654_Trailing_Stop_When_SL_Used/CS/TrailingStopWhenSlUsedStrategy.cs
+++ b/API/3654_Trailing_Stop_When_SL_Used/CS/TrailingStopWhenSlUsedStrategy.cs
@@ -88,34 +88,32 @@ public class TrailingStopWhenSlUsedStrategy : Strategy
 			ResetTrailingState();
 	}
 
-	private void ProcessTrade(ITickTradeMessage trade)
-	{
-		var price = trade.TradePrice;
-		if (price == null || price.Value <= 0m)
-			return;
-
-		if (!IsFormedAndOnlineAndAllowTrading())
-			return;
-
-		var stepDistance = TrailingStepPoints * _priceStep;
-		if (stepDistance <= 0m)
-			return;
-
-		var entryPrice = PositionPrice;
-		if (entryPrice == null || entryPrice.Value <= 0m)
-			return;
-
-		var volume = Math.Abs(Position);
-		if (volume <= 0m)
-			return;
-
-		if (Position > 0m)
+		private void ProcessTrade(ITickTradeMessage trade)
 		{
-			ProcessLong(price.Value, entryPrice.Value, volume, stepDistance);
+			var price = trade.Price;
+
+			if (!IsFormedAndOnlineAndAllowTrading())
+			return;
+
+			var stepDistance = TrailingStepPoints * _priceStep;
+			if (stepDistance <= 0m)
+			return;
+
+			var entryPrice = PositionPrice;
+			if (entryPrice == null || entryPrice.Value <= 0m)
+			return;
+
+			var volume = Math.Abs(Position);
+			if (volume <= 0m)
+			return;
+
+			if (Position > 0m)
+		{
+			ProcessLong(price, entryPrice.Value, volume, stepDistance);
 		}
-		else if (Position < 0m)
+			else if (Position < 0m)
 		{
-			ProcessShort(price.Value, entryPrice.Value, volume, stepDistance);
+			ProcessShort(price, entryPrice.Value, volume, stepDistance);
 		}
 	}
 

--- a/API/3655_Trailing_StopLoss_All_Orders/CS/TrailingStopLossAllOrdersStrategy.cs
+++ b/API/3655_Trailing_StopLoss_All_Orders/CS/TrailingStopLossAllOrdersStrategy.cs
@@ -80,7 +80,7 @@ public class TrailingStopLossAllOrdersStrategy : Strategy
 		if (_pipSize <= 0m)
 			_pipSize = 1m;
 
-		RecalculateDistances();
+			RecalculateDistances();
 
 		SubscribeTicks()
 			.Bind(ProcessTrade)
@@ -96,30 +96,28 @@ public class TrailingStopLossAllOrdersStrategy : Strategy
 			ResetState();
 	}
 
-	private void ProcessTrade(ITickTradeMessage trade)
-	{
-		var price = trade.TradePrice;
-		if (price is null || price.Value <= 0m)
+		private void ProcessTrade(ITickTradeMessage trade)
+		{
+			var price = trade.Price;
+
+			if (!IsFormedAndOnlineAndAllowTrading())
 			return;
 
-		if (!IsFormedAndOnlineAndAllowTrading())
-			return;
+			var lastPrice = price;
 
-		var lastPrice = price.Value;
+			RecalculateDistances();
 
-		RecalculateDistances();
-
-		if (Position > 0 && PositionPrice is decimal entryPrice)
+			if (Position > 0 && PositionPrice is decimal entryPrice)
 		{
 			UpdateLongTrailing(entryPrice, lastPrice);
 		}
-		else if (Position < 0 && PositionPrice is decimal entryPriceShort)
+			else if (Position < 0 && PositionPrice is decimal entryPriceShort)
 		{
 			UpdateShortTrailing(entryPriceShort, lastPrice);
 		}
-		else
-		{
-			ResetState();
+			else
+			{
+				ResetState();
 		}
 	}
 

--- a/API/3663_Trailing_Close_Manager/CS/TrailingCloseManagerStrategy.cs
+++ b/API/3663_Trailing_Close_Manager/CS/TrailingCloseManagerStrategy.cs
@@ -254,13 +254,11 @@ public class TrailingCloseManagerStrategy : Strategy
 		UpdatePositionTargets();
 	}
 
-	private void ProcessTrade(ITickTradeMessage trade)
-	{
-		var price = trade.TradePrice;
-		if (price == null || price.Value <= 0m)
-			return;
+		private void ProcessTrade(ITickTradeMessage trade)
+		{
+			var price = trade.Price;
 
-		_lastTradePrice = price.Value;
+			_lastTradePrice = price;
 
 		if (!IsFormedAndOnlineAndAllowTrading())
 			return;
@@ -273,7 +271,7 @@ public class TrailingCloseManagerStrategy : Strategy
 		ProcessFloatingThresholds(time);
 		ProcessCloseRequests(time);
 
-		ManageTrailing(price.Value);
+		ManageTrailing(price);
 	}
 
 	private void ProcessManualButtons(DateTimeOffset time)

--- a/API/3710_RRSRandomness/CS/RrsRandomnessStrategy.cs
+++ b/API/3710_RRSRandomness/CS/RrsRandomnessStrategy.cs
@@ -262,8 +262,8 @@ public class RrsRandomnessStrategy : Strategy
 
 	private void ProcessTrade(ITickTradeMessage trade)
 	{
-		if (trade.TradePrice > 0m)
-			_lastTradePrice = trade.TradePrice;
+		if (trade.Price > 0m)
+			_lastTradePrice = trade.Price;
 	}
 
 	private void ProcessCandle(ICandleMessage candle)

--- a/API/3867_Equal_Volume_Range_Bars/CS/EqualVolumeRangeBarsStrategy.cs
+++ b/API/3867_Equal_Volume_Range_Bars/CS/EqualVolumeRangeBarsStrategy.cs
@@ -203,8 +203,7 @@ public class EqualVolumeRangeBarsStrategy : Strategy
 
 	private void ProcessTrade(ITickTradeMessage trade)
 	{
-		if (trade.TradePrice is not decimal price)
-			return;
+		var price = trade.Price;
 
 		var volume = trade.TradeVolume ?? 1m;
 		if (volume <= 0m)

--- a/API/3910_Elite_eFibo_Trader_v2_1/CS/EliteEfiboTraderV21Strategy.cs
+++ b/API/3910_Elite_eFibo_Trader_v2_1/CS/EliteEfiboTraderV21Strategy.cs
@@ -224,8 +224,7 @@ public class EliteEfiboTraderV21Strategy : Strategy
 
 	private void ProcessTrade(ITickTradeMessage trade)
 	{
-		if (trade.TradePrice is not decimal price)
-			return;
+		var price = trade.Price;
 
 		if (TradeAgainAfterProfit)
 			_allowTrading = true;

--- a/API/3980_EES_Hedger/CS/EesHedgerAdvancedStrategy.cs
+++ b/API/3980_EES_Hedger/CS/EesHedgerAdvancedStrategy.cs
@@ -237,13 +237,11 @@ public class EesHedgerAdvancedStrategy : Strategy
 			SellMarket(volume, comment: HedgerOrderComment);
 	}
 
-	private void ProcessTrade(ITickTradeMessage trade)
-	{
-		var price = trade.TradePrice;
-		if (price == null)
-			return;
+		private void ProcessTrade(ITickTradeMessage trade)
+		{
+			var price = trade.Price;
 
-		UpdateRiskManagement(price.Value);
+			UpdateRiskManagement(price);
 	}
 
 	private void RefreshProtection()

--- a/API/4063_Locker/CS/LockerStrategy.cs
+++ b/API/4063_Locker/CS/LockerStrategy.cs
@@ -112,13 +112,11 @@ public class LockerStrategy : Strategy
 		SubscribeTicks().Bind(ProcessTrade).Start();
 	}
 
-	private void ProcessTrade(ITickTradeMessage trade)
-	{
-		var price = trade.TradePrice ?? 0m;
-		if (price <= 0m)
-			return;
+		private void ProcessTrade(ITickTradeMessage trade)
+		{
+			var price = trade.Price;
 
-		_lastTradePrice = price;
+			_lastTradePrice = price;
 
 		if (_pipSize <= 0m)
 			UpdatePipSize();

--- a/API/4068_TrailingProfit/CS/TrailingProfitStrategy.cs
+++ b/API/4068_TrailingProfit/CS/TrailingProfitStrategy.cs
@@ -77,8 +77,7 @@ public class TrailingProfitStrategy : Strategy
 
 	private void ProcessTrade(ITickTradeMessage trade)
 	{
-		if (trade.TradePrice is not decimal price)
-			return;
+		var price = trade.Price;
 
 		if (Position == 0m || PositionPrice == 0m)
 		{

--- a/API/4124_Training_Simulator/CS/TrainingSimulatorStrategy.cs
+++ b/API/4124_Training_Simulator/CS/TrainingSimulatorStrategy.cs
@@ -342,8 +342,7 @@ public class TrainingSimulatorStrategy : Strategy
 
 	private void ProcessTrade(ITickTradeMessage trade)
 	{
-		if (trade.TradePrice is not decimal price)
-			return;
+		var price = trade.Price;
 
 		_lastTradePrice = price;
 

--- a/API/4148_Renko_Live_Chart/CS/RenkoLiveChartStrategy.cs
+++ b/API/4148_Renko_Live_Chart/CS/RenkoLiveChartStrategy.cs
@@ -231,9 +231,7 @@ public class RenkoLiveChartStrategy : Strategy
 
 	private void ProcessTrade(ITickTradeMessage trade)
 	{
-		if (trade.TradePrice is not decimal price)
-		// Skip trade messages that do not contain an actual price.
-		return;
+		var price = trade.Price;
 
 		var time = trade.ServerTime;
 		EnsureInitialized(price, time);

--- a/API/4165_Peak_Volume_Counter/CS/PeakVolumeCounterStrategy.cs
+++ b/API/4165_Peak_Volume_Counter/CS/PeakVolumeCounterStrategy.cs
@@ -75,13 +75,11 @@ public class PeakVolumeCounterStrategy : Strategy
 		_frameStartTime = null;
 	}
 
-	private void ProcessTrade(ITickTradeMessage trade)
-	{
-		// Fall back to the last known price when the feed omits a trade price.
-		var price = trade.TradePrice ?? _lastTradePrice;
-
-		if (trade.TradePrice is decimal tradePrice)
-			_lastTradePrice = tradePrice;
+		private void ProcessTrade(ITickTradeMessage trade)
+		{
+			// Remember the most recent trade price for diagnostics.
+			var price = trade.Price;
+			_lastTradePrice = price;
 
 		// MetaTrader counted ticks, so treat missing or zero volumes as a single unit.
 		var volumeIncrement = trade.Volume ?? 0m;


### PR DESCRIPTION
## Summary
- remove the zero/negative trade price checks in trade handlers so the strategies rely on the non-null ITickTradeMessage.Price value
- keep trailing and price-tracking helpers consistent by updating cached price storage and null-guarding own-trade handlers where necessary

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7dd3c7e7c832384e7c0f55fa76b9f