### PR TITLE
Ensure API strategies 0051-0200 include shared using directives

### DIFF
--- a/API/0051_Volume_Weighted_Price_Breakout/CS/VolumeWeightedPriceBreakoutStrategy.cs
+++ b/API/0051_Volume_Weighted_Price_Breakout/CS/VolumeWeightedPriceBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0052_Volume_Divergence/CS/VolumeDivergenceStrategy.cs
+++ b/API/0052_Volume_Divergence/CS/VolumeDivergenceStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0053_Volume_MA_Cross/CS/VolumeMAXrossStrategy.cs
+++ b/API/0053_Volume_MA_Cross/CS/VolumeMAXrossStrategy.cs
@@ -1,9 +1,15 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
-using System;
-using System.Collections.Generic;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0054_Cumulative_Delta_Breakout/CS/CumulativeDeltaBreakoutStrategy.cs
+++ b/API/0054_Cumulative_Delta_Breakout/CS/CumulativeDeltaBreakoutStrategy.cs
@@ -1,6 +1,10 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0055_Volume_Surge/CS/VolumeSurgeStrategy.cs
+++ b/API/0055_Volume_Surge/CS/VolumeSurgeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0056_Double_Bottom/CS/DoubleBottomStrategy.cs
+++ b/API/0056_Double_Bottom/CS/DoubleBottomStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0057_Double_Top/CS/DoubleTopStrategy.cs
+++ b/API/0057_Double_Top/CS/DoubleTopStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0058_RSI_Overbought_Oversold/CS/RsiOverboughtOversoldStrategy.cs
+++ b/API/0058_RSI_Overbought_Oversold/CS/RsiOverboughtOversoldStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0059_Hammer_Candle/CS/HammerCandleStrategy.cs
+++ b/API/0059_Hammer_Candle/CS/HammerCandleStrategy.cs
@@ -1,9 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using StockSharp.Algo;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0060_Shooting_Star/CS/ShootingStarStrategy.cs
+++ b/API/0060_Shooting_Star/CS/ShootingStarStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0061_MACD_Divergence/CS/MacdDivergenceStrategy.cs
+++ b/API/0061_MACD_Divergence/CS/MacdDivergenceStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0062_Stochastic_Overbought_Oversold/CS/StochasticOverboughtOversoldStrategy.cs
+++ b/API/0062_Stochastic_Overbought_Oversold/CS/StochasticOverboughtOversoldStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0063_Engulfing_Bullish/CS/EngulfingBullishStrategy.cs
+++ b/API/0063_Engulfing_Bullish/CS/EngulfingBullishStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0064_Engulfing_Bearish/CS/EngulfingBearishStrategy.cs
+++ b/API/0064_Engulfing_Bearish/CS/EngulfingBearishStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0065_Pinbar_Reversal/CS/PinbarReversalStrategy.cs
+++ b/API/0065_Pinbar_Reversal/CS/PinbarReversalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0066_Three_Bar_Reversal_Up/CS/ThreeBarReversalUpStrategy.cs
+++ b/API/0066_Three_Bar_Reversal_Up/CS/ThreeBarReversalUpStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0067_Three_Bar_Reversal_Down/CS/ThreeBarReversalDownStrategy.cs
+++ b/API/0067_Three_Bar_Reversal_Down/CS/ThreeBarReversalDownStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0068_CCI_Divergence/CS/CciDivergenceStrategy.cs
+++ b/API/0068_CCI_Divergence/CS/CciDivergenceStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0069_Bollinger_Band_Reversal/CS/BollingerBandReversalStrategy.cs
+++ b/API/0069_Bollinger_Band_Reversal/CS/BollingerBandReversalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0070_Morning_Star/CS/MorningStarStrategy.cs
+++ b/API/0070_Morning_Star/CS/MorningStarStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0071_Evening_Star/CS/EveningStarStrategy.cs
+++ b/API/0071_Evening_Star/CS/EveningStarStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0072_Doji_Reversal/CS/DojiReversalStrategy.cs
+++ b/API/0072_Doji_Reversal/CS/DojiReversalStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0073_Keltner_Channel_Reversal/CS/KeltnerChannelReversalStrategy.cs
+++ b/API/0073_Keltner_Channel_Reversal/CS/KeltnerChannelReversalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0074_Williams_R_Divergence/CS/WilliamsPercentRDivergenceStrategy.cs
+++ b/API/0074_Williams_R_Divergence/CS/WilliamsPercentRDivergenceStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0075_OBV_Divergence/CS/ObvDivergenceStrategy.cs
+++ b/API/0075_OBV_Divergence/CS/ObvDivergenceStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0076_Fibonacci_Retracement_Reversal/CS/FibonacciRetracementReversalStrategy.cs
+++ b/API/0076_Fibonacci_Retracement_Reversal/CS/FibonacciRetracementReversalStrategy.cs
@@ -1,7 +1,12 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0077_Inside_Bar_Breakout/CS/InsideBarBreakoutStrategy.cs
+++ b/API/0077_Inside_Bar_Breakout/CS/InsideBarBreakoutStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0078_Outside_Bar_Reversal/CS/OutsideBarReversalStrategy.cs
+++ b/API/0078_Outside_Bar_Reversal/CS/OutsideBarReversalStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0079_Trendline_Bounce/CS/TrendlineBounceStrategy.cs
+++ b/API/0079_Trendline_Bounce/CS/TrendlineBounceStrategy.cs
@@ -1,6 +1,10 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0080_Pivot_Point_Reversal/CS/PivotPointReversalStrategy.cs
+++ b/API/0080_Pivot_Point_Reversal/CS/PivotPointReversalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0081_VWAP_Bounce/CS/VwapBounceStrategy.cs
+++ b/API/0081_VWAP_Bounce/CS/VwapBounceStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0082_Volume_Exhaustion/CS/VolumeExhaustionStrategy.cs
+++ b/API/0082_Volume_Exhaustion/CS/VolumeExhaustionStrategy.cs
@@ -1,9 +1,15 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
-using System;
-using System.Collections.Generic;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0083_ADX_Weakening/CS/AdxWeakeningStrategy.cs
+++ b/API/0083_ADX_Weakening/CS/AdxWeakeningStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0084_ATR_Exhaustion/CS/AtrExhaustionStrategy.cs
+++ b/API/0084_ATR_Exhaustion/CS/AtrExhaustionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0085_Ichimoku_Tenkan/CS/IchimokuTenkanKijunStrategy.cs
+++ b/API/0085_Ichimoku_Tenkan/CS/IchimokuTenkanKijunStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0086_Heikin_Ashi_Reversal/CS/HeikinAshiReversalStrategy.cs
+++ b/API/0086_Heikin_Ashi_Reversal/CS/HeikinAshiReversalStrategy.cs
@@ -1,9 +1,16 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
 using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/0087_Parabolic_SAR_Reversal/CS/ParabolicSarReversalStrategy.cs
