### PR TITLE
Add common using directives to strategies 0201-0500

### DIFF
--- a/API/0201_VWAP_Williams_R/CS/VwapWilliamsRStrategy.cs
+++ b/API/0201_VWAP_Williams_R/CS/VwapWilliamsRStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0202_Donchian_CCI/CS/DonchianCciStrategy.cs
+++ b/API/0202_Donchian_CCI/CS/DonchianCciStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0203_Keltner_Williams_R/CS/KeltnerWilliamsRStrategy.cs
+++ b/API/0203_Keltner_Williams_R/CS/KeltnerWilliamsRStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0204_Parabolic_SAR_CCI/CS/ParabolicSarCciStrategy.cs
+++ b/API/0204_Parabolic_SAR_CCI/CS/ParabolicSarCciStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0205_Hull_MA_CCI/CS/HullMaCciStrategy.cs
+++ b/API/0205_Hull_MA_CCI/CS/HullMaCciStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0206_MACD_Bollinger/CS/MacdBollingerStrategy.cs
+++ b/API/0206_MACD_Bollinger/CS/MacdBollingerStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0207_RSI_Hull_MA/CS/RsiHullMaStrategy.cs
+++ b/API/0207_RSI_Hull_MA/CS/RsiHullMaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0208_Stochastic_Keltner/CS/StochasticKeltnerStrategy.cs
+++ b/API/0208_Stochastic_Keltner/CS/StochasticKeltnerStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0209_Volume_Supertrend/CS/VolumeSupertrendStrategy.cs
+++ b/API/0209_Volume_Supertrend/CS/VolumeSupertrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0210_ADX_Donchian/CS/AdxDonchianStrategy.cs
+++ b/API/0210_ADX_Donchian/CS/AdxDonchianStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0211_CCI_VWAP/CS/CciVwapStrategy.cs
+++ b/API/0211_CCI_VWAP/CS/CciVwapStrategy.cs
@@ -1,6 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using StockSharp.Algo;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0212_Williams_R_Ichimoku/CS/WilliamsIchimokuStrategy.cs
+++ b/API/0212_Williams_R_Ichimoku/CS/WilliamsIchimokuStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0213_MA_Parabolic_SAR/CS/MaParabolicSarStrategy.cs
+++ b/API/0213_MA_Parabolic_SAR/CS/MaParabolicSarStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0214_Bollinger_Supertrend/CS/BollingerSupertrendStrategy.cs
+++ b/API/0214_Bollinger_Supertrend/CS/BollingerSupertrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0215_RSI_Donchian/CS/RsiDonchianStrategy.cs
+++ b/API/0215_RSI_Donchian/CS/RsiDonchianStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0216_Mean_Reversion/CS/MeanReversionStrategy.cs
+++ b/API/0216_Mean_Reversion/CS/MeanReversionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0217_Pairs_Trading/CS/PairsTradingStrategy.cs
+++ b/API/0217_Pairs_Trading/CS/PairsTradingStrategy.cs
@@ -1,6 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using Ecng.ComponentModel;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0218_ZScore_Reversal/CS/ZScoreReversalStrategy.cs
+++ b/API/0218_ZScore_Reversal/CS/ZScoreReversalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0219_Statistical_Arbitrage/CS/StatisticalArbitrageStrategy.cs
+++ b/API/0219_Statistical_Arbitrage/CS/StatisticalArbitrageStrategy.cs
@@ -1,6 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using Ecng.ComponentModel;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0220_Volatility_Breakout/CS/VolatilityBreakoutStrategy.cs
+++ b/API/0220_Volatility_Breakout/CS/VolatilityBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0221_Bollinger_Band_Squeeze/CS/BollingerBandSqueezeStrategy.cs
+++ b/API/0221_Bollinger_Band_Squeeze/CS/BollingerBandSqueezeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0222_Cointegration_Pairs/CS/CointegrationPairsStrategy.cs
+++ b/API/0222_Cointegration_Pairs/CS/CointegrationPairsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0223_Momentum_Divergence/CS/MomentumDivergenceStrategy.cs
+++ b/API/0223_Momentum_Divergence/CS/MomentumDivergenceStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0224_ATR_Mean_Reversion/CS/AtrMeanReversionStrategy.cs
+++ b/API/0224_ATR_Mean_Reversion/CS/AtrMeanReversionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0225_Kalman_Filter_Trend/CS/KalmanFilterTrendStrategy.cs
+++ b/API/0225_Kalman_Filter_Trend/CS/KalmanFilterTrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0226_Volatility_Adjusted_Mean_Reversion/CS/VolatilityAdjustedMeanReversionStrategy.cs
+++ b/API/0226_Volatility_Adjusted_Mean_Reversion/CS/VolatilityAdjustedMeanReversionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0227_Hurst_Exponent_Trend/CS/HurstExponentTrendStrategy.cs
+++ b/API/0227_Hurst_Exponent_Trend/CS/HurstExponentTrendStrategy.cs
@@ -1,6 +1,10 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0228_Hurst_Exponent_Reversion/CS/HurstExponentReversionStrategy.cs
+++ b/API/0228_Hurst_Exponent_Reversion/CS/HurstExponentReversionStrategy.cs
@@ -1,10 +1,15 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0229_Autocorrelation_Reversal/CS/AutocorrelationReversionStrategy.cs
+++ b/API/0229_Autocorrelation_Reversal/CS/AutocorrelationReversionStrategy.cs
@@ -1,11 +1,15 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0230_Delta_Neutral_Arbitrage/CS/DeltaNeutralArbitrageStrategy.cs
+++ b/API/0230_Delta_Neutral_Arbitrage/CS/DeltaNeutralArbitrageStrategy.cs
@@ -1,10 +1,15 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0231_Volatility_Skew_Arbitrage/CS/VolatilitySkewArbitrageStrategy.cs
+++ b/API/0231_Volatility_Skew_Arbitrage/CS/VolatilitySkewArbitrageStrategy.cs
@@ -1,6 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using StockSharp.Algo;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0232_Correlation_Breakout/CS/CorrelationBreakoutStrategy.cs
+++ b/API/0232_Correlation_Breakout/CS/CorrelationBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0233_Beta_Neutral_Arbitrage/CS/BetaNeutralArbitrageStrategy.cs
+++ b/API/0233_Beta_Neutral_Arbitrage/CS/BetaNeutralArbitrageStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0235_VWAP_Mean_Reversion/CS/VwapMeanReversionStrategy.cs
+++ b/API/0235_VWAP_Mean_Reversion/CS/VwapMeanReversionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0236_RSI_Mean_Reversion/CS/RsiMeanReversionStrategy.cs
+++ b/API/0236_RSI_Mean_Reversion/CS/RsiMeanReversionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0237_Stochastic_Mean_Reversion/CS/StochasticMeanReversionStrategy.cs
+++ b/API/0237_Stochastic_Mean_Reversion/CS/StochasticMeanReversionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0244_OBV_Mean_Reversion/CS/ObvMeanReversionStrategy.cs
+++ b/API/0244_OBV_Mean_Reversion/CS/ObvMeanReversionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0245_Momentum_Breakout/CS/MomentumBreakoutStrategy.cs
+++ b/API/0245_Momentum_Breakout/CS/MomentumBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0247_RSI_Breakout/CS/RsiBreakoutStrategy.cs
+++ b/API/0247_RSI_Breakout/CS/RsiBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0248_Stochastic_Breakout/CS/StochasticBreakoutStrategy.cs
+++ b/API/0248_Stochastic_Breakout/CS/StochasticBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0250_Williams_R_Breakout/CS/WilliamsRBreakoutStrategy.cs
+++ b/API/0250_Williams_R_Breakout/CS/WilliamsRBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0251_MACD_Breakout/CS/MacdBreakoutStrategy.cs
+++ b/API/0251_MACD_Breakout/CS/MacdBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0252_ADX_Breakout/CS/ADXBreakoutStrategy.cs
+++ b/API/0252_ADX_Breakout/CS/ADXBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0254_Volume_Breakout/CS/VolumeBreakoutStrategy.cs
+++ b/API/0254_Volume_Breakout/CS/VolumeBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0256_Bollinger_Band_Width_Breakout/CS/BollingerWidthBreakoutStrategy.cs
+++ b/API/0256_Bollinger_Band_Width_Breakout/CS/BollingerWidthBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0257_Keltner_Channel_Width_Breakout/CS/KeltnerWidthBreakoutStrategy.cs
+++ b/API/0257_Keltner_Channel_Width_Breakout/CS/KeltnerWidthBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0258_Donchian_Channel_Width_Breakout/CS/DonchianWidthBreakoutStrategy.cs
+++ b/API/0258_Donchian_Channel_Width_Breakout/CS/DonchianWidthBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0259_Ichimoku_Cloud_Width_Breakout/CS/IchimokuWidthBreakoutStrategy.cs
+++ b/API/0259_Ichimoku_Cloud_Width_Breakout/CS/IchimokuWidthBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0260_Supertrend_Distance_Breakout/CS/SupertrendDistanceBreakoutStrategy.cs
+++ b/API/0260_Supertrend_Distance_Breakout/CS/SupertrendDistanceBreakoutStrategy.cs
@@ -1,9 +1,13 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
-using StockSharp.Algo.Strategies.Quoting;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 

