### PR TITLE
Add common using directives to API strategies 0501-1000

### DIFF
--- a/API/0501_Advanced_Multi_Seasonality/CS/AdvancedMultiSeasonalityStrategy.cs
+++ b/API/0501_Advanced_Multi_Seasonality/CS/AdvancedMultiSeasonalityStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0502_Fib_Hurst_Breakout/CS/FibHurstBreakoutStrategy.cs
+++ b/API/0502_Fib_Hurst_Breakout/CS/FibHurstBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0503_Advanced_Position_Management/CS/AdvancedPositionManagementStrategy.cs
+++ b/API/0503_Advanced_Position_Management/CS/AdvancedPositionManagementStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0504_Advanced_Supertrend/CS/AdvancedSupertrendStrategy.cs
+++ b/API/0504_Advanced_Supertrend/CS/AdvancedSupertrendStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0505_ADX_CCI_MA/CS/AdxCciMaStrategy.cs
+++ b/API/0505_ADX_CCI_MA/CS/AdxCciMaStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0506_ADX_Volume_Multiplier/CS/AdxVolumeMultiplierStrategy.cs
+++ b/API/0506_ADX_Volume_Multiplier/CS/AdxVolumeMultiplierStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0507_ADX_Range_Breakout/CS/AdxRangeBreakoutStrategy.cs
+++ b/API/0507_ADX_Range_Breakout/CS/AdxRangeBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0508_ADX_for_BTC/CS/AdxForBtcStrategy.cs
+++ b/API/0508_ADX_for_BTC/CS/AdxForBtcStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0509_Aftershock_Playbook_Stock_Earnings_Drift_Engine/CS/AftershockPlaybookStrategy.cs
+++ b/API/0509_Aftershock_Playbook_Stock_Earnings_Drift_Engine/CS/AftershockPlaybookStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0510_Aggregate_Btc_Candles/CS/AggregateBtcCandlesStrategy.cs
+++ b/API/0510_Aggregate_Btc_Candles/CS/AggregateBtcCandlesStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0511_Aggressive_High_IV/CS/AggressiveHighIvStrategy.cs
+++ b/API/0511_Aggressive_High_IV/CS/AggressiveHighIvStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0512_Williams_Alligator_ATR/CS/WilliamsAlligatorAtrStrategy.cs
+++ b/API/0512_Williams_Alligator_ATR/CS/WilliamsAlligatorAtrStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0513_AI_SuperTrend/CS/AiSuperTrendStrategy.cs
+++ b/API/0513_AI_SuperTrend/CS/AiSuperTrendStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0514_Ai_Supertrend_Pivot_Percentile/CS/AiSupertrendPivotPercentileStrategy.cs
+++ b/API/0514_Ai_Supertrend_Pivot_Percentile/CS/AiSupertrendPivotPercentileStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0515_AI_Volume/CS/AiVolumeStrategy.cs
+++ b/API/0515_AI_Volume/CS/AiVolumeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0516_All_Divergences/CS/AllDivergencesStrategy.cs
+++ b/API/0516_All_Divergences/CS/AllDivergencesStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0517_Alligator_Ma_Trend_Catcher/CS/AlligatorMaTrendCatcherStrategy.cs
+++ b/API/0517_Alligator_Ma_Trend_Catcher/CS/AlligatorMaTrendCatcherStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0518_ALMA_UT_Bot_Confluence/CS/AlmaUtBotConfluenceStrategy.cs
+++ b/API/0518_ALMA_UT_Bot_Confluence/CS/AlmaUtBotConfluenceStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0519_ALMA_Optimized/CS/AlmaOptimizedStrategy.cs
+++ b/API/0519_ALMA_Optimized/CS/AlmaOptimizedStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0520_Altcoin_Index_Correlation/CS/AltcoinIndexCorrelationStrategy.cs
+++ b/API/0520_Altcoin_Index_Correlation/CS/AltcoinIndexCorrelationStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0521_Anands/CS/AnandsStrategy.cs
+++ b/API/0521_Anands/CS/AnandsStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0522_Anomalous_Holonomy_Field_Theory/CS/AnomalousHolonomyFieldTheoryStrategy.cs
+++ b/API/0522_Anomalous_Holonomy_Field_Theory/CS/AnomalousHolonomyFieldTheoryStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0523_Anomaly_Counter_Trend/CS/AnomalyCounterTrendStrategy.cs
+++ b/API/0523_Anomaly_Counter_Trend/CS/AnomalyCounterTrendStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0524_Ao_Ac_Trading_Zones/CS/AoAcTradingZonesStrategy.cs
+++ b/API/0524_Ao_Ac_Trading_Zones/CS/AoAcTradingZonesStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/0525_AO_Divergence/CS/AoDivergenceStrategy.cs
+++ b/API/0525_AO_Divergence/CS/AoDivergenceStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0526_Spot_Futures_Arbitrage/CS/SpotFuturesArbitrageStrategy.cs
+++ b/API/0526_Spot_Futures_Arbitrage/CS/SpotFuturesArbitrageStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0527_Arpeet_Macd/CS/ArpeetMacdStrategy.cs
+++ b/API/0527_Arpeet_Macd/CS/ArpeetMacdStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0528_Arpit_Bollinger_Band/CS/ArpitBollingerBandStrategy.cs
+++ b/API/0528_Arpit_Bollinger_Band/CS/ArpitBollingerBandStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0529_ARSI_VWAP_ATR/CS/ArsiVwapAtrStrategy.cs
+++ b/API/0529_ARSI_VWAP_ATR/CS/ArsiVwapAtrStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0530_ATR_Based_Trendlines/CS/AtrBasedTrendlinesStrategy.cs
+++ b/API/0530_ATR_Based_Trendlines/CS/AtrBasedTrendlinesStrategy.cs
@@ -1,6 +1,11 @@
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0531_ATR_God/CS/AtrGodStrategy.cs
+++ b/API/0531_ATR_God/CS/AtrGodStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0532_Atr_Stop_Loss_Double_Sma/CS/AtrStopLossDoubleSmaStrategy.cs
+++ b/API/0532_Atr_Stop_Loss_Double_Sma/CS/AtrStopLossDoubleSmaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0533_AudUsd_Scalping/CS/AudUsdScalpingStrategy.cs
+++ b/API/0533_AudUsd_Scalping/CS/AudUsdScalpingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0534_Pearsons_R_Oscillator/CS/PearsonsROscillatorStrategy.cs
+++ b/API/0534_Pearsons_R_Oscillator/CS/PearsonsROscillatorStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0535_Auto_Fibo_Gann_Fan_Retracements/CS/AutoFiboGannFanRetracementsStrategy.cs
+++ b/API/0535_Auto_Fibo_Gann_Fan_Retracements/CS/AutoFiboGannFanRetracementsStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/0536_State_Aware_MA_Cross/CS/StateAwareMaCrossStrategy.cs
+++ b/API/0536_State_Aware_MA_Cross/CS/StateAwareMaCrossStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0537_AutoFib_Breakout/CS/AutoFibBreakoutStrategy.cs
+++ b/API/0537_AutoFib_Breakout/CS/AutoFibBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0538_Automatic_Trendlines/CS/AutomaticTrendlinesStrategy.cs
+++ b/API/0538_Automatic_Trendlines/CS/AutomaticTrendlinesStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0539_Autonomous_5_Minute_Robot/CS/Autonomous5MinuteRobotStrategy.cs
+++ b/API/0539_Autonomous_5_Minute_Robot/CS/Autonomous5MinuteRobotStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0540_Average_Force/CS/AverageForceStrategy.cs
+++ b/API/0540_Average_Force/CS/AverageForceStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0541_Average_High_Low_Range_IBS_Reversal/CS/AverageHighLowRangeIbsReversalStrategy.cs
+++ b/API/0541_Average_High_Low_Range_IBS_Reversal/CS/AverageHighLowRangeIbsReversalStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0542_Averaging_Down/CS/AveragingDown2Strategy.cs
+++ b/API/0542_Averaging_Down/CS/AveragingDown2Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0543_BabyShark_VWAP/CS/BabySharkVwapStrategy.cs
+++ b/API/0543_BabyShark_VWAP/CS/BabySharkVwapStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0544_Backtesting_Module/CS/BacktestingModuleStrategy.cs
+++ b/API/0544_Backtesting_Module/CS/BacktestingModuleStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0545_Backward_Number_of_Bars/CS/BackwardNumberOfBarsStrategy.cs
+++ b/API/0545_Backward_Number_of_Bars/CS/BackwardNumberOfBarsStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0546_Balance_Of_Power/CS/BalanceOfPowerStrategy.cs
+++ b/API/0546_Balance_Of_Power/CS/BalanceOfPowerStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0547_Bar_Balance/CS/BarBalanceStrategy.cs
+++ b/API/0547_Bar_Balance/CS/BarBalanceStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0548_Bar_Range/CS/BarRangeStrategy.cs
+++ b/API/0548_Bar_Range/CS/BarRangeStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0549_Baseline2/CS/Baseline2Strategy.cs
+++ b/API/0549_Baseline2/CS/Baseline2Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0550_Bayesian_Bbsma_Oscillator/CS/BayesianBbsmaOscillatorStrategy.cs
+++ b/API/0550_Bayesian_Bbsma_Oscillator/CS/BayesianBbsmaOscillatorStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0551_BB_RSI_Trailing_Stop/CS/BbRsiTrailingStopStrategy.cs
+++ b/API/0551_BB_RSI_Trailing_Stop/CS/BbRsiTrailingStopStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0552_BB_RSI/CS/BbRsiStrategy.cs
+++ b/API/0552_BB_RSI/CS/BbRsiStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0553_BB_Breakout_Momentum_Squeeze/CS/BbBreakoutMomentumSqueezeStrategy.cs
+++ b/API/0553_BB_Breakout_Momentum_Squeeze/CS/BbBreakoutMomentumSqueezeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0554_BB_Heikin_Ashi_Entry/CS/BollingerHeikinAshiEntryStrategy.cs
+++ b/API/0554_BB_Heikin_Ashi_Entry/CS/BollingerHeikinAshiEntryStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0555_BB_HeikinAshi_Entry/CS/BbHeikinAshiEntryStrategy.cs
+++ b/API/0555_BB_HeikinAshi_Entry/CS/BbHeikinAshiEntryStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0556_Bbsr_Extreme/CS/BbsrExtremeStrategy.cs
+++ b/API/0556_Bbsr_Extreme/CS/BbsrExtremeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0557_Bbtrend_Supertrend_Decision/CS/BbtrendSupertrendDecisionStrategy.cs
+++ b/API/0557_Bbtrend_Supertrend_Decision/CS/BbtrendSupertrendDecisionStrategy.cs
@@ -1,6 +1,11 @@
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0558_Bearish_Wick_Reversal/CS/BearishWickReversalStrategy.cs
+++ b/API/0558_Bearish_Wick_Reversal/CS/BearishWickReversalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0559_Bedo_Osaimi_Istr/CS/BedoOsaimiIstrStrategy.cs
+++ b/API/0559_Bedo_Osaimi_Istr/CS/BedoOsaimiIstrStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0560_Bot_For_Spot_Market_Custom_Grid/CS/BotForSpotMarketCustomGridStrategy.cs
+++ b/API/0560_Bot_For_Spot_Market_Custom_Grid/CS/BotForSpotMarketCustomGridStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0561_Bench/CS/BenchStrategy.cs
+++ b/API/0561_Bench/CS/BenchStrategy.cs
@@ -1,10 +1,17 @@
 using System;
-using System.Diagnostics;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using System.Diagnostics;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0561_Breadth_Thrust_Volatility_Stop/CS/BreadthThrustVolatilityStopStrategy.cs
+++ b/API/0561_Breadth_Thrust_Volatility_Stop/CS/BreadthThrustVolatilityStopStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0562_Berlin_Candles/CS/BerlinCandlesStrategy.cs
+++ b/API/0562_Berlin_Candles/CS/BerlinCandlesStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/0562_Breakouts_With_Timefilter/CS/BreakoutsWithTimeFilterStrategy.cs
+++ b/API/0562_Breakouts_With_Timefilter/CS/BreakoutsWithTimeFilterStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0563_Berlin_Range_Index/CS/BerlinRangeIndexStrategy.cs
+++ b/API/0563_Berlin_Range_Index/CS/BerlinRangeIndexStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0563_Breaks_and_Retests/CS/BreaksAndRetestsStrategy.cs
+++ b/API/0563_Breaks_and_Retests/CS/BreaksAndRetestsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0564_Best_Dollar_Cost_Average/CS/BestDollarCostAverageStrategy.cs
+++ b/API/0564_Best_Dollar_Cost_Average/CS/BestDollarCostAverageStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0564_Btc_Chop_Reversal/CS/BtcChopReversalStrategy.cs
+++ b/API/0564_Btc_Chop_Reversal/CS/BtcChopReversalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0565_Bias_Sentiment_Strength/CS/BiasSentimentStrengthStrategy.cs
+++ b/API/0565_Bias_Sentiment_Strength/CS/BiasSentimentStrengthStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0566_Bias_Ratio/CS/BiasRatioStrategy.cs
+++ b/API/0566_Bias_Ratio/CS/BiasRatioStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0566_Btc_Difficulty_Adjustments/CS/BtcDifficultyAdjustmentsStrategy.cs
+++ b/API/0566_Btc_Difficulty_Adjustments/CS/BtcDifficultyAdjustmentsStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0567_BTC_Future_Gamma_Weighted_Momentum_Model/CS/BtcFutureGammaWeightedMomentumModelStrategy.cs
+++ b/API/0567_BTC_Future_Gamma_Weighted_Momentum_Model/CS/BtcFutureGammaWeightedMomentumModelStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0567_Big_Candle_Rsi_Divergence/CS/BigCandleRsiDivergenceStrategy.cs
+++ b/API/0567_Big_Candle_Rsi_Divergence/CS/BigCandleRsiDivergenceStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0568_Big_Mover_Catcher/CS/BigMoverCatcherStrategy.cs
+++ b/API/0568_Big_Mover_Catcher/CS/BigMoverCatcherStrategy.cs
@@ -1,7 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
 using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0568_Btc_Outperform/CS/BtcOutperformStrategy.cs