+++ b/API/0087_Parabolic_SAR_Reversal/CS/ParabolicSarReversalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0088_Supertrend_Reversal/CS/SupertrendReversalStrategy.cs
+++ b/API/0088_Supertrend_Reversal/CS/SupertrendReversalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0089_Hull_MA_Reversal/CS/HullMaReversalStrategy.cs
+++ b/API/0089_Hull_MA_Reversal/CS/HullMaReversalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0090_Donchian_Reversal/CS/DonchianReversalStrategy.cs
+++ b/API/0090_Donchian_Reversal/CS/DonchianReversalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0091_MACD_Histogram_Reversal/CS/MacdHistogramReversalStrategy.cs
+++ b/API/0091_MACD_Histogram_Reversal/CS/MacdHistogramReversalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0092_RSI_Hook_Reversal/CS/RsiHookReversalStrategy.cs
+++ b/API/0092_RSI_Hook_Reversal/CS/RsiHookReversalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0093_Stochastic_Hook_Reversal/CS/StochasticHookReversalStrategy.cs
+++ b/API/0093_Stochastic_Hook_Reversal/CS/StochasticHookReversalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0094_CCI_Hook_Reversal/CS/CciHookReversalStrategy.cs
+++ b/API/0094_CCI_Hook_Reversal/CS/CciHookReversalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0095_Williams_R_Hook_Reversal/CS/WilliamsRHookReversalStrategy.cs
+++ b/API/0095_Williams_R_Hook_Reversal/CS/WilliamsRHookReversalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0096_Three_White_Soldiers/CS/ThreeWhiteSoldiersStrategy.cs
+++ b/API/0096_Three_White_Soldiers/CS/ThreeWhiteSoldiersStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0097_Three_Black_Crows/CS/ThreeBlackCrowsStrategy.cs
+++ b/API/0097_Three_Black_Crows/CS/ThreeBlackCrowsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0098_Gap_Fill_Reversal/CS/GapFillReversalStrategy.cs
+++ b/API/0098_Gap_Fill_Reversal/CS/GapFillReversalStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0099_Tweezer_Bottom/CS/TweezerBottomStrategy.cs
+++ b/API/0099_Tweezer_Bottom/CS/TweezerBottomStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0100_Tweezer_Top/CS/TweezerTopStrategy.cs
+++ b/API/0100_Tweezer_Top/CS/TweezerTopStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0101_Harami_Bullish/CS/HaramiBullishStrategy.cs
+++ b/API/0101_Harami_Bullish/CS/HaramiBullishStrategy.cs
@@ -1,11 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
 using Ecng.Common;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0102_Harami_Bearish/CS/HaramiBearishStrategy.cs