--- a/API/0261_Parabolic_SAR_Distance_Breakout/CS/ParabolicSarDistanceBreakoutStrategy.cs
+++ b/API/0261_Parabolic_SAR_Distance_Breakout/CS/ParabolicSarDistanceBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0262_Hull_MA_Slope_Breakout/CS/HullMaSlopeBreakoutStrategy.cs
+++ b/API/0262_Hull_MA_Slope_Breakout/CS/HullMaSlopeBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0263_MA_Slope_Breakout/CS/MaSlopeBreakoutStrategy.cs
+++ b/API/0263_MA_Slope_Breakout/CS/MaSlopeBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0264_EMA_Slope_Breakout/CS/EmaSlopeBreakoutStrategy.cs
+++ b/API/0264_EMA_Slope_Breakout/CS/EmaSlopeBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0265_Volatility_Adjusted_Momentum/CS/VolatilityAdjustedMomentumStrategy.cs
+++ b/API/0265_Volatility_Adjusted_Momentum/CS/VolatilityAdjustedMomentumStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0266_VWAP_Slope_Breakout/CS/VwapSlopeBreakoutStrategy.cs
+++ b/API/0266_VWAP_Slope_Breakout/CS/VwapSlopeBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0267_RSI_Slope_Breakout/CS/RsiSlopeBreakoutStrategy.cs
+++ b/API/0267_RSI_Slope_Breakout/CS/RsiSlopeBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0268_Stochastic_Slope_Breakout/CS/StochasticSlopeBreakoutStrategy.cs
+++ b/API/0268_Stochastic_Slope_Breakout/CS/StochasticSlopeBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0269_CCI_Slope_Breakout/CS/CciSlopeBreakoutStrategy.cs
+++ b/API/0269_CCI_Slope_Breakout/CS/CciSlopeBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0270_Williams_R_Slope_Breakout/CS/WilliamsRSlopeBreakoutStrategy.cs
+++ b/API/0270_Williams_R_Slope_Breakout/CS/WilliamsRSlopeBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0271_MACD_Slope_Breakout/CS/MacdSlopeBreakoutStrategy.cs
+++ b/API/0271_MACD_Slope_Breakout/CS/MacdSlopeBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0272_ADX_Slope_Breakout/CS/AdxSlopeBreakoutStrategy.cs
+++ b/API/0272_ADX_Slope_Breakout/CS/AdxSlopeBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0273_ATR_Slope_Breakout/CS/AtrSlopeBreakoutStrategy.cs
+++ b/API/0273_ATR_Slope_Breakout/CS/AtrSlopeBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0274_Volume_Slope_Breakout/CS/VolumeSlopeBreakoutStrategy.cs
+++ b/API/0274_Volume_Slope_Breakout/CS/VolumeSlopeBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0278_Donchian_Width_Mean_Reversion/CS/DonchianWidthMeanReversionStrategy.cs
+++ b/API/0278_Donchian_Width_Mean_Reversion/CS/DonchianWidthMeanReversionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0279_Ichimoku_Cloud_Width_Mean_Reversion/CS/IchimokuCloudWidthMeanReversionStrategy.cs
+++ b/API/0279_Ichimoku_Cloud_Width_Mean_Reversion/CS/IchimokuCloudWidthMeanReversionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0280_Supertrend_Distance_Mean_Reversion/CS/SupertrendDistanceMeanReversionStrategy.cs
+++ b/API/0280_Supertrend_Distance_Mean_Reversion/CS/SupertrendDistanceMeanReversionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0281_Parabolic_SAR_Distance_Mean_Reversion/CS/ParabolicSarDistanceMeanReversionStrategy.cs
+++ b/API/0281_Parabolic_SAR_Distance_Mean_Reversion/CS/ParabolicSarDistanceMeanReversionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0282_Hull_MA_Slope_Mean_Reversion/CS/HullMaSlopeMeanReversionStrategy.cs
+++ b/API/0282_Hull_MA_Slope_Mean_Reversion/CS/HullMaSlopeMeanReversionStrategy.cs
@@ -1,9 +1,15 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
-using System;
-using System.Collections.Generic;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0283_MA_Slope_Mean_Reversion/CS/MaSlopeMeanReversionStrategy.cs
+++ b/API/0283_MA_Slope_Mean_Reversion/CS/MaSlopeMeanReversionStrategy.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0284_EMA_Slope_Mean_Reversion/CS/EmaSlopeMeanReversionStrategy.cs
+++ b/API/0284_EMA_Slope_Mean_Reversion/CS/EmaSlopeMeanReversionStrategy.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0285_VWAP_Slope_Mean_Reversion/CS/VwapSlopeMeanReversionStrategy.cs
+++ b/API/0285_VWAP_Slope_Mean_Reversion/CS/VwapSlopeMeanReversionStrategy.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0286_RSI_Slope_Mean_Reversion/CS/RsiSlopeMeanReversionStrategy.cs
+++ b/API/0286_RSI_Slope_Mean_Reversion/CS/RsiSlopeMeanReversionStrategy.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0287_Stochastic_Slope_Mean_Reversion/CS/StochasticSlopeMeanReversionStrategy.cs
+++ b/API/0287_Stochastic_Slope_Mean_Reversion/CS/StochasticSlopeMeanReversionStrategy.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0288_CCI_Slope_Mean_Reversion/CS/CciSlopeMeanReversionStrategy.cs
+++ b/API/0288_CCI_Slope_Mean_Reversion/CS/CciSlopeMeanReversionStrategy.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0289_Williams_R_Slope_Mean_Reversion/CS/WilliamsRSlopeMeanReversionStrategy.cs
+++ b/API/0289_Williams_R_Slope_Mean_Reversion/CS/WilliamsRSlopeMeanReversionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0290_MACD_Slope_Mean_Reversion/CS/MacdSlopeMeanReversionStrategy.cs
+++ b/API/0290_MACD_Slope_Mean_Reversion/CS/MacdSlopeMeanReversionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0291_ADX_Slope_Mean_Reversion/CS/AdxSlopeMeanReversionStrategy.cs
+++ b/API/0291_ADX_Slope_Mean_Reversion/CS/AdxSlopeMeanReversionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0292_ATR_Slope_Mean_Reversion/CS/AtrSlopeMeanReversionStrategy.cs
+++ b/API/0292_ATR_Slope_Mean_Reversion/CS/AtrSlopeMeanReversionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0293_Volume_Slope_Mean_Reversion/CS/VolumeSlopeMeanReversionStrategy.cs
+++ b/API/0293_Volume_Slope_Mean_Reversion/CS/VolumeSlopeMeanReversionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0294_OBV_Slope_Mean_Reversion/CS/ObvSlopeMeanReversionStrategy.cs
+++ b/API/0294_OBV_Slope_Mean_Reversion/CS/ObvSlopeMeanReversionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0295_Pairs_Trading_Volatility_Filter/CS/PairsTradingVolatilityFilterStrategy.cs
+++ b/API/0295_Pairs_Trading_Volatility_Filter/CS/PairsTradingVolatilityFilterStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0296_Z-Score_Volume_Filter/CS/ZScoreVolumeFilterStrategy.cs
+++ b/API/0296_Z-Score_Volume_Filter/CS/ZScoreVolumeFilterStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0298_Correlation_Mean_Reversion/CS/CorrelationMeanReversionStrategy.cs
+++ b/API/0298_Correlation_Mean_Reversion/CS/CorrelationMeanReversionStrategy.cs
@@ -1,6 +1,10 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0299_Beta_Adjusted_Pairs_Trading/CS/BetaAdjustedPairsStrategy.cs
+++ b/API/0299_Beta_Adjusted_Pairs_Trading/CS/BetaAdjustedPairsStrategy.cs
@@ -1,7 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using Ecng.ComponentModel;
-using StockSharp.Algo;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0300_Hurst_Exponent_Volatility_Filter/CS/HurstVolatilityFilterStrategy.cs
+++ b/API/0300_Hurst_Exponent_Volatility_Filter/CS/HurstVolatilityFilterStrategy.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0301_Adaptive_EMA_Breakout/CS/AdaptiveEmaBreakoutStrategy.cs
+++ b/API/0301_Adaptive_EMA_Breakout/CS/AdaptiveEmaBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0302_Volatility_Cluster_Breakout/CS/VolatilityClusterBreakoutStrategy.cs
+++ b/API/0302_Volatility_Cluster_Breakout/CS/VolatilityClusterBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0303_Seasonality_Adjusted_Momentum/CS/SeasonalityAdjustedMomentumStrategy.cs
+++ b/API/0303_Seasonality_Adjusted_Momentum/CS/SeasonalityAdjustedMomentumStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0305_RSI_Dynamic_Overbought_Oversold/CS/RsiDynamicOverboughtOversoldStrategy.cs
+++ b/API/0305_RSI_Dynamic_Overbought_Oversold/CS/RsiDynamicOverboughtOversoldStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0306_Bollinger_Volatility_Breakout/CS/BollingerVolatilityBreakoutStrategy.cs
+++ b/API/0306_Bollinger_Volatility_Breakout/CS/BollingerVolatilityBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0307_MACD_Adaptive_Histogram/CS/MacdAdaptiveHistogramStrategy.cs
+++ b/API/0307_MACD_Adaptive_Histogram/CS/MacdAdaptiveHistogramStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0308_Ichimoku_Volume_Cluster/CS/IchimokuVolumeClusterStrategy.cs
+++ b/API/0308_Ichimoku_Volume_Cluster/CS/IchimokuVolumeClusterStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0309_Supertrend_Momentum_Filter/CS/SupertrendWithMomentumStrategy.cs
+++ b/API/0309_Supertrend_Momentum_Filter/CS/SupertrendWithMomentumStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0310_Donchian_Volatility_Contraction/CS/DonchianWithVolatilityContractionStrategy.cs
+++ b/API/0310_Donchian_Volatility_Contraction/CS/DonchianWithVolatilityContractionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0311_Keltner_RSI_Divergence/CS/KeltnerWithRsiDivergenceStrategy.cs
+++ b/API/0311_Keltner_RSI_Divergence/CS/KeltnerWithRsiDivergenceStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0312_Hull_MA_Volume_Spike/CS/HullMaWithVolumeSpikeStrategy.cs
+++ b/API/0312_Hull_MA_Volume_Spike/CS/HullMaWithVolumeSpikeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0313_VWAP_ADX_Trend_Strength/CS/VwapWithAdxTrendStrengthStrategy.cs
+++ b/API/0313_VWAP_ADX_Trend_Strength/CS/VwapWithAdxTrendStrengthStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0314_Parabolic_SAR_Volatility_Expansion/CS/ParabolicSarWithVolatilityExpansionStrategy.cs
+++ b/API/0314_Parabolic_SAR_Volatility_Expansion/CS/ParabolicSarWithVolatilityExpansionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0315_Stochastic_Dynamic_Zones/CS/StochasticWithDynamicZonesStrategy.cs
+++ b/API/0315_Stochastic_Dynamic_Zones/CS/StochasticWithDynamicZonesStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0316_ADX_Volume_Breakout/CS/AdxWithVolumeBreakoutStrategy.cs
+++ b/API/0316_ADX_Volume_Breakout/CS/AdxWithVolumeBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0317_CCI_Volatility_Filter/CS/CciWithVolatilityFilterStrategy.cs
+++ b/API/0317_CCI_Volatility_Filter/CS/CciWithVolatilityFilterStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0318_Williams_R_Momentum/CS/WilliamsPercentRWithMomentumStrategy.cs
+++ b/API/0318_Williams_R_Momentum/CS/WilliamsPercentRWithMomentumStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0319_Bollinger_K-Means_Cluster/CS/BollingerKMeansStrategy.cs
+++ b/API/0319_Bollinger_K-Means_Cluster/CS/BollingerKMeansStrategy.cs
@@ -1,16 +1,15 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
 using Ecng.Common;
 using Ecng.Collections;