+++ b/API/0568_Btc_Outperform/CS/BtcOutperformStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0569_Big_Runner/CS/BigRunnerStrategy.cs
+++ b/API/0569_Big_Runner/CS/BigRunnerStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0569_Btc_Seasonality/CS/BtcSeasonalityStrategy.cs
+++ b/API/0569_Btc_Seasonality/CS/BtcSeasonalityStrategy.cs
@@ -1,5 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0570_Binomial_Option_Pricing_Model/CS/BinomialOptionPricingModelStrategy.cs
+++ b/API/0570_Binomial_Option_Pricing_Model/CS/BinomialOptionPricingModelStrategy.cs
@@ -1,4 +1,11 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0570_Btc_Trading_Robot/CS/BtcTradingRobotStrategy.cs
+++ b/API/0570_Btc_Trading_Robot/CS/BtcTradingRobotStrategy.cs
@@ -1,6 +1,11 @@
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0571_BTCUSD_Momentum_After_Abnormal_Days/CS/BtcusdMomentumAfterAbnormalDaysStrategy.cs
+++ b/API/0571_BTCUSD_Momentum_After_Abnormal_Days/CS/BtcusdMomentumAfterAbnormalDaysStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0571_Bitcoin_1H15M_Breakout/CS/Bitcoin1H15MBreakoutStrategy.cs
+++ b/API/0571_Bitcoin_1H15M_Breakout/CS/Bitcoin1H15MBreakoutStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0572_BTCUSD_Adjustable_SLTP/CS/BtcusdAdjustableSltpStrategy.cs
+++ b/API/0572_BTCUSD_Adjustable_SLTP/CS/BtcusdAdjustableSltpStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0572_Bitcoin_Bullish_Percent_Index/CS/BitcoinBullishPercentIndexStrategy.cs
+++ b/API/0572_Bitcoin_Bullish_Percent_Index/CS/BitcoinBullishPercentIndexStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0573_BTFD/CS/BtfdStrategy.cs
+++ b/API/0573_BTFD/CS/BtfdStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0573_Bitcoin_CME_Spot_Spread/CS/BitcoinCmeSpotSpreadStrategy.cs
+++ b/API/0573_Bitcoin_CME_Spot_Spread/CS/BitcoinCmeSpotSpreadStrategy.cs
@@ -1,5 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0574_Bitcoin_Exponential_Profit/CS/BitcoinExponentialProfitStrategy.cs
+++ b/API/0574_Bitcoin_Exponential_Profit/CS/BitcoinExponentialProfitStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0574_BuiltIn_Kelly_Ratio/CS/BuiltInKellyRatioStrategy.cs
+++ b/API/0574_BuiltIn_Kelly_Ratio/CS/BuiltInKellyRatioStrategy.cs
@@ -1,8 +1,15 @@
-using StockSharp.Algo.Strategies;
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
-using System.Collections.Generic;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0575_Bitcoin_Futures_Spot_TriFrame/CS/BitcoinFuturesSpotTriFrameStrategy.cs
+++ b/API/0575_Bitcoin_Futures_Spot_TriFrame/CS/BitcoinFuturesSpotTriFrameStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0575_BullBear_Volume_Percentile_TP/CS/BullBearVolumePercentileTpStrategy.cs
+++ b/API/0575_BullBear_Volume_Percentile_TP/CS/BullBearVolumePercentileTpStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0576_Bitcoin_Leverage_Sentiment/CS/BitcoinLeverageSentimentStrategy.cs
+++ b/API/0576_Bitcoin_Leverage_Sentiment/CS/BitcoinLeverageSentimentStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0576_Bullish_Bs_Rsi_Divergence/CS/BullishBsRsiDivergenceStrategy.cs
+++ b/API/0576_Bullish_Bs_Rsi_Divergence/CS/BullishBsRsiDivergenceStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0577_Bitcoin_Liquidity_Breakout/CS/BitcoinLiquidityBreakoutStrategy.cs
+++ b/API/0577_Bitcoin_Liquidity_Breakout/CS/BitcoinLiquidityBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0577_Bullish_Divergence_Short_Term_Long_Trade_Finder/CS/BullishDivergenceShortTermLongTradeFinderStrategy.cs
+++ b/API/0577_Bullish_Divergence_Short_Term_Long_Trade_Finder/CS/BullishDivergenceShortTermLongTradeFinderStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0578_Bitcoin_Momentum/CS/BitcoinMomentumStrategy.cs
+++ b/API/0578_Bitcoin_Momentum/CS/BitcoinMomentumStrategy.cs
@@ -1,4 +1,11 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0578_Bullish_Reversal_Bar/CS/BullishReversalBarStrategy.cs
+++ b/API/0578_Bullish_Reversal_Bar/CS/BullishReversalBarStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0579_Bj_Candle_Patterns/CS/BjCandlePatternsStrategy.cs
+++ b/API/0579_Bj_Candle_Patterns/CS/BjCandlePatternsStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0579_Buy_And_Hold/CS/BuyAndHoldStrategy.cs
+++ b/API/0579_Buy_And_Hold/CS/BuyAndHoldStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0580_Bjorgum_Double_Tap/CS/BjorgumDoubleTapStrategy.cs
+++ b/API/0580_Bjorgum_Double_Tap/CS/BjorgumDoubleTapStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0580_Buy_Sell_Renko_Based/CS/BuySellRenkoBasedStrategy.cs
+++ b/API/0580_Buy_Sell_Renko_Based/CS/BuySellRenkoBasedStrategy.cs
@@ -1,9 +1,16 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
 using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/0581_Black_Scholes_Delta_Hedge/CS/BlackScholesDeltaHedgeStrategy.cs
+++ b/API/0581_Black_Scholes_Delta_Hedge/CS/BlackScholesDeltaHedgeStrategy.cs
@@ -1,4 +1,12 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0581_Buy_Dip_Multiple_Positions/CS/BuyDipMultiplePositionsStrategy.cs
+++ b/API/0581_Buy_Dip_Multiple_Positions/CS/BuyDipMultiplePositionsStrategy.cs
@@ -1,7 +1,12 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0582_Black_Scholes_Option_Pricing/CS/BlackScholesOptionPricingStrategy.cs
+++ b/API/0582_Black_Scholes_Option_Pricing/CS/BlackScholesOptionPricingStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/0582_Buy_On_5_Day_Low/CS/BuyOn5DayLowStrategy.cs
+++ b/API/0582_Buy_On_5_Day_Low/CS/BuyOn5DayLowStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0583_Bober_XM/CS/BoberXmStrategy.cs
+++ b/API/0583_Bober_XM/CS/BoberXmStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0583_ZScore_Buy_Sell/CS/ZScoreBuySellStrategy.cs
+++ b/API/0583_ZScore_Buy_Sell/CS/ZScoreBuySellStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0584_Blood_In_The_Streets/CS/BloodInTheStreetsStrategy.cs
+++ b/API/0584_Blood_In_The_Streets/CS/BloodInTheStreetsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0584_Boilerplate_Configurable/CS/BoilerplateConfigurableStrategy.cs
+++ b/API/0584_Boilerplate_Configurable/CS/BoilerplateConfigurableStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0585_Bollinger_Ema_Stats/CS/BollingerEmaStatsStrategy.cs
+++ b/API/0585_Bollinger_Ema_Stats/CS/BollingerEmaStatsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0585_BuySell_Bullish_Engulfing/CS/BuySellBullishEngulfingStrategy.cs
+++ b/API/0585_BuySell_Bullish_Engulfing/CS/BuySellBullishEngulfingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0586_Bollinger_Stochastic_Trailing_Stop/CS/BollingerStochasticTrailingStopStrategy.cs
+++ b/API/0586_Bollinger_Stochastic_Trailing_Stop/CS/BollingerStochasticTrailingStopStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0586_Buying_Selling_Volume/CS/BuyingSellingVolumeStrategy.cs
+++ b/API/0586_Buying_Selling_Volume/CS/BuyingSellingVolumeStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0587_Bollinger_Band_Touch_SMI_MACD_Angle/CS/BollingerBandTouchSmiMacdAngleStrategy.cs
+++ b/API/0587_Bollinger_Band_Touch_SMI_MACD_Angle/CS/BollingerBandTouchSmiMacdAngleStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0587_Buy_The_Dips_Trend/CS/BuyTheDipsTrendStrategy.cs
+++ b/API/0587_Buy_The_Dips_Trend/CS/BuyTheDipsTrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0588_Bollinger_Bands_Fibonacci/CS/BollingerBandsFibonacciStrategy.cs
+++ b/API/0588_Bollinger_Bands_Fibonacci/CS/BollingerBandsFibonacciStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0588_Buy_Only_EMA_BB/CS/BuyOnlyEmaBbStrategy.cs
+++ b/API/0588_Buy_Only_EMA_BB/CS/BuyOnlyEmaBbStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0589_Bollinger_Bands_RSI/CS/BollingerBandsRsiStrategy.cs
+++ b/API/0589_Bollinger_Bands_RSI/CS/BollingerBandsRsiStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0589_Candle_Body_Shapes/CS/CandleBodyShapesStrategy.cs
+++ b/API/0589_Candle_Body_Shapes/CS/CandleBodyShapesStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0590_Bollinger_Bands_Enhanced/CS/BollingerBandsEnhancedStrategy.cs
+++ b/API/0590_Bollinger_Bands_Enhanced/CS/BollingerBandsEnhancedStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0591_Bollinger_Bands_Long/CS/BollingerBandsLongStrategy.cs
+++ b/API/0591_Bollinger_Bands_Long/CS/BollingerBandsLongStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0592_Bollinger_Bands_Mean_Reversion/CS/BollingerBandsMeanReversionStrategy.cs
+++ b/API/0592_Bollinger_Bands_Mean_Reversion/CS/BollingerBandsMeanReversionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0593_Bollinger_Bands_Modified/CS/BollingerBandsModifiedStrategy.cs
+++ b/API/0593_Bollinger_Bands_Modified/CS/BollingerBandsModifiedStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0594_Bollinger_Bands_SMA_20_2/CS/BollingerBandsSma202Strategy.cs
+++ b/API/0594_Bollinger_Bands_SMA_20_2/CS/BollingerBandsSma202Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0595_Bollinger_Bands/CS/BollingerBandsStrategy.cs
+++ b/API/0595_Bollinger_Bands/CS/BollingerBandsStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0596_Bollinger_Bounce_Reversal/CS/BollingerBounceReversalStrategy.cs
+++ b/API/0596_Bollinger_Bounce_Reversal/CS/BollingerBounceReversalStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0597_Bollinger_Breakout_Direction/CS/BollingerBreakoutDirectionStrategy.cs
+++ b/API/0597_Bollinger_Breakout_Direction/CS/BollingerBreakoutDirectionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0598_Bonk_Long_Volatility/CS/BonkLongVolatilityStrategy.cs
+++ b/API/0598_Bonk_Long_Volatility/CS/BonkLongVolatilityStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0599_DCA_Dual_Trailing/CS/DcaDualTrailingStrategy.cs
+++ b/API/0599_DCA_Dual_Trailing/CS/DcaDualTrailingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0600_CANX_MA_Crossover/CS/CanxMaCrossoverStrategy.cs
+++ b/API/0600_CANX_MA_Crossover/CS/CanxMaCrossoverStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0601_Captain_Backtest_Model/CS/CaptainBacktestModelStrategy.cs
+++ b/API/0601_Captain_Backtest_Model/CS/CaptainBacktestModelStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0602_CBC_Trend_Confirmation_Separate_Stop_Loss/CS/CbcWithTrendConfirmationAndSeparateStopLossStrategy.cs
+++ b/API/0602_CBC_Trend_Confirmation_Separate_Stop_Loss/CS/CbcWithTrendConfirmationAndSeparateStopLossStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0603_CC_Trend_Downtrend_Short/CS/CCTrend2DowntrendShortStrategy.cs
+++ b/API/0603_CC_Trend_Downtrend_Short/CS/CCTrend2DowntrendShortStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0604_CCI_Support_Resistance/CS/CciSupportResistanceStrategy.cs
+++ b/API/0604_CCI_Support_Resistance/CS/CciSupportResistanceStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0605_CCI_Threshold/CS/CciThresholdStrategy.cs
+++ b/API/0605_CCI_Threshold/CS/CciThresholdStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0606_CCI_EMA_ATR_TP_SL/CS/CciEmaAtrTpSlStrategy.cs
+++ b/API/0606_CCI_EMA_ATR_TP_SL/CS/CciEmaAtrTpSlStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0607_CCI_MACD/CS/CciMacdStrategy.cs
+++ b/API/0607_CCI_MACD/CS/CciMacdStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0608_CE_XAU_USDT/CS/CE_XAU_USDTStrategy.cs
+++ b/API/0608_CE_XAU_USDT/CS/CE_XAU_USDTStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0609_Ce_Zlsma_5Min_Candlechart/CS/CeZlsma5MinCandlechartStrategy.cs
+++ b/API/0609_Ce_Zlsma_5Min_Candlechart/CS/CeZlsma5MinCandlechartStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0610_Chaikin_Momentum_Scalper/CS/ChaikinMomentumScalperStrategy.cs
+++ b/API/0610_Chaikin_Momentum_Scalper/CS/ChaikinMomentumScalperStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0611_Chande_Kroll_Trend/CS/ChandeKrollTrendStrategy.cs
+++ b/API/0611_Chande_Kroll_Trend/CS/ChandeKrollTrendStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0613_Chande_Momentum_Oscillator/CS/ChandeMomentumOscillatorStrategy.cs
+++ b/API/0613_Chande_Momentum_Oscillator/CS/ChandeMomentumOscillatorStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0614_Chandelier_Exit_With_200_EMA_Filter/CS/ChandelierExitWith200EmaFilterStrategy.cs
+++ b/API/0614_Chandelier_Exit_With_200_EMA_Filter/CS/ChandelierExitWith200EmaFilterStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0615_Channels_With_NVI/CS/ChannelsWithNviStrategy.cs
+++ b/API/0615_Channels_With_NVI/CS/ChannelsWithNviStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0616_Chart_Oscillator/CS/ChartOscillatorStrategy.cs
+++ b/API/0616_Chart_Oscillator/CS/ChartOscillatorStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0617_ChartPatterns/CS/ChartPatternsStrategy.cs
+++ b/API/0617_ChartPatterns/CS/ChartPatternsStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0618_ChopFlow_ATR_Scalp/CS/ChopFlowAtrScalpStrategy.cs
+++ b/API/0618_ChopFlow_ATR_Scalp/CS/ChopFlowAtrScalpStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0619_Classic_Nacked_Z-Score_Arbitrage/CS/ClassicNackedZScoreArbitrageStrategy.cs
+++ b/API/0619_Classic_Nacked_Z-Score_Arbitrage/CS/ClassicNackedZScoreArbitrageStrategy.cs
@@ -1,12 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using Ecng.ComponentModel;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using Ecng.ComponentModel;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0620_Cleaner_Screeners_Library/CS/CleanerScreenersLibraryStrategy.cs
+++ b/API/0620_Cleaner_Screeners_Library/CS/CleanerScreenersLibraryStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0621_CME_Equity_Futures_Price_Limits/CS/CmeEquityFuturesPriceLimitsStrategy.cs
+++ b/API/0621_CME_Equity_Futures_Price_Limits/CS/CmeEquityFuturesPriceLimitsStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0622_Cnagda_Fixed_Swing/CS/CnagdaFixedSwingStrategy.cs
+++ b/API/0622_Cnagda_Fixed_Swing/CS/CnagdaFixedSwingStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0623_Color_Code_Overlay/CS/ColorCodeOverlayStrategy.cs
+++ b/API/0623_Color_Code_Overlay/CS/ColorCodeOverlayStrategy.cs
@@ -1,6 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/0624_Color_Gradient_Framework/CS/ColorGradientFrameworkStrategy.cs
+++ b/API/0624_Color_Gradient_Framework/CS/ColorGradientFrameworkStrategy.cs
@@ -1,9 +1,17 @@
 using System;