+++ b/API/0102_Harami_Bearish/CS/HaramiBearishStrategy.cs
@@ -1,11 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
 using Ecng.Common;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0103_Dark_Pool_Prints/CS/DarkPoolPrintsStrategy.cs
+++ b/API/0103_Dark_Pool_Prints/CS/DarkPoolPrintsStrategy.cs
@@ -1,11 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0104_Rejection_Candle/CS/RejectionCandleStrategy.cs
+++ b/API/0104_Rejection_Candle/CS/RejectionCandleStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
 using Ecng.Common;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0105_False_Breakout_Trap/CS/FalseBreakoutTrapStrategy.cs
+++ b/API/0105_False_Breakout_Trap/CS/FalseBreakoutTrapStrategy.cs
@@ -1,11 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0106_Spring_Reversal/CS/SpringReversalStrategy.cs
+++ b/API/0106_Spring_Reversal/CS/SpringReversalStrategy.cs
@@ -1,11 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0107_Upthrust_Reversal/CS/UpthrustReversalStrategy.cs
+++ b/API/0107_Upthrust_Reversal/CS/UpthrustReversalStrategy.cs
@@ -1,11 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0108_Wyckoff_Accumulation/CS/WyckoffAccumulationStrategy.cs
+++ b/API/0108_Wyckoff_Accumulation/CS/WyckoffAccumulationStrategy.cs
@@ -1,11 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0109_Wyckoff_Distribution/CS/WyckoffDistributionStrategy.cs
+++ b/API/0109_Wyckoff_Distribution/CS/WyckoffDistributionStrategy.cs
@@ -1,11 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0110_RSI_Failure_Swing/CS/RsiFailureSwingStrategy.cs
+++ b/API/0110_RSI_Failure_Swing/CS/RsiFailureSwingStrategy.cs
@@ -1,11 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0111_Stochastic_Failure_Swing/CS/StochasticFailureSwingStrategy.cs
+++ b/API/0111_Stochastic_Failure_Swing/CS/StochasticFailureSwingStrategy.cs
@@ -1,11 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0112_CCI_Failure_Swing/CS/CciFailureSwingStrategy.cs
+++ b/API/0112_CCI_Failure_Swing/CS/CciFailureSwingStrategy.cs
@@ -1,11 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0113_Bullish_Abandoned_Baby/CS/BullishAbandonedBabyStrategy.cs
+++ b/API/0113_Bullish_Abandoned_Baby/CS/BullishAbandonedBabyStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0114_Bearish_Abandoned_Baby/CS/BearishAbandonedBabyStrategy.cs
+++ b/API/0114_Bearish_Abandoned_Baby/CS/BearishAbandonedBabyStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0115_Volume_Climax_Reversal/CS/VolumeClimaxReversalStrategy.cs
+++ b/API/0115_Volume_Climax_Reversal/CS/VolumeClimaxReversalStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0116_Day_of_Week/CS/DayOfWeekStrategy.cs
+++ b/API/0116_Day_of_Week/CS/DayOfWeekStrategy.cs
@@ -1,8 +1,13 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 