+using Ecng.Serialization;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
-using System.Linq;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0320_MACD_Hidden_Markov_Model/CS/MacdHmmStrategy.cs
+++ b/API/0320_MACD_Hidden_Markov_Model/CS/MacdHmmStrategy.cs
@@ -1,11 +1,11 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
 using Ecng.Collections;
+using Ecng.Serialization;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0321_Ichimoku_Hurst_Exponent/CS/IchimokuHurstStrategy.cs
+++ b/API/0321_Ichimoku_Hurst_Exponent/CS/IchimokuHurstStrategy.cs
@@ -1,11 +1,11 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
 using Ecng.Collections;
+using Ecng.Serialization;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0322_Supertrend_RSI_Divergence/CS/SupertrendRsiDivergenceStrategy.cs
+++ b/API/0322_Supertrend_RSI_Divergence/CS/SupertrendRsiDivergenceStrategy.cs
@@ -1,10 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
 using Ecng.Collections;
+using Ecng.Serialization;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0323_Donchian_Seasonal_Filter/CS/DonchianSeasonalStrategy.cs
+++ b/API/0323_Donchian_Seasonal_Filter/CS/DonchianSeasonalStrategy.cs
@@ -1,11 +1,11 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
 using Ecng.Collections;
+using Ecng.Serialization;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0324_Keltner_Kalman_Filter/CS/KeltnerKalmanStrategy.cs
+++ b/API/0324_Keltner_Kalman_Filter/CS/KeltnerKalmanStrategy.cs
@@ -1,11 +1,11 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
 using Ecng.Collections;
+using Ecng.Serialization;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0325_Hull_MA_Volatility_Contraction/CS/HullMaVolatilityContractionStrategy.cs
+++ b/API/0325_Hull_MA_Volatility_Contraction/CS/HullMaVolatilityContractionStrategy.cs
@@ -1,11 +1,11 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
 using Ecng.Collections;
+using Ecng.Serialization;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0326_VWAP_Stochastic_Divergence/CS/VwapAdxTrendStrategy.cs
+++ b/API/0326_VWAP_Stochastic_Divergence/CS/VwapAdxTrendStrategy.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
 using Ecng.Common;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0327_Parabolic_SAR_Hurst_Filter/CS/ParabolicSarHurstStrategy.cs