-using System.Drawing;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using System.Drawing;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0625_Color/CS/ColorStrategy.cs
+++ b/API/0625_Color/CS/ColorStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using System.Drawing;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using System.Drawing;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0626_Combo_2_20_EMA_Bandpass_Filter/CS/Combo220EmaBandpassFilterStrategy.cs
+++ b/API/0626_Combo_2_20_EMA_Bandpass_Filter/CS/Combo220EmaBandpassFilterStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0627_Combo_2_20_EMA_CCI/CS/Combo220EmaCciStrategy.cs
+++ b/API/0627_Combo_2_20_EMA_CCI/CS/Combo220EmaCciStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0628_Combo_123_Reversal_Fractal_Chaos_Bands/CS/Combo123ReversalFractalChaosBandsStrategy.cs
+++ b/API/0628_Combo_123_Reversal_Fractal_Chaos_Bands/CS/Combo123ReversalFractalChaosBandsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0629_Commitment_of_Trader_R/CS/CommitmentOfTraderRStrategy.cs
+++ b/API/0629_Commitment_of_Trader_R/CS/CommitmentOfTraderRStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0630_Connors_VIX_Reversal_III/CS/ConnorsVixReversalIIIStrategy.cs
+++ b/API/0630_Connors_VIX_Reversal_III/CS/ConnorsVixReversalIIIStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using Ecng.ComponentModel;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using Ecng.ComponentModel;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0631_Consecutive_Bars_Above_Below_EMA_Buy_The_Dip/CS/ConsecutiveBarsAboveBelowEMABuyTheDipStrategy.cs
+++ b/API/0631_Consecutive_Bars_Above_Below_EMA_Buy_The_Dip/CS/ConsecutiveBarsAboveBelowEMABuyTheDipStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0632_Consecutive_Bearish_Candle/CS/ConsecutiveBearishCandleStrategy.cs
+++ b/API/0632_Consecutive_Bearish_Candle/CS/ConsecutiveBearishCandleStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0633_Contrarian_DC/CS/ContrarianDcStrategy.cs
+++ b/API/0633_Contrarian_DC/CS/ContrarianDcStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0634_Correlation_Cycle/CS/CorrelationCycleStrategy.cs
+++ b/API/0634_Correlation_Cycle/CS/CorrelationCycleStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0635_Correlation_Matrix_Heatmap/CS/CorrelationMatrixHeatmapStrategy.cs
+++ b/API/0635_Correlation_Matrix_Heatmap/CS/CorrelationMatrixHeatmapStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0636_Correlation_Arrays/CS/CorrelationArraysStrategy.cs
+++ b/API/0636_Correlation_Arrays/CS/CorrelationArraysStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0637_COSTAR/CS/CostarStrategy.cs
+++ b/API/0637_COSTAR/CS/CostarStrategy.cs
@@ -1,6 +1,11 @@
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0638_Covid_Statistics_Tracker/CS/CovidStatisticsTrackerStrategy.cs
+++ b/API/0638_Covid_Statistics_Tracker/CS/CovidStatisticsTrackerStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0639_CP_Strat_ORB/CS/CpStratOrbStrategy.cs
+++ b/API/0639_CP_Strat_ORB/CS/CpStratOrbStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0640_Crunchsters_Normalised_Trend/CS/CrunchstersNormalisedTrendStrategy.cs
+++ b/API/0640_Crunchsters_Normalised_Trend/CS/CrunchstersNormalisedTrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0641_Crunchsters_Turtle_and_Trend_System/CS/CrunchstersTurtleAndTrendSystemStrategy.cs
+++ b/API/0641_Crunchsters_Turtle_and_Trend_System/CS/CrunchstersTurtleAndTrendSystemStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0642_Crypto_MVRV_ZScore/CS/CryptoMvrvZScoreStrategy.cs
+++ b/API/0642_Crypto_MVRV_ZScore/CS/CryptoMvrvZScoreStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0643_Crypto_SUSDT_10_min/CS/CryptoSusdt10MinStrategy.cs
+++ b/API/0643_Crypto_SUSDT_10_min/CS/CryptoSusdt10MinStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0644_Crypto_Volatility_Bitcoin_Correlation/CS/CryptoVolatilityBitcoinCorrelationStrategy.cs
+++ b/API/0644_Crypto_Volatility_Bitcoin_Correlation/CS/CryptoVolatilityBitcoinCorrelationStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0645_Cup_Finder/CS/CupFinderStrategy.cs
+++ b/API/0645_Cup_Finder/CS/CupFinderStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0646_Custom_Buy_BID/CS/CustomBuyBidStrategy.cs
+++ b/API/0646_Custom_Buy_BID/CS/CustomBuyBidStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0647_Custom_Signal_Oscillator/CS/CustomSignalOscillatorStrategy.cs
+++ b/API/0647_Custom_Signal_Oscillator/CS/CustomSignalOscillatorStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0648_Customizable_Btc_Seasonality/CS/CustomizableBtcSeasonalityStrategy.cs
+++ b/API/0648_Customizable_Btc_Seasonality/CS/CustomizableBtcSeasonalityStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0649_CVD_Divergence_Volume_HMA_RSI_MACD/CS/CvdDivergenceVolumeHmaRsiMacdStrategy.cs
+++ b/API/0649_CVD_Divergence_Volume_HMA_RSI_MACD/CS/CvdDivergenceVolumeHmaRsiMacdStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0650_CVD_Divergence/CS/CvdDivergenceStrategy.cs
+++ b/API/0650_CVD_Divergence/CS/CvdDivergenceStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0651_Cycle_Biologique/CS/CycleBiologiqueStrategy.cs
+++ b/API/0651_Cycle_Biologique/CS/CycleBiologiqueStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0652_D-BoT_Alpha_Short_SMA_and_RSI/CS/DBoTAlphaShortSmaAndRsiStrategy.cs
+++ b/API/0652_D-BoT_Alpha_Short_SMA_and_RSI/CS/DBoTAlphaShortSmaAndRsiStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0653_DBot_Alpha_RSI_Breakout/CS/DBotAlphaRsiBreakoutStrategy.cs
+++ b/API/0653_DBot_Alpha_RSI_Breakout/CS/DBotAlphaRsiBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0654_Daily_Bollinger_Band/CS/DailyBollingerBandStrategy.cs
+++ b/API/0654_Daily_Bollinger_Band/CS/DailyBollingerBandStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0655_Daily_Breakout_Daily_Shadow/CS/DailyBreakoutDailyShadowStrategy.cs
+++ b/API/0655_Daily_Breakout_Daily_Shadow/CS/DailyBreakoutDailyShadowStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0656_Daily_Performance_Analysis/CS/DailyPerformanceAnalysisStrategy.cs
+++ b/API/0656_Daily_Performance_Analysis/CS/DailyPerformanceAnalysisStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0657_Daily_Play_Ace_Spectrum/CS/DailyPlayAceSpectrumStrategy.cs
+++ b/API/0657_Daily_Play_Ace_Spectrum/CS/DailyPlayAceSpectrumStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0658_Daily_Supertrend_Ema_Crossover_Rsi_Filter/CS/DailySupertrendEmaCrossoverRsiFilterStrategy.cs
+++ b/API/0658_Daily_Supertrend_Ema_Crossover_Rsi_Filter/CS/DailySupertrendEmaCrossoverRsiFilterStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0659_DataChart/CS/DataChartStrategy.cs
+++ b/API/0659_DataChart/CS/DataChartStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0660_Day_Trading_Risk_Management/CS/DayTradingStrategy.cs
+++ b/API/0660_Day_Trading_Risk_Management/CS/DayTradingStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0661_Daytrading_ES_Wick_Length/CS/DaytradingESWickLengthStrategy.cs
+++ b/API/0661_Daytrading_ES_Wick_Length/CS/DaytradingESWickLengthStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0662_DCA_Simulation_for_CryptoCommunity/CS/DcaSimulationForCryptoCommunityStrategy.cs
+++ b/API/0662_DCA_Simulation_for_CryptoCommunity/CS/DcaSimulationForCryptoCommunityStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0663_DCA_2/CS/Dca2Strategy.cs
+++ b/API/0663_DCA_2/CS/Dca2Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0664_DCA_with_Hedging/CS/DcaWithHedgingStrategy.cs
+++ b/API/0664_DCA_with_Hedging/CS/DcaWithHedgingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0665_DCA_Mean_Reversion_Bollinger_Band/CS/DcaMeanReversionBollingerBandStrategy.cs
+++ b/API/0665_DCA_Mean_Reversion_Bollinger_Band/CS/DcaMeanReversionBollingerBandStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0666_DCA/CS/DcaStrategy.cs
+++ b/API/0666_DCA/CS/DcaStrategy.cs
@@ -1,5 +1,12 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0667_DCA_Support_and_Resistance_with_RSI_and_Trend_Filter/CS/DcaSupportAndResistanceWithRsiAndTrendFilterStrategy.cs
+++ b/API/0667_DCA_Support_and_Resistance_with_RSI_and_Trend_Filter/CS/DcaSupportAndResistanceWithRsiAndTrendFilterStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0668_DebugConsole/CS/DebugConsoleStrategy.cs
+++ b/API/0668_DebugConsole/CS/DebugConsoleStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0670_Dekidaka_Ashi_Candles_Volume/CS/DekidakaAshiCandlesVolumeStrategy.cs
+++ b/API/0670_Dekidaka_Ashi_Candles_Volume/CS/DekidakaAshiCandlesVolumeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0671_Delta_SMA_1Year_High_Low/CS/DeltaSma1YearHighLowStrategy.cs
+++ b/API/0671_Delta_SMA_1Year_High_Low/CS/DeltaSma1YearHighLowStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0672_Delta_RSI_Oscillator/CS/DeltaRsiOscillatorStrategy.cs
+++ b/API/0672_Delta_RSI_Oscillator/CS/DeltaRsiOscillatorStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0673_DEMA_Trend_Oscillator/CS/DemaTrendOscillatorStrategy.cs
+++ b/API/0673_DEMA_Trend_Oscillator/CS/DemaTrendOscillatorStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0674_Dema_RSI/CS/DemaRsiStrategy.cs
+++ b/API/0674_Dema_RSI/CS/DemaRsiStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0675_Demo_GPT_Day_Trading_Scalping/CS/DemoGptDayTradingScalpingStrategy.cs
+++ b/API/0675_Demo_GPT_Day_Trading_Scalping/CS/DemoGptDayTradingScalpingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0676_Directional_Index_K_xDMI/CS/DirectionalIndexKxDMIStrategy.cs
+++ b/API/0676_Directional_Index_K_xDMI/CS/DirectionalIndexKxDMIStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0677_Distance_to_Demand_Vector/CS/DistanceToDemandVectorStrategy.cs
+++ b/API/0677_Distance_to_Demand_Vector/CS/DistanceToDemandVectorStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0678_Divergence_For_Many_Indicators/CS/DivergenceForManyIndicatorsStrategy.cs
+++ b/API/0678_Divergence_For_Many_Indicators/CS/DivergenceForManyIndicatorsStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0679_Divergence_for_Many_Indicators_v4/CS/DivergenceForManyIndicatorsV4Strategy.cs
+++ b/API/0679_Divergence_for_Many_Indicators_v4/CS/DivergenceForManyIndicatorsV4Strategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0680_Divergence_Indicator_Any_Oscillator/CS/DivergenceIndicatorAnyOscillatorStrategy.cs
+++ b/API/0680_Divergence_Indicator_Any_Oscillator/CS/DivergenceIndicatorAnyOscillatorStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0681_Divergence/CS/DivergenceStrategy.cs
+++ b/API/0681_Divergence/CS/DivergenceStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0682_Dkoderweb_Repainting_Issue_Fix/CS/DkoderwebRepaintingIssueFixStrategy.cs
+++ b/API/0682_Dkoderweb_Repainting_Issue_Fix/CS/DkoderwebRepaintingIssueFixStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0683_Doji_Trading/CS/DojiTradingStrategy.cs
+++ b/API/0683_Doji_Trading/CS/DojiTradingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0684_Dominance_Tagcloud/CS/DominanceTagcloudStrategy.cs
+++ b/API/0684_Dominance_Tagcloud/CS/DominanceTagcloudStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/0685_Donchian_Breakout/CS/DonchianBreakoutStrategy.cs
+++ b/API/0685_Donchian_Breakout/CS/DonchianBreakoutStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0686_Donchian_Quest_Research/CS/DonchianQuestResearchStrategy.cs
+++ b/API/0686_Donchian_Quest_Research/CS/DonchianQuestResearchStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0687_Donchian_WMA_Crossover/CS/DonchianWmaCrossoverStrategy.cs
+++ b/API/0687_Donchian_WMA_Crossover/CS/DonchianWmaCrossoverStrategy.cs
@@ -1,6 +1,11 @@
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0688_Donchian_Zig_Zag_LuxAlgo/CS/DonchianZigZagLuxAlgoStrategy.cs
+++ b/API/0688_Donchian_Zig_Zag_LuxAlgo/CS/DonchianZigZagLuxAlgoStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0689_Donky_MA_TP_SL/CS/DonkyMaTpSlStrategy.cs
+++ b/API/0689_Donky_MA_TP_SL/CS/DonkyMaTpSlStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0690_Dont_Make_Me_Cross/CS/DontMakeMeCrossStrategy.cs
+++ b/API/0690_Dont_Make_Me_Cross/CS/DontMakeMeCrossStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0691_Double_AI_Super_Trend_Trading/CS/DoubleAiSuperTrendTradingStrategy.cs
+++ b/API/0691_Double_AI_Super_Trend_Trading/CS/DoubleAiSuperTrendTradingStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0692_Double_Bollinger_Bands_Signals/CS/DoubleBollingerBandsSignalsStrategy.cs
+++ b/API/0692_Double_Bollinger_Bands_Signals/CS/DoubleBollingerBandsSignalsStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0693_Double_Bottom_and_Top_Hunter/CS/DoubleBottomAndTopHunterStrategy.cs
+++ b/API/0693_Double_Bottom_and_Top_Hunter/CS/DoubleBottomAndTopHunterStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0694_Double_CCI_Confirmed_Hull_Moving_Average_Reversal/CS/DoubleCciConfirmedHullMovingAverageReversalStrategy.cs
+++ b/API/0694_Double_CCI_Confirmed_Hull_Moving_Average_Reversal/CS/DoubleCciConfirmedHullMovingAverageReversalStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0695_Double_Macd/CS/DoubleMacdStrategy.cs
+++ b/API/0695_Double_Macd/CS/DoubleMacdStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0696_Double_Vegas_SuperTrend_Enhanced/CS/DoubleVegasSuperTrendEnhancedStrategy.cs
+++ b/API/0696_Double_Vegas_SuperTrend_Enhanced/CS/DoubleVegasSuperTrendEnhancedStrategy.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
 using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0697_Dow_Theory_Trend/CS/DowTheoryTrendStrategy.cs