--- a/API/0117_Month_of_Year/CS/MonthOfYearStrategy.cs
+++ b/API/0117_Month_of_Year/CS/MonthOfYearStrategy.cs
@@ -1,8 +1,13 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 

--- a/API/0118_Turnaround_Tuesday/CS/TurnaroundTuesdayStrategy.cs
+++ b/API/0118_Turnaround_Tuesday/CS/TurnaroundTuesdayStrategy.cs
@@ -1,8 +1,13 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 

--- a/API/0119_End_of_Month_Strength/CS/EndOfMonthStrengthStrategy.cs
+++ b/API/0119_End_of_Month_Strength/CS/EndOfMonthStrengthStrategy.cs
@@ -1,8 +1,13 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 

--- a/API/0120_First_Day_of_Month/CS/FirstDayOfMonthStrategy.cs
+++ b/API/0120_First_Day_of_Month/CS/FirstDayOfMonthStrategy.cs
@@ -1,8 +1,13 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 

--- a/API/0121_Santa_Claus_Rally/CS/SantaClausRallyStrategy.cs
+++ b/API/0121_Santa_Claus_Rally/CS/SantaClausRallyStrategy.cs
@@ -1,8 +1,13 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 

--- a/API/0122_January_Effect/CS/JanuaryEffectStrategy.cs
+++ b/API/0122_January_Effect/CS/JanuaryEffectStrategy.cs
@@ -1,8 +1,13 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 

--- a/API/0123_Monday_Weakness/CS/MondayWeaknessStrategy.cs
+++ b/API/0123_Monday_Weakness/CS/MondayWeaknessStrategy.cs
@@ -1,8 +1,13 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 

--- a/API/0124_Pre-Holiday_Strength/CS/PreHolidayStrengthStrategy.cs
+++ b/API/0124_Pre-Holiday_Strength/CS/PreHolidayStrengthStrategy.cs
@@ -1,8 +1,13 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 

--- a/API/0125_Post-Holiday_Weakness/CS/PostHolidayWeaknessStrategy.cs
+++ b/API/0125_Post-Holiday_Weakness/CS/PostHolidayWeaknessStrategy.cs
@@ -1,8 +1,13 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 

--- a/API/0126_Quarterly_Expiry/CS/QuarterlyExpiryStrategy.cs
+++ b/API/0126_Quarterly_Expiry/CS/QuarterlyExpiryStrategy.cs
@@ -1,8 +1,13 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 

--- a/API/0127_Open_Drive/CS/OpenDriveStrategy.cs
+++ b/API/0127_Open_Drive/CS/OpenDriveStrategy.cs
@@ -1,8 +1,13 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 

--- a/API/0128_Midday_Reversal/CS/MiddayReversalStrategy.cs
+++ b/API/0128_Midday_Reversal/CS/MiddayReversalStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0129_Overnight_Gap/CS/OvernightGapStrategy.cs
+++ b/API/0129_Overnight_Gap/CS/OvernightGapStrategy.cs
@@ -1,8 +1,13 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 