+++ b/API/0327_Parabolic_SAR_Hurst_Filter/CS/ParabolicSarHurstStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0328_Bollinger_Kalman_Filter/CS/BollingerKalmanFilterStrategy.cs
+++ b/API/0328_Bollinger_Kalman_Filter/CS/BollingerKalmanFilterStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0329_MACD_Volume_Cluster/CS/MacdVolumeClusterStrategy.cs
+++ b/API/0329_MACD_Volume_Cluster/CS/MacdVolumeClusterStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0330_Ichimoku_Volatility_Contraction/CS/IchimokuVolatilityContractionStrategy.cs
+++ b/API/0330_Ichimoku_Volatility_Contraction/CS/IchimokuVolatilityContractionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0332_Donchian_Hurst_Exponent/CS/DonchianHurstStrategy.cs
+++ b/API/0332_Donchian_Hurst_Exponent/CS/DonchianHurstStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0333_Keltner_Seasonal_Filter/CS/KeltnerSeasonalStrategy.cs
+++ b/API/0333_Keltner_Seasonal_Filter/CS/KeltnerSeasonalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0334_Hull_MA_K-Means_Cluster/CS/HullKMeansClusterStrategy.cs
+++ b/API/0334_Hull_MA_K-Means_Cluster/CS/HullKMeansClusterStrategy.cs
@@ -1,12 +1,15 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
-using StockSharp.Localization;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0335_VWAP_Hidden_Markov_Model/CS/VwapHiddenMarkovModelStrategy.cs
+++ b/API/0335_VWAP_Hidden_Markov_Model/CS/VwapHiddenMarkovModelStrategy.cs
@@ -1,6 +1,10 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0336_Parabolic_SAR_RSI_Divergence/CS/ParabolicSarRsiDivergenceStrategy.cs
+++ b/API/0336_Parabolic_SAR_RSI_Divergence/CS/ParabolicSarRsiDivergenceStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0337_Adaptive_RSI_Volume_Filter/CS/AdaptiveRsiVolumeStrategy.cs
+++ b/API/0337_Adaptive_RSI_Volume_Filter/CS/AdaptiveRsiVolumeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0338_Adaptive_Bollinger_Breakout/CS/AdaptiveBollingerBreakoutStrategy.cs
+++ b/API/0338_Adaptive_Bollinger_Breakout/CS/AdaptiveBollingerBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -259,4 +264,3 @@ public class AdaptiveBollingerBreakoutStrategy : Strategy
 		}
 	}
 }
-

--- a/API/0339_MACD_Sentiment_Filter/CS/MacdWithSentimentFilterStrategy.cs
+++ b/API/0339_MACD_Sentiment_Filter/CS/MacdWithSentimentFilterStrategy.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
 using Ecng.Common;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -294,4 +297,3 @@ public class MacdWithSentimentFilterStrategy : Strategy
 		return _prevMacd == 0 && _prevSignal == 0;
 	}
 }
-

--- a/API/0340_Ichimoku_Implied_Volatility/CS/IchimokuWithImpliedVolatilityStrategy.cs
+++ b/API/0340_Ichimoku_Implied_Volatility/CS/IchimokuWithImpliedVolatilityStrategy.cs
@@ -1,12 +1,15 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
 using Ecng.Common;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
-using System;
-using System.Collections.Generic;
 
 namespace StockSharp.Samples.Strategies;
 
@@ -321,4 +324,3 @@ public class IchimokuWithImpliedVolatilityStrategy : Strategy
 		}
 	}
 }
-

--- a/API/0341_Supertrend_Put_Call_Ratio/CS/SupertrendWithPutCallRatioStrategy.cs
+++ b/API/0341_Supertrend_Put_Call_Ratio/CS/SupertrendWithPutCallRatioStrategy.cs
@@ -1,10 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
 using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0342_Donchian_Sentiment_Spike/CS/DonchianWithSentimentSpikeStrategy.cs
+++ b/API/0342_Donchian_Sentiment_Spike/CS/DonchianWithSentimentSpikeStrategy.cs
@@ -1,12 +1,15 @@
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
-using System;
-using System.Collections.Generic;
-using Ecng.Common;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0343_Keltner_Reinforcement_Learning_Signal/CS/KeltnerWithRLSignalStrategy.cs
+++ b/API/0343_Keltner_Reinforcement_Learning_Signal/CS/KeltnerWithRLSignalStrategy.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0344_Hull_MA_Implied_Volatility_Breakout/CS/HullMAWithImpliedVolatilityBreakoutStrategy.cs
+++ b/API/0344_Hull_MA_Implied_Volatility_Breakout/CS/HullMAWithImpliedVolatilityBreakoutStrategy.cs
@@ -1,12 +1,15 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
 using Ecng.Common;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
-using System;
-using System.Collections.Generic;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0345_VWAP_Behavioral_Bias_Filter/CS/VwapWithBehavioralBiasFilterStrategy.cs
+++ b/API/0345_VWAP_Behavioral_Bias_Filter/CS/VwapWithBehavioralBiasFilterStrategy.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0346_Parabolic_SAR_Sentiment_Divergence/CS/ParabolicSarSentimentDivergenceStrategy.cs
+++ b/API/0346_Parabolic_SAR_Sentiment_Divergence/CS/ParabolicSarSentimentDivergenceStrategy.cs
@@ -1,11 +1,15 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
 using Ecng.Common;
-using StockSharp.Algo.Candles;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
-using System;
-using System.Collections.Generic;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0347_RSI_Option_Open_Interest/CS/RsiWithOptionOpenInterestStrategy.cs
+++ b/API/0347_RSI_Option_Open_Interest/CS/RsiWithOptionOpenInterestStrategy.cs
@@ -1,11 +1,15 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
 using Ecng.Common;
-using StockSharp.Algo.Candles;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
-using System;
-using System.Collections.Generic;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0348_Stochastic_Implied_Volatility_Skew/CS/StochasticImpliedVolatilitySkewStrategy.cs
+++ b/API/0348_Stochastic_Implied_Volatility_Skew/CS/StochasticImpliedVolatilitySkewStrategy.cs
@@ -1,7 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0349_ADX_Sentiment_Momentum/CS/AdxSentimentMomentumStrategy.cs
+++ b/API/0349_ADX_Sentiment_Momentum/CS/AdxSentimentMomentumStrategy.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
 using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
-using StockSharp.Algo.Candles;
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0350_CCI_Put_Call_Ratio_Divergence/CS/CciPutCallRatioDivergenceStrategy.cs
+++ b/API/0350_CCI_Put_Call_Ratio_Divergence/CS/CciPutCallRatioDivergenceStrategy.cs
@@ -1,11 +1,15 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
 using Ecng.Common;
-using StockSharp.Algo.Candles;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
-using System;
-using System.Collections.Generic;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0351_Accrual_Anomaly/CS/AccrualAnomalyStrategy.cs
+++ b/API/0351_Accrual_Anomaly/CS/AccrualAnomalyStrategy.cs
@@ -1,9 +1,13 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using StockSharp.Algo;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
-using StockSharp.Algo.Candles;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 

--- a/API/0352_Asset_Class_Trend_Following/CS/AssetClassTrendFollowingStrategy.cs
+++ b/API/0352_Asset_Class_Trend_Following/CS/AssetClassTrendFollowingStrategy.cs
@@ -1,8 +1,11 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0353_Asset_Growth_Effect/CS/AssetGrowthEffectStrategy.cs
+++ b/API/0353_Asset_Growth_Effect/CS/AssetGrowthEffectStrategy.cs
@@ -1,9 +1,12 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0354_Betting_Against_Beta_Stocks/CS/BettingAgainstBetaStocksStrategy.cs
+++ b/API/0354_Betting_Against_Beta_Stocks/CS/BettingAgainstBetaStocksStrategy.cs
@@ -3,10 +3,14 @@
 // Date: 2 August 2025
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0355_Betting_Against_Beta/CS/BettingAgainstBetaStrategy.cs
+++ b/API/0355_Betting_Against_Beta/CS/BettingAgainstBetaStrategy.cs
@@ -3,11 +3,14 @@
 // Date: 2 August 2025
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0356_Bitcoin_Intraday_Seasonality/CS/BitcoinIntradaySeasonalityStrategy.cs
+++ b/API/0356_Bitcoin_Intraday_Seasonality/CS/BitcoinIntradaySeasonalityStrategy.cs
@@ -1,8 +1,12 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
@@ -142,4 +146,3 @@ public class BitcoinIntradaySeasonalityStrategy : Strategy
 
 	private decimal PositionBy(Security s) => GetPositionValue(s, Portfolio) ?? 0;
 }