+++ b/API/0697_Dow_Theory_Trend/CS/DowTheoryTrendStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0698_Dskyz_DAFE_Adaptive_Regime_Quant_Machine_Pro/CS/DskyzDafeAdaptiveRegimeQuantMachineProStrategy.cs
+++ b/API/0698_Dskyz_DAFE_Adaptive_Regime_Quant_Machine_Pro/CS/DskyzDafeAdaptiveRegimeQuantMachineProStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0699_Dskyz_AI_Adaptive_Regime_Beginners/CS/DskyzAiAdaptiveRegimeBeginnersStrategy.cs
+++ b/API/0699_Dskyz_AI_Adaptive_Regime_Beginners/CS/DskyzAiAdaptiveRegimeBeginnersStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0700_Aurora_Divergence/CS/AuroraDivergenceStrategy.cs
+++ b/API/0700_Aurora_Divergence/CS/AuroraDivergenceStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0701_Dskyz_DAFE_GENESIS/CS/DskyzDafeGenesisStrategy.cs
+++ b/API/0701_Dskyz_DAFE_GENESIS/CS/DskyzDafeGenesisStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0702_Dskyz_DAFE_MAtrix_ATR_Precision/CS/DskyzDafeMatrixAtrPrecisionStrategy.cs
+++ b/API/0702_Dskyz_DAFE_MAtrix_ATR_Precision/CS/DskyzDafeMatrixAtrPrecisionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0703_Quantum_Sentiment_Flux_Beginners/CS/QuantumSentimentFluxBeginnersStrategy.cs
+++ b/API/0703_Quantum_Sentiment_Flux_Beginners/CS/QuantumSentimentFluxBeginnersStrategy.cs
@@ -1,5 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0704_Dskyz_Adaptive_Futures_Elite/CS/DskyzAdaptiveFuturesEliteStrategy.cs
+++ b/API/0704_Dskyz_Adaptive_Futures_Elite/CS/DskyzAdaptiveFuturesEliteStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0705_DSL/CS/DslStrategy.cs
+++ b/API/0705_DSL/CS/DslStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0706_Dual_Keltner_Channels/CS/DualKeltnerChannelsStrategy.cs
+++ b/API/0706_Dual_Keltner_Channels/CS/DualKeltnerChannelsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0707_Dual_MACD/CS/DualMacdStrategy.cs
+++ b/API/0707_Dual_MACD/CS/DualMacdStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0708_Dual_Momentum/CS/DualMomentumStrategy.cs
+++ b/API/0708_Dual_Momentum/CS/DualMomentumStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0709_Dual_Rsi_Differential/CS/DualRsiDifferentialStrategy.cs
+++ b/API/0709_Dual_Rsi_Differential/CS/DualRsiDifferentialStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0710_Dual_Selector_V2_Cryptogyani/CS/DualSelectorV2CryptogyaniStrategy.cs
+++ b/API/0710_Dual_Selector_V2_Cryptogyani/CS/DualSelectorV2CryptogyaniStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/0711_Dual_SuperTrend_VIX_Filter/CS/DualSuperTrendVixFilterStrategy.cs
+++ b/API/0711_Dual_SuperTrend_VIX_Filter/CS/DualSuperTrendVixFilterStrategy.cs
@@ -1,6 +1,11 @@
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0712_Dual_Phase_Trend_Regime/CS/DualPhaseTrendRegimeStrategy.cs
+++ b/API/0712_Dual_Phase_Trend_Regime/CS/DualPhaseTrendRegimeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0713_Dual_Supertrend_MACD/CS/DualSupertrendMacdStrategy.cs
+++ b/API/0713_Dual_Supertrend_MACD/CS/DualSupertrendMacdStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 using StockSharp.Charting;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/0714_Dubic_Ema/CS/DubicEmaStrategy.cs
+++ b/API/0714_Dubic_Ema/CS/DubicEmaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0715_Dynamic_Breakout_Master/CS/DynamicBreakoutMasterStrategy.cs
+++ b/API/0715_Dynamic_Breakout_Master/CS/DynamicBreakoutMasterStrategy.cs
@@ -1,4 +1,17 @@
 
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0716_Dynamic_Dots_Dashboard/CS/DynamicDotsDashboardStrategy.cs
+++ b/API/0716_Dynamic_Dots_Dashboard/CS/DynamicDotsDashboardStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0717_Dynamic_Support_and_Resistance_Pivot/CS/DynamicSupportAndResistancePivotStrategy.cs
+++ b/API/0717_Dynamic_Support_and_Resistance_Pivot/CS/DynamicSupportAndResistancePivotStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0718_Dynamic_Ticks_Oscillator_Model/CS/DynamicTicksOscillatorModelStrategy.cs
+++ b/API/0718_Dynamic_Ticks_Oscillator_Model/CS/DynamicTicksOscillatorModelStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0719_Dynamic_Volatility_Differential_Model/CS/DynamicVolatilityDifferentialModelStrategy.cs
+++ b/API/0719_Dynamic_Volatility_Differential_Model/CS/DynamicVolatilityDifferentialModelStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0720_E9_Shark_32_Pattern/CS/E9Shark32PatternStrategy.cs
+++ b/API/0720_E9_Shark_32_Pattern/CS/E9Shark32PatternStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0721_Earnings_Trading/CS/EarningsTradingStrategy.cs
+++ b/API/0721_Earnings_Trading/CS/EarningsTradingStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0722_Earnings_Splits_Dividends/CS/EarningsSplitsDividendsStrategy.cs
+++ b/API/0722_Earnings_Splits_Dividends/CS/EarningsSplitsDividendsStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0723_Economic_Policy_Uncertainty/CS/EconomicPolicyUncertaintyStrategy.cs
+++ b/API/0723_Economic_Policy_Uncertainty/CS/EconomicPolicyUncertaintyStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0724_Efficient_Work/CS/EfficientWorkStrategy.cs
+++ b/API/0724_Efficient_Work/CS/EfficientWorkStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0725_Ehlers_Combo/CS/EhlersComboStrategy.cs
+++ b/API/0725_Ehlers_Combo/CS/EhlersComboStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/0726_Eliora_Gold_1m_Heikin_Ashi/CS/ElioraGold1mHeikinAshiStrategy.cs
+++ b/API/0726_Eliora_Gold_1m_Heikin_Ashi/CS/ElioraGold1mHeikinAshiStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0727_Elliott_Wave_Supertrend_Exit/CS/ElliottWaveSupertrendExitStrategy.cs
+++ b/API/0727_Elliott_Wave_Supertrend_Exit/CS/ElliottWaveSupertrendExitStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0728_Elliotts_Quadratic_Momentum/CS/ElliottsQuadraticMomentumStrategy.cs
+++ b/API/0728_Elliotts_Quadratic_Momentum/CS/ElliottsQuadraticMomentumStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0729_EMA_MA_Crossover/CS/EmaMaCrossoverStrategy.cs
+++ b/API/0729_EMA_MA_Crossover/CS/EmaMaCrossoverStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0730_Ema_Rsi_Trail_Stop/CS/EmaRsiTrailStopStrategy.cs
+++ b/API/0730_Ema_Rsi_Trail_Stop/CS/EmaRsiTrailStopStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0731_EMA_10_20_50_Alignment/CS/Ema102050AlignmentStrategy.cs
+++ b/API/0731_EMA_10_20_50_Alignment/CS/Ema102050AlignmentStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0732_EMA_10_55_200_Long_Only_MTF/CS/Ema1055200LongOnlyMtfStrategy.cs
+++ b/API/0732_EMA_10_55_200_Long_Only_MTF/CS/Ema1055200LongOnlyMtfStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0733_EMA_34_Crossover_with_Break_Even_Stop_Loss/CS/Ema34CrossoverWithBreakEvenStopLossStrategy.cs
+++ b/API/0733_EMA_34_Crossover_with_Break_Even_Stop_Loss/CS/Ema34CrossoverWithBreakEvenStopLossStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/0734_EMA_5_Alert_Candle_Short/CS/Ema5AlertCandleShortStrategy.cs
+++ b/API/0734_EMA_5_Alert_Candle_Short/CS/Ema5AlertCandleShortStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0735_EMA_Dow_Theory/CS/EmaDowTheoryStrategy.cs
+++ b/API/0735_EMA_Dow_Theory/CS/EmaDowTheoryStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0736_Ema_Cross_Macd_Session_Start/CS/EmaCrossMacdSessionStartStrategy.cs
+++ b/API/0736_Ema_Cross_Macd_Session_Start/CS/EmaCrossMacdSessionStartStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0737_EMA_Crossover_Short_Focus_Trailing_Stop/CS/EmaCrossoverShortFocusTrailingStopStrategy.cs
+++ b/API/0737_EMA_Crossover_Short_Focus_Trailing_Stop/CS/EmaCrossoverShortFocusTrailingStopStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0738_Ema_Crossover_Filters/CS/EmaCrossoverFiltersStrategy.cs
+++ b/API/0738_Ema_Crossover_Filters/CS/EmaCrossoverFiltersStrategy.cs
@@ -1,6 +1,11 @@
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0739_EMA_Crossover_Take_Profit/CS/EMACrossoverTakeProfitStrategy.cs
+++ b/API/0739_EMA_Crossover_Take_Profit/CS/EMACrossoverTakeProfitStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0740_Ema_Crossover_Trailing_Stop/CS/EmaCrossoverTrailingStopStrategy.cs
+++ b/API/0740_Ema_Crossover_Trailing_Stop/CS/EmaCrossoverTrailingStopStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0741_EMA_Crossover_RSI_Distance/CS/EmaCrossoverRsiDistanceStrategy.cs
+++ b/API/0741_EMA_Crossover_RSI_Distance/CS/EmaCrossoverRsiDistanceStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0742_EMA_Crossover_Volume_Stacked_TP_Trailing_SL/CS/EmaCrossoverVolumeStackedTpTrailingSlStrategy.cs
+++ b/API/0742_EMA_Crossover_Volume_Stacked_TP_Trailing_SL/CS/EmaCrossoverVolumeStackedTpTrailingSlStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0743_Ema_Grid_Martingale_Cooldown/CS/EmaGridMartingaleCooldownStrategy.cs
+++ b/API/0743_Ema_Grid_Martingale_Cooldown/CS/EmaGridMartingaleCooldownStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0744_Ema_Pullback_Speed/CS/EmaPullbackSpeedStrategy.cs
+++ b/API/0744_Ema_Pullback_Speed/CS/EmaPullbackSpeedStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0745_Ema_Rsi_Trend_Reversal/CS/EmaRsiTrendReversalStrategy.cs
+++ b/API/0745_Ema_Rsi_Trend_Reversal/CS/EmaRsiTrendReversalStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0746_EMA_Scoring/CS/EmaScoringStrategy.cs
+++ b/API/0746_EMA_Scoring/CS/EmaScoringStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0747_EMA_Shift_Parallel/CS/EmaShiftParallelStrategy.cs
+++ b/API/0747_EMA_Shift_Parallel/CS/EmaShiftParallelStrategy.cs
@@ -1,5 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0748_Ema_Rsi_Swing_Trend_Filter/CS/EmaRsiSwingTrendFilterStrategy.cs
+++ b/API/0748_Ema_Rsi_Swing_Trend_Filter/CS/EmaRsiSwingTrendFilterStrategy.cs
@@ -1,6 +1,11 @@
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0749_EMATrend_Heikin_Ashi_Entry/CS/EmaTrendHeikinAshiEntryStrategy.cs
+++ b/API/0749_EMATrend_Heikin_Ashi_Entry/CS/EmaTrendHeikinAshiEntryStrategy.cs
@@ -1,4 +1,17 @@
 
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0750_Energy_Advanced_Policy/CS/EnergyAdvancedPolicyStrategy.cs
+++ b/API/0750_Energy_Advanced_Policy/CS/EnergyAdvancedPolicyStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0751_Engulfing_Pin_Bar_Breakout/CS/EngulfingPinBarBreakoutStrategy.cs
+++ b/API/0751_Engulfing_Pin_Bar_Breakout/CS/EngulfingPinBarBreakoutStrategy.cs
@@ -1,10 +1,16 @@
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0752_Engulfing_Candlestick/CS/EngulfingCandlestickStrategy.cs
+++ b/API/0752_Engulfing_Candlestick/CS/EngulfingCandlestickStrategy.cs
@@ -1,7 +1,13 @@
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0753_Engulfing_With_Trend/CS/EngulfingWithTrendStrategy.cs
+++ b/API/0753_Engulfing_With_Trend/CS/EngulfingWithTrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0754_Enhanced_BarUpDn/CS/EnhancedBarUpDnStrategy.cs
+++ b/API/0754_Enhanced_BarUpDn/CS/EnhancedBarUpDnStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0755_Enhanced_Bollinger_Bands_SL_TP/CS/EnhancedBollingerBandsStrategy.cs
+++ b/API/0755_Enhanced_Bollinger_Bands_SL_TP/CS/EnhancedBollingerBandsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0756_Enhanced_Doji_Candle/CS/EnhancedDojiCandleStrategy.cs
+++ b/API/0756_Enhanced_Doji_Candle/CS/EnhancedDojiCandleStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0757_Enhanced_Ichimoku_Cloud/CS/EnhancedIchimokuCloudStrategy.cs
+++ b/API/0757_Enhanced_Ichimoku_Cloud/CS/EnhancedIchimokuCloudStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0758_Enhanced_Market_Structure/CS/EnhancedMarketStructureStrategy.cs
+++ b/API/0758_Enhanced_Market_Structure/CS/EnhancedMarketStructureStrategy.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
 using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0759_Enhanced_Range_Filter_ATR_TP_SL/CS/EnhancedRangeFilterAtrTpSlStrategy.cs