--- a/API/0130_Lunch_Break_Fade/CS/LunchBreakFadeStrategy.cs
+++ b/API/0130_Lunch_Break_Fade/CS/LunchBreakFadeStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0131_MACD_RSI/CS/MacdRsiStrategy.cs
+++ b/API/0131_MACD_RSI/CS/MacdRsiStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0132_Bollinger_Stochastic/CS/BollingerStochasticStrategy.cs
+++ b/API/0132_Bollinger_Stochastic/CS/BollingerStochasticStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0133_MA_Volume/CS/MaVolumeStrategy.cs
+++ b/API/0133_MA_Volume/CS/MaVolumeStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0134_ADX_MACD/CS/AdxMacdStrategy.cs
+++ b/API/0134_ADX_MACD/CS/AdxMacdStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0135_Ichimoku_RSI/CS/IchimokuRsiStrategy.cs
+++ b/API/0135_Ichimoku_RSI/CS/IchimokuRsiStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0136_Supertrend_Volume/CS/SupertrendVolumeStrategy.cs
+++ b/API/0136_Supertrend_Volume/CS/SupertrendVolumeStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0137_Bollinger_RSI/CS/BollingerRsiStrategy.cs
+++ b/API/0137_Bollinger_RSI/CS/BollingerRsiStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0138_MA_Stochastic/CS/MaStochasticStrategy.cs
+++ b/API/0138_MA_Stochastic/CS/MaStochasticStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0139_ATR_MACD/CS/AtrMacdStrategy.cs
+++ b/API/0139_ATR_MACD/CS/AtrMacdStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0140_VWAP_RSI/CS/VwapRsiStrategy.cs
+++ b/API/0140_VWAP_RSI/CS/VwapRsiStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0141_Donchian_Volume/CS/DonchianVolumeStrategy.cs
+++ b/API/0141_Donchian_Volume/CS/DonchianVolumeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0142_Keltner_Stochastic/CS/KeltnerStochasticStrategy.cs
+++ b/API/0142_Keltner_Stochastic/CS/KeltnerStochasticStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0143_Parabolic_SAR_RSI/CS/ParabolicSarRsiStrategy.cs
+++ b/API/0143_Parabolic_SAR_RSI/CS/ParabolicSarRsiStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0144_Hull_MA_Volume/CS/HullMaVolumeStrategy.cs
+++ b/API/0144_Hull_MA_Volume/CS/HullMaVolumeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0145_ADX_Stochastic/CS/AdxStochasticStrategy.cs
+++ b/API/0145_ADX_Stochastic/CS/AdxStochasticStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0146_MACD_Volume/CS/MacdVolumeStrategy.cs
+++ b/API/0146_MACD_Volume/CS/MacdVolumeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0147_Bollinger_Volume/CS/BollingerVolumeStrategy.cs
+++ b/API/0147_Bollinger_Volume/CS/BollingerVolumeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0148_RSI_Stochastic/CS/RsiStochasticStrategy.cs
+++ b/API/0148_RSI_Stochastic/CS/RsiStochasticStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0149_MA_ADX/CS/MaAdxStrategy.cs
+++ b/API/0149_MA_ADX/CS/MaAdxStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0150_VWAP_Stochastic/CS/VwapStochasticStrategy.cs
+++ b/API/0150_VWAP_Stochastic/CS/VwapStochasticStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0151_Ichimoku_Volume/CS/IchimokuVolumeStrategy.cs
+++ b/API/0151_Ichimoku_Volume/CS/IchimokuVolumeStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0152_Supertrend_RSI/CS/SupertrendRsiStrategy.cs
+++ b/API/0152_Supertrend_RSI/CS/SupertrendRsiStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0153_Bollinger_ADX/CS/BollingerAdxStrategy.cs
+++ b/API/0153_Bollinger_ADX/CS/BollingerAdxStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0154_MA_CCI/CS/MaCciStrategy.cs
+++ b/API/0154_MA_CCI/CS/MaCciStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0155_VWAP_Volume/CS/VwapVolumeStrategy.cs
+++ b/API/0155_VWAP_Volume/CS/VwapVolumeStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0156_Donchian_RSI/CS/DonchianRsiStrategy.cs
+++ b/API/0156_Donchian_RSI/CS/DonchianRsiStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0157_Keltner_Volume/CS/KeltnerVolumeStrategy.cs
+++ b/API/0157_Keltner_Volume/CS/KeltnerVolumeStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0158_Parabolic_SAR_Stochastic/CS/ParabolicSarStochasticStrategy.cs
+++ b/API/0158_Parabolic_SAR_Stochastic/CS/ParabolicSarStochasticStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0159_Hull_MA_RSI/CS/HullMaRsiStrategy.cs
+++ b/API/0159_Hull_MA_RSI/CS/HullMaRsiStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0160_ADX_Volume/CS/AdxVolumeStrategy.cs
+++ b/API/0160_ADX_Volume/CS/AdxVolumeStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0161_MACD_CCI/CS/MacdCciStrategy.cs
+++ b/API/0161_MACD_CCI/CS/MacdCciStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0162_Bollinger_CCI/CS/BollingerCciStrategy.cs
+++ b/API/0162_Bollinger_CCI/CS/BollingerCciStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0163_RSI_Williams_R/CS/RsiWilliamsRStrategy.cs
+++ b/API/0163_RSI_Williams_R/CS/RsiWilliamsRStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0164_MA_Williams_R/CS/MaWilliamsRStrategy.cs
+++ b/API/0164_MA_Williams_R/CS/MaWilliamsRStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0165_VWAP_CCI/CS/VwapCciStrategy.cs
+++ b/API/0165_VWAP_CCI/CS/VwapCciStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0166_Donchian_Stochastic/CS/DonchianStochasticStrategy.cs
+++ b/API/0166_Donchian_Stochastic/CS/DonchianStochasticStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0167_Keltner_RSI/CS/KeltnerRsiStrategy.cs
+++ b/API/0167_Keltner_RSI/CS/KeltnerRsiStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0169_Hull_MA_Stochastic/CS/HullMaStochasticStrategy.cs
+++ b/API/0169_Hull_MA_Stochastic/CS/HullMaStochasticStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0170_ADX_CCI/CS/AdxCciStrategy.cs
+++ b/API/0170_ADX_CCI/CS/AdxCciStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0171_MACD_Williams_R/CS/MacdWilliamsRStrategy.cs
+++ b/API/0171_MACD_Williams_R/CS/MacdWilliamsRStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0172_Bollinger_Williams_R/CS/BollingerWilliamsRStrategy.cs
+++ b/API/0172_Bollinger_Williams_R/CS/BollingerWilliamsRStrategy.cs
@@ -1,10 +1,15 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
 using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