-

--- a/API/0357_Book_To_Market_Value/CS/BookToMarketValueStrategy.cs
+++ b/API/0357_Book_To_Market_Value/CS/BookToMarketValueStrategy.cs
@@ -6,9 +6,14 @@
 // Date: 2 Aug 2025
 // -----------------------------------------------------------------------------
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0358_Commodity_Momentum/CS/CommodityMomentumStrategy.cs
+++ b/API/0358_Commodity_Momentum/CS/CommodityMomentumStrategy.cs
@@ -7,10 +7,14 @@
 // -----------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0359_Consistent_Momentum/CS/ConsistentMomentumStrategy.cs
+++ b/API/0359_Consistent_Momentum/CS/ConsistentMomentumStrategy.cs
@@ -1,9 +1,12 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
@@ -290,4 +293,3 @@ public class ConsistentMomentumStrategy : Strategy
 
 	#endregion
 }
-

--- a/API/0360_Country_Value_Factor/CS/CountryValueFactorStrategy.cs
+++ b/API/0360_Country_Value_Factor/CS/CountryValueFactorStrategy.cs
@@ -1,7 +1,12 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
@@ -91,4 +96,3 @@ public class CountryValueFactorStrategy : Strategy
 		// TODO: implement factor logic. Placeholder keeps portfolio flat.
 	}
 }
-

--- a/API/0361_Crude_Oil_Predicts_Equity/CS/CrudeOilPredictsEquityStrategy.cs
+++ b/API/0361_Crude_Oil_Predicts_Equity/CS/CrudeOilPredictsEquityStrategy.cs
@@ -1,8 +1,12 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0362_Crypto_Rebalancing_Premium/CS/CryptoRebalancingPremiumStrategy.cs
+++ b/API/0362_Crypto_Rebalancing_Premium/CS/CryptoRebalancingPremiumStrategy.cs
@@ -2,8 +2,11 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0363_Currency_Momentum_Factor/CS/CurrencyMomentumFactorStrategy.cs
+++ b/API/0363_Currency_Momentum_Factor/CS/CurrencyMomentumFactorStrategy.cs
@@ -1,8 +1,12 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
@@ -247,4 +251,3 @@ public class CurrencyMomentumFactorStrategy : Strategy
 
 	#endregion
 }
-

--- a/API/0364_Currency_PPPValue/CS/CurrencyPPPValueStrategy.cs
+++ b/API/0364_Currency_PPPValue/CS/CurrencyPPPValueStrategy.cs
@@ -1,8 +1,12 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0365_Dispersion_Trading/CS/DispersionTradingStrategy.cs
+++ b/API/0365_Dispersion_Trading/CS/DispersionTradingStrategy.cs
@@ -1,8 +1,12 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
@@ -291,4 +295,3 @@ public class DispersionTradingStrategy : Strategy
 
 	#endregion
 }
-

--- a/API/0366_Dollar_Carry_Trade/CS/DollarCarryTradeStrategy.cs
+++ b/API/0366_Dollar_Carry_Trade/CS/DollarCarryTradeStrategy.cs
@@ -5,11 +5,14 @@
 // Date: 2 August 2025
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0367_Earnings_Announcement_Premium/CS/EarningsAnnouncementPremiumStrategy.cs
+++ b/API/0367_Earnings_Announcement_Premium/CS/EarningsAnnouncementPremiumStrategy.cs
@@ -7,10 +7,14 @@
 // ------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0368_Earnings_Announcement_Reversal/CS/EarningsAnnouncementReversalStrategy.cs
+++ b/API/0368_Earnings_Announcement_Reversal/CS/EarningsAnnouncementReversalStrategy.cs
@@ -1,9 +1,12 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
@@ -217,4 +220,3 @@ public class EarningsAnnouncementReversalStrategy : Strategy
 		return false;
 	}
 }
-

--- a/API/0369_Earnings_Announcements_With_Buybacks/CS/EarningsAnnouncementsWithBuybacksStrategy.cs
+++ b/API/0369_Earnings_Announcements_With_Buybacks/CS/EarningsAnnouncementsWithBuybacksStrategy.cs
@@ -1,9 +1,12 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0370_Earnings_Quality_Factor/CS/EarningsQualityFactorStrategy.cs
+++ b/API/0370_Earnings_Quality_Factor/CS/EarningsQualityFactorStrategy.cs
@@ -3,10 +3,14 @@
 // Date: 2 August 2025
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0371_ESGFactor_Momentum/CS/ESGFactorMomentumStrategy.cs
+++ b/API/0371_ESGFactor_Momentum/CS/ESGFactorMomentumStrategy.cs
@@ -4,11 +4,14 @@
 // Date: 2 August 2025
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0372_Fed_Model/CS/FedModelStrategy.cs
+++ b/API/0372_Fed_Model/CS/FedModelStrategy.cs
@@ -1,8 +1,12 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0373_FScore_Reversal/CS/FScoreReversalStrategy.cs
+++ b/API/0373_FScore_Reversal/CS/FScoreReversalStrategy.cs
@@ -5,11 +5,14 @@
 // Date: 2 August 2025
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
+
 using Ecng.Common;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0374_FXCarry_Trade/CS/FXCarryTradeStrategy.cs
+++ b/API/0374_FXCarry_Trade/CS/FXCarryTradeStrategy.cs
@@ -4,10 +4,14 @@
 // Date: 2 Aug 2025
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0375_January_Barometer/CS/JanuaryBarometerStrategy.cs
+++ b/API/0375_January_Barometer/CS/JanuaryBarometerStrategy.cs
@@ -8,10 +8,14 @@
 // -----------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0376_Lexical_Density_Filings/CS/LexicalDensityFilingsStrategy.cs
+++ b/API/0376_Lexical_Density_Filings/CS/LexicalDensityFilingsStrategy.cs
@@ -1,9 +1,12 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
@@ -215,4 +218,3 @@ public class LexicalDensityFilingsStrategy : Strategy
 		return _latestPrices.TryGetValue(security, out var price) ? price : 0m;
 	}
 }
-

--- a/API/0377_Low_Volatility_Stocks/CS/LowVolatilityStocksStrategy.cs
+++ b/API/0377_Low_Volatility_Stocks/CS/LowVolatilityStocksStrategy.cs
@@ -1,9 +1,12 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0378_Momentum_Asset_Growth/CS/MomentumAssetGrowthStrategy.cs
+++ b/API/0378_Momentum_Asset_Growth/CS/MomentumAssetGrowthStrategy.cs
@@ -1,9 +1,12 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0379_Momentum_Factor_Stocks/CS/MomentumFactorStocksStrategy.cs
+++ b/API/0379_Momentum_Factor_Stocks/CS/MomentumFactorStocksStrategy.cs
@@ -1,9 +1,12 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0380_Momentum_Rev_Vol/CS/MomentumRevVolStrategy.cs
+++ b/API/0380_Momentum_Rev_Vol/CS/MomentumRevVolStrategy.cs
@@ -9,10 +9,14 @@
 // -----------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0381_Momentum_Style_Rotation/CS/MomentumStyleRotationStrategy.cs
+++ b/API/0381_Momentum_Style_Rotation/CS/MomentumStyleRotationStrategy.cs
@@ -7,10 +7,14 @@
 // -----------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0382_Month12Cycle/CS/Month12CycleStrategy.cs
+++ b/API/0382_Month12Cycle/CS/Month12CycleStrategy.cs
@@ -3,12 +3,14 @@
 // Date: 2 August 2025
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
 using Ecng.Common;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0383_Mutual_Fund_Momentum/CS/MutualFundMomentumStrategy.cs