+++ b/API/0759_Enhanced_Range_Filter_ATR_TP_SL/CS/EnhancedRangeFilterAtrTpSlStrategy.cs
@@ -1,13 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
 using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
-using StockSharp.Algo.Candles;
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0760_Enhanced_Time_Segmented_Volume/CS/EnhancedTimeSegmentedVolumeStrategy.cs
+++ b/API/0760_Enhanced_Time_Segmented_Volume/CS/EnhancedTimeSegmentedVolumeStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0761_Entry_Fragger/CS/EntryFraggerStrategy.cs
+++ b/API/0761_Entry_Fragger/CS/EntryFraggerStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0762_Equilibrium_Candles_Pattern/CS/EquilibriumCandlesPatternStrategy.cs
+++ b/API/0762_Equilibrium_Candles_Pattern/CS/EquilibriumCandlesPatternStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/0763_Equivolume_Bars/CS/EquivolumeBarsStrategy.cs
+++ b/API/0763_Equivolume_Bars/CS/EquivolumeBarsStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0764_Equivolume_Overlay_Volume_Bars/CS/EquivolumeOverlayVolumeBarsStrategy.cs
+++ b/API/0764_Equivolume_Overlay_Volume_Bars/CS/EquivolumeOverlayVolumeBarsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0766_NY_ORB_CP/CS/NyOrbCpStrategy.cs
+++ b/API/0766_NY_ORB_CP/CS/NyOrbCpStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0767_Eth_Signal_15m/CS/EthSignal15mStrategy.cs
+++ b/API/0767_Eth_Signal_15m/CS/EthSignal15mStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0768_ETH_USDT_EMA_Crossover/CS/EthUsdtEmaCrossoverStrategy.cs
+++ b/API/0768_ETH_USDT_EMA_Crossover/CS/EthUsdtEmaCrossoverStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0769_Rsi_Cci_WilliamsR/CS/RsiCciWilliamsRStrategy.cs
+++ b/API/0769_Rsi_Cci_WilliamsR/CS/RsiCciWilliamsRStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0770_EUR_USD_Multi_Layer_Statistical_Regression/CS/EurUsdMultiLayerStatisticalRegressionStrategy.cs
+++ b/API/0770_EUR_USD_Multi_Layer_Statistical_Regression/CS/EurUsdMultiLayerStatisticalRegressionStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0771_Graph_Style_4th_Dimension_RSI/CS/GraphStyle4thDimensionRSIStrategy.cs
+++ b/API/0771_Graph_Style_4th_Dimension_RSI/CS/GraphStyle4thDimensionRSIStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0772_Exodus/CS/ExodusStrategy.cs
+++ b/API/0772_Exodus/CS/ExodusStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0773_Express_Generator/CS/ExpressGeneratorStrategy.cs
+++ b/API/0773_Express_Generator/CS/ExpressGeneratorStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0774_External_Signals_Tester/CS/ExternalSignalsTesterStrategy.cs
+++ b/API/0774_External_Signals_Tester/CS/ExternalSignalsTesterStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0776_Extrapolated_Pivot_Connector/CS/ExtrapolatedPivotConnectorStrategy.cs
+++ b/API/0776_Extrapolated_Pivot_Connector/CS/ExtrapolatedPivotConnectorStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0777_Faith_Indicator/CS/FaithIndicatorStrategy.cs
+++ b/API/0777_Faith_Indicator/CS/FaithIndicatorStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0778_Falcon_Liquidity_Grab/CS/FalconLiquidityGrabStrategy.cs
+++ b/API/0778_Falcon_Liquidity_Grab/CS/FalconLiquidityGrabStrategy.cs
@@ -1,4 +1,11 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0779_Fancy_Bollinger_Bands/CS/FancyBollingerBandsStrategy.cs
+++ b/API/0779_Fancy_Bollinger_Bands/CS/FancyBollingerBandsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0780_Fearzone_Panel/CS/FearzonePanelStrategy.cs
+++ b/API/0780_Fearzone_Panel/CS/FearzonePanelStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0781_Fibonacci_Bollinger_Bands/CS/FibonacciBollingerBandsStrategy.cs
+++ b/API/0781_Fibonacci_Bollinger_Bands/CS/FibonacciBollingerBandsStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0782_Fibonacci_TP_SL/CS/FibonacciTpSlStrategy.cs
+++ b/API/0782_Fibonacci_TP_SL/CS/FibonacciTpSlStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using System.Globalization;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using System.Globalization;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0783_Fibonacci_ATR_Fusion/CS/FibonacciAtrFusionStrategy.cs
+++ b/API/0783_Fibonacci_ATR_Fusion/CS/FibonacciAtrFusionStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0784_Fibonacci_Counter_Trend_Trading/CS/FibonacciCounterTrendTradingStrategy.cs
+++ b/API/0784_Fibonacci_Counter_Trend_Trading/CS/FibonacciCounterTrendTradingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0785_Fibonacci_Levels_High_Low/CS/FibonacciLevelsHighLowStrategy.cs
+++ b/API/0785_Fibonacci_Levels_High_Low/CS/FibonacciLevelsHighLowStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0786_Fibonacci_Retracement_Crypto/CS/FibonacciRetracementCryptoStrategy.cs
+++ b/API/0786_Fibonacci_Retracement_Crypto/CS/FibonacciRetracementCryptoStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0787_Fibonacci_Swing_Trading_Bot/CS/FibonacciSwingTradingBotStrategy.cs
+++ b/API/0787_Fibonacci_Swing_Trading_Bot/CS/FibonacciSwingTradingBotStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0788_Fibonacci_Trend/CS/FibonacciTrendStrategy.cs
+++ b/API/0788_Fibonacci_Trend/CS/FibonacciTrendStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0789_Fibonacci_Trend_Reversal/CS/FibonacciTrendReversalStrategy.cs
+++ b/API/0789_Fibonacci_Trend_Reversal/CS/FibonacciTrendReversalStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0790_Fibonacci_Only_V2/CS/FibonacciOnlyV2Strategy.cs
+++ b/API/0790_Fibonacci_Only_V2/CS/FibonacciOnlyV2Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0791_Fibonacci_Only/CS/FibonacciOnlyStrategy.cs
+++ b/API/0791_Fibonacci_Only/CS/FibonacciOnlyStrategy.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
 using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0793_Financial_Ratios_Fundamental/CS/FinancialRatiosFundamentalStrategy.cs
+++ b/API/0793_Financial_Ratios_Fundamental/CS/FinancialRatiosFundamentalStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0794_Fine_Tune_Inputs_Fourier_Smoothed_Hybrid_Volume_Spread_Analysis/CS/FineTuneInputsFourierSmoothedHybridVolumeSpreadAnalysisStrategy.cs
+++ b/API/0794_Fine_Tune_Inputs_Fourier_Smoothed_Hybrid_Volume_Spread_Analysis/CS/FineTuneInputsFourierSmoothedHybridVolumeSpreadAnalysisStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/0795_Fine-tune_Inputs_Fourier_Smoothed_Volume_zone_oscillator_WFSVZ0/CS/FourierSmoothedVzoStrategy.cs
+++ b/API/0795_Fine-tune_Inputs_Fourier_Smoothed_Volume_zone_oscillator_WFSVZ0/CS/FourierSmoothedVzoStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0796_Fine_tune_Inputs_Gann_Laplace_Smooth_Volume_Zone_Oscillator/CS/FineTuneGannLaplaceVzoStrategy.cs
+++ b/API/0796_Fine_tune_Inputs_Gann_Laplace_Smooth_Volume_Zone_Oscillator/CS/FineTuneGannLaplaceVzoStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0797_Finish_Renaming/CS/FinishRenamingStrategy.cs
+++ b/API/0797_Finish_Renaming/CS/FinishRenamingStrategy.cs
@@ -1,11 +1,18 @@
 using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using System.IO;