-using System;
-using System.Collections.Generic;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0174_MACD_VWAP/CS/MacdVwapStrategy.cs
+++ b/API/0174_MACD_VWAP/CS/MacdVwapStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0175_RSI_Supertrend/CS/RsiSupertrendStrategy.cs
+++ b/API/0175_RSI_Supertrend/CS/RsiSupertrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0176_ADX_Bollinger/CS/AdxBollingerStrategy.cs
+++ b/API/0176_ADX_Bollinger/CS/AdxBollingerStrategy.cs
@@ -1,10 +1,15 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
 using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
-using System;
-using System.Collections.Generic;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0177_Ichimoku_Stochastic/CS/IchimokuStochasticStrategy.cs
+++ b/API/0177_Ichimoku_Stochastic/CS/IchimokuStochasticStrategy.cs
@@ -1,10 +1,15 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
 using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
-using System;
-using System.Collections.Generic;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0185_Supertrend_Stochastic/CS/SupertrendStochasticStrategy.cs
+++ b/API/0185_Supertrend_Stochastic/CS/SupertrendStochasticStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0187_Donchian_MACD/CS/DonchianMacdStrategy.cs
+++ b/API/0187_Donchian_MACD/CS/DonchianMacdStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
-using StockSharp.Algo.Candles;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0188_Parabolic_SAR_Volume/CS/ParabolicSarVolumeStrategy.cs
+++ b/API/0188_Parabolic_SAR_Volume/CS/ParabolicSarVolumeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0190_VWAP_ADX/CS/VwapAdxStrategy.cs
+++ b/API/0190_VWAP_ADX/CS/VwapAdxStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0193_Supertrend_ADX/CS/SupertrendAdxStrategy.cs
+++ b/API/0193_Supertrend_ADX/CS/SupertrendAdxStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0194_Keltner_MACD/CS/KeltnerMacdStrategy.cs
+++ b/API/0194_Keltner_MACD/CS/KeltnerMacdStrategy.cs
@@ -1,11 +1,18 @@
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
-using System;
-using System.Collections.Generic;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0197_Hull_MA_ADX/CS/HullMaAdxStrategy.cs
+++ b/API/0197_Hull_MA_ADX/CS/HullMaAdxStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0198_VWAP_MACD/CS/VwapMacdStrategy.cs
+++ b/API/0198_VWAP_MACD/CS/VwapMacdStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0200_Ichimoku_ADX/CS/IchimokuAdxStrategy.cs
+++ b/API/0200_Ichimoku_ADX/CS/IchimokuAdxStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;


### PR DESCRIPTION
## Summary
- add the shared using directives block to every API C# strategy from 0051 through 0200 to align dependencies

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d807ae174c83238ae86bda68f6d784