+++ b/API/0383_Mutual_Fund_Momentum/CS/MutualFundMomentumStrategy.cs
@@ -3,12 +3,16 @@
 // Date: 2 Aug 2025
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using StockSharp.Algo;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
-using StockSharp.Algo.Candles;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/0384_Option_Expiration_Week/CS/OptionExpirationWeekStrategy.cs
+++ b/API/0384_Option_Expiration_Week/CS/OptionExpirationWeekStrategy.cs
@@ -4,9 +4,14 @@
 // Date: 2 Aug 2025
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0385_Overnight_Sentiment_Anomaly/CS/OvernightSentimentAnomalyStrategy.cs
+++ b/API/0385_Overnight_Sentiment_Anomaly/CS/OvernightSentimentAnomalyStrategy.cs
@@ -9,9 +9,14 @@
 // -----------------------------------------------------------------------------
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0386_Paired_Switching/CS/PairedSwitchingStrategy.cs
+++ b/API/0386_Paired_Switching/CS/PairedSwitchingStrategy.cs
@@ -5,14 +5,18 @@
 // -----------------------------------------------------------------------------
 // Date: 2 Aug 2025
 // -----------------------------------------------------------------------------
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0387_Pairs_Trading_Country_ETFs/CS/PairsTradingCountryETFsStrategy.cs
+++ b/API/0387_Pairs_Trading_Country_ETFs/CS/PairsTradingCountryETFsStrategy.cs
@@ -12,10 +12,14 @@
 // -----------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0388_Pairs_Trading_Stocks/CS/PairsTradingStocksStrategy.cs
+++ b/API/0388_Pairs_Trading_Stocks/CS/PairsTradingStocksStrategy.cs
@@ -7,10 +7,14 @@
 // Date: 2 Aug 2025
 // -----------------------------------------------------------------------------
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0389_Payday_Anomaly/CS/PaydayAnomalyStrategy.cs
+++ b/API/0389_Payday_Anomaly/CS/PaydayAnomalyStrategy.cs
@@ -8,9 +8,14 @@
 // Date: 2 Aug 2025
 // -----------------------------------------------------------------------------
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0390_RDExpenditures/CS/RDExpendituresStrategy.cs
+++ b/API/0390_RDExpenditures/CS/RDExpendituresStrategy.cs
@@ -7,10 +7,14 @@
 // Date: 2 Aug 2025
 // -----------------------------------------------------------------------------
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0391_Residual_Momentum_Factor/CS/ResidualMomentumFactorStrategy.cs
+++ b/API/0391_Residual_Momentum_Factor/CS/ResidualMomentumFactorStrategy.cs
@@ -7,11 +7,14 @@
 // Date: 2 Aug 2025	 
 // -----------------------------------------------------------------------------
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0392_Return_Asymmetry_Commodity/CS/ReturnAsymmetryCommodityStrategy.cs
+++ b/API/0392_Return_Asymmetry_Commodity/CS/ReturnAsymmetryCommodityStrategy.cs
@@ -9,11 +9,14 @@
 // Date: 2 Aug 2025
 // -----------------------------------------------------------------------------
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0393_ROAEffect_Stocks/CS/ROAEffectStocksStrategy.cs
+++ b/API/0393_ROAEffect_Stocks/CS/ROAEffectStocksStrategy.cs
@@ -6,11 +6,14 @@
 // Date: 2 Aug 2025
 // -----------------------------------------------------------------------------
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0394_Sector_Momentum_Rotation/CS/SectorMomentumRotationStrategy.cs
+++ b/API/0394_Sector_Momentum_Rotation/CS/SectorMomentumRotationStrategy.cs
@@ -7,11 +7,14 @@
 // Date: 2 Aug 2025
 // -----------------------------------------------------------------------------
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0395_Short_Interest_Effect/CS/ShortInterestEffectStrategy.cs
+++ b/API/0395_Short_Interest_Effect/CS/ShortInterestEffectStrategy.cs
@@ -7,11 +7,14 @@
 // Date: 2 Aug 2025
 // -----------------------------------------------------------------------------
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0396_Short_Term_Reversal_Futures/CS/ShortTermReversalFuturesStrategy.cs
+++ b/API/0396_Short_Term_Reversal_Futures/CS/ShortTermReversalFuturesStrategy.cs
@@ -6,13 +6,18 @@
 // Date: 2 Aug 2025
 // -----------------------------------------------------------------------------
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 /// <summary>

--- a/API/0397_Short_Term_Reversal_Stocks/CS/ShortTermReversalStocksStrategy.cs
+++ b/API/0397_Short_Term_Reversal_Stocks/CS/ShortTermReversalStocksStrategy.cs
@@ -6,10 +6,14 @@
 // Date: 2 Aug 2025
 // -----------------------------------------------------------------------------
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0398_Skewness_Commodity/CS/SkewnessCommodityStrategy.cs
+++ b/API/0398_Skewness_Commodity/CS/SkewnessCommodityStrategy.cs
@@ -10,10 +10,14 @@
 // ----------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0399_Small_Cap_Premium/CS/SmallCapPremiumStrategy.cs
+++ b/API/0399_Small_Cap_Premium/CS/SmallCapPremiumStrategy.cs
@@ -7,10 +7,14 @@
 // Date: 2 Aug 2025
 // -----------------------------------------------------------------------------
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0400_Smart_Factors_Momentum_Market/CS/SmartFactorsMomentumMarketStrategy.cs
+++ b/API/0400_Smart_Factors_Momentum_Market/CS/SmartFactorsMomentumMarketStrategy.cs
@@ -3,11 +3,14 @@
 // Date: 2 August 2025
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
+
 using Ecng.Common;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0401_Soccer_Clubs_Arbitrage/CS/SoccerClubsArbitrageStrategy.cs
+++ b/API/0401_Soccer_Clubs_Arbitrage/CS/SoccerClubsArbitrageStrategy.cs
@@ -8,10 +8,14 @@
 // Date: 2 Aug 2025
 // -----------------------------------------------------------------------------
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0402_Synthetic_Lending_Rates/CS/SyntheticLendingRatesStrategy.cs
+++ b/API/0402_Synthetic_Lending_Rates/CS/SyntheticLendingRatesStrategy.cs
@@ -10,9 +10,14 @@
 // Date: 2 Aug 2025
 // -----------------------------------------------------------------------------
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0403_Term_Structure_Commodities/CS/TermStructureCommoditiesStrategy.cs
+++ b/API/0403_Term_Structure_Commodities/CS/TermStructureCommoditiesStrategy.cs
@@ -6,10 +6,14 @@
 // Date: 2 Aug 2025
 // -----------------------------------------------------------------------------
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0404_Time_Series_Momentum/CS/TimeSeriesMomentumStrategy.cs
+++ b/API/0404_Time_Series_Momentum/CS/TimeSeriesMomentumStrategy.cs
@@ -5,10 +5,14 @@
 // Date: 2 Aug 2025
 // -----------------------------------------------------------------------------
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0405_Trend_Following_Stocks/CS/TrendFollowingStocksStrategy.cs
+++ b/API/0405_Trend_Following_Stocks/CS/TrendFollowingStocksStrategy.cs
@@ -6,10 +6,14 @@
 // Date: 2 Aug 2025
 // -----------------------------------------------------------------------------
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0406_Turn_Of_Month/CS/TurnOfMonthStrategy.cs
+++ b/API/0406_Turn_Of_Month/CS/TurnOfMonthStrategy.cs
@@ -8,9 +8,14 @@
 // Date: 2 Aug 2025
 // -----------------------------------------------------------------------------
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0407_Value_Momentum_Across_Assets/CS/ValueMomentumAcrossAssetsStrategy.cs
+++ b/API/0407_Value_Momentum_Across_Assets/CS/ValueMomentumAcrossAssetsStrategy.cs
@@ -6,9 +6,14 @@
 // Date: 2 Aug 2025
 // -----------------------------------------------------------------------------
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0408_Volatility_Risk_Premium/CS/VolatilityRiskPremiumStrategy.cs
+++ b/API/0408_Volatility_Risk_Premium/CS/VolatilityRiskPremiumStrategy.cs
@@ -6,9 +6,14 @@
 // Date: 2 Aug 2025
 // -----------------------------------------------------------------------------
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0409_Weeks52High/CS/Weeks52HighStrategy.cs
+++ b/API/0409_Weeks52High/CS/Weeks52HighStrategy.cs
@@ -7,12 +7,14 @@
 // Date: 2 August 2025
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
 using Ecng.Common;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0410_WTIBrent_Spread/CS/WTIBrentSpreadStrategy.cs