+using System.Text.RegularExpressions;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0798_Fisher_Crossover/CS/FisherCrossoverStrategy.cs
+++ b/API/0798_Fisher_Crossover/CS/FisherCrossoverStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0799_Flex_ATR/CS/FlexAtrStrategy.cs
+++ b/API/0799_Flex_ATR/CS/FlexAtrStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0800_Flexible_Moving_Average/CS/FlexibleMovingAverageStrategy.cs
+++ b/API/0800_Flexible_Moving_Average/CS/FlexibleMovingAverageStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0801_FlexiMA_Variance_Tracker/CS/FlexiMaVarianceTrackerStrategy.cs
+++ b/API/0801_FlexiMA_Variance_Tracker/CS/FlexiMaVarianceTrackerStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0802_FlexiMA_x_FlexiST/CS/FlexiMaXFlexiStStrategy.cs
+++ b/API/0802_FlexiMA_x_FlexiST/CS/FlexiMaXFlexiStStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0803_FlexiSuperTrend/CS/FlexiSuperTrendStrategy.cs
+++ b/API/0803_FlexiSuperTrend/CS/FlexiSuperTrendStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0804_Follow_Line/CS/FollowLineStrategy.cs
+++ b/API/0804_Follow_Line/CS/FollowLineStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0805_FON60DK/CS/Fon60DkStrategy.cs
+++ b/API/0805_FON60DK/CS/Fon60DkStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0806_Footprint/CS/FootprintStrategy.cs
+++ b/API/0806_Footprint/CS/FootprintStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0807_Forex_Fire_EMA_MA_RSI/CS/ForexFireEmaMaRsiStrategy.cs
+++ b/API/0807_Forex_Fire_EMA_MA_RSI/CS/ForexFireEmaMaRsiStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0808_Forex_Hammer_and_Hanging_Man/CS/ForexHammerAndHangingManStrategy.cs
+++ b/API/0808_Forex_Hammer_and_Hanging_Man/CS/ForexHammerAndHangingManStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0809_Forex_Pair_Yield_Momentum/CS/ForexPairYieldMomentumStrategy.cs
+++ b/API/0809_Forex_Pair_Yield_Momentum/CS/ForexPairYieldMomentumStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0810_Four_WMA_TP_and_SL/CS/FourWmaTpSlStrategy.cs
+++ b/API/0810_Four_WMA_TP_and_SL/CS/FourWmaTpSlStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0811_Fractal_Breakout_Trend_Following/CS/FractalBreakoutTrendFollowingStrategy.cs
+++ b/API/0811_Fractal_Breakout_Trend_Following/CS/FractalBreakoutTrendFollowingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0812_FreedX_Grid_Backtest/CS/FreedxGridBacktestStrategy.cs
+++ b/API/0812_FreedX_Grid_Backtest/CS/FreedxGridBacktestStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0813_Friday_Bond_Short/CS/FridayBondShortStrategy.cs
+++ b/API/0813_Friday_Bond_Short/CS/FridayBondShortStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0814_FTMO_Rules_Monitor/CS/FtmoRulesMonitorStrategy.cs
+++ b/API/0814_FTMO_Rules_Monitor/CS/FtmoRulesMonitorStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0815_Funamental_and_financials/CS/FunamentalAndFinancialsStrategy.cs
+++ b/API/0815_Funamental_and_financials/CS/FunamentalAndFinancialsStrategy.cs
@@ -1,6 +1,15 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0816_Function_Logistic_Equation/CS/FunctionLogisticEquationStrategy.cs
+++ b/API/0816_Function_Logistic_Equation/CS/FunctionLogisticEquationStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/0817_Function_Simple_Markov_Chain_Monte_Carlo_Simulation/CS/FunctionSimpleMarkovChainMonteCarloSimulationStrategy.cs
+++ b/API/0817_Function_Simple_Markov_Chain_Monte_Carlo_Simulation/CS/FunctionSimpleMarkovChainMonteCarloSimulationStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0818_Function_Sorted_Indices/CS/FunctionSortedIndicesStrategy.cs
+++ b/API/0818_Function_Sorted_Indices/CS/FunctionSortedIndicesStrategy.cs
@@ -1,5 +1,15 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0819_Weighted_Standard_Deviation/CS/WeightedStandardDeviationStrategy.cs
+++ b/API/0819_Weighted_Standard_Deviation/CS/WeightedStandardDeviationStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/0820_Function_Highest_Lowest/CS/FunctionHighestLowestStrategy.cs
+++ b/API/0820_Function_Highest_Lowest/CS/FunctionHighestLowestStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0821_Function_Adf/CS/FunctionAdfStrategy.cs
+++ b/API/0821_Function_Adf/CS/FunctionAdfStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0822_Function_Linear_Regression/CS/FunctionLinearRegressionStrategy.cs
+++ b/API/0822_Function_Linear_Regression/CS/FunctionLinearRegressionStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0823_Futures_Engulfing_Candle_Size/CS/FuturesEngulfingCandleSizeStrategy.cs
+++ b/API/0823_Futures_Engulfing_Candle_Size/CS/FuturesEngulfingCandleSizeStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0824_Futures_Trading_Hours_Rsi/CS/FuturesTradingHoursRsiStrategy.cs
+++ b/API/0824_Futures_Trading_Hours_Rsi/CS/FuturesTradingHoursRsiStrategy.cs
@@ -1,10 +1,15 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0825_FVG_Breakout_Lite/CS/FvgBreakoutLiteStrategy.cs
+++ b/API/0825_FVG_Breakout_Lite/CS/FvgBreakoutLiteStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0826_FVG_Positioning_Average_with_200EMA_Auto_Trading/CS/FvgPositioningAverageWith200EmaAutoTradingStrategy.cs
+++ b/API/0826_FVG_Positioning_Average_with_200EMA_Auto_Trading/CS/FvgPositioningAverageWith200EmaAutoTradingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0827_G_Channel_Ema/CS/GChannelEmaStrategy.cs
+++ b/API/0827_G_Channel_Ema/CS/GChannelEmaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0828_Game_Theory_Trading/CS/GameTheoryTradingStrategy.cs
+++ b/API/0828_Game_Theory_Trading/CS/GameTheoryTradingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0829_Gann_Laplace_Smoothed_Hybrid_VSA/CS/GannLaplaceSmoothedHybridVsaStrategy.cs
+++ b/API/0829_Gann_Laplace_Smoothed_Hybrid_VSA/CS/GannLaplaceSmoothedHybridVsaStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/0830_Gann_Swing_Multi_Layer/CS/GannSwingMultiLayerStrategy.cs
+++ b/API/0830_Gann_Swing_Multi_Layer/CS/GannSwingMultiLayerStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0831_Gap_Down_Reversal/CS/GapDownReversalStrategy.cs
+++ b/API/0831_Gap_Down_Reversal/CS/GapDownReversalStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0832_Gap_Filling/CS/GapFillingStrategy.cs
+++ b/API/0832_Gap_Filling/CS/GapFillingStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0833_Gartley_222/CS/Gartley222Strategy.cs
+++ b/API/0833_Gartley_222/CS/Gartley222Strategy.cs
@@ -1,5 +1,12 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0834_Gaussian_Channel/CS/GaussianChannelStrategy.cs
+++ b/API/0834_Gaussian_Channel/CS/GaussianChannelStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0835_Gaussian_Detrended_Reversion/CS/GaussianDetrendedReversionStrategy.cs
+++ b/API/0835_Gaussian_Detrended_Reversion/CS/GaussianDetrendedReversionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0836_GC_with_Trend_Filter_and_Sudden_Move_Profit_Taking/CS/GcWithTrendFilterAndSuddenMoveProfitTakingStrategy.cs
+++ b/API/0836_GC_with_Trend_Filter_and_Sudden_Move_Profit_Taking/CS/GcWithTrendFilterAndSuddenMoveProfitTakingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0837_Gemini_Trend_Following_System/CS/GeminiTrendFollowingSystemStrategy.cs
+++ b/API/0837_Gemini_Trend_Following_System/CS/GeminiTrendFollowingSystemStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0838_Geo/CS/GeoStrategy.cs
+++ b/API/0838_Geo/CS/GeoStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0839_Get_Value_From_N_Years_Ago/CS/GetValueFromNYearsAgoStrategy.cs
+++ b/API/0839_Get_Value_From_N_Years_Ago/CS/GetValueFromNYearsAgoStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0840_Global_Index_Spread_RSI/CS/GlobalIndexSpreadRsiStrategy.cs
+++ b/API/0840_Global_Index_Spread_RSI/CS/GlobalIndexSpreadRsiStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0841_Macd_Momentum_Reversal/CS/MacdMomentumReversalStrategy.cs
+++ b/API/0841_Macd_Momentum_Reversal/CS/MacdMomentumReversalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0842_GM8_ADX_Second_Ema/CS/Gm8AdxSecondEmaStrategy.cs
+++ b/API/0842_GM8_ADX_Second_Ema/CS/Gm8AdxSecondEmaStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/0843_Gold_EUR_USD/CS/GoldEurUsdStrategy.cs
+++ b/API/0843_Gold_EUR_USD/CS/GoldEurUsdStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0844_Gold_Breakout_RR_4/CS/GoldBreakoutRr4Strategy.cs
+++ b/API/0844_Gold_Breakout_RR_4/CS/GoldBreakoutRr4Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0845_Gold_Friday_Anomaly/CS/GoldFridayAnomalyStrategy.cs
+++ b/API/0845_Gold_Friday_Anomaly/CS/GoldFridayAnomalyStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0846_Gold_ORB/CS/GoldOrbStrategy.cs
+++ b/API/0846_Gold_ORB/CS/GoldOrbStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0847_Gold_Pro/CS/GoldProStrategy.cs
+++ b/API/0847_Gold_Pro/CS/GoldProStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0848_Gold_Pullback/CS/GoldPullbackStrategy.cs
+++ b/API/0848_Gold_Pullback/CS/GoldPullbackStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0849_Gold_Scalping_BOS_CHoCH/CS/GoldScalpingBosChochStrategy.cs
+++ b/API/0849_Gold_Scalping_BOS_CHoCH/CS/GoldScalpingBosChochStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0850_Gold_Scalping_with_Precise_Entries/CS/GoldScalpingWithPreciseEntriesStrategy.cs
+++ b/API/0850_Gold_Scalping_with_Precise_Entries/CS/GoldScalpingWithPreciseEntriesStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0851_Gold_Trade_Setup/CS/GoldTradeSetupStrategy.cs
+++ b/API/0851_Gold_Trade_Setup/CS/GoldTradeSetupStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0852_Gold_Volume_Based_Entry/CS/GoldVolumeBasedEntryStrategy.cs
+++ b/API/0852_Gold_Volume_Based_Entry/CS/GoldVolumeBasedEntryStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0853_Golden_Cross_VWMA_EMA/CS/GoldenCrossVwmaEmaStrategy.cs
+++ b/API/0853_Golden_Cross_VWMA_EMA/CS/GoldenCrossVwmaEmaStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0854_Golden_Transform/CS/GoldenTransformStrategy.cs
+++ b/API/0854_Golden_Transform/CS/GoldenTransformStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0855_Good_Mode_Rsi_V2/CS/GoodModeRsiV2Strategy.cs
+++ b/API/0855_Good_Mode_Rsi_V2/CS/GoodModeRsiV2Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0856_Volume_Support_Resistance_Zones/CS/VolumeSupportResistanceZonesStrategy.cs
+++ b/API/0856_Volume_Support_Resistance_Zones/CS/VolumeSupportResistanceZonesStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0857_Gradient_Trend_Filter/CS/GradientTrendFilterStrategy.cs
+++ b/API/0857_Gradient_Trend_Filter/CS/GradientTrendFilterStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0858_Grease_Trap/CS/GreaseTrapStrategy.cs
+++ b/API/0858_Grease_Trap/CS/GreaseTrapStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0859_Grid_Bot_Backtesting/CS/GridBotBacktestingStrategy.cs
+++ b/API/0859_Grid_Bot_Backtesting/CS/GridBotBacktestingStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0860_Grid_Like/CS/GridLikeStrategy.cs
+++ b/API/0860_Grid_Like/CS/GridLikeStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0861_Grid_Tendence_V1/CS/GridTendenceV1Strategy.cs
+++ b/API/0861_Grid_Tendence_V1/CS/GridTendenceV1Strategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0862_Grid_TLong_V1/CS/GridTLongV1Strategy.cs
+++ b/API/0862_Grid_TLong_V1/CS/GridTLongV1Strategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0863_Grim_Slash/CS/GrimSlashStrategy.cs
+++ b/API/0863_Grim_Slash/CS/GrimSlashStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0864_Grim309_CallPut/CS/Grim309CallPutStrategy.cs
+++ b/API/0864_Grim309_CallPut/CS/Grim309CallPutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0865_Grover_Llorens_Activator/CS/GroverLlorensActivatorStrategy.cs
+++ b/API/0865_Grover_Llorens_Activator/CS/GroverLlorensActivatorStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0866_Guage/CS/GuageStrategy.cs
+++ b/API/0866_Guage/CS/GuageStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0867_Hammer_Shooting_Star/CS/HammerShootingStarStrategy.cs
+++ b/API/0867_Hammer_Shooting_Star/CS/HammerShootingStarStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0868_Hammer_Ema_Tick_Sl_Tp/CS/HammerEmaTickSlTpStrategy.cs
+++ b/API/0868_Hammer_Ema_Tick_Sl_Tp/CS/HammerEmaTickSlTpStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0869_Hamster_Bot_MRS_2/CS/HamsterBotMrs2Strategy.cs
+++ b/API/0869_Hamster_Bot_MRS_2/CS/HamsterBotMrs2Strategy.cs
@@ -1,6 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/0870_Hancock_Rsi_Volume/CS/HancockRsiVolumeStrategy.cs
+++ b/API/0870_Hancock_Rsi_Volume/CS/HancockRsiVolumeStrategy.cs
@@ -1,6 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/0871_HarmonicPattern/CS/HarmonicPatternStrategy.cs
+++ b/API/0871_HarmonicPattern/CS/HarmonicPatternStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0872_Harmony_Signal_Flow_By_Arun/CS/HarmonySignalFlowByArunStrategy.cs
+++ b/API/0872_Harmony_Signal_Flow_By_Arun/CS/HarmonySignalFlowByArunStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0873_Heatmap_MACD/CS/HeatmapMacdStrategy.cs
+++ b/API/0873_Heatmap_MACD/CS/HeatmapMacdStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0874_Heatmap_Macd/CS/HeatmapMacd2Strategy.cs
+++ b/API/0874_Heatmap_Macd/CS/HeatmapMacd2Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0875_Heiken_Ashi_Supertrend_ADX/CS/HeikenAshiSupertrendAdxStrategy.cs
+++ b/API/0875_Heiken_Ashi_Supertrend_ADX/CS/HeikenAshiSupertrendAdxStrategy.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
 using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0876_Heiken_Ashi_Supertrend_ATR_SL/CS/HeikenAshiSupertrendAtrSlStrategy.cs
