### PR TITLE
Add required usings to initial strategy set

### DIFF
--- a/API/0001_MA_CrossOver/CS/MaCrossoverStrategy.cs
+++ b/API/0001_MA_CrossOver/CS/MaCrossoverStrategy.cs
@@ -1,7 +1,12 @@
 namespace StockSharp.Samples.Strategies;
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0002_NDay_Breakout/CS/NdayBreakoutStrategy.cs
+++ b/API/0002_NDay_Breakout/CS/NdayBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0003_ADX_Trend/CS/AdxTrendStrategy.cs
+++ b/API/0003_ADX_Trend/CS/AdxTrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0004_Parabolic_SAR_Trend/CS/ParabolicSarTrendStrategy.cs
+++ b/API/0004_Parabolic_SAR_Trend/CS/ParabolicSarTrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0005_Donchian_Channel/CS/DonchianChannelStrategy.cs
+++ b/API/0005_Donchian_Channel/CS/DonchianChannelStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0006_Tripple_MA/CS/TripleMAStrategy.cs
+++ b/API/0006_Tripple_MA/CS/TripleMAStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0007_Keltner_Channel_Breakout/CS/KeltnerChannelBreakoutStrategy.cs
+++ b/API/0007_Keltner_Channel_Breakout/CS/KeltnerChannelBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0008_Hull_MA_Trend/CS/HullMaTrendStrategy.cs
+++ b/API/0008_Hull_MA_Trend/CS/HullMaTrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0009_MACD_Trend/CS/MacdTrendStrategy.cs
+++ b/API/0009_MACD_Trend/CS/MacdTrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0010_Super_Trend/CS/SupertrendStrategy.cs
+++ b/API/0010_Super_Trend/CS/SupertrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0011_Ichimoku_Kumo_Breakout/CS/IchimokuKumoBreakoutStrategy.cs
+++ b/API/0011_Ichimoku_Kumo_Breakout/CS/IchimokuKumoBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0012_Heikin_Ashi_Consecutive/CS/HeikinAshiConsecutiveStrategy.cs
+++ b/API/0012_Heikin_Ashi_Consecutive/CS/HeikinAshiConsecutiveStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0013_DMI_Power_Move/CS/DmiPowerMoveStrategy.cs
+++ b/API/0013_DMI_Power_Move/CS/DmiPowerMoveStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0014_TradingView_Supertrend_Flip/CS/TradingViewSupertrendFlipStrategy.cs
+++ b/API/0014_TradingView_Supertrend_Flip/CS/TradingViewSupertrendFlipStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0015_Gann_Swing_Breakout/CS/GannSwingBreakoutStrategy.cs
+++ b/API/0015_Gann_Swing_Breakout/CS/GannSwingBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0016_RSI_Divergence/CS/RsiDivergenceStrategy.cs
+++ b/API/0016_RSI_Divergence/CS/RsiDivergenceStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0017_Williams_R/CS/WilliamsPercentRStrategy.cs
+++ b/API/0017_Williams_R/CS/WilliamsPercentRStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0018_ROC_Impulce/CS/RocImpulseStrategy.cs
+++ b/API/0018_ROC_Impulce/CS/RocImpulseStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0019_CCI_Breakout/CS/CciBreakoutStrategy.cs
+++ b/API/0019_CCI_Breakout/CS/CciBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0020_Momentum_Percentage/CS/MomentumPercentageStrategy.cs
+++ b/API/0020_Momentum_Percentage/CS/MomentumPercentageStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0021_Bollinger_Squeeze/CS/BollingerSqueezeStrategy.cs
+++ b/API/0021_Bollinger_Squeeze/CS/BollingerSqueezeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0022_ADX_DI/CS/AdxDiStrategy.cs
+++ b/API/0022_ADX_DI/CS/AdxDiStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0023_Elder_Impulse/CS/ElderImpulseStrategy.cs
+++ b/API/0023_Elder_Impulse/CS/ElderImpulseStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0024_RSI_Laguerre/CS/LaguerreRsiStrategy.cs
+++ b/API/0024_RSI_Laguerre/CS/LaguerreRsiStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0025_Stochastic_RSI_Cross/CS/StochasticRsiCrossStrategy.cs
+++ b/API/0025_Stochastic_RSI_Cross/CS/StochasticRsiCrossStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0026_RSI_Reversion/CS/RsiReversionStrategy.cs
+++ b/API/0026_RSI_Reversion/CS/RsiReversionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0027_Bollinger_Reversion/CS/BollingerReversionStrategy.cs
+++ b/API/0027_Bollinger_Reversion/CS/BollingerReversionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0028_ZScore/CS/ZScoreStrategy.cs
+++ b/API/0028_ZScore/CS/ZScoreStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0029_MA_Deviation/CS/MADeviationStrategy.cs
+++ b/API/0029_MA_Deviation/CS/MADeviationStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0030_VWAP_Reversion/CS/VwapReversionStrategy.cs
+++ b/API/0030_VWAP_Reversion/CS/VwapReversionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0031_Keltner_Reversion/CS/KeltnerReversionStrategy.cs
+++ b/API/0031_Keltner_Reversion/CS/KeltnerReversionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0032_ATR_Reversion/CS/AtrReversionStrategy.cs
+++ b/API/0032_ATR_Reversion/CS/AtrReversionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0033_MACD_Zero/CS/MacdZeroStrategy.cs
+++ b/API/0033_MACD_Zero/CS/MacdZeroStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0034_Low_Vol_Reversion/CS/LowVolReversionStrategy.cs
+++ b/API/0034_Low_Vol_Reversion/CS/LowVolReversionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0035_Bollinger_B_Reversion/CS/BollingerPercentBStrategy.cs
+++ b/API/0035_Bollinger_B_Reversion/CS/BollingerPercentBStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0036_ATR_Expansion/CS/AtrExpansionStrategy.cs
+++ b/API/0036_ATR_Expansion/CS/AtrExpansionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0037_VIX_Trigger/CS/VixTriggerStrategy.cs
+++ b/API/0037_VIX_Trigger/CS/VixTriggerStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 using Ecng.ComponentModel;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0038_BB_Width/CS/BollingerBandWidthStrategy.cs
+++ b/API/0038_BB_Width/CS/BollingerBandWidthStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0039_HV_Breakout/CS/HvBreakoutStrategy.cs
+++ b/API/0039_HV_Breakout/CS/HvBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0040_ATR_Trailing/CS/AtrTrailingStrategy.cs
+++ b/API/0040_ATR_Trailing/CS/AtrTrailingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0041_Vol_Adjusted_MA/CS/VolAdjustedMaStrategy.cs
+++ b/API/0041_Vol_Adjusted_MA/CS/VolAdjustedMaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0042_IV_Spike/CS/IvSpikeStrategy.cs
+++ b/API/0042_IV_Spike/CS/IvSpikeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0043_VCP/CS/VcpStrategy.cs
+++ b/API/0043_VCP/CS/VcpStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0044_ATR_Range/CS/AtrRangeStrategy.cs
+++ b/API/0044_ATR_Range/CS/AtrRangeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0045_Choppiness_Index_Breakout/CS/ChoppinessIndexBreakoutStrategy.cs
+++ b/API/0045_Choppiness_Index_Breakout/CS/ChoppinessIndexBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0046_Volume_Spike/CS/VolumeSpikeStrategy.cs
+++ b/API/0046_Volume_Spike/CS/VolumeSpikeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0047_OBV_Breakout/CS/ObvBreakoutStrategy.cs
+++ b/API/0047_OBV_Breakout/CS/ObvBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0048_VWAP_Breakout/CS/VWAPBreakoutStrategy.cs
+++ b/API/0048_VWAP_Breakout/CS/VWAPBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0049_VWMA/CS/VWMAStrategy.cs
+++ b/API/0049_VWMA/CS/VWMAStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0050_AD/CS/ADStrategy.cs
+++ b/API/0050_AD/CS/ADStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;


### PR DESCRIPTION
## Summary
- add the standard System, Ecng, and StockSharp using directives to the C# strategies in API folders 0001-0050

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8063669c88323a4f4b7e1592635d8