+++ b/API/0410_WTIBrent_Spread/CS/WTIBrentSpreadStrategy.cs
@@ -1,8 +1,12 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0411_Asset_Class_Momentum_Rotational/CS/AssetClassMomentumRotationalStrategy.cs
+++ b/API/0411_Asset_Class_Momentum_Rotational/CS/AssetClassMomentumRotationalStrategy.cs
@@ -1,10 +1,13 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
-using StockSharp.Algo.Strategies;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 

--- a/API/0412_Bollinger_Aroon/CS/BollingerAroonStrategy.cs
+++ b/API/0412_Bollinger_Aroon/CS/BollingerAroonStrategy.cs
@@ -3,15 +3,13 @@ using System.Linq;
 using System.Collections.Generic;
 
 using Ecng.Common;
-using Ecng.Drawing;
+using Ecng.Collections;
+using Ecng.Serialization;
 
-using StockSharp.Messages;
-using StockSharp.Algo;
-using StockSharp.Algo.Strategies;
 using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
-using StockSharp.Localization;
-using StockSharp.Charting;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0413_Bollinger_Divergence/CS/BollingerDivergenceStrategy.cs
+++ b/API/0413_Bollinger_Divergence/CS/BollingerDivergenceStrategy.cs
@@ -3,15 +3,13 @@ using System.Linq;
 using System.Collections.Generic;
 
 using Ecng.Common;
-using Ecng.Drawing;
+using Ecng.Collections;
+using Ecng.Serialization;
 
-using StockSharp.Messages;
-using StockSharp.Algo;
-using StockSharp.Algo.Strategies;
 using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
-using StockSharp.Localization;
-using StockSharp.Charting;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0414_Bollinger_Winner_Lite/CS/BollingerWinnerLiteStrategy.cs
+++ b/API/0414_Bollinger_Winner_Lite/CS/BollingerWinnerLiteStrategy.cs
@@ -3,15 +3,13 @@ using System.Linq;
 using System.Collections.Generic;
 
 using Ecng.Common;
-using Ecng.Drawing;
+using Ecng.Collections;
+using Ecng.Serialization;
 
-using StockSharp.Messages;
-using StockSharp.Algo;
-using StockSharp.Algo.Strategies;
 using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
-using StockSharp.Localization;
-using StockSharp.Charting;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0415_Bollinger_Winner_Pro/CS/BollingerWinnerProStrategy.cs
+++ b/API/0415_Bollinger_Winner_Pro/CS/BollingerWinnerProStrategy.cs
@@ -3,15 +3,13 @@ using System.Linq;
 using System.Collections.Generic;
 
 using Ecng.Common;
-using Ecng.Drawing;
+using Ecng.Collections;
+using Ecng.Serialization;
 
-using StockSharp.Messages;
-using StockSharp.Algo;
-using StockSharp.Algo.Strategies;
 using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
-using StockSharp.Localization;
-using StockSharp.Charting;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0417_Dmi_Winner/CS/DmiWinnerStrategy.cs
+++ b/API/0417_Dmi_Winner/CS/DmiWinnerStrategy.cs
@@ -3,15 +3,13 @@ using System.Linq;
 using System.Collections.Generic;
 
 using Ecng.Common;
-using Ecng.Drawing;
+using Ecng.Collections;
+using Ecng.Serialization;
 
-using StockSharp.Messages;
-using StockSharp.Algo;
-using StockSharp.Algo.Strategies;
 using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
-using StockSharp.Localization;
-using StockSharp.Charting;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0418_Double_Rsi/CS/DoubleRsiStrategy.cs
+++ b/API/0418_Double_Rsi/CS/DoubleRsiStrategy.cs
@@ -3,15 +3,13 @@ using System.Linq;
 using System.Collections.Generic;
 
 using Ecng.Common;
-using Ecng.Drawing;
+using Ecng.Collections;
+using Ecng.Serialization;
 
-using StockSharp.Messages;
-using StockSharp.Algo;
-using StockSharp.Algo.Strategies;
 using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
-using StockSharp.Localization;
-using StockSharp.Charting;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0419_Double_Supertrend/CS/DoubleSupertrendStrategy.cs
+++ b/API/0419_Double_Supertrend/CS/DoubleSupertrendStrategy.cs
@@ -3,15 +3,13 @@ using System.Linq;
 using System.Collections.Generic;
 
 using Ecng.Common;
-using Ecng.Drawing;
+using Ecng.Collections;
+using Ecng.Serialization;
 
-using StockSharp.Messages;
-using StockSharp.Algo;
-using StockSharp.Algo.Strategies;
 using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
-using StockSharp.Localization;
-using StockSharp.Charting;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0422_Exceeded_Candle/CS/ExceededCandleStrategy.cs
+++ b/API/0422_Exceeded_Candle/CS/ExceededCandleStrategy.cs
@@ -3,15 +3,13 @@ using System.Linq;
 using System.Collections.Generic;
 
 using Ecng.Common;
-using Ecng.Drawing;
+using Ecng.Collections;
+using Ecng.Serialization;
 
-using StockSharp.Messages;
-using StockSharp.Algo;
-using StockSharp.Algo.Strategies;
 using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