+++ b/API/0876_Heiken_Ashi_Supertrend_ATR_SL/CS/HeikenAshiSupertrendAtrSlStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0877_Heikin_Ashi_ROC_Percentile/CS/HeikinAshiRocPercentileStrategy.cs
+++ b/API/0877_Heikin_Ashi_ROC_Percentile/CS/HeikinAshiRocPercentileStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0878_Hierarchical_K_Means_Clustering/CS/HierarchicalKMeansClusteringStrategy.cs
+++ b/API/0878_Hierarchical_K_Means_Clustering/CS/HierarchicalKMeansClusteringStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0879_High_Low_Breakout_Statistical_Analysis/CS/HighLowBreakoutStatisticalAnalysisStrategy.cs
+++ b/API/0879_High_Low_Breakout_Statistical_Analysis/CS/HighLowBreakoutStatisticalAnalysisStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0880_High_Yield_Spread_SMA_Filter/CS/HighYieldSpreadSmaFilterStrategy.cs
+++ b/API/0880_High_Yield_Spread_SMA_Filter/CS/HighYieldSpreadSmaFilterStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0880_High_Yield_Spread_with_SMA_Filter/CS/HighYieldSpreadWithSmaFilterStrategy.cs
+++ b/API/0880_High_Yield_Spread_with_SMA_Filter/CS/HighYieldSpreadWithSmaFilterStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0881_High_Low_Breakout_ATR_Trailing/CS/HighLowBreakoutAtrTrailingStopStrategy.cs
+++ b/API/0881_High_Low_Breakout_ATR_Trailing/CS/HighLowBreakoutAtrTrailingStopStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0882_Higher_Order_Pivots/CS/HigherOrderPivotsStrategy.cs
+++ b/API/0882_Higher_Order_Pivots/CS/HigherOrderPivotsStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0883_Highs_Lows/CS/HighsLowsStrategy.cs
+++ b/API/0883_Highs_Lows/CS/HighsLowsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0884_Hma200_Ema20_Crossover/CS/Hma200Ema20CrossoverStrategy.cs
+++ b/API/0884_Hma200_Ema20_Crossover/CS/Hma200Ema20CrossoverStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0885_Hma_Crossover_Atr_Curvature/CS/HmaCrossoverAtrCurvatureStrategy.cs
+++ b/API/0885_Hma_Crossover_Atr_Curvature/CS/HmaCrossoverAtrCurvatureStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0886_HMA_Crossover_RSI_Stochastic_Trailing_Stop/CS/HmaCrossoverRsiStochasticTrailingStopStrategy.cs
+++ b/API/0886_HMA_Crossover_RSI_Stochastic_Trailing_Stop/CS/HmaCrossoverRsiStochasticTrailingStopStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0887_HOD_LOD_PMH_PML_PDH_PDL/CS/HodLodPmhPmlPdhPdlStrategy.cs
+++ b/API/0887_HOD_LOD_PMH_PML_PDH_PDL/CS/HodLodPmhPmlPdhPdlStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0888_Hoffman_Heiken_Bias/CS/HoffmanHeikenBiasStrategy.cs
+++ b/API/0888_Hoffman_Heiken_Bias/CS/HoffmanHeikenBiasStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0889_Honest_Volatility_Grid/CS/HonestVolatilityGridStrategy.cs
+++ b/API/0889_Honest_Volatility_Grid/CS/HonestVolatilityGridStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0890_Stochastic_Exit_Alerts/CS/StochasticExitAlertsStrategy.cs
+++ b/API/0890_Stochastic_Exit_Alerts/CS/StochasticExitAlertsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0891_How_To_Set_Backtest_Time_Ranges/CS/HowToSetBacktestTimeRangesStrategy.cs
+++ b/API/0891_How_To_Set_Backtest_Time_Ranges/CS/HowToSetBacktestTimeRangesStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0892_How_to_use_Leverage_and_Margin/CS/HowToUseLeverageAndMarginStrategy.cs
+++ b/API/0892_How_to_use_Leverage_and_Margin/CS/HowToUseLeverageAndMarginStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0893_HSI_First_30m_Candle/CS/HsiFirst30mCandleStrategy.cs
+++ b/API/0893_HSI_First_30m_Candle/CS/HsiFirst30mCandleStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0894_Hsv_And_Hsl_Gradient_Tools/CS/HsvAndHslGradientToolsStrategy.cs
+++ b/API/0894_Hsv_And_Hsl_Gradient_Tools/CS/HsvAndHslGradientToolsStrategy.cs
@@ -1,7 +1,17 @@
 using System;
-using System.Drawing;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
+using System.Drawing;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0895_HTF_Candles_Lib/CS/HtfCandlesLibStrategy.cs
+++ b/API/0895_HTF_Candles_Lib/CS/HtfCandlesLibStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0896_Hulk_Grid_Algorithm_V2/CS/HulkGridAlgorithmV2Strategy.cs
+++ b/API/0896_Hulk_Grid_Algorithm_V2/CS/HulkGridAlgorithmV2Strategy.cs
@@ -1,5 +1,12 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0897_Hull_Candles/CS/HullCandlesStrategy.cs
+++ b/API/0897_Hull_Candles/CS/HullCandlesStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0898_Hull_Suite_by_MRS/CS/HullSuiteByMRSStrategy.cs
+++ b/API/0898_Hull_Suite_by_MRS/CS/HullSuiteByMRSStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0899_Hull_Suite_1_Risk_No_SL_TP/CS/HullSuite1RiskNoSlTpStrategy.cs
+++ b/API/0899_Hull_Suite_1_Risk_No_SL_TP/CS/HullSuite1RiskNoSlTpStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0900_Hull_Suite_No_SL_TP/CS/HullSuiteNoSlTpStrategy.cs
+++ b/API/0900_Hull_Suite_No_SL_TP/CS/HullSuiteNoSlTpStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0901_Hurst_Exponent/CS/HurstExponentStrategy.cs
+++ b/API/0901_Hurst_Exponent/CS/HurstExponentStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0902_Hurst_Future_Lines_of_Demarcation/CS/HurstFutureLinesOfDemarcationStrategy.cs
+++ b/API/0902_Hurst_Future_Lines_of_Demarcation/CS/HurstFutureLinesOfDemarcationStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using StockSharp.Algo.Strategies;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/0903_Hybrid_RSI_Breakout_Dashboard/CS/HybridRsiBreakoutDashboardStrategy.cs
+++ b/API/0903_Hybrid_RSI_Breakout_Dashboard/CS/HybridRsiBreakoutDashboardStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0904_Ibs_Internal_Bar_Strength/CS/IbsInternalBarStrengthStrategy.cs
+++ b/API/0904_Ibs_Internal_Bar_Strength/CS/IbsInternalBarStrengthStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0905_Ichimoku_Daily_Candle_X_Hull_Ma_X_Macd/CS/IchimokuDailyCandleXHullMaXMacdStrategy.cs
+++ b/API/0905_Ichimoku_Daily_Candle_X_Hull_Ma_X_Macd/CS/IchimokuDailyCandleXHullMaXMacdStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0906_Ichimoku_Rsi_Macd/CS/IchimokuRsiMacdStrategy.cs
+++ b/API/0906_Ichimoku_Rsi_Macd/CS/IchimokuRsiMacdStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0907_Ichimoku_by_FarmerBTC/CS/IchimokuByFarmerBtcStrategy.cs
+++ b/API/0907_Ichimoku_by_FarmerBTC/CS/IchimokuByFarmerBtcStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0908_Ichimoku_Cloud_Breakout_Only_Long/CS/IchimokuCloudBreakoutOnlyLongStrategy.cs
+++ b/API/0908_Ichimoku_Cloud_Breakout_Only_Long/CS/IchimokuCloudBreakoutOnlyLongStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0909_Ichimoku_Cloud_Buy_Custom_EMA_Exit/CS/IchimokuCloudBuyCustomEmaExitStrategy.cs
+++ b/API/0909_Ichimoku_Cloud_Buy_Custom_EMA_Exit/CS/IchimokuCloudBuyCustomEmaExitStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0910_Ichimoku_Cloud_Buy_Sell/CS/IchimokuCloudBuySellStrategy.cs
+++ b/API/0910_Ichimoku_Cloud_Buy_Sell/CS/IchimokuCloudBuySellStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0911_Ichimoku_Clouds_Long_and_Short/CS/IchimokuCloudsLongAndShortStrategy.cs
+++ b/API/0911_Ichimoku_Clouds_Long_and_Short/CS/IchimokuCloudsLongAndShortStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0912_ICT_Bread_and_Butter_Sell_Setup/CS/IctBreadAndButterSellSetupStrategy.cs
+++ b/API/0912_ICT_Bread_and_Butter_Sell_Setup/CS/IctBreadAndButterSellSetupStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0913_ICT_Indicator_with_Paper_Trading/CS/IctIndicatorWithPaperTradingStrategy.cs
+++ b/API/0913_ICT_Indicator_with_Paper_Trading/CS/IctIndicatorWithPaperTradingStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0914_ICT_Master_Suite_Trading_IQ/CS/IctMasterSuiteTradingIqStrategy.cs
+++ b/API/0914_ICT_Master_Suite_Trading_IQ/CS/IctMasterSuiteTradingIqStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0915_Ict_Ny_Kill_Zone_Auto_Trading/CS/IctNyKillZoneAutoTradingStrategy.cs
+++ b/API/0915_Ict_Ny_Kill_Zone_Auto_Trading/CS/IctNyKillZoneAutoTradingStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0916_iD_EMARSI_on_Chart/CS/IdEmarsiOnChartStrategy.cs
+++ b/API/0916_iD_EMARSI_on_Chart/CS/IdEmarsiOnChartStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/0917_IMACD_Sniper/CS/ImacdSniperStrategy.cs
+++ b/API/0917_IMACD_Sniper/CS/ImacdSniperStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0918_Imlib/CS/ImlibStrategy.cs
+++ b/API/0918_Imlib/CS/ImlibStrategy.cs
@@ -1,7 +1,15 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0919_Improved_Ema_Cdc_Trailing_Stop/CS/ImprovedEmaCdcTrailingStopStrategy.cs
+++ b/API/0919_Improved_Ema_Cdc_Trailing_Stop/CS/ImprovedEmaCdcTrailingStopStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0921_Indicator_Panel/CS/IndicatorPanelStrategy.cs
+++ b/API/0921_Indicator_Panel/CS/IndicatorPanelStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0922_Indicator_Test_With_Conditions_Table/CS/IndicatorTestWithConditionsTableStrategy.cs
+++ b/API/0922_Indicator_Test_With_Conditions_Table/CS/IndicatorTestWithConditionsTableStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/0923_Indices_Sector_SigmaSpikes/CS/IndicesSectorSigmaSpikesStrategy.cs
+++ b/API/0923_Indices_Sector_SigmaSpikes/CS/IndicesSectorSigmaSpikesStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0924_Innocent_Heikin_Ashi_Ethereum/CS/InnocentHeikinAshiEthereumStrategy.cs
+++ b/API/0924_Innocent_Heikin_Ashi_Ethereum/CS/InnocentHeikinAshiEthereumStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0925_Inside_Candle/CS/InsideCandleStrategy.cs
+++ b/API/0925_Inside_Candle/CS/InsideCandleStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0926_Intelle_city_World_Cycle_Ath_Atl_Logarithmic/CS/IntelleCityWorldCycleAthAtlLogarithmicStrategy.cs
+++ b/API/0926_Intelle_city_World_Cycle_Ath_Atl_Logarithmic/CS/IntelleCityWorldCycleAthAtlLogarithmicStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0927_Internal_Bar_Strength_IBS/CS/InternalBarStrengthIbsStrategy.cs
+++ b/API/0927_Internal_Bar_Strength_IBS/CS/InternalBarStrengthIbsStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0928_Intra_Bullish_Profit_Ping_v4_0/CS/IntraBullishProfitPingV40Strategy.cs
+++ b/API/0928_Intra_Bullish_Profit_Ping_v4_0/CS/IntraBullishProfitPingV40Strategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0929_Intraday_Combo_HH/CS/IntradayComboHHStrategy.cs
+++ b/API/0929_Intraday_Combo_HH/CS/IntradayComboHHStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0930_Intraday_Momentum/CS/IntradayMomentumStrategy.cs
+++ b/API/0930_Intraday_Momentum/CS/IntradayMomentumStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0931_Intraday_Volume_Swings/CS/IntradayVolumeSwingsStrategy.cs
+++ b/API/0931_Intraday_Volume_Swings/CS/IntradayVolumeSwingsStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0932_InwCoin_Martingale/CS/InwCoinMartingaleStrategy.cs
+++ b/API/0932_InwCoin_Martingale/CS/InwCoinMartingaleStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0933_Iron_Bot_Statistical_Trend_Filter/CS/IronBotStatisticalTrendFilterStrategy.cs
+++ b/API/0933_Iron_Bot_Statistical_Trend_Filter/CS/IronBotStatisticalTrendFilterStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/0934_is/CS/IsStrategy.cs
+++ b/API/0934_is/CS/IsStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0935_IU_4_Bar_UP/CS/Iu4BarUpStrategy.cs
+++ b/API/0935_IU_4_Bar_UP/CS/Iu4BarUpStrategy.cs
@@ -1,6 +1,10 @@
+using System;
+using System.Linq;
 using System.Collections.Generic;
 
 using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0936_IU_BBB_Big_Body_Bar/CS/IuBbbBigBodyBarStrategy.cs