-using StockSharp.Localization;
-using StockSharp.Charting;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0441_Rsi_Plus_1200/CS/RsiPlus1200Strategy.cs
+++ b/API/0441_Rsi_Plus_1200/CS/RsiPlus1200Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0442_Rsi_Ema/CS/RsiEmaStrategy.cs
+++ b/API/0442_Rsi_Ema/CS/RsiEmaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0443_Stoch_Rsi_Crossover/CS/StochRsiCrossoverStrategy.cs
+++ b/API/0443_Stoch_Rsi_Crossover/CS/StochRsiCrossoverStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0444_Stoch_Rsi_Supertrend/CS/StochRsiSupertrendStrategy.cs
+++ b/API/0444_Stoch_Rsi_Supertrend/CS/StochRsiSupertrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0445_ADX_Tester/CS/AdxTesterStrategy.cs
+++ b/API/0445_ADX_Tester/CS/AdxTesterStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0446_Strat_Base/CS/StratBaseStrategy.cs
+++ b/API/0446_Strat_Base/CS/StratBaseStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0447_Supertrend_Ema_Rebound/CS/SupertrendEmaReboundStrategy.cs
+++ b/API/0447_Supertrend_Ema_Rebound/CS/SupertrendEmaReboundStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0450_Tendency_Ema_Rsi/CS/TendencyEmaRsiStrategy.cs
+++ b/API/0450_Tendency_Ema_Rsi/CS/TendencyEmaRsiStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0451_Three_Ema_Cross/CS/ThreeEmaCrossStrategy.cs
+++ b/API/0451_Three_Ema_Cross/CS/ThreeEmaCrossStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0452_Ttm_Squeeze/CS/TtmSqueezeStrategy.cs
+++ b/API/0452_Ttm_Squeeze/CS/TtmSqueezeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0453_Vela_Superada/CS/VelaSuperadaStrategy.cs
+++ b/API/0453_Vela_Superada/CS/VelaSuperadaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0454_Williams_Vix_Fix/CS/WilliamsVixFixStrategy.cs
+++ b/API/0454_Williams_Vix_Fix/CS/WilliamsVixFixStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0455_Golden_Ratio_Cubes/CS/GoldenRatioCubesStrategy.cs
+++ b/API/0455_Golden_Ratio_Cubes/CS/GoldenRatioCubesStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0456_Squeeze_Pro_Overlays/CS/SqueezeProOverlaysStrategy.cs
+++ b/API/0456_Squeeze_Pro_Overlays/CS/SqueezeProOverlaysStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0457_Averaging_Down/CS/AveragingDownStrategy.cs
+++ b/API/0457_Averaging_Down/CS/AveragingDownStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0458_Smc_Bb_Breakout/CS/SmcBbBreakoutStrategy.cs
+++ b/API/0458_Smc_Bb_Breakout/CS/SmcBbBreakoutStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0459_OneTwoThree_Reversal/CS/OneTwoThreeReversalStrategy.cs
+++ b/API/0459_OneTwoThree_Reversal/CS/OneTwoThreeReversalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0459_Opening_Range_Breakout/CS/OpeningRangeBreakoutStrategy.cs
+++ b/API/0459_Opening_Range_Breakout/CS/OpeningRangeBreakoutStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0460_Smc_OrderBlock_Zones/CS/SmcOrderBlockZonesStrategy.cs
+++ b/API/0460_Smc_OrderBlock_Zones/CS/SmcOrderBlockZonesStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0461_Ema_Macd_Rsi/CS/EmaMacdRsiStrategy.cs
+++ b/API/0461_Ema_Macd_Rsi/CS/EmaMacdRsiStrategy.cs
@@ -1,6 +1,10 @@
-
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0462_Liquidity_Swings/CS/LiquiditySwingsStrategy.cs
+++ b/API/0462_Liquidity_Swings/CS/LiquiditySwingsStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0463_Candle245_Breakout/CS/Candle245BreakoutStrategy.cs
+++ b/API/0463_Candle245_Breakout/CS/Candle245BreakoutStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0464_MA_PSAR_ATR_Trend/CS/MaPsarAtrTrendStrategy.cs
+++ b/API/0464_MA_PSAR_ATR_Trend/CS/MaPsarAtrTrendStrategy.cs
@@ -1,7 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0465_200_SMA_Buffer/CS/SmaBufferStrategy.cs
+++ b/API/0465_200_SMA_Buffer/CS/SmaBufferStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0466_MA_BB_Supertrend/CS/MaBbSupertrendStrategy.cs
+++ b/API/0466_MA_BB_Supertrend/CS/MaBbSupertrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0467_2Mars_Okx/CS/TwoMarsOkxStrategy.cs
+++ b/API/0467_2Mars_Okx/CS/TwoMarsOkxStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0468_Two_X_Spy_Tips/CS/TwoXSpyTipsStrategy.cs
+++ b/API/0468_Two_X_Spy_Tips/CS/TwoXSpyTipsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0469_Three_Down_Three_Up/CS/ThreeDownThreeUpStrategy.cs
+++ b/API/0469_Three_Down_Three_Up/CS/ThreeDownThreeUpStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0470_Three_Red_Green_Volatility/CS/ThreeRedGreenVolatilityStrategy.cs
+++ b/API/0470_Three_Red_Green_Volatility/CS/ThreeRedGreenVolatilityStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0471_Three_Bar_Low/CS/ThreeBarLowStrategy.cs
+++ b/API/0471_Three_Bar_Low/CS/ThreeBarLowStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0472_Three_Signal_Directional_Trend/CS/ThreeSignalDirectionalTrendStrategy.cs
+++ b/API/0472_Three_Signal_Directional_Trend/CS/ThreeSignalDirectionalTrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0473_Rsi_30_70/CS/Rsi3070Strategy.cs
+++ b/API/0473_Rsi_30_70/CS/Rsi3070Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0474_30_Minute_Candle/CS/ThirtyMinuteCandleStrategy.cs
+++ b/API/0474_30_Minute_Candle/CS/ThirtyMinuteCandleStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0475_Scalping_Ema_Rsi_Macd/CS/ScalpingEmaRsiMacdStrategy.cs
+++ b/API/0475_Scalping_Ema_Rsi_Macd/CS/ScalpingEmaRsiMacdStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0476_3Commas_Bot/CS/ThreeCommasBotStrategy.cs
+++ b/API/0476_3Commas_Bot/CS/ThreeCommasBotStrategy.cs
@@ -1,7 +1,14 @@
+using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/0477_3D_Wave_PM/CS/ThreeDWavePmStrategy.cs
+++ b/API/0477_3D_Wave_PM/CS/ThreeDWavePmStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0479_3x_Supertrend/CS/TripleSupertrendStrategy.cs
+++ b/API/0479_3x_Supertrend/CS/TripleSupertrendStrategy.cs
@@ -1,5 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0480_Four_Bar_Momentum_Reversal/CS/FourBarMomentumReversalStrategy.cs
+++ b/API/0480_Four_Bar_Momentum_Reversal/CS/FourBarMomentumReversalStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0481_Bollinger_Breakout/CS/BollingerBreakout2Strategy.cs
+++ b/API/0481_Bollinger_Breakout/CS/BollingerBreakout2Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0482_Vietnamese_3x_Supertrend/CS/Vietnamese3xSupertrendStrategy.cs
+++ b/API/0482_Vietnamese_3x_Supertrend/CS/Vietnamese3xSupertrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0483_Five_Ema_NoTouch_Breakout/CS/FiveEmaNoTouchBreakoutStrategy.cs
+++ b/API/0483_Five_Ema_NoTouch_Breakout/CS/FiveEmaNoTouchBreakoutStrategy.cs
@@ -1,6 +1,10 @@
-
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0484_Five_Ema/CS/FiveEmaStrategy.cs
+++ b/API/0484_Five_Ema/CS/FiveEmaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0486_Adaptive_HMA_Plus/CS/AdaptiveHmaPlusStrategy.cs
+++ b/API/0486_Adaptive_HMA_Plus/CS/AdaptiveHmaPlusStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0487_Sma_Pullback_Atr_Exits/CS/SmaPullbackAtrExitsStrategy.cs
+++ b/API/0487_Sma_Pullback_Atr_Exits/CS/SmaPullbackAtrExitsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0488_80_20/CS/EightyTwentyStrategy.cs
+++ b/API/0488_80_20/CS/EightyTwentyStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0489_Beta_Weighted_MA/CS/BetaWeightedMaStrategy.cs
+++ b/API/0489_Beta_Weighted_MA/CS/BetaWeightedMaStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0491_Adaptive_Fractal_Grid_Scalping/CS/AdaptiveFractalGridScalpingStrategy.cs
+++ b/API/0491_Adaptive_Fractal_Grid_Scalping/CS/AdaptiveFractalGridScalpingStrategy.cs
@@ -1,7 +1,14 @@
 using System;
-using Ecng.ComponentModel;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/0492_Adaptive_KDJ_MTF/CS/AdaptiveKdjMtfStrategy.cs
+++ b/API/0492_Adaptive_KDJ_MTF/CS/AdaptiveKdjMtfStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0495_Adaptive_Squeeze_Momentum/CS/AdaptiveSqueezeMomentumStrategy.cs
+++ b/API/0495_Adaptive_Squeeze_Momentum/CS/AdaptiveSqueezeMomentumStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0496_Adaptive_Trend_Flow/CS/AdaptiveTrendFlowStrategy.cs
+++ b/API/0496_Adaptive_Trend_Flow/CS/AdaptiveTrendFlowStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0497_Adjustable_Ma_Alternating_Extremities/CS/AdjustableMaAlternatingExtremitiesStrategy.cs
+++ b/API/0497_Adjustable_Ma_Alternating_Extremities/CS/AdjustableMaAlternatingExtremitiesStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0498_Advanced_Adaptive_Grid/CS/AdvancedAdaptiveGridStrategy.cs
+++ b/API/0498_Advanced_Adaptive_Grid/CS/AdvancedAdaptiveGridStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0499_Advanced_Ema_Cross/CS/AdvancedEmaCrossStrategy.cs
+++ b/API/0499_Advanced_Ema_Cross/CS/AdvancedEmaCrossStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0500_Gold_Rsi_Divergence/CS/GoldRsiDivergenceStrategy.cs
+++ b/API/0500_Gold_Rsi_Divergence/CS/GoldRsiDivergenceStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;


### PR DESCRIPTION
## Summary
- add the shared System, Ecng, and StockSharp using directives to every API strategy from 0201 through 0500

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d807d9089083238fde29cb599e15a4