+++ b/API/0936_IU_BBB_Big_Body_Bar/CS/IuBbbBigBodyBarStrategy.cs
@@ -1,6 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
 using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0937_IU_Bigger_Than_Range/CS/IuBiggerThanRangeStrategy.cs
+++ b/API/0937_IU_Bigger_Than_Range/CS/IuBiggerThanRangeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0938_IU_Break_Of_Any_Session/CS/IUBreakOfAnySessionStrategy.cs
+++ b/API/0938_IU_Break_Of_Any_Session/CS/IUBreakOfAnySessionStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0939_Iu_Ema_Channel/CS/IuEmaChannelStrategy.cs
+++ b/API/0939_Iu_Ema_Channel/CS/IuEmaChannelStrategy.cs
@@ -1,9 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using StockSharp.Algo;
-using StockSharp.Algo.Strategies;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0940_IU_Gap_Fill/CS/IUGapFillStrategy.cs
+++ b/API/0940_IU_Gap_Fill/CS/IUGapFillStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0941_IU_Higher_Timeframe_MA_Cross/CS/IUHigherTimeframeMACrossStrategy.cs
+++ b/API/0941_IU_Higher_Timeframe_MA_Cross/CS/IUHigherTimeframeMACrossStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0942_IU_Open_Equal_To_High_Low/CS/IuOpenEqualToHighLowStrategy.cs
+++ b/API/0942_IU_Open_Equal_To_High_Low/CS/IuOpenEqualToHighLowStrategy.cs
@@ -1,7 +1,13 @@
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0943_IU_Opening_Range_Breakout/CS/IUOpeningRangeBreakoutStrategy.cs
+++ b/API/0943_IU_Opening_Range_Breakout/CS/IUOpeningRangeBreakoutStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0944_IU_Range_Trading/CS/IuRangeTradingStrategy.cs
+++ b/API/0944_IU_Range_Trading/CS/IuRangeTradingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0945_JLines_Ribbon_4_Cycle_Engine/CS/JLinesRibbon4CycleEngineStrategy.cs
+++ b/API/0945_JLines_Ribbon_4_Cycle_Engine/CS/JLinesRibbon4CycleEngineStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0946_JMA_Quantum_Edge/CS/JmaQuantumEdgeStrategy.cs
+++ b/API/0946_JMA_Quantum_Edge/CS/JmaQuantumEdgeStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0947_John_Bob_Trading_Bot/CS/JohnBobTradingBotStrategy.cs
+++ b/API/0947_John_Bob_Trading_Bot/CS/JohnBobTradingBotStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0948_The_Price_Radio/CS/ThePriceRadioStrategy.cs
+++ b/API/0948_The_Price_Radio/CS/ThePriceRadioStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0949_Kaito_Box_with_Rsi_Div/CS/KaitoBoxWithRsiDivStrategy.cs
+++ b/API/0949_Kaito_Box_with_Rsi_Div/CS/KaitoBoxWithRsiDivStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0950_Kaufman_Adaptive_Moving_Average/CS/KaufmanAdaptiveMovingAverageStrategy.cs
+++ b/API/0950_Kaufman_Adaptive_Moving_Average/CS/KaufmanAdaptiveMovingAverageStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0951_Kaufman_Trend/CS/KaufmanTrendStrategy.cs
+++ b/API/0951_Kaufman_Trend/CS/KaufmanTrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0952_Keltner_Channel_Based_Grid/CS/KeltnerChannelBasedGridStrategy.cs
+++ b/API/0952_Keltner_Channel_Based_Grid/CS/KeltnerChannelBasedGridStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0953_Keltner_Channel_by_Kevin_Davey/CS/KeltnerChannelByKevinDaveyStrategy.cs
+++ b/API/0953_Keltner_Channel_by_Kevin_Davey/CS/KeltnerChannelByKevinDaveyStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0954_Keltner_Channel_Golden_Cross/CS/KeltnerChannelGoldenCrossStrategy.cs
+++ b/API/0954_Keltner_Channel_Golden_Cross/CS/KeltnerChannelGoldenCrossStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/0955_Keltner_Channel/CS/KeltnerChannelStrategy.cs
+++ b/API/0955_Keltner_Channel/CS/KeltnerChannelStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0956_Khaled_Tamims_Avellaneda_Stoikov/CS/KhaledTamimsAvellanedaStoikovStrategy.cs
+++ b/API/0956_Khaled_Tamims_Avellaneda_Stoikov/CS/KhaledTamimsAvellanedaStoikovStrategy.cs
@@ -1,6 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/0957_KST_Skyrexio/CS/KstSkyrexioStrategy.cs
+++ b/API/0957_KST_Skyrexio/CS/KstSkyrexioStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0958_KumoTrade_Ichimoku/CS/KumoTradeIchimokuStrategy.cs
+++ b/API/0958_KumoTrade_Ichimoku/CS/KumoTradeIchimokuStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0959_Kyrie_Crossover/CS/KyrieCrossoverStrategy.cs
+++ b/API/0959_Kyrie_Crossover/CS/KyrieCrossoverStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0960_Lanz_1_0_Backtest/CS/Lanz10BacktestStrategy.cs
+++ b/API/0960_Lanz_1_0_Backtest/CS/Lanz10BacktestStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0961_LANZ_2_0_Backtest/CS/Lanz20BacktestStrategy.cs
+++ b/API/0961_LANZ_2_0_Backtest/CS/Lanz20BacktestStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0962_Lanz_3_0_Backtest/CS/Lanz30BacktestStrategy.cs
+++ b/API/0962_Lanz_3_0_Backtest/CS/Lanz30BacktestStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0963_Lanz_4_0_Backtest/CS/Lanz40BacktestStrategy.cs
+++ b/API/0963_Lanz_4_0_Backtest/CS/Lanz40BacktestStrategy.cs
@@ -1,5 +1,11 @@
 
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0964_Lanz_50/CS/Lanz50Strategy.cs
+++ b/API/0964_Lanz_50/CS/Lanz50Strategy.cs
@@ -1,6 +1,11 @@
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0965_Lanz_6_0_Backtest/CS/Lanz60BacktestStrategy.cs
+++ b/API/0965_Lanz_6_0_Backtest/CS/Lanz60BacktestStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0966_Larry_Conners_SMTP/CS/LarryConnersSmtpStrategy.cs
+++ b/API/0966_Larry_Conners_SMTP/CS/LarryConnersSmtpStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/0967_Larry_Conners_Vix_Reversal_II/CS/LarryConnersVixReversalIIStrategy.cs
+++ b/API/0967_Larry_Conners_Vix_Reversal_II/CS/LarryConnersVixReversalIIStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0968_Larry_Connors_Bollinger_PercentB/CS/LarryConnorsPercentBStrategy.cs
+++ b/API/0968_Larry_Connors_Bollinger_PercentB/CS/LarryConnorsPercentBStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0969_Larry_Connors_3_Day_High_Low/CS/LarryConnors3DayHighLowStrategy.cs
+++ b/API/0969_Larry_Connors_3_Day_High_Low/CS/LarryConnors3DayHighLowStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0970_Larry_Connors_Rsi_3/CS/LarryConnorsRsi3Strategy.cs
+++ b/API/0970_Larry_Connors_Rsi_3/CS/LarryConnorsRsi3Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0971_Let_It_Snow/CS/LetItSnowStrategy.cs
+++ b/API/0971_Let_It_Snow/CS/LetItSnowStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0972_LibraryCOT/CS/LibraryCOTStrategy.cs
+++ b/API/0972_LibraryCOT/CS/LibraryCOTStrategy.cs
@@ -1,7 +1,15 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0973_Linear_Continuation/CS/LinearContinuationStrategy.cs
+++ b/API/0973_Linear_Continuation/CS/LinearContinuationStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/0974_Linear_Correlation_Oscillator/CS/LinearCorrelationOscillatorStrategy.cs
+++ b/API/0974_Linear_Correlation_Oscillator/CS/LinearCorrelationOscillatorStrategy.cs
@@ -1,5 +1,12 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0975_Linear_Cross_Trading/CS/LinearCrossTradingStrategy.cs
+++ b/API/0975_Linear_Cross_Trading/CS/LinearCrossTradingStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0976_Linear_Mean_Reversion/CS/LinearMeanReversionStrategy.cs
+++ b/API/0976_Linear_Mean_Reversion/CS/LinearMeanReversionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0977_Linear_On_MACD/CS/LinearOnMacdStrategy.cs
+++ b/API/0977_Linear_On_MACD/CS/LinearOnMacdStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0978_Linear_Regression_All_Data/CS/LinearRegressionAllDataStrategy.cs
+++ b/API/0978_Linear_Regression_All_Data/CS/LinearRegressionAllDataStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0979_Linear_Regression_Channel/CS/LinearRegressionChannelStrategy.cs
+++ b/API/0979_Linear_Regression_Channel/CS/LinearRegressionChannelStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0980_Liquid_Pulse/CS/LiquidPulseStrategy.cs
+++ b/API/0980_Liquid_Pulse/CS/LiquidPulseStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0981_Liquidity_Engulfment/CS/LiquidityEngulfmentStrategy.cs
+++ b/API/0981_Liquidity_Engulfment/CS/LiquidityEngulfmentStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0982_Liquidity_Internal_Market_Shift/CS/LiquidityInternalMarketShiftStrategy.cs
+++ b/API/0982_Liquidity_Internal_Market_Shift/CS/LiquidityInternalMarketShiftStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0983_Liquidity_Breakout/CS/LiquidityBreakoutStrategy.cs
+++ b/API/0983_Liquidity_Breakout/CS/LiquidityBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0984_Liquidity_Grab_Volume_Trap/CS/LiquidityGrabVolumeTrapStrategy.cs
+++ b/API/0984_Liquidity_Grab_Volume_Trap/CS/LiquidityGrabVolumeTrapStrategy.cs
@@ -1,4 +1,11 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0985_Liquidity_Sweep_Filter/CS/LiquiditySweepFilterStrategy.cs
+++ b/API/0985_Liquidity_Sweep_Filter/CS/LiquiditySweepFilterStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0986_Litecoin_Trailing_Stop/CS/LitecoinTrailingStopStrategy.cs
+++ b/API/0986_Litecoin_Trailing_Stop/CS/LitecoinTrailingStopStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0987_Livermore_Seykota_Breakout/CS/LivermoreSeykotaBreakoutStrategy.cs
+++ b/API/0987_Livermore_Seykota_Breakout/CS/LivermoreSeykotaBreakoutStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/0988_Logistic_RSI_STOCH_ROC_AO/CS/LogisticRsiStochRocAoStrategy.cs
+++ b/API/0988_Logistic_RSI_STOCH_ROC_AO/CS/LogisticRsiStochRocAoStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/0989_London_BreakOut_Classic/CS/LondonBreakOutClassicStrategy.cs
+++ b/API/0989_London_BreakOut_Classic/CS/LondonBreakOutClassicStrategy.cs
@@ -1,5 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0990_Long_and_Short_with_Multi_Indicators/CS/LongAndShortWithMultiIndicatorsStrategy.cs
+++ b/API/0990_Long_and_Short_with_Multi_Indicators/CS/LongAndShortWithMultiIndicatorsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0991_Long_EMA_Advanced_Exit/CS/LongEmaAdvancedExitStrategy.cs
+++ b/API/0991_Long_EMA_Advanced_Exit/CS/LongEmaAdvancedExitStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/0992_Long_Explosive_V1/CS/LongExplosiveV1Strategy.cs
+++ b/API/0992_Long_Explosive_V1/CS/LongExplosiveV1Strategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/0993_Long_Short_Exit_Risk_Management/CS/LongShortExitRiskManagementStrategy.cs
+++ b/API/0993_Long_Short_Exit_Risk_Management/CS/LongShortExitRiskManagementStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0994_Long_Term_Profitable_Swing_Abbas/CS/LongTermProfitableSwingAbbasStrategy.cs
+++ b/API/0994_Long_Term_Profitable_Swing_Abbas/CS/LongTermProfitableSwingAbbasStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0995_Long_Leg_Doji_Breakout/CS/LongLegDojiBreakoutStrategy.cs
+++ b/API/0995_Long_Leg_Doji_Breakout/CS/LongLegDojiBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/0996_Long_Only_MTF_EMA_Cloud/CS/LongOnlyMtfEmaCloudStrategy.cs
+++ b/API/0996_Long_Only_MTF_EMA_Cloud/CS/LongOnlyMtfEmaCloudStrategy.cs
@@ -1,4 +1,11 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/0997_Long_Only_Opening_Range_Breakout_ORB_with_Pivot_Points/CS/LongOnlyOpeningRangeBreakoutWithPivotPointsStrategy.cs
+++ b/API/0997_Long_Only_Opening_Range_Breakout_ORB_with_Pivot_Points/CS/LongOnlyOpeningRangeBreakoutWithPivotPointsStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0998_LSMA_Fast_Simple_Alternative_Calculation/CS/LsmaFastSimpleAlternativeCalculationStrategy.cs
+++ b/API/0998_LSMA_Fast_Simple_Alternative_Calculation/CS/LsmaFastSimpleAlternativeCalculationStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/0999_Lube/CS/LubeStrategy.cs
+++ b/API/0999_Lube/CS/LubeStrategy.cs
@@ -1,7 +1,13 @@
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1000_Lunar_calendar_day_Crypto_Trading/CS/LunarCalendarDayCryptoTradingStrategy.cs
+++ b/API/1000_Lunar_calendar_day_Crypto_Trading/CS/LunarCalendarDayCryptoTradingStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;


### PR DESCRIPTION
## Summary
- add the standard System, Ecng, and StockSharp using directives to every C# strategy in API folders 0501-1000 to align with project guidelines

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8091201248323aac16cb0e252e52c