### PR TITLE
Add standard using directives to strategies 1001-2000

### DIFF
--- a/API/1001_Lux_Clara_Ema_Vwap/CS/LuxClaraEmaVwapStrategy.cs
+++ b/API/1001_Lux_Clara_Ema_Vwap/CS/LuxClaraEmaVwapStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1002_MA_Crossover_with_TP_SL_5_EMA_Filter/CS/MaCrossoverTpSl5EmaFilterStrategy.cs
+++ b/API/1002_MA_Crossover_with_TP_SL_5_EMA_Filter/CS/MaCrossoverTpSl5EmaFilterStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1003_MA_Crossover_Demand_Supply_Zones_SLTP/CS/MaCrossoverDemandSupplyZonesSltpStrategy.cs
+++ b/API/1003_MA_Crossover_Demand_Supply_Zones_SLTP/CS/MaCrossoverDemandSupplyZonesSltpStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1004_MA_MACD_BB_BackTester/CS/MaMacdBbBackTesterStrategy.cs
+++ b/API/1004_MA_MACD_BB_BackTester/CS/MaMacdBbBackTesterStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1005_MA_With_Logistic/CS/MaWithLogisticStrategy.cs
+++ b/API/1005_MA_With_Logistic/CS/MaWithLogisticStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1006_Macd_Rsi_Ema_Bb_Atr_Day_Trading/CS/MacdRsiEmaBbAtrDayTradingStrategy.cs
+++ b/API/1006_Macd_Rsi_Ema_Bb_Atr_Day_Trading/CS/MacdRsiEmaBbAtrDayTradingStrategy.cs
@@ -1,6 +1,11 @@
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1007_MACD_Aggressive_Scalp_Simple/CS/MacdAggressiveScalpSimpleStrategy.cs
+++ b/API/1007_MACD_Aggressive_Scalp_Simple/CS/MacdAggressiveScalpSimpleStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -169,4 +174,3 @@ public class MacdAggressiveScalpSimpleStrategy : Strategy
 		_prevHist = macdHist;
 	}
 }
-

--- a/API/1008_MACD_Crossover/CS/MacdCrossoverStrategy.cs
+++ b/API/1008_MACD_Crossover/CS/MacdCrossoverStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1009_MACD_Enhanced_MTF_With_Stop_Loss/CS/MacdEnhancedMtfWithStopLossStrategy.cs
+++ b/API/1009_MACD_Enhanced_MTF_With_Stop_Loss/CS/MacdEnhancedMtfWithStopLossStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1010_MACD_Liquidity_Tracker/CS/MacdLiquidityTrackerStrategy.cs
+++ b/API/1010_MACD_Liquidity_Tracker/CS/MacdLiquidityTrackerStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1011_MACD_of_Relative_Strenght/CS/MacdOfRelativeStrenghtStrategy.cs
+++ b/API/1011_MACD_of_Relative_Strenght/CS/MacdOfRelativeStrenghtStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1012_MACD_Volume_BBO_Reversal/CS/MacdVolumeBboReversalStrategy.cs
+++ b/API/1012_MACD_Volume_BBO_Reversal/CS/MacdVolumeBboReversalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1013_Macd_Volume_Xauusd/CS/MacdVolumeXauusdStrategy.cs
+++ b/API/1013_Macd_Volume_Xauusd/CS/MacdVolumeXauusdStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1014_MACD_with_1D_Stochastic_Confirmation_Reversal/CS/MacdStochasticConfirmationReversalStrategy.cs
+++ b/API/1014_MACD_with_1D_Stochastic_Confirmation_Reversal/CS/MacdStochasticConfirmationReversalStrategy.cs
@@ -1,9 +1,17 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
@@ -197,4 +205,3 @@ public class MacdStochasticConfirmationReversalStrategy : Strategy
 		_hasPrev = true;
 	}
 }
-

--- a/API/1015_Machine_Learning_Logistic_Regression/CS/MachineLearningLogisticRegressionStrategy.cs
+++ b/API/1015_Machine_Learning_Logistic_Regression/CS/MachineLearningLogisticRegressionStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1016_Machine_Learning_SuperTrend_TP_SL/CS/MachineLearningSuperTrendStrategy.cs
+++ b/API/1016_Machine_Learning_SuperTrend_TP_SL/CS/MachineLearningSuperTrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1017_Magic_Wand_STSM/CS/MagicWandStsmStrategy.cs
+++ b/API/1017_Magic_Wand_STSM/CS/MagicWandStsmStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1018_Manadi_Buy_Sell_Ema_Macd_Rsi/CS/ManadiBuySellStrategy.cs
+++ b/API/1018_Manadi_Buy_Sell_Ema_Macd_Rsi/CS/ManadiBuySellStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1019_Markdown_The_Pine_Editors_Hidden_Gem/CS/MarkdownThePineEditorsHiddenGemStrategy.cs
+++ b/API/1019_Markdown_The_Pine_Editors_Hidden_Gem/CS/MarkdownThePineEditorsHiddenGemStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1020_Market_EKG/CS/MarketEKGStrategy.cs
+++ b/API/1020_Market_EKG/CS/MarketEKGStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1021_Market_Slayer/CS/MarketSlayerStrategy.cs
+++ b/API/1021_Market_Slayer/CS/MarketSlayerStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1022_Market_Trend_Levels_Non_Repainting/CS/MarketTrendLevelsNonRepaintingStrategy.cs
+++ b/API/1022_Market_Trend_Levels_Non_Repainting/CS/MarketTrendLevelsNonRepaintingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1023_MarketHolidays/CS/MarketHolidaysStrategy.cs
+++ b/API/1023_MarketHolidays/CS/MarketHolidaysStrategy.cs
@@ -1,7 +1,15 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1024_Martin_No_Loss_Exit_V3/CS/MartinNoLossExitV3Strategy.cs
+++ b/API/1024_Martin_No_Loss_Exit_V3/CS/MartinNoLossExitV3Strategy.cs
@@ -1,9 +1,15 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1025_Martingale_with_MACD_KDJ_opening_conditions/CS/MartingaleWithMacdKdjOpeningConditionsStrategy.cs
+++ b/API/1025_Martingale_with_MACD_KDJ_opening_conditions/CS/MartingaleWithMacdKdjOpeningConditionsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -315,4 +320,3 @@ public class MartingaleWithMacdKdjOpeningConditionsStrategy : Strategy
 		_bestPrice = 0m;
 	}
 }
-

--- a/API/1026_Mateos_Time_of_Day_Analysis_LE/CS/MateosTimeOfDayAnalysisLeStrategy.cs
+++ b/API/1026_Mateos_Time_of_Day_Analysis_LE/CS/MateosTimeOfDayAnalysisLeStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1027_MathConstants/CS/MathConstantsStrategy.cs
+++ b/API/1027_MathConstants/CS/MathConstantsStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 /// <summary>

--- a/API/1028_MathSpecialFunctionsConvolve1D/CS/MathSpecialFunctionsConvolve1DStrategy.cs
+++ b/API/1028_MathSpecialFunctionsConvolve1D/CS/MathSpecialFunctionsConvolve1DStrategy.cs
@@ -1,6 +1,15 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1029_MathStatisticsKernelFunctions/CS/MathStatisticsKernelFunctionsStrategy.cs
+++ b/API/1029_MathStatisticsKernelFunctions/CS/MathStatisticsKernelFunctionsStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1030_Matrix_Functions/CS/MatrixFunctionsStrategy.cs
+++ b/API/1030_Matrix_Functions/CS/MatrixFunctionsStrategy.cs
@@ -1,8 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using System.Text;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
+using System.Text;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1031_Function_Matrix_Library/CS/FunctionMatrixLibraryStrategy.cs
+++ b/API/1031_Function_Matrix_Library/CS/FunctionMatrixLibraryStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1032_Mawreez_RSI_Divergence_Detector/CS/MawreezRsiDivergenceDetectorStrategy.cs
+++ b/API/1032_Mawreez_RSI_Divergence_Detector/CS/MawreezRsiDivergenceDetectorStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1033_Max_Drawdown_Calculating_Functions_Optimized/CS/MaxDrawdownCalculatingFunctionsOptimizedStrategy.cs
+++ b/API/1033_Max_Drawdown_Calculating_Functions_Optimized/CS/MaxDrawdownCalculatingFunctionsOptimizedStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1034_Max_Gain/CS/MaxGainStrategy.cs
+++ b/API/1034_Max_Gain/CS/MaxGainStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1035_Max_Pain/CS/MaxPainStrategy.cs
+++ b/API/1035_Max_Pain/CS/MaxPainStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1036_Max_Profit_Min_Loss_Options/CS/MaxProfitMinLossOptionsStrategy.cs
+++ b/API/1036_Max_Profit_Min_Loss_Options/CS/MaxProfitMinLossOptionsStrategy.cs
@@ -1,12 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using Ecng.Common;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1037_McClellan_AD_Volume_Integration_Model/CS/McClellanAdVolumeIntegrationModelStrategy.cs
+++ b/API/1037_McClellan_AD_Volume_Integration_Model/CS/McClellanAdVolumeIntegrationModelStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1038_McGinley_Dynamic_Improved/CS/McGinleyDynamicImprovedStrategy.cs
+++ b/API/1038_McGinley_Dynamic_Improved/CS/McGinleyDynamicImprovedStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1039_MCOTs_Intuition/CS/McotsIntuitionStrategy.cs
+++ b/API/1039_MCOTs_Intuition/CS/McotsIntuitionStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1040_Mean_Deviation_Index/CS/MeanDeviationIndexStrategy.cs
+++ b/API/1040_Mean_Deviation_Index/CS/MeanDeviationIndexStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1041_Mean_Reversion_Pro/CS/MeanReversionProStrategy.cs
+++ b/API/1041_Mean_Reversion_Pro/CS/MeanReversionProStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1042_Mean_Reversion_V_F/CS/MeanReversionVFStrategy.cs
+++ b/API/1042_Mean_Reversion_V_F/CS/MeanReversionVFStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -275,4 +280,3 @@ public class MeanReversionVFStrategy : Strategy
 		};
 	}
 }
-

--- a/API/1043_Mean_Reversion_With_Incremental_Entry/CS/MeanReversionWithIncrementalEntryStrategy.cs
+++ b/API/1043_Mean_Reversion_With_Incremental_Entry/CS/MeanReversionWithIncrementalEntryStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1044_Mechanical_Trading/CS/MechanicalTradingStrategy.cs
+++ b/API/1044_Mechanical_Trading/CS/MechanicalTradingStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1045_Medico_Action_Zone_Self_Adjust_TF_Version_2/CS/MedicoActionZoneSelfAdjustTfVersion2Strategy.cs
+++ b/API/1045_Medico_Action_Zone_Self_Adjust_TF_Version_2/CS/MedicoActionZoneSelfAdjustTfVersion2Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -135,4 +140,3 @@ public class MedicoActionZoneSelfAdjustTfVersion2Strategy : Strategy
 		_prevSlow = emaSlow;
 	}
 }
-

--- a/API/1046_Megabar_Breakout_Range_Volume_Rsi/CS/MegabarBreakoutStrategy.cs
+++ b/API/1046_Megabar_Breakout_Range_Volume_Rsi/CS/MegabarBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1047_Merovinh_Mean_Reversion_Lowest_Low/CS/MerovinhMeanReversionLowestLowStrategy.cs
+++ b/API/1047_Merovinh_Mean_Reversion_Lowest_Low/CS/MerovinhMeanReversionLowestLowStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1048_MESA_Stochastic_Multi_Length/CS/MesaStochasticMultiLengthStrategy.cs
+++ b/API/1048_MESA_Stochastic_Multi_Length/CS/MesaStochasticMultiLengthStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1049_MFI_with_Oversold_Zone_Exit_and_Averaging/CS/MfiWithOversoldZoneExitAndAveragingStrategy.cs
+++ b/API/1049_MFI_with_Oversold_Zone_Exit_and_Averaging/CS/MfiWithOversoldZoneExitAndAveragingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1050_MFS_3_Bars_Pattern/CS/Mfs3BarsPatternStrategy.cs
+++ b/API/1050_MFS_3_Bars_Pattern/CS/Mfs3BarsPatternStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1051_MH_Hull_Moving_Average_Based_Trading/CS/MhHullMovingAverageBasedTradingStrategy.cs
+++ b/API/1051_MH_Hull_Moving_Average_Based_Trading/CS/MhHullMovingAverageBasedTradingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1052_MicuRobert_Ema_Cross/CS/MicuRobertEmaCrossStrategy.cs
+++ b/API/1052_MicuRobert_Ema_Cross/CS/MicuRobertEmaCrossStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1053_Mikuls_Ichimoku_Cloud_v2/CS/MikulsIchimokuCloudV2Strategy.cs
+++ b/API/1053_Mikuls_Ichimoku_Cloud_v2/CS/MikulsIchimokuCloudV2Strategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1054_MK_Custome_Adaptive_SuperTrend/CS/MKCustomeAdaptiveSuperTrendStrategy.cs
+++ b/API/1054_MK_Custome_Adaptive_SuperTrend/CS/MKCustomeAdaptiveSuperTrendStrategy.cs
@@ -1,13 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
 using Ecng.Common;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1055_MM_Fibonacci/CS/MmFibonacciStrategy.cs
+++ b/API/1055_MM_Fibonacci/CS/MmFibonacciStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1056_MNQ_EMA/CS/MNQEMAStrategy.cs
+++ b/API/1056_MNQ_EMA/CS/MNQEMAStrategy.cs
@@ -1,4 +1,11 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/1057_MOC_Delta_MOO_Entry_V2_REVERSE/CS/MocDeltaMooEntryV2ReverseStrategy.cs
+++ b/API/1057_MOC_Delta_MOO_Entry_V2_REVERSE/CS/MocDeltaMooEntryV2ReverseStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1058_MOC_Delta_MOO_Entry_v2/CS/MocDeltaMooEntryV2Strategy.cs
+++ b/API/1058_MOC_Delta_MOO_Entry_v2/CS/MocDeltaMooEntryV2Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -186,4 +191,3 @@ public class MocDeltaMooEntryV2Strategy : Strategy
 		CloseAll("15:50 Close");
 	}
 }
-

--- a/API/1059_MOC_Delta_MOO_Entry/CS/MocDeltaMooEntryStrategy.cs
+++ b/API/1059_MOC_Delta_MOO_Entry/CS/MocDeltaMooEntryStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1060_Modified_OBV_With_Divergence_Detection/CS/ModifiedObvWithDivergenceDetectionStrategy.cs
+++ b/API/1060_Modified_OBV_With_Divergence_Detection/CS/ModifiedObvWithDivergenceDetectionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1061_Modular_Range_Trading/CS/ModularRangeTradingStrategy.cs
+++ b/API/1061_Modular_Range_Trading/CS/ModularRangeTradingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1062_MollyETF_EMA_Crossover/CS/MollyEtfEmaCrossoverStrategy.cs
+++ b/API/1062_MollyETF_EMA_Crossover/CS/MollyEtfEmaCrossoverStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1063_Momentum_Keltner_Stochastic_Combo/CS/MomentumKeltnerStochasticComboStrategy.cs
+++ b/API/1063_Momentum_Keltner_Stochastic_Combo/CS/MomentumKeltnerStochasticComboStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1064_Momentum_Alligator_4h_Bitcoin/CS/MomentumAlligator4hBitcoinStrategy.cs
+++ b/API/1064_Momentum_Alligator_4h_Bitcoin/CS/MomentumAlligator4hBitcoinStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1065_Momentum_Long_Short/CS/MomentumLongShortStrategy.cs
+++ b/API/1065_Momentum_Long_Short/CS/MomentumLongShortStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1066_MomentumSync_PSAR_RSI_ADX_Filtered_3_Tier_Exit/CS/MomentumSyncPsarRsiAdxFiltered3TierExitStrategy.cs
+++ b/API/1066_MomentumSync_PSAR_RSI_ADX_Filtered_3_Tier_Exit/CS/MomentumSyncPsarRsiAdxFiltered3TierExitStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1067_Monday_Open/CS/MondayOpenStrategy.cs
+++ b/API/1067_Monday_Open/CS/MondayOpenStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1068_Monte_Carlo_Range_Forecast/CS/MonteCarloRangeForecastStrategy.cs
+++ b/API/1068_Monte_Carlo_Range_Forecast/CS/MonteCarloRangeForecastStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1069_Monte_Carlo_Simulation_Random_Walk/CS/MonteCarloSimulationRandomWalkStrategy.cs
+++ b/API/1069_Monte_Carlo_Simulation_Random_Walk/CS/MonteCarloSimulationRandomWalkStrategy.cs
@@ -1,7 +1,12 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1070_Monthly_Breakout/CS/MonthlyBreakoutStrategy.cs
+++ b/API/1070_Monthly_Breakout/CS/MonthlyBreakoutStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1071_Monthly_Day_Long_VIX/CS/MonthlyDayLongVixStrategy.cs
+++ b/API/1071_Monthly_Day_Long_VIX/CS/MonthlyDayLongVixStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1072_Monthly_Performance_Table/CS/MonthlyPerformanceTableStrategy.cs
+++ b/API/1072_Monthly_Performance_Table/CS/MonthlyPerformanceTableStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -92,4 +97,3 @@ public class MonthlyPerformanceTableStrategy : Strategy
 			SellMarket(Volume + Math.Abs(Position));
 	}
 }
-

--- a/API/1073_Monthly_Purchase_with_Dynamic_Contract_Size/CS/MonthlyPurchaseWithDynamicContractSizeStrategy.cs
+++ b/API/1073_Monthly_Purchase_with_Dynamic_Contract_Size/CS/MonthlyPurchaseWithDynamicContractSizeStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1074_Monthly_Returns/CS/MonthlyReturnsStrategy.cs
+++ b/API/1074_Monthly_Returns/CS/MonthlyReturnsStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1075_Motion/CS/MotionStrategy.cs
+++ b/API/1075_Motion/CS/MotionStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1076_MA_Crossover_with_Take_Profit_and_Stop_Loss/CS/MaCrossoverTpSlStrategy.cs
+++ b/API/1076_MA_Crossover_with_Take_Profit_and_Stop_Loss/CS/MaCrossoverTpSlStrategy.cs
@@ -1,4 +1,10 @@
+using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1077_Moving_Average_Crossover/CS/MovingAverageCrossoverStrategy.cs
+++ b/API/1077_Moving_Average_Crossover/CS/MovingAverageCrossoverStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1078_Moving_Average_Crossover_Swing/CS/MovingAverageCrossoverSwingStrategy.cs
+++ b/API/1078_Moving_Average_Crossover_Swing/CS/MovingAverageCrossoverSwingStrategy.cs
@@ -1,4 +1,11 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/1079_Moving_Average_Entanglement/CS/MovingAverageEntanglementStrategy.cs
+++ b/API/1079_Moving_Average_Entanglement/CS/MovingAverageEntanglementStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1080_Moving_Average_Rainbow_Stormer/CS/MovingAverageRainbowStormerStrategy.cs
+++ b/API/1080_Moving_Average_Rainbow_Stormer/CS/MovingAverageRainbowStormerStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1081_Moving_Average_Shift_WaveTrend/CS/MovingAverageShiftWaveTrendStrategy.cs
+++ b/API/1081_Moving_Average_Shift_WaveTrend/CS/MovingAverageShiftWaveTrendStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1082_Moving_Average/CS/MovingAverageStrategy.cs
+++ b/API/1082_Moving_Average/CS/MovingAverageStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -220,4 +225,3 @@ public enum PriceTypeEnum
 	Typical,
 	Center
 }
-

--- a/API/1083_Moving_Regression/CS/MovingRegressionStrategy.cs
+++ b/API/1083_Moving_Regression/CS/MovingRegressionStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1084_MTF_Oscillator_Framework/CS/MtfOscillatorFrameworkStrategy.cs
+++ b/API/1084_MTF_Oscillator_Framework/CS/MtfOscillatorFrameworkStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1085_MTF_Seconds_Values_JD/CS/MtfSecondsValuesJDStrategy.cs
+++ b/API/1085_MTF_Seconds_Values_JD/CS/MtfSecondsValuesJDStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1086_Multi_Conditions_Curve_Fitting/CS/MultiConditionsCurveFittingStrategy.cs
+++ b/API/1086_Multi_Conditions_Curve_Fitting/CS/MultiConditionsCurveFittingStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1087_Multi_Time_Frame_Candles_with_Volume_Info_3D/CS/MultiTimeFrameCandlesWithVolumeInfo3DStrategy.cs
+++ b/API/1087_Multi_Time_Frame_Candles_with_Volume_Info_3D/CS/MultiTimeFrameCandlesWithVolumeInfo3DStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;
@@ -127,4 +140,3 @@ public class MultiTimeFrameCandlesWithVolumeInfo3DStrategy : Strategy
 		return result.TrimEnd();
 	}
 }
-

--- a/API/1088_Multi_Time_Frame_Candles/CS/MultiTimeFrameCandlesStrategy.cs
+++ b/API/1088_Multi_Time_Frame_Candles/CS/MultiTimeFrameCandlesStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1089_Multi_Timeframe_RSI_Buy_Sell/CS/MultiTimeframeRsiBuySellStrategy.cs
+++ b/API/1089_Multi_Timeframe_RSI_Buy_Sell/CS/MultiTimeframeRsiBuySellStrategy.cs
@@ -1,9 +1,18 @@
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1090_Multi_Band_Comparison/CS/MultiBandComparisonStrategy.cs
+++ b/API/1090_Multi_Band_Comparison/CS/MultiBandComparisonStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1091_Multi_Confluence_Swing_Hunter_V1/CS/MultiConfluenceSwingHunterV1Strategy.cs
+++ b/API/1091_Multi_Confluence_Swing_Hunter_V1/CS/MultiConfluenceSwingHunterV1Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1092_Multi_EMA_Crossover/CS/MultiEmaCrossoverStrategy.cs
+++ b/API/1092_Multi_EMA_Crossover/CS/MultiEmaCrossoverStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1093_Multi-Factor/CS/MultiFactorStrategy.cs
+++ b/API/1093_Multi-Factor/CS/MultiFactorStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1094_Multi_Indicator_Swing/CS/MultiIndicatorSwingStrategy.cs
+++ b/API/1094_Multi_Indicator_Swing/CS/MultiIndicatorSwingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1095_Multi_Indicator_Trend_Following/CS/MultiIndicatorTrendFollowingStrategy.cs
+++ b/API/1095_Multi_Indicator_Trend_Following/CS/MultiIndicatorTrendFollowingStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1096_Multi_Regression/CS/MultiRegressionStrategy.cs
+++ b/API/1096_Multi_Regression/CS/MultiRegressionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1097_Multi_Step_FlexiMA/CS/MultiStepFlexiMaStrategy.cs
+++ b/API/1097_Multi_Step_FlexiMA/CS/MultiStepFlexiMaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1098_Multi_Step_FlexiSuperTrend/CS/MultiStepFlexiSuperTrendStrategy.cs
+++ b/API/1098_Multi_Step_FlexiSuperTrend/CS/MultiStepFlexiSuperTrendStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1099_Multi-Step_Vegas_SuperTrend/CS/MultiStepVegasSuperTrendStrategy.cs
+++ b/API/1099_Multi-Step_Vegas_SuperTrend/CS/MultiStepVegasSuperTrendStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1100_Multi_TF_AI_SuperTrend_with_ADX/CS/MultiTfAiSuperTrendWithAdxStrategy.cs
+++ b/API/1100_Multi_TF_AI_SuperTrend_with_ADX/CS/MultiTfAiSuperTrendWithAdxStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1101_Multi_Timeframe_MACD/CS/MultiTimeframeMacdStrategy.cs
+++ b/API/1101_Multi_Timeframe_MACD/CS/MultiTimeframeMacdStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1102_Multi_Timeframe_Parabolic_SAR/CS/MultiTimeframeParabolicSarStrategy.cs
+++ b/API/1102_Multi_Timeframe_Parabolic_SAR/CS/MultiTimeframeParabolicSarStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1103_Multi_Timeframe_RSI_Grid_with_Arrows/CS/MultiTimeframeRsiGridWithArrowsStrategy.cs
+++ b/API/1103_Multi_Timeframe_RSI_Grid_with_Arrows/CS/MultiTimeframeRsiGridWithArrowsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1104_Multi_Timeframe_Trend_200_EMA_Filter_Longs_Only/CS/MultiTimeframeTrend200EmaFilterLongsOnlyStrategy.cs
+++ b/API/1104_Multi_Timeframe_Trend_200_EMA_Filter_Longs_Only/CS/MultiTimeframeTrend200EmaFilterLongsOnlyStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1105_MultiLayer_Acceleration_Deceleration/CS/MultiLayerAccelerationDecelerationStrategy.cs
+++ b/API/1105_MultiLayer_Acceleration_Deceleration/CS/MultiLayerAccelerationDecelerationStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1106_MultiLayer_Awesome_Oscillator_Saucer/CS/MultiLayerAwesomeOscillatorSaucerStrategy.cs
+++ b/API/1106_MultiLayer_Awesome_Oscillator_Saucer/CS/MultiLayerAwesomeOscillatorSaucerStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1107_Mutanabby_AI_Algo_Pro/CS/MutanabbyAiAlgoProStrategy.cs
+++ b/API/1107_Mutanabby_AI_Algo_Pro/CS/MutanabbyAiAlgoProStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -301,4 +306,3 @@ _prevOpen = candle.OpenPrice;
 _prevClose = candle.ClosePrice;
 }
 }
-

--- a/API/1108_MVO_MA_Signal/CS/MvoMaSignalStrategy.cs
+++ b/API/1108_MVO_MA_Signal/CS/MvoMaSignalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1109_Nadaraya_Watson_Envelope/CS/NadarayaWatsonEnvelopeStrategy.cs
+++ b/API/1109_Nadaraya_Watson_Envelope/CS/NadarayaWatsonEnvelopeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1110_Narrow_Range/CS/NarrowRangeStrategy.cs
+++ b/API/1110_Narrow_Range/CS/NarrowRangeStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1111_NAS100_and_gold_Smart_Scalping_PRO_Enhanced_v2/CS/Nas100AndGoldSmartScalpingProEnhancedV2Strategy.cs
+++ b/API/1111_NAS100_and_gold_Smart_Scalping_PRO_Enhanced_v2/CS/Nas100AndGoldSmartScalpingProEnhancedV2Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1112_Nasdaq_100_Peak_Hours/CS/Nasdaq100PeakHoursStrategy.cs
+++ b/API/1112_Nasdaq_100_Peak_Hours/CS/Nasdaq100PeakHoursStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1113_Nasdaq_Day_and_Night_Breakdown/CS/NasdaqDayAndNightBreakdownStrategy.cs
+++ b/API/1113_Nasdaq_Day_and_Night_Breakdown/CS/NasdaqDayAndNightBreakdownStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1114_Negroni_Opening_Range/CS/NegroniOpeningRangeStrategy.cs
+++ b/API/1114_Negroni_Opening_Range/CS/NegroniOpeningRangeStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1115_NEO_IMACD_SL_y_TP/CS/NeoImacdSlTpStrategy.cs
+++ b/API/1115_NEO_IMACD_SL_y_TP/CS/NeoImacdSlTpStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1116_Neon_Momentum_Waves/CS/NeonMomentumWavesStrategy.cs
+++ b/API/1116_Neon_Momentum_Waves/CS/NeonMomentumWavesStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1117_New_Intraday_High_With_Weak_Bar/CS/NewIntradayHighWithWeakBarStrategy.cs
+++ b/API/1117_New_Intraday_High_With_Weak_Bar/CS/NewIntradayHighWithWeakBarStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -128,4 +133,3 @@ public class NewIntradayHighWithWeakBarStrategy : Strategy
 		_prevHigh = high;
 	}
 }
-

--- a/API/1118_Nifty_50_5mint/CS/Nifty505mintStrategy.cs
+++ b/API/1118_Nifty_50_5mint/CS/Nifty505mintStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1119_Nifty_Options_Trendy_Markets_with_TSL/CS/NiftyOptionsTrendyMarketsWithTslStrategy.cs
+++ b/API/1119_Nifty_Options_Trendy_Markets_with_TSL/CS/NiftyOptionsTrendyMarketsWithTslStrategy.cs
@@ -1,6 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
 using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1120_Non_Repainting_Renko_Emulation/CS/NonRepaintingRenkoEmulationStrategy.cs
+++ b/API/1120_Non_Repainting_Renko_Emulation/CS/NonRepaintingRenkoEmulationStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1121_Normalized_Oscillators_Spider_Chart/CS/NormalizedOscillatorsSpiderChartStrategy.cs
+++ b/API/1121_Normalized_Oscillators_Spider_Chart/CS/NormalizedOscillatorsSpiderChartStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1122_Nova_Futures_Pro_Safe_v6/CS/NovaFuturesProSafeV6Strategy.cs
+++ b/API/1122_Nova_Futures_Pro_Safe_v6/CS/NovaFuturesProSafeV6Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1123_NQ_Phantom_Scalper_Pro/CS/NqPhantomScalperProStrategy.cs
+++ b/API/1123_NQ_Phantom_Scalper_Pro/CS/NqPhantomScalperProStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1124_NSE_Index_with_Entry_Exit_Markers/CS/NseIndexWithEntryExitMarkersStrategy.cs
+++ b/API/1124_NSE_Index_with_Entry_Exit_Markers/CS/NseIndexWithEntryExitMarkersStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1125_Nunchucks/CS/NunchucksStrategy.cs
+++ b/API/1125_Nunchucks/CS/NunchucksStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1126_NY_First_Candle_Break_and_Retest/CS/NyFirstCandleBreakAndRetestStrategy.cs
+++ b/API/1126_NY_First_Candle_Break_and_Retest/CS/NyFirstCandleBreakAndRetestStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1127_NY_Opening_Range_Breakout_MA_Stop/CS/NyOpeningRangeBreakoutMaStopStrategy.cs
+++ b/API/1127_NY_Opening_Range_Breakout_MA_Stop/CS/NyOpeningRangeBreakoutMaStopStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1128_NY_Breakout/CS/NyBreakoutStrategy.cs
+++ b/API/1128_NY_Breakout/CS/NyBreakoutStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1129_OBV_ATR/CS/ObvAtrStrategy.cs
+++ b/API/1129_OBV_ATR/CS/ObvAtrStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1130_OBV_Traffic_Lights/CS/ObvTrafficLightsStrategy.cs
+++ b/API/1130_OBV_Traffic_Lights/CS/ObvTrafficLightsStrategy.cs
@@ -1,14 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using System.Drawing;
 
 using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
-using StockSharp.Algo;
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using System.Drawing;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1131_Obvious_MA/CS/ObviousMaStrategy.cs
+++ b/API/1131_Obvious_MA/CS/ObviousMaStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
@@ -219,4 +225,3 @@ var shortExitCond = _prevObv <= _prevShortExitMa && obvValue > shortExit && Posi
 		_isFirst = false;
 	}
 }
-

--- a/API/1132_Octopus_Nest/CS/OctopusNestStrategy.cs
+++ b/API/1132_Octopus_Nest/CS/OctopusNestStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1133_OKX_MA_Crossover/CS/OkxMaCrossoverStrategy.cs
+++ b/API/1133_OKX_MA_Crossover/CS/OkxMaCrossoverStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1134_Omega_Galsky/CS/OmegaGalskyStrategy.cs
+++ b/API/1134_Omega_Galsky/CS/OmegaGalskyStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1135_Opening_Range_Breakout/CS/OpeningRangeBreakout2Strategy.cs
+++ b/API/1135_Opening_Range_Breakout/CS/OpeningRangeBreakout2Strategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1136_Optimized_Auto_Detect/CS/OptimizedAutoDetectStrategy.cs
+++ b/API/1136_Optimized_Auto_Detect/CS/OptimizedAutoDetectStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1137_Optimized_Grid_with_KNN/CS/OptimizedGridWithKnnStrategy.cs
+++ b/API/1137_Optimized_Grid_with_KNN/CS/OptimizedGridWithKnnStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1138_Optimized_Heikin_Ashi_Buy_Sell/CS/OptimizedHeikinAshiBuySellStrategy.cs
+++ b/API/1138_Optimized_Heikin_Ashi_Buy_Sell/CS/OptimizedHeikinAshiBuySellStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1139_Lorenzo_Super_Scalp/CS/LorenzoSuperScalpStrategy.cs
+++ b/API/1139_Lorenzo_Super_Scalp/CS/LorenzoSuperScalpStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1140_Options_V13/CS/OptionsV13Strategy.cs
+++ b/API/1140_Options_V13/CS/OptionsV13Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1141_Options_V2_0/CS/OptionsV20Strategy.cs
+++ b/API/1141_Options_V2_0/CS/OptionsV20Strategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1142_ORB_15m_First_15min_Breakout_Long_Short/CS/Orb15mFirst15minBreakoutStrategy.cs
+++ b/API/1142_ORB_15m_First_15min_Breakout_Long_Short/CS/Orb15mFirst15minBreakoutStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1143_ORB_VWAP_Braid_Filter/CS/OrbVwapBraidFilterStrategy.cs
+++ b/API/1143_ORB_VWAP_Braid_Filter/CS/OrbVwapBraidFilterStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1144_ORB_Heikin_Ashi_SPY_Correlation/CS/OrbHeikinAshiSpyCorrelationStrategy.cs
+++ b/API/1144_ORB_Heikin_Ashi_SPY_Correlation/CS/OrbHeikinAshiSpyCorrelationStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1145_Order_Block_Finder/CS/OrderBlockFinderStrategy.cs
+++ b/API/1145_Order_Block_Finder/CS/OrderBlockFinderStrategy.cs
@@ -1,9 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.BusinessEntities;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1146_Oscillator_Evaluator/CS/OscillatorEvaluatorStrategy.cs
+++ b/API/1146_Oscillator_Evaluator/CS/OscillatorEvaluatorStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1147_Out_of_the_Noise_Intraday_with_VWAP/CS/OutOfTheNoiseIntradayWithVwapStrategy.cs
+++ b/API/1147_Out_of_the_Noise_Intraday_with_VWAP/CS/OutOfTheNoiseIntradayWithVwapStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1148_Outlier_Detector_with_N_Sigma_Confidence_Intervals/CS/OutlierDetectorWithNSigmaConfidenceIntervalsStrategy.cs
+++ b/API/1148_Outlier_Detector_with_N_Sigma_Confidence_Intervals/CS/OutlierDetectorWithNSigmaConfidenceIntervalsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1149_Outside_Bar/CS/OutsideBarStrategy.cs
+++ b/API/1149_Outside_Bar/CS/OutsideBarStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1150_Overnight_Effect_High_Volatility_Crypto/CS/OvernightEffectHighVolatilityCryptoStrategy.cs
+++ b/API/1150_Overnight_Effect_High_Volatility_Crypto/CS/OvernightEffectHighVolatilityCryptoStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1151_Overnight_Positioning_EMA/CS/OvernightPositioningEmaStrategy.cs
+++ b/API/1151_Overnight_Positioning_EMA/CS/OvernightPositioningEmaStrategy.cs
@@ -1,5 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/1152_P_Square_Nth_Percentile/CS/PSquareNthPercentileStrategy.cs
+++ b/API/1152_P_Square_Nth_Percentile/CS/PSquareNthPercentileStrategy.cs
@@ -1,6 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1153_Pairs/CS/PairsStrategy.cs
+++ b/API/1153_Pairs/CS/PairsStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1154_Parabolic_RSI/CS/ParabolicRsiStrategy.cs
+++ b/API/1154_Parabolic_RSI/CS/ParabolicRsiStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1155_Parabolic_SAR_MACD_Trend_Zone/CS/ParabolicSarMacdTrendZoneStrategy.cs
+++ b/API/1155_Parabolic_SAR_MACD_Trend_Zone/CS/ParabolicSarMacdTrendZoneStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1156_Parabolic_SAR_Early_Buy_MA_Exit/CS/ParabolicSarEarlyBuyMaExitStrategy.cs
+++ b/API/1156_Parabolic_SAR_Early_Buy_MA_Exit/CS/ParabolicSarEarlyBuyMaExitStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1157_Parabolic_SAR_Early_Buy_MA_Based_Exit/CS/ParabolicSarEarlyBuyMaBasedExitStrategy.cs
+++ b/API/1157_Parabolic_SAR_Early_Buy_MA_Based_Exit/CS/ParabolicSarEarlyBuyMaBasedExitStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1158_Parent_Session_Sweeps_Alert/CS/ParentSessionSweepsAlertStrategy.cs
+++ b/API/1158_Parent_Session_Sweeps_Alert/CS/ParentSessionSweepsAlertStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1159_Pavan_CPR/CS/PavanCprStrategy.cs
+++ b/API/1159_Pavan_CPR/CS/PavanCprStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1160_Payday_Anomaly/CS/PaydayAnomaly2Strategy.cs
+++ b/API/1160_Payday_Anomaly/CS/PaydayAnomaly2Strategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1161_PEAD/CS/PeadStrategy.cs
+++ b/API/1161_PEAD/CS/PeadStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1162_Penrose_Diagram/CS/PenroseDiagramStrategy.cs
+++ b/API/1162_Penrose_Diagram/CS/PenroseDiagramStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1163_PercentX_Trend_Follower/CS/PercentXTrendFollowerStrategy.cs
+++ b/API/1163_PercentX_Trend_Follower/CS/PercentXTrendFollowerStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1164_Phase_Cross_with_Zone/CS/PhaseCrossWithZoneStrategy.cs
+++ b/API/1164_Phase_Cross_with_Zone/CS/PhaseCrossWithZoneStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -98,4 +103,3 @@ public class PhaseCrossWithZoneStrategy : Strategy
 		_prevLag = lag;
 	}
 }
-

--- a/API/1165_Pin_Bar_Reversal/CS/PinBarReversalStrategy.cs
+++ b/API/1165_Pin_Bar_Reversal/CS/PinBarReversalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1166_Pineconnector_Template/CS/PineconnectorTemplateStrategy.cs
+++ b/API/1166_Pineconnector_Template/CS/PineconnectorTemplateStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1167_Common_Label_Line_Array_Functions/CS/CommonLabelLineArrayFunctionsStrategy.cs
+++ b/API/1167_Common_Label_Line_Array_Functions/CS/CommonLabelLineArrayFunctionsStrategy.cs
@@ -1,7 +1,15 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1168_Pivot_Percentile_Trend/CS/PivotPercentileTrendStrategy.cs
+++ b/API/1168_Pivot_Percentile_Trend/CS/PivotPercentileTrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1169_Pivot_Point_SuperTrend_TrendFilter/CS/PivotPointSuperTrendTrendFilterStrategy.cs
+++ b/API/1169_Pivot_Point_SuperTrend_TrendFilter/CS/PivotPointSuperTrendTrendFilterStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1170_Pivot_Point_Supertrend/CS/PivotPointSupertrendStrategy.cs
+++ b/API/1170_Pivot_Point_Supertrend/CS/PivotPointSupertrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -273,4 +278,3 @@ SellMarket(Volume + Math.Abs(Position));
 _lastClose = candle.ClosePrice;
 }
 }
-

--- a/API/1171_Pixel_Art/CS/PixelArtStrategy.cs
+++ b/API/1171_Pixel_Art/CS/PixelArtStrategy.cs
@@ -1,7 +1,15 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1172_Polynomial_Regression_Bands_Channel/CS/PolynomialRegressionBandsChannelStrategy.cs
+++ b/API/1172_Polynomial_Regression_Bands_Channel/CS/PolynomialRegressionBandsChannelStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
@@ -197,4 +203,3 @@ public class PolynomialRegressionBandsChannelStrategy : Strategy
 		return (decimal)Math.Sqrt((double)(sum / n));
 	}
 }
-

--- a/API/1173_Portfolio_Alpha_Beta_Stdev_Variance_Mean_Max_Drawdown/CS/PortfolioAlphaBetaStdevVarianceMeanMaxDrawdownStrategy.cs
+++ b/API/1173_Portfolio_Alpha_Beta_Stdev_Variance_Mean_Max_Drawdown/CS/PortfolioAlphaBetaStdevVarianceMeanMaxDrawdownStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1174_Portfolio_Tracker_v2/CS/PortfolioTrackerV2Strategy.cs
+++ b/API/1174_Portfolio_Tracker_v2/CS/PortfolioTrackerV2Strategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1175_Post_Open_Long_ATR_Stop_Loss_Take_Profit/CS/PostOpenLongAtrStopLossTakeProfitStrategy.cs
+++ b/API/1175_Post_Open_Long_ATR_Stop_Loss_Take_Profit/CS/PostOpenLongAtrStopLossTakeProfitStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1176_Power_Hour_Money/CS/PowerHourMoneyStrategy.cs
+++ b/API/1176_Power_Hour_Money/CS/PowerHourMoneyStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1177_PowerHouse_SwiftEdge_AI_v2_10/CS/PowerHouseSwiftEdgeAiV210Strategy.cs
+++ b/API/1177_PowerHouse_SwiftEdge_AI_v2_10/CS/PowerHouseSwiftEdgeAiV210Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1178_Powertrend_Volume_Range_Filter/CS/PowertrendVolumeRangeFilterStrategy.cs
+++ b/API/1178_Powertrend_Volume_Range_Filter/CS/PowertrendVolumeRangeFilterStrategy.cs
@@ -1,6 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
 using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1179_PowerZone/CS/PowerZoneStrategy.cs
+++ b/API/1179_PowerZone/CS/PowerZoneStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1180_Precision_Trading_Golden_Edge/CS/PrecisionTradingGoldenEdgeStrategy.cs
+++ b/API/1180_Precision_Trading_Golden_Edge/CS/PrecisionTradingGoldenEdgeStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -164,4 +170,3 @@ public class PrecisionTradingGoldenEdgeStrategy : Strategy
 		_prevHma = hma;
 	}
 }
-

--- a/API/1181_Premarket_Gap_MomoTrader/CS/PremarketGapMomoTraderStrategy.cs
+++ b/API/1181_Premarket_Gap_MomoTrader/CS/PremarketGapMomoTraderStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1182_PresentTrend/CS/PresentTrendStrategy.cs
+++ b/API/1182_PresentTrend/CS/PresentTrendStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1183_PresentTrend_RMI_Synergy/CS/PresentTrendRmiSynergyStrategy.cs
+++ b/API/1183_PresentTrend_RMI_Synergy/CS/PresentTrendRmiSynergyStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -186,4 +191,3 @@ else if ((Direction is null or Sides.Sell) && rsiValue < 40m && trendDir == -1)
 		}
 	}
 }
-

--- a/API/1184_Previous_Day_High_Low_Long/CS/PreviousDayHighLowLongStrategy.cs
+++ b/API/1184_Previous_Day_High_Low_Long/CS/PreviousDayHighLowLongStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1185_Previous_Period_Levels_X_Alerts/CS/PreviousPeriodLevelsXAlertsStrategy.cs
+++ b/API/1185_Previous_Period_Levels_X_Alerts/CS/PreviousPeriodLevelsXAlertsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1186_Price_and_Volume_Breakout_Buy/CS/PriceAndVolumeBreakoutBuyStrategy.cs
+++ b/API/1186_Price_and_Volume_Breakout_Buy/CS/PriceAndVolumeBreakoutBuyStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1187_Price_Based_Z_Trend/CS/PriceBasedZTrendStrategy.cs
+++ b/API/1187_Price_Based_Z_Trend/CS/PriceBasedZTrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1188_Price_Convergence/CS/PriceConvergenceStrategy.cs
+++ b/API/1188_Price_Convergence/CS/PriceConvergenceStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1189_Price_Flip/CS/PriceFlipStrategy.cs
+++ b/API/1189_Price_Flip/CS/PriceFlipStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -195,4 +200,3 @@ public class PriceFlipStrategy : Strategy
 		_prevClose = candle.ClosePrice;
 	}
 }
-

--- a/API/1190_Price_Statistical_ZScore/CS/PriceStatisticalZScoreStrategy.cs
+++ b/API/1190_Price_Statistical_ZScore/CS/PriceStatisticalZScoreStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1191_Probability_of_ATR_Index/CS/ProbabilityOfAtrIndexStrategy.cs
+++ b/API/1191_Probability_of_ATR_Index/CS/ProbabilityOfAtrIndexStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1192_Professional_ORB/CS/ProfessionalOrbStrategy.cs
+++ b/API/1192_Professional_ORB/CS/ProfessionalOrbStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1193_Profitable_Pullback_Mark804/CS/ProfitablePullbackMark804Strategy.cs
+++ b/API/1193_Profitable_Pullback_Mark804/CS/ProfitablePullbackMark804Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1194_Profitable_SuperTrend_MA_Stoch/CS/ProfitableSuperTrendMAStochStrategy.cs
+++ b/API/1194_Profitable_SuperTrend_MA_Stoch/CS/ProfitableSuperTrendMAStochStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1195_ProfitView_Template/CS/ProfitViewTemplateStrategy.cs
+++ b/API/1195_ProfitView_Template/CS/ProfitViewTemplateStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1196_Projection/CS/ProjectionStrategy.cs
+++ b/API/1196_Projection/CS/ProjectionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1197_Prop_Firm_Business_Simulator/CS/PropFirmBusinessSimulatorStrategy.cs
+++ b/API/1197_Prop_Firm_Business_Simulator/CS/PropFirmBusinessSimulatorStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1198_Proxy_Financial_Stress_Index/CS/ProxyFinancialStressIndexStrategy.cs
+++ b/API/1198_Proxy_Financial_Stress_Index/CS/ProxyFinancialStressIndexStrategy.cs
@@ -1,4 +1,11 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/1199_PS_January_Barometer_Backtester/CS/PSJanuaryBarometerBacktesterStrategy.cs
+++ b/API/1199_PS_January_Barometer_Backtester/CS/PSJanuaryBarometerBacktesterStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1200_Bollinger_Bands_Trailing_Stop/CS/BollingerBandsTrailingStopStrategy.cs
+++ b/API/1200_Bollinger_Bands_Trailing_Stop/CS/BollingerBandsTrailingStopStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1201_Pullback_Pro_Dow/CS/PullbackProDowStrategy.cs
+++ b/API/1201_Pullback_Pro_Dow/CS/PullbackProDowStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1202_PulseWave_Markking77/CS/PulseWaveStrategy.cs
+++ b/API/1202_PulseWave_Markking77/CS/PulseWaveStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1203_Pure_Price_Action_Breakout_with_1_5_RR/CS/PurePriceActionBreakoutWith15RRStrategy.cs
+++ b/API/1203_Pure_Price_Action_Breakout_with_1_5_RR/CS/PurePriceActionBreakoutWith15RRStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1204_Pure_Price_Action/CS/PurePriceActionStrategy.cs
+++ b/API/1204_Pure_Price_Action/CS/PurePriceActionStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1205_PVSRA_v5/CS/PvsraV5Strategy.cs
+++ b/API/1205_PVSRA_v5/CS/PvsraV5Strategy.cs
@@ -1,5 +1,15 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1206_PVT_Crossover/CS/PvtCrossoverStrategy.cs
+++ b/API/1206_PVT_Crossover/CS/PvtCrossoverStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1207_PyMath/CS/PyMathStrategy.cs
+++ b/API/1207_PyMath/CS/PyMathStrategy.cs
@@ -1,4 +1,15 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1208_QQQ_v2_ESL_easy_peasy_x/CS/QqqV2EslEasyPeasyXStrategy.cs
+++ b/API/1208_QQQ_v2_ESL_easy_peasy_x/CS/QqqV2EslEasyPeasyXStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -123,4 +128,3 @@ public class QqqV2EslEasyPeasyXStrategy : Strategy
 		_prevClose = candle.ClosePrice;
 	}
 }
-

--- a/API/1209_Quadratic_Regression/CS/QuadraticRegressionStrategy.cs
+++ b/API/1209_Quadratic_Regression/CS/QuadraticRegressionStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1210_Quality_Screen/CS/QualityScreenStrategy.cs
+++ b/API/1210_Quality_Screen/CS/QualityScreenStrategy.cs
@@ -1,6 +1,15 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1211_Quantitative_Trend_Uptrend_Long/CS/QuantitativeTrendUptrendLongStrategy.cs
+++ b/API/1211_Quantitative_Trend_Uptrend_Long/CS/QuantitativeTrendUptrendLongStrategy.cs
@@ -1,7 +1,13 @@
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1212_Quantum_Reversal/CS/QuantumReversalStrategy.cs
+++ b/API/1212_Quantum_Reversal/CS/QuantumReversalStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1213_Quatro_SMA/CS/QuatroSmaStrategy.cs
+++ b/API/1213_Quatro_SMA/CS/QuatroSmaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1214_R_Based_Template/CS/RBasedTemplateStrategy.cs
+++ b/API/1214_R_Based_Template/CS/RBasedTemplateStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1215_Rally_Base_Drop_SND_Pivots/CS/RallyBaseDropSndPivotsStrategy.cs
+++ b/API/1215_Rally_Base_Drop_SND_Pivots/CS/RallyBaseDropSndPivotsStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1216_Random_ATR_Bybit/CS/RandomAtrBybitStrategy.cs
+++ b/API/1216_Random_ATR_Bybit/CS/RandomAtrBybitStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1217_Random_Coin_Toss/CS/RandomCoinTossStrategy.cs
+++ b/API/1217_Random_Coin_Toss/CS/RandomCoinTossStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -137,4 +142,3 @@ public class RandomCoinTossStrategy : Strategy
 		}
 	}
 }
-

--- a/API/1218_Random_Entry_and_Exit/CS/RandomEntryAndExitStrategy.cs
+++ b/API/1218_Random_Entry_and_Exit/CS/RandomEntryAndExitStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1219_Random_State_Machine/CS/RandomStateMachineStrategy.cs
+++ b/API/1219_Random_State_Machine/CS/RandomStateMachineStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1220_Random_Synthetic_Asset_Generation/CS/RandomSyntheticAssetGenerationStrategy.cs
+++ b/API/1220_Random_Synthetic_Asset_Generation/CS/RandomSyntheticAssetGenerationStrategy.cs
@@ -1,6 +1,15 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1221_Range_Filter_ATR_Low_Drawdown/CS/RangeFilterAtrLowDrawdownStrategy.cs
+++ b/API/1221_Range_Filter_ATR_Low_Drawdown/CS/RangeFilterAtrLowDrawdownStrategy.cs
@@ -1,12 +1,17 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
 using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
-using StockSharp.Algo.Candles;
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1222_Range_Filter_ATR_TP_SL/CS/RangeFilterAtrTpSlStrategy.cs
+++ b/API/1222_Range_Filter_ATR_TP_SL/CS/RangeFilterAtrTpSlStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1224_Range_Filter/CS/RangeFilterStrategy.cs
+++ b/API/1224_Range_Filter/CS/RangeFilterStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1225_Range_Filter_DW/CS/RangeFilterDwStrategy.cs
+++ b/API/1225_Range_Filter_DW/CS/RangeFilterDwStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1226_Rate_of_Change/CS/RateOfChangeStrategy.cs
+++ b/API/1226_Rate_of_Change/CS/RateOfChangeStrategy.cs
@@ -1,5 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/1227_Rawstocks_15_Minute_Model/CS/Rawstocks15MinuteModelStrategy.cs
+++ b/API/1227_Rawstocks_15_Minute_Model/CS/Rawstocks15MinuteModelStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1228_RCI/CS/RciStrategy.cs
+++ b/API/1228_RCI/CS/RciStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1229_Realtime_Delta_Volume_Action/CS/RealtimeDeltaVolumeActionStrategy.cs
+++ b/API/1229_Realtime_Delta_Volume_Action/CS/RealtimeDeltaVolumeActionStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1230_RedK_Compound_Ratio_MA/CS/RedkCompoundRatioMaStrategy.cs
+++ b/API/1230_RedK_Compound_Ratio_MA/CS/RedkCompoundRatioMaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1231_RedK_Slow_Smooth_Average_RSS_WMA/CS/RedkSlowSmoothAverageRssWmaStrategy.cs
+++ b/API/1231_RedK_Slow_Smooth_Average_RSS_WMA/CS/RedkSlowSmoothAverageRssWmaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -145,4 +150,3 @@ _prevLl = ll;
 _prevUptrend = uptrend;
 }
 }
-

--- a/API/1232_Refined_MA_Engulfing/CS/RefinedMaEngulfingStrategy.cs
+++ b/API/1232_Refined_MA_Engulfing/CS/RefinedMaEngulfingStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1233_Refined_SMA_EMA_Crossover_with_Ichimoku_and_200_SMA_Filter/CS/RefinedSmaEmaCrossoverWithIchimokuAnd200SmaFilterStrategy.cs
+++ b/API/1233_Refined_SMA_EMA_Crossover_with_Ichimoku_and_200_SMA_Filter/CS/RefinedSmaEmaCrossoverWithIchimokuAnd200SmaFilterStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1234_Reflected_Ema_Difference_RED/CS/ReflectedEmaDifferenceRedStrategy.cs
+++ b/API/1234_Reflected_Ema_Difference_RED/CS/ReflectedEmaDifferenceRedStrategy.cs
@@ -1,4 +1,15 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1235_Reflex_Oscillator/CS/ReflexOscillatorStrategy.cs
+++ b/API/1235_Reflex_Oscillator/CS/ReflexOscillatorStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1236_Relative_Candle/CS/RelativeCandleStrategy.cs
+++ b/API/1236_Relative_Candle/CS/RelativeCandleStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1237_Relative_Currency_Strength/CS/RelativeCurrencyStrengthStrategy.cs
+++ b/API/1237_Relative_Currency_Strength/CS/RelativeCurrencyStrengthStrategy.cs
@@ -1,9 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using Ecng.ComponentModel;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using Ecng.ComponentModel;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1238_Relative_Strength_RSMK_Plus_Perk/CS/RelativeStrengthRsmkPlusPerkStrategy.cs
+++ b/API/1238_Relative_Strength_RSMK_Plus_Perk/CS/RelativeStrengthRsmkPlusPerkStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1239_Relative_Strength/CS/RelativeStrengthStrategy.cs
+++ b/API/1239_Relative_Strength/CS/RelativeStrengthStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1240_Relative_Volume_at_Time/CS/RelativeVolumeAtTimeStrategy.cs
+++ b/API/1240_Relative_Volume_at_Time/CS/RelativeVolumeAtTimeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1241_Reminder_Message_With_Color_Picker/CS/ReminderMessageWithColorPickerStrategy.cs
+++ b/API/1241_Reminder_Message_With_Color_Picker/CS/ReminderMessageWithColorPickerStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1242_Renko_RSI/CS/RenkoRsiStrategy.cs
+++ b/API/1242_Renko_RSI/CS/RenkoRsiStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
@@ -127,4 +134,3 @@ public class RenkoRsiStrategy : Strategy
 		_prevRsi = rsi;
 	}
 }
-

--- a/API/1243_Renko/CS/RenkoStrategy.cs
+++ b/API/1243_Renko/CS/RenkoStrategy.cs
@@ -1,9 +1,16 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
 using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1244_Resampling_Filter_Pack/CS/ResamplingFilterPackStrategy.cs
+++ b/API/1244_Resampling_Filter_Pack/CS/ResamplingFilterPackStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1245_Resampling_Reverse_Engineering_Bands/CS/ResamplingReverseEngineeringBandsStrategy.cs
+++ b/API/1245_Resampling_Reverse_Engineering_Bands/CS/ResamplingReverseEngineeringBandsStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1246_Responsive_Linear_Regression_Channels/CS/ResponsiveLinearRegressionChannelsStrategy.cs
+++ b/API/1246_Responsive_Linear_Regression_Channels/CS/ResponsiveLinearRegressionChannelsStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
@@ -248,4 +254,3 @@ private readonly Queue<decimal> _closes = new();
 		return DaysToBars(weeks * 7);
 	}
 }
-

--- a/API/1247_Revelations/CS/RevelationsStrategy.cs
+++ b/API/1247_Revelations/CS/RevelationsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1248_Reversal_Breakout_ORB/CS/ReversalBreakoutOrbStrategy.cs
+++ b/API/1248_Reversal_Breakout_ORB/CS/ReversalBreakoutOrbStrategy.cs
@@ -1,6 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1249_Reversal_Finder/CS/ReversalFinderStrategy.cs
+++ b/API/1249_Reversal_Finder/CS/ReversalFinderStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -192,4 +197,3 @@ SellMarket(volume);
 }
 }
 }
-

--- a/API/1250_Reversal_Trading_Bot/CS/ReversalTradingBotStrategy.cs
+++ b/API/1250_Reversal_Trading_Bot/CS/ReversalTradingBotStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1251_Reversal_Trap_Sniper/CS/ReversalTrapSniperStrategy.cs
+++ b/API/1251_Reversal_Trap_Sniper/CS/ReversalTrapSniperStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1252_Reverse_Keltner_Channel/CS/ReverseKeltnerChannelStrategy.cs
+++ b/API/1252_Reverse_Keltner_Channel/CS/ReverseKeltnerChannelStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1253_Revolution_Volatility_Bands_With_Range_Contraction_Signal_VII/CS/RevolutionVolatilityBandsWithRangeContractionSignalVIIStrategy.cs
+++ b/API/1253_Revolution_Volatility_Bands_With_Range_Contraction_Signal_VII/CS/RevolutionVolatilityBandsWithRangeContractionSignalVIIStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1254_Risk_Management_and_Positionsize_MACD_Example/CS/RiskManagementAndPositionsizeMacdExampleStrategy.cs
+++ b/API/1254_Risk_Management_and_Positionsize_MACD_Example/CS/RiskManagementAndPositionsizeMacdExampleStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1255_Risk_to_Reward_FIXED_SL_Backtester/CS/RiskToRewardFixedSlBacktesterStrategy.cs
+++ b/API/1255_Risk_to_Reward_FIXED_SL_Backtester/CS/RiskToRewardFixedSlBacktesterStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1256_RKs_Framework_Auto_Color_Gradient/CS/RksFrameworkAutoColorGradientStrategy.cs
+++ b/API/1256_RKs_Framework_Auto_Color_Gradient/CS/RksFrameworkAutoColorGradientStrategy.cs
@@ -1,9 +1,17 @@
 using System;
-using System.Drawing;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using System.Drawing;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1257_RMI_Trend_Sync/CS/RmiTrendSyncStrategy.cs
+++ b/API/1257_RMI_Trend_Sync/CS/RmiTrendSyncStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1258_RSI_ADX_Long_Short/CS/RsiAdxLongShortStrategy.cs
+++ b/API/1258_RSI_ADX_Long_Short/CS/RsiAdxLongShortStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1259_RSI_Backed_Weighted_MA/CS/RsiBackedWeightedMaStrategy.cs
+++ b/API/1259_RSI_Backed_Weighted_MA/CS/RsiBackedWeightedMaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1260_RSI_MACD_Long_Only/CS/RsiMacdLongOnlyStrategy.cs
+++ b/API/1260_RSI_MACD_Long_Only/CS/RsiMacdLongOnlyStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1261_RSI_Stochastic_WMA/CS/RsiStochasticWmaStrategy.cs
+++ b/API/1261_RSI_Stochastic_WMA/CS/RsiStochasticWmaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -182,4 +187,3 @@ public class RsiStochasticWmaStrategy : Strategy
 		_hasPrev = true;
 	}
 }
-

--- a/API/1262_RSI_and_ATR_Trend_Reversal_SL_TP/CS/RsiAndAtrTrendReversalSlTpStrategy.cs
+++ b/API/1262_RSI_and_ATR_Trend_Reversal_SL_TP/CS/RsiAndAtrTrendReversalSlTpStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
@@ -214,4 +220,3 @@ public class RsiAndAtrTrendReversalSlTpStrategy : Strategy
 		}
 	}
 }
-

--- a/API/1263_RSI_Box_Pseudo_Grid_Bot/CS/RsiBoxPseudoGridBotStrategy.cs
+++ b/API/1263_RSI_Box_Pseudo_Grid_Bot/CS/RsiBoxPseudoGridBotStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1264_RSI_Buy_Sell_Force/CS/RsiBuySellForceStrategy.cs
+++ b/API/1264_RSI_Buy_Sell_Force/CS/RsiBuySellForceStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1265_RSI_Crossover_with_Compounding_Monthly/CS/RsiCrossoverWithCompoundingMonthlyStrategy.cs
+++ b/API/1265_RSI_Crossover_with_Compounding_Monthly/CS/RsiCrossoverWithCompoundingMonthlyStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1266_RSI_Cyclic_Smoothed/CS/RsiCyclicSmoothedStrategy.cs
+++ b/API/1266_RSI_Cyclic_Smoothed/CS/RsiCyclicSmoothedStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -197,4 +203,3 @@ public class RsiCyclicSmoothedStrategy : Strategy
 		_prevCrsi = crsi;
 	}
 }
-

--- a/API/1267_RSI_Divergence_AliferCrypto/CS/RsiDivergenceAliferCryptoStrategy.cs
+++ b/API/1267_RSI_Divergence_AliferCrypto/CS/RsiDivergenceAliferCryptoStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1268_RSI_Divergence/CS/RsiDivergence2Strategy.cs
+++ b/API/1268_RSI_Divergence/CS/RsiDivergence2Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1269_RSI_Long_Only_with_Confirmed_Crossbacks/CS/RsiLongOnlyWithConfirmedCrossbacksStrategy.cs
+++ b/API/1269_RSI_Long_Only_with_Confirmed_Crossbacks/CS/RsiLongOnlyWithConfirmedCrossbacksStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1270_Rsi_Long_Term_15min/CS/RsiLongTerm15minStrategy.cs
+++ b/API/1270_Rsi_Long_Term_15min/CS/RsiLongTerm15minStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using StockSharp.Algo.Indicators;

--- a/API/1271_RSI_ProPlus_Bear_Market/CS/RsiProPlusBearMarketStrategy.cs
+++ b/API/1271_RSI_ProPlus_Bear_Market/CS/RsiProPlusBearMarketStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1272_RSI_Long_Position_DAX_2_hours_Dow_Jones_1_hour/CS/RsiLongPositionDax2HoursDowJones1HourStrategy.cs
+++ b/API/1272_RSI_Long_Position_DAX_2_hours_Dow_Jones_1_hour/CS/RsiLongPositionDax2HoursDowJones1HourStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1273_RSI_with_Adjustable_RSI_and_Stop_Loss/CS/RsiWithAdjustableRsiAndStopLossStrategy.cs
+++ b/API/1273_RSI_with_Adjustable_RSI_and_Stop_Loss/CS/RsiWithAdjustableRsiAndStopLossStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -144,4 +149,3 @@ public class RsiWithAdjustableRsiAndStopLossStrategy : Strategy
 		_previousHigh = candle.HighPrice;
 	}
 }
-

--- a/API/1274_RSI_with_Manual_TP_and_SL/CS/RsiWithManualTpAndSlStrategy.cs
+++ b/API/1274_RSI_with_Manual_TP_and_SL/CS/RsiWithManualTpAndSlStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1275_RSI_With_TP_SL_Lower_TF/CS/RsiWithTpSlLowerTfStrategy.cs
+++ b/API/1275_RSI_With_TP_SL_Lower_TF/CS/RsiWithTpSlLowerTfStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -148,4 +153,3 @@ var allowShort = Direction != Sides.Buy;
 			SellMarket(Volume);
 	}
 }
-

--- a/API/1276_RSI/CS/RsiStrategy.cs
+++ b/API/1276_RSI/CS/RsiStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1277_RSI_Swing_Radar/CS/RsiSwingRadarStrategy.cs
+++ b/API/1277_RSI_Swing_Radar/CS/RsiSwingRadarStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1278_RSI_Trend_Following/CS/RsiTrendFollowingStrategy.cs
+++ b/API/1278_RSI_Trend_Following/CS/RsiTrendFollowingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1279_RSI_Volume_MACD_EMA_Combo/CS/RsiVolumeMacdEmaComboStrategy.cs
+++ b/API/1279_RSI_Volume_MACD_EMA_Combo/CS/RsiVolumeMacdEmaComboStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1280_RSI_Adaptive_T3_Squeeze_Momentum/CS/RsiAdaptiveT3SqueezeMomentumStrategy.cs
+++ b/API/1280_RSI_Adaptive_T3_Squeeze_Momentum/CS/RsiAdaptiveT3SqueezeMomentumStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1281_RSI_Adaptive_T3/CS/RsiAdaptiveT3Strategy.cs
+++ b/API/1281_RSI_Adaptive_T3/CS/RsiAdaptiveT3Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -126,4 +131,3 @@ public class RsiAdaptiveT3Strategy : Strategy
 		return c1 * _e6.Value + c2 * _e5.Value + c3 * _e4.Value + c4 * _e3.Value;
 	}
 }
-

--- a/API/1282_RSI_CCI_Fusion/CS/RsiCciFusionStrategy.cs
+++ b/API/1282_RSI_CCI_Fusion/CS/RsiCciFusionStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
 using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1283_RTB_Momentum_Breakout/CS/RtbMomentumBreakoutStrategy.cs
+++ b/API/1283_RTB_Momentum_Breakout/CS/RtbMomentumBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1284_RVI_Crossover/CS/RviCrossoverStrategy.cs
+++ b/API/1284_RVI_Crossover/CS/RviCrossoverStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1285_SP_100_Option_Expiration_Week/CS/SP100OptionExpirationWeekStrategy.cs
+++ b/API/1285_SP_100_Option_Expiration_Week/CS/SP100OptionExpirationWeekStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1286_S4_IBS_Mean_Rev_3candleExit/CS/S4IBSMeanRev3candleExitStrategy.cs
+++ b/API/1286_S4_IBS_Mean_Rev_3candleExit/CS/S4IBSMeanRev3candleExitStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1287_Safa_Bot_Alert/CS/SafaBotAlertStrategy.cs
+++ b/API/1287_Safa_Bot_Alert/CS/SafaBotAlertStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1288_Scale_In_Scale_Out/CS/ScaleInScaleOutStrategy.cs
+++ b/API/1288_Scale_In_Scale_Out/CS/ScaleInScaleOutStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1289_Scalping_15min_EMA_MACD_RSI_ATR/CS/Scalping15minEmaMacdRsiAtrStrategy.cs
+++ b/API/1289_Scalping_15min_EMA_MACD_RSI_ATR/CS/Scalping15minEmaMacdRsiAtrStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -293,4 +298,3 @@ public class Scalping15minEmaMacdRsiAtrStrategy : Strategy
 		}
 	}
 }
-

--- a/API/1290_Scalping_By_TradingConToto/CS/ScalpingByTradingConTotoStrategy.cs
+++ b/API/1290_Scalping_By_TradingConToto/CS/ScalpingByTradingConTotoStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1291_Scalping_With_Williams_R_MACD_and_SMA/CS/ScalpingWithWilliamsRMacdAndSmaStrategy.cs
+++ b/API/1291_Scalping_With_Williams_R_MACD_and_SMA/CS/ScalpingWithWilliamsRMacdAndSmaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1292_Screener_Mean_Reversion_Channel/CS/ScreenerMeanReversionChannelStrategy.cs
+++ b/API/1292_Screener_Mean_Reversion_Channel/CS/ScreenerMeanReversionChannelStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1293_Security_Free_MTF_Example/CS/SecurityFreeMtfExampleStrategy.cs
+++ b/API/1293_Security_Free_MTF_Example/CS/SecurityFreeMtfExampleStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1294_Separated_Moving_Average/CS/SeparatedMovingAverageStrategy.cs
+++ b/API/1294_Separated_Moving_Average/CS/SeparatedMovingAverageStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
@@ -130,4 +137,3 @@ public class SeparatedMovingAverageStrategy : Strategy
 			SellMarket();
 	}
 }
-

--- a/API/1295_Session_Breakout_Scalper_Trading_Bot/CS/SessionBreakoutScalperTradingBotStrategy.cs
+++ b/API/1295_Session_Breakout_Scalper_Trading_Bot/CS/SessionBreakoutScalperTradingBotStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1296_Setup_Smooth_Gaussian_Adaptive_Supertrend_Manual_Vol/CS/SetupSmoothGaussianAdaptiveSupertrendManualVolStrategy.cs
+++ b/API/1296_Setup_Smooth_Gaussian_Adaptive_Supertrend_Manual_Vol/CS/SetupSmoothGaussianAdaptiveSupertrendManualVolStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1297_Sharpe_Ratio_Forced_Selling/CS/SharpeRatioForcedSellingStrategy.cs
+++ b/API/1297_Sharpe_Ratio_Forced_Selling/CS/SharpeRatioForcedSellingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1298_Sigma_Spike_Filtered_Binned_OPR/CS/SigmaSpikeFilteredBinnedOprStrategy.cs
+++ b/API/1298_Sigma_Spike_Filtered_Binned_OPR/CS/SigmaSpikeFilteredBinnedOprStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1299_Signal_Tester/CS/SignalTesterStrategy.cs
+++ b/API/1299_Signal_Tester/CS/SignalTesterStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1300_SILVER_Midnight_Candle_Color_1_Hour_Delay_and_SL_TP/CS/SilverMidnightCandleColorStrategy.cs
+++ b/API/1300_SILVER_Midnight_Candle_Color_1_Hour_Delay_and_SL_TP/CS/SilverMidnightCandleColorStrategy.cs
@@ -1,9 +1,15 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1301_SimilarityMeasures/CS/SimilarityMeasuresStrategy.cs
+++ b/API/1301_SimilarityMeasures/CS/SimilarityMeasuresStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1302_Simple_APF_Backtesting/CS/SimpleApfBacktestingStrategy.cs
+++ b/API/1302_Simple_APF_Backtesting/CS/SimpleApfBacktestingStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1303_Simple_DCA/CS/SimpleDcaStrategy.cs
+++ b/API/1303_Simple_DCA/CS/SimpleDcaStrategy.cs
@@ -1,5 +1,12 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1304_Simple_Fibonacci_Retracement/CS/SimpleFibonacciRetracementStrategy.cs
+++ b/API/1304_Simple_Fibonacci_Retracement/CS/SimpleFibonacciRetracementStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1305_Simple_Pull_Back_TJlv26/CS/SimplePullBackTjlv26Strategy.cs
+++ b/API/1305_Simple_Pull_Back_TJlv26/CS/SimplePullBackTjlv26Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1306_Simple_RSI_Stock_1D/CS/SimpleRsiStock1DStrategy.cs
+++ b/API/1306_Simple_RSI_Stock_1D/CS/SimpleRsiStock1DStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1307_Simple_Trendlines/CS/SimpleTrendlinesStrategy.cs
+++ b/API/1307_Simple_Trendlines/CS/SimpleTrendlinesStrategy.cs
@@ -1,6 +1,13 @@
 
+using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1308_Simplified_Gap_with_SMA_Filter/CS/SimplifiedGapWithSmaFilterStrategy.cs
+++ b/API/1308_Simplified_Gap_with_SMA_Filter/CS/SimplifiedGapWithSmaFilterStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1309_SJ_NIFTY/CS/SjNiftyStrategy.cs
+++ b/API/1309_SJ_NIFTY/CS/SjNiftyStrategy.cs
@@ -1,14 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
 using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1310_SMA_RSI_Volume_ATR/CS/SmaRsiVolumeAtrStrategy.cs
+++ b/API/1310_SMA_RSI_Volume_ATR/CS/SmaRsiVolumeAtrStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;
@@ -155,4 +168,3 @@ public class SmaRsiVolumeAtrStrategy : Strategy
 		_prevAtr = atr;
 	}
 }
-

--- a/API/1311_SMA_Slope_Dynamic_TP_SL/CS/SmaSlopeDynamicTpSlStrategy.cs
+++ b/API/1311_SMA_Slope_Dynamic_TP_SL/CS/SmaSlopeDynamicTpSlStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1312_SMA_Crossover/CS/SmaCrossoverStrategy.cs
+++ b/API/1312_SMA_Crossover/CS/SmaCrossoverStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1313_SMA_Directional_Matrix_LuxAlgo/CS/SMADirectionalMatrixLuxAlgoStrategy.cs
+++ b/API/1313_SMA_Directional_Matrix_LuxAlgo/CS/SMADirectionalMatrixLuxAlgoStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using System.Text;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using System.Text;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1314_Smart_Fib/CS/SmartFibStrategy.cs
+++ b/API/1314_Smart_Fib/CS/SmartFibStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1315_Smart_Grid_Scalping_Pullback/CS/SmartGridScalpingPullbackStrategy.cs
+++ b/API/1315_Smart_Grid_Scalping_Pullback/CS/SmartGridScalpingPullbackStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1316_Smart_MA_Crossover_Backtester/CS/SmartMaCrossoverBacktesterStrategy.cs
+++ b/API/1316_Smart_MA_Crossover_Backtester/CS/SmartMaCrossoverBacktesterStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1317_Smart_Money_Concept_Uncle_Sam/CS/SmartMoneyConceptUncleSamStrategy.cs
+++ b/API/1317_Smart_Money_Concept_Uncle_Sam/CS/SmartMoneyConceptUncleSamStrategy.cs
@@ -1,5 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/1318_Smart_Money_Pivot/CS/SmartMoneyPivotStrategy.cs
+++ b/API/1318_Smart_Money_Pivot/CS/SmartMoneyPivotStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1319_SmartScale_Envelope_DCA/CS/SmartScaleEnvelopeDcaStrategy.cs
+++ b/API/1319_SmartScale_Envelope_DCA/CS/SmartScaleEnvelopeDcaStrategy.cs
@@ -1,6 +1,11 @@
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1320_SMB_Magic/CS/SmbMagicStrategy.cs
+++ b/API/1320_SMB_Magic/CS/SmbMagicStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1321_SMC_BTC_1H_OB_FVG/CS/SmcBtc1HObFvgStrategy.cs
+++ b/API/1321_SMC_BTC_1H_OB_FVG/CS/SmcBtc1HObFvgStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1322_SMC/CS/SmcStrategy.cs
+++ b/API/1322_SMC/CS/SmcStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1323_Smoothed_Heiken_Ashi_Long_Only/CS/SmoothedHeikenAshiLongOnlyStrategy.cs
+++ b/API/1323_Smoothed_Heiken_Ashi_Long_Only/CS/SmoothedHeikenAshiLongOnlyStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1324_Smoothed_Heiken_Ashi/CS/SmoothedHeikenAshiStrategy.cs
+++ b/API/1324_Smoothed_Heiken_Ashi/CS/SmoothedHeikenAshiStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -151,4 +156,3 @@ public class SmoothedHeikenAshiStrategy : Strategy
 		_prevShaClose = shaClose;
 	}
 }
-

--- a/API/1325_SMU_STDEV_Candles/CS/SmuStdevCandlesStrategy.cs
+++ b/API/1325_SMU_STDEV_Candles/CS/SmuStdevCandlesStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;
@@ -120,4 +133,3 @@ public class SmuStdevCandlesStrategy : Strategy
 		_prevCloseStd = closeStd;
 	}
 }
-

--- a/API/1326_Sniper_Trade_Pro_ES_15_Min_Topstep_Optimized/CS/SniperTradeProStrategy.cs
+++ b/API/1326_Sniper_Trade_Pro_ES_15_Min_Topstep_Optimized/CS/SniperTradeProStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1327_Source/CS/SourceStrategy.cs
+++ b/API/1327_Source/CS/SourceStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1328_SOXL_Trend_Surge_Profit_Only_Runner/CS/SoxlTrendSurgeProfitOnlyRunnerStrategy.cs
+++ b/API/1328_SOXL_Trend_Surge_Profit_Only_Runner/CS/SoxlTrendSurgeProfitOnlyRunnerStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1329_Spearman_Rank_Correlation_Coefficient/CS/SpearmanRankCorrelationCoefficientStrategy.cs
+++ b/API/1329_Spearman_Rank_Correlation_Coefficient/CS/SpearmanRankCorrelationCoefficientStrategy.cs
@@ -1,7 +1,12 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
@@ -240,4 +245,3 @@ public class SpearmanRankCorrelationCoefficientStrategy : Strategy
 		}
 	}
 }
-

--- a/API/1330_SpeedBullish_Confirm_V62/CS/SpeedBullishConfirmV62Strategy.cs
+++ b/API/1330_SpeedBullish_Confirm_V62/CS/SpeedBullishConfirmV62Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1331_Speedometer_Toolbox/CS/SpeedometerToolboxStrategy.cs
+++ b/API/1331_Speedometer_Toolbox/CS/SpeedometerToolboxStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
-using StockSharp.Charting;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Charting;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1332_Spread_by/CS/SpreadByStrategy.cs
+++ b/API/1332_Spread_by/CS/SpreadByStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1333_SPY_TLT/CS/SpyTltStrategy.cs
+++ b/API/1333_SPY_TLT/CS/SpyTltStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1334_Squeeze_Momentum_Indicator/CS/SqueezeMomentumIndicatorStrategy.cs
+++ b/API/1334_Squeeze_Momentum_Indicator/CS/SqueezeMomentumIndicatorStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -250,4 +255,3 @@ public class SqueezeMomentumIndicatorStrategy : Strategy
 		_prevHighestVal = highMomentum;
 	}
 }
-

--- a/API/1335_Starter_Edge/CS/StarterEdgeStrategy.cs
+++ b/API/1335_Starter_Edge/CS/StarterEdgeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -240,4 +245,3 @@ _prevSignal = signalValue;
 _prevRsi = rsiValue;
 }
 }
-

--- a/API/1336_Statistical_Arbitrage_Pairs_Trading_Long_Side_Only/CS/StatisticalArbitragePairsTradingLongSideOnlyStrategy.cs
+++ b/API/1336_Statistical_Arbitrage_Pairs_Trading_Long_Side_Only/CS/StatisticalArbitragePairsTradingLongSideOnlyStrategy.cs
@@ -1,5 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/1337_Statistical_Arbitrage/CS/StatisticalArbitrageSpreadStrategy.cs
+++ b/API/1337_Statistical_Arbitrage/CS/StatisticalArbitrageSpreadStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using Ecng.ComponentModel;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using Ecng.ComponentModel;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1338_Stepped_Trailing_Example/CS/SteppedTrailingExampleStrategy.cs
+++ b/API/1338_Stepped_Trailing_Example/CS/SteppedTrailingExampleStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1339_Stochastic_Heat_Map/CS/StochasticHeatMapStrategy.cs
+++ b/API/1339_Stochastic_Heat_Map/CS/StochasticHeatMapStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1340_Stochastic_RSI_OHLC/CS/StochasticRsiOhlcStrategy.cs
+++ b/API/1340_Stochastic_RSI_OHLC/CS/StochasticRsiOhlcStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -265,4 +270,3 @@ public class StochasticRsiOhlcStrategy : Strategy
 		_prev1 = stochClose;
 	}
 }
-

--- a/API/1341_Stochastic/CS/StochasticStrategy.cs
+++ b/API/1341_Stochastic/CS/StochasticStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1342_Stochastic_Z_Score_Oscillator/CS/StochasticZScoreOscillatorStrategy.cs
+++ b/API/1342_Stochastic_Z_Score_Oscillator/CS/StochasticZScoreOscillatorStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1343_Stochastic_Dynamic_Volatility_Band_Model/CS/StochasticDynamicVolatilityBandModelStrategy.cs
+++ b/API/1343_Stochastic_Dynamic_Volatility_Band_Model/CS/StochasticDynamicVolatilityBandModelStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1344_VWAP_Pro_V21/CS/VwapProV21Strategy.cs
+++ b/API/1344_VWAP_Pro_V21/CS/VwapProV21Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1345_Stop_Loss_Take_Profit_Money/CS/StopLossTakeProfitMoneyStrategy.cs
+++ b/API/1345_Stop_Loss_Take_Profit_Money/CS/StopLossTakeProfitMoneyStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1346_Strategic_Multi_Step_Supertrend/CS/StrategicMultiStepSupertrendStrategy.cs
+++ b/API/1346_Strategic_Multi_Step_Supertrend/CS/StrategicMultiStepSupertrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1347_Connectable/CS/ConnectableStrategy.cs
+++ b/API/1347_Connectable/CS/ConnectableStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1348_Builder_With_Indicators/CS/BuilderWithIndicatorsStrategy.cs
+++ b/API/1348_Builder_With_Indicators/CS/BuilderWithIndicatorsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1349_Chameleon/CS/ChameleonStrategy.cs
+++ b/API/1349_Chameleon/CS/ChameleonStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -379,4 +384,3 @@ public class ChameleonStrategy : Strategy
 		_stopDistance = 0;
 	}
 }
-

--- a/API/1350_Fibonacci_Levels_With_High_Low_Criteria_Aynet/CS/FibonacciLevelsWithHighLowCriteriaAynetStrategy.cs
+++ b/API/1350_Fibonacci_Levels_With_High_Low_Criteria_Aynet/CS/FibonacciLevelsWithHighLowCriteriaAynetStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1351_Gaussian_Anomaly_Derivative/CS/GaussianAnomalyDerivativeStrategy.cs
+++ b/API/1351_Gaussian_Anomaly_Derivative/CS/GaussianAnomalyDerivativeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1352_Reversal_Catcher/CS/ReversalCatcherStrategy.cs
+++ b/API/1352_Reversal_Catcher/CS/ReversalCatcherStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1353_SEMA_SDI_Webhook/CS/SemaSdiWebhookStrategy.cs
+++ b/API/1353_SEMA_SDI_Webhook/CS/SemaSdiWebhookStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1354_Stats_PresentTrading/CS/StatsPresentTradingStrategy.cs
+++ b/API/1354_Stats_PresentTrading/CS/StatsPresentTradingStrategy.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
 using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1355_SuperTrend_SDI_Webhook/CS/SuperTrendSdiWebhookStrategy.cs
+++ b/API/1355_SuperTrend_SDI_Webhook/CS/SuperTrendSdiWebhookStrategy.cs
@@ -1,9 +1,16 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 /// <summary>
 /// Strategy combining SuperTrend and Smoothed Directional Indicator.

--- a/API/1356_Percent_Stop_TakeProfit/CS/PercentStopTakeProfitStrategy.cs
+++ b/API/1356_Percent_Stop_TakeProfit/CS/PercentStopTakeProfitStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1357_Bollinger_Channel_Rebound/CS/BollingerChannelReboundStrategy.cs
+++ b/API/1357_Bollinger_Channel_Rebound/CS/BollingerChannelReboundStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using StockSharp.Algo;
-using StockSharp.Algo.Strategies;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
-using StockSharp.Messages;
+using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1358_Streak_Based_Trading/CS/StreakBasedTradingStrategy.cs
+++ b/API/1358_Streak_Based_Trading/CS/StreakBasedTradingStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1359_Stx_Monthly_Trades_Profit/CS/StxMonthlyTradesProfitStrategy.cs
+++ b/API/1359_Stx_Monthly_Trades_Profit/CS/StxMonthlyTradesProfitStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1360_Sunil_2_Bar_Breakout/CS/Sunil2BarBreakoutStrategy.cs
+++ b/API/1360_Sunil_2_Bar_Breakout/CS/Sunil2BarBreakoutStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1361_Sunil_BB_Blast_Heikin_Ashi/CS/SunilBbBlastHeikinAshiStrategy.cs
+++ b/API/1361_Sunil_BB_Blast_Heikin_Ashi/CS/SunilBbBlastHeikinAshiStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1362_Sunil_High_Frequency_with_Simple_MACD_and_RSI/CS/SunilHighFrequencyMacdRsiStrategy.cs
+++ b/API/1362_Sunil_High_Frequency_with_Simple_MACD_and_RSI/CS/SunilHighFrequencyMacdRsiStrategy.cs
@@ -1,6 +1,11 @@
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1363_SuperATR_7Step_Profit/CS/SuperAtr7StepProfitStrategy.cs
+++ b/API/1363_SuperATR_7Step_Profit/CS/SuperAtr7StepProfitStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1364_SuperTrade_Ichimoku_Cloud/CS/SuperTradeIchimokuCloudStrategy.cs
+++ b/API/1364_SuperTrade_Ichimoku_Cloud/CS/SuperTradeIchimokuCloudStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1365_SuperTrade_ST1/CS/SuperTradeSt1Strategy.cs
+++ b/API/1365_SuperTrade_ST1/CS/SuperTradeSt1Strategy.cs
@@ -1,11 +1,16 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-	
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
-	
+
 namespace StockSharp.Samples.Strategies;
 	
 	/// <summary>

--- a/API/1366_Supertrade_RVI_LongOnly/CS/SupertradeRviLongOnlyStrategy.cs
+++ b/API/1366_Supertrade_RVI_LongOnly/CS/SupertradeRviLongOnlyStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -194,4 +199,3 @@ public class SupertradeRviLongOnlyStrategy : Strategy
 		}
 	}
 }
-

--- a/API/1367_Supertrend_CCI_Scalp/CS/SupertrendCciScalpStrategy.cs
+++ b/API/1367_Supertrend_CCI_Scalp/CS/SupertrendCciScalpStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -214,4 +219,3 @@ public class SupertrendCciScalpStrategy : Strategy
 	VolumeWeighted
 	}
 }
-

--- a/API/1368_Supertrend_Macd_Crossover/CS/SupertrendMacdCrossoverStrategy.cs
+++ b/API/1368_Supertrend_Macd_Crossover/CS/SupertrendMacdCrossoverStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1369_Supertrend_Ssl_Toggle/CS/SupertrendSslToggleStrategy.cs
+++ b/API/1369_Supertrend_Ssl_Toggle/CS/SupertrendSslToggleStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1370_Supertrend_Advance_Pullback/CS/SupertrendAdvancePullbackStrategy.cs
+++ b/API/1370_Supertrend_Advance_Pullback/CS/SupertrendAdvancePullbackStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1371_SuperTrend_AI_Oscillator/CS/SuperTrendAiOscillatorStrategy.cs
+++ b/API/1371_SuperTrend_AI_Oscillator/CS/SuperTrendAiOscillatorStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1372_Supertrend_And_MACD/CS/SupertrendAndMacdStrategy.cs
+++ b/API/1372_Supertrend_And_MACD/CS/SupertrendAndMacdStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1373_Supertrend_AT_v1_0/CS/SupertrendAtV10Strategy.cs
+++ b/API/1373_Supertrend_AT_v1_0/CS/SupertrendAtV10Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1374_Supertrend_Ema_Vol/CS/SupertrendEmaVolStrategy.cs
+++ b/API/1374_Supertrend_Ema_Vol/CS/SupertrendEmaVolStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1375_SuperTrend_Enhanced_Pivot_Reversal/CS/SuperTrendEnhancedPivotReversalStrategy.cs
+++ b/API/1375_SuperTrend_Enhanced_Pivot_Reversal/CS/SuperTrendEnhancedPivotReversalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1376_Supertrend_Fixed_TP_Unified_with_Time_Filter_MSK/CS/SupertrendFixedTpUnifiedWithTimeFilterMskStrategy.cs
+++ b/API/1376_Supertrend_Fixed_TP_Unified_with_Time_Filter_MSK/CS/SupertrendFixedTpUnifiedWithTimeFilterMskStrategy.cs
@@ -1,5 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/1377_Supertrend_Hombrok_Bot/CS/SupertrendHombrokBotStrategy.cs
+++ b/API/1377_Supertrend_Hombrok_Bot/CS/SupertrendHombrokBotStrategy.cs
@@ -1,5 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/1378_Supertrend_Long-Only_for_QQQ/CS/SupertrendLongOnlyForQqqStrategy.cs
+++ b/API/1378_Supertrend_Long-Only_for_QQQ/CS/SupertrendLongOnlyForQqqStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1379_Supertrend_5m/CS/Supertrend5mStrategy.cs
+++ b/API/1379_Supertrend_5m/CS/Supertrend5mStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1380_Supertrend_nitin/CS/SupertrendNitinStrategy.cs
+++ b/API/1380_Supertrend_nitin/CS/SupertrendNitinStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1381_Supertrend_with_Money_Ocean_Trade/CS/SupertrendWithMoneyOceanTradeStrategy.cs
+++ b/API/1381_Supertrend_with_Money_Ocean_Trade/CS/SupertrendWithMoneyOceanTradeStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1382_Supertrend_Cross_RSI/CS/SupertrendCrossRsiStrategy.cs
+++ b/API/1382_Supertrend_Cross_RSI/CS/SupertrendCrossRsiStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1383_Supertrend_TP_SL_PRO/CS/SupertrendTpSlProStrategy.cs
+++ b/API/1383_Supertrend_TP_SL_PRO/CS/SupertrendTpSlProStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1384_Supertrend_Target_Stoploss/CS/SupertrendTargetStopStrategy.cs
+++ b/API/1384_Supertrend_Target_Stoploss/CS/SupertrendTargetStopStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1385_Supply_Demand_Order_Block/CS/SupplyDemandOrderBlockStrategy.cs
+++ b/API/1385_Supply_Demand_Order_Block/CS/SupplyDemandOrderBlockStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1386_Supply_Demand_Engulfment/CS/SupplyDemandEngulfmentStrategy.cs
+++ b/API/1386_Supply_Demand_Engulfment/CS/SupplyDemandEngulfmentStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1387_Support_Resistance_MTF/CS/SupportResistanceMtfStrategy.cs
+++ b/API/1387_Support_Resistance_MTF/CS/SupportResistanceMtfStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1388_Swing_Breakout_PRO/CS/SwingBreakoutProStrategy.cs
+++ b/API/1388_Swing_Breakout_PRO/CS/SwingBreakoutProStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1389_Swing_FX_Pro_Panel_v1/CS/SwingFxProPanelV1Strategy.cs
+++ b/API/1389_Swing_FX_Pro_Panel_v1/CS/SwingFxProPanelV1Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1390_Swing_High_Low_Anchored_Spiral/CS/SwingHighLowAnchoredSpiralStrategy.cs
+++ b/API/1390_Swing_High_Low_Anchored_Spiral/CS/SwingHighLowAnchoredSpiralStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1391_Swing_High_Low_Pivots_LV/CS/SwingHighLowPivotsLvStrategy.cs
+++ b/API/1391_Swing_High_Low_Pivots_LV/CS/SwingHighLowPivotsLvStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1392_SwingArm_ATR_Trend_Indicator/CS/SwingArmAtrTrendIndicatorStrategy.cs
+++ b/API/1392_SwingArm_ATR_Trend_Indicator/CS/SwingArmAtrTrendIndicatorStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1396_Ta/CS/TaStrategy.cs
+++ b/API/1396_Ta/CS/TaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1397_ta/CS/TaLibraryStrategy.cs
+++ b/API/1397_ta/CS/TaLibraryStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1398_Table_to_filter_trades_per_day/CS/TableToFilterTradesPerDayStrategy.cs
+++ b/API/1398_Table_to_filter_trades_per_day/CS/TableToFilterTradesPerDayStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1399_MADH_Moving_Average_Difference_Hann/CS/MadhMovingAverageDifferenceHannStrategy.cs
+++ b/API/1399_MADH_Moving_Average_Difference_Hann/CS/MadhMovingAverageDifferenceHannStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1400_The_Weekly_Factor/CS/TheWeeklyFactorStrategy.cs
+++ b/API/1400_The_Weekly_Factor/CS/TheWeeklyFactorStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1401_Gap_Momentum_System/CS/GapMomentumSystemStrategy.cs
+++ b/API/1401_Gap_Momentum_System/CS/GapMomentumSystemStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1402_REIT_ETF_Trading_System/CS/ReitEtfTradingSystemStrategy.cs
+++ b/API/1402_REIT_ETF_Trading_System/CS/ReitEtfTradingSystemStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1403_Volume_Confirmation_For_A_Trend_System/CS/VolumeConfirmationForATrendSystemStrategy.cs
+++ b/API/1403_Volume_Confirmation_For_A_Trend_System/CS/VolumeConfirmationForATrendSystemStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1404_Adaptive_Oscillator_Threshold/CS/AdaptiveOscillatorThresholdStrategy.cs
+++ b/API/1404_Adaptive_Oscillator_Threshold/CS/AdaptiveOscillatorThresholdStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -223,4 +229,3 @@ public class AdaptiveOscillatorThresholdStrategy : Strategy
 		}
 	}
 }
-

--- a/API/1405_Trading_The_Channel/CS/TradingTheChannelStrategy.cs
+++ b/API/1405_Trading_The_Channel/CS/TradingTheChannelStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1406_Technical_Rank/CS/TechnicalRankStrategy.cs
+++ b/API/1406_Technical_Rank/CS/TechnicalRankStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1407_Technical_Ratings_on_Multi_frames_Assets/CS/TechnicalRatingsOnMultiFramesAssetsStrategy.cs
+++ b/API/1407_Technical_Ratings_on_Multi_frames_Assets/CS/TechnicalRatingsOnMultiFramesAssetsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1408_Tema_Obos_Pakun/CS/TemaObosPakunStrategy.cs
+++ b/API/1408_Tema_Obos_Pakun/CS/TemaObosPakunStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1409_Template_Trailing_Backtester/CS/TemplateTrailingBacktesterStrategy.cs
+++ b/API/1409_Template_Trailing_Backtester/CS/TemplateTrailingBacktesterStrategy.cs
@@ -1,6 +1,11 @@
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1410_Temporary_Help_Services_Jobs_Trend_Allocation/CS/TemporaryHelpServicesJobsTrendAllocationStrategy.cs
+++ b/API/1410_Temporary_Help_Services_Jobs_Trend_Allocation/CS/TemporaryHelpServicesJobsTrendAllocationStrategy.cs
@@ -1,7 +1,13 @@
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1411_Test_Bot_Bearish_Buy_Bullish_Sell/CS/TestBotBearishBuyBullishSellStrategy.cs
+++ b/API/1411_Test_Bot_Bearish_Buy_Bullish_Sell/CS/TestBotBearishBuyBullishSellStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1412_Text/CS/TextStrategy.cs
+++ b/API/1412_Text/CS/TextStrategy.cs
@@ -1,8 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using System.Text;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
+using System.Text;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1413_HSI1_First_30m_Candle/CS/Hsi1First30mCandleStrategy.cs
+++ b/API/1413_HSI1_First_30m_Candle/CS/Hsi1First30mCandleStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1414_TF_Segmented_Linear_Regression/CS/TfSegmentedLinearRegressionStrategy.cs
+++ b/API/1414_TF_Segmented_Linear_Regression/CS/TfSegmentedLinearRegressionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1415_TFM/CS/TfmStrategy.cs
+++ b/API/1415_TFM/CS/TfmStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1416_The_950_Bar/CS/The950BarStrategy.cs
+++ b/API/1416_The_950_Bar/CS/The950BarStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1417_Bar_Counter_Trend_Reversal/CS/BarCounterTrendReversalStrategy.cs
+++ b/API/1417_Bar_Counter_Trend_Reversal/CS/BarCounterTrendReversalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1418_Flash_Minervini_Qualifier/CS/FlashMinerviniQualifierStrategy.cs
+++ b/API/1418_Flash_Minervini_Qualifier/CS/FlashMinerviniQualifierStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1420_Most_Powerful_Tqqq_Ema_Crossover/CS/MostPowerfulTqqqEmaCrossoverStrategy.cs
+++ b/API/1420_Most_Powerful_Tqqq_Ema_Crossover/CS/MostPowerfulTqqqEmaCrossoverStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1421_VoVix_Experiment/CS/VoVixExperimentStrategy.cs
+++ b/API/1421_VoVix_Experiment/CS/VoVixExperimentStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1422_Z_Score/CS/ZScore2Strategy.cs
+++ b/API/1422_Z_Score/CS/ZScore2Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1423_ThinkTech_AI_Signals/CS/ThinkTechAISignalsStrategy.cs
+++ b/API/1423_ThinkTech_AI_Signals/CS/ThinkTechAISignalsStrategy.cs
@@ -1,8 +1,17 @@
 using System;
-using Ecng.ComponentModel;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using Ecng.ComponentModel;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1424_Three_Candle_Bullish_Engulfing/CS/ThreeCandleBullishEngulfingStrategy.cs
+++ b/API/1424_Three_Candle_Bullish_Engulfing/CS/ThreeCandleBullishEngulfingStrategy.cs
@@ -1,8 +1,17 @@
 using System;
-using Ecng.ComponentModel;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using Ecng.ComponentModel;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1425_Three_Moving_Averages/CS/ThreeMovingAveragesStrategy.cs
+++ b/API/1425_Three_Moving_Averages/CS/ThreeMovingAveragesStrategy.cs
@@ -1,8 +1,17 @@
 using System;
-using Ecng.ComponentModel;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using Ecng.ComponentModel;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1426_Three_Supertrend_EMA/CS/ThreeSupertrendEmaStrategy.cs
+++ b/API/1426_Three_Supertrend_EMA/CS/ThreeSupertrendEmaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1427_Tian_Di_Grid_Merge/CS/TianDiGridMergeStrategy.cs
+++ b/API/1427_Tian_Di_Grid_Merge/CS/TianDiGridMergeStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1428_Tick_Chart/CS/TickChartStrategy.cs
+++ b/API/1428_Tick_Chart/CS/TickChartStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1429_Tick_Data_Detailed/CS/TickDataDetailedStrategy.cs
+++ b/API/1429_Tick_Data_Detailed/CS/TickDataDetailedStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1430_Tick_Delta_Volume/CS/TickDeltaVolumeStrategy.cs
+++ b/API/1430_Tick_Delta_Volume/CS/TickDeltaVolumeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1431_Tick_Marubozu/CS/TickMarubozuStrategy.cs
+++ b/API/1431_Tick_Marubozu/CS/TickMarubozuStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1432_Ticker_Pulse_Meter_Fear_EKG/CS/TickerPulseMeterFearEkgStrategy.cs
+++ b/API/1432_Ticker_Pulse_Meter_Fear_EKG/CS/TickerPulseMeterFearEkgStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1433_Time_of_Day_Day_of_Week_Sigma_Spike/CS/TimeOfDayDayOfWeekSigmaSpikeStrategy.cs
+++ b/API/1433_Time_of_Day_Day_of_Week_Sigma_Spike/CS/TimeOfDayDayOfWeekSigmaSpikeStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1434_Time_Range_Statistics/CS/TimeRangeStatisticsStrategy.cs
+++ b/API/1434_Time_Range_Statistics/CS/TimeRangeStatisticsStrategy.cs
@@ -1,5 +1,12 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1435_Time_Series_Lag_Reduction_Filter_by_Cryptorhythms/CS/TimeSeriesLagReductionFilterStrategy.cs
+++ b/API/1435_Time_Series_Lag_Reduction_Filter_by_Cryptorhythms/CS/TimeSeriesLagReductionFilterStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1436_Time_Session_Filter_MACD_example/CS/TimeSessionFilterMacdExampleStrategy.cs
+++ b/API/1436_Time_Session_Filter_MACD_example/CS/TimeSessionFilterMacdExampleStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1437_Time/CS/TimeStrategy.cs
+++ b/API/1437_Time/CS/TimeStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1438_Timeframe/CS/TimeframeStrategy.cs
+++ b/API/1438_Timeframe/CS/TimeframeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1439_Timeshifter_Triple_Timeframe_w_Sessions/CS/TimeshifterTripleTimeframeStrategy.cs
+++ b/API/1439_Timeshifter_Triple_Timeframe_w_Sessions/CS/TimeshifterTripleTimeframeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1441_Time_Candles/CS/TimeCandlesStrategy.cs
+++ b/API/1441_Time_Candles/CS/TimeCandlesStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -110,4 +115,3 @@ public class TimeCandlesStrategy : Strategy
 		AddInfo($"RSI: {rsiValue:F2} SMA: {smaValue:F2}");
 	}
 }
-

--- a/API/1442_TMA/CS/TmaStrategy.cs
+++ b/API/1442_TMA/CS/TmaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -182,4 +187,3 @@ public class TmaStrategy : Strategy
 		return time >= start && time <= end;
 	}
 }
-

--- a/API/1443_Tomas_Ratio_with_Multi-Timeframe_Analysis/CS/TomasRatioWithMultiTimeFrameAnalysisStrategy.cs
+++ b/API/1443_Tomas_Ratio_with_Multi-Timeframe_Analysis/CS/TomasRatioWithMultiTimeFrameAnalysisStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -169,4 +174,3 @@ public class TomasRatioWithMultiTimeFrameAnalysisStrategy : Strategy
 		_prevHlc3 = hlc3;
 	}
 }
-

--- a/API/1444_TOT_ORB_Titan/CS/TotOrbTitanStrategy.cs
+++ b/API/1444_TOT_ORB_Titan/CS/TotOrbTitanStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -178,4 +183,3 @@ public class TotOrbTitanStrategy : Strategy
 		}
 	}
 }
-

--- a/API/1445_TPC_XAUUSD_M5/CS/TpcXauusdStrategy.cs
+++ b/API/1445_TPC_XAUUSD_M5/CS/TpcXauusdStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -129,4 +134,3 @@ public class TpcXauusdStrategy : Strategy
 		_prevSignal = signalLine;
 	}
 }
-

--- a/API/1446_Tps_Short_Larry_Conners/CS/TpsShortLarryConnersStrategy.cs
+++ b/API/1446_Tps_Short_Larry_Conners/CS/TpsShortLarryConnersStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -112,4 +117,3 @@ public class TpsShortLarryConnersStrategy : Strategy
 		_prevSma30 = sma30;
 	}
 }
-

--- a/API/1447_Trade_Entry_Detector_Wick_to_Body_Ratio/CS/TradeEntryDetectorWickToBodyRatioStrategy.cs
+++ b/API/1447_Trade_Entry_Detector_Wick_to_Body_Ratio/CS/TradeEntryDetectorWickToBodyRatioStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1448_Trading_ABC/CS/TradingABCStrategy.cs
+++ b/API/1448_Trading_ABC/CS/TradingABCStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1450_TradingToolsLibrary/CS/TradingToolsLibraryStrategy.cs
+++ b/API/1450_TradingToolsLibrary/CS/TradingToolsLibraryStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1451_TradingViewTo_Template_With_Dynamic_Alerts/CS/TradingViewToTemplateWithDynamicAlertsStrategy.cs
+++ b/API/1451_TradingViewTo_Template_With_Dynamic_Alerts/CS/TradingViewToTemplateWithDynamicAlertsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1452_Trailing_Monster/CS/TrailingMonsterStrategy.cs
+++ b/API/1452_Trailing_Monster/CS/TrailingMonsterStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1453_Trailing_Stop_with_RSI_Momentum_Based/CS/TrailingStopWithRsiMomentumBasedStrategy.cs
+++ b/API/1453_Trailing_Stop_with_RSI_Momentum_Based/CS/TrailingStopWithRsiMomentumBasedStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1454_Trailing_Take_Profit_Close_Based/CS/TrailingTakeProfitCloseBasedStrategy.cs
+++ b/API/1454_Trailing_Take_Profit_Close_Based/CS/TrailingTakeProfitCloseBasedStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1455_Trailing_TP_Bot/CS/TrailingTpBotStrategy.cs
+++ b/API/1455_Trailing_TP_Bot/CS/TrailingTpBotStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1456_TrailingTakeProfit_Example/CS/TrailingTakeProfitExampleStrategy.cs
+++ b/API/1456_TrailingTakeProfit_Example/CS/TrailingTakeProfitExampleStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1457_TRAX_Detrended_Price/CS/TraxDetrendedPriceStrategy.cs
+++ b/API/1457_TRAX_Detrended_Price/CS/TraxDetrendedPriceStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1458_Trend_Confirmation/CS/TrendConfirmationStrategy.cs
+++ b/API/1458_Trend_Confirmation/CS/TrendConfirmationStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1459_Trend_Deviation_BTC/CS/TrendDeviationBtcStrategy.cs
+++ b/API/1459_Trend_Deviation_BTC/CS/TrendDeviationBtcStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1460_Trend_Following_MM3_High_Low/CS/TrendFollowingMm3HighLowStrategy.cs
+++ b/API/1460_Trend_Following_MM3_High_Low/CS/TrendFollowingMm3HighLowStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1461_Trend_Following_ADX_Parabolic_SAR/CS/TrendFollowingAdxParabolicSarStrategy.cs
+++ b/API/1461_Trend_Following_ADX_Parabolic_SAR/CS/TrendFollowingAdxParabolicSarStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1462_Trend_Following_MAs_3D/CS/TrendFollowingMas3DStrategy.cs
+++ b/API/1462_Trend_Following_MAs_3D/CS/TrendFollowingMas3DStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1463_Trend_Following_Moving_Averages/CS/TrendFollowingMovingAveragesStrategy.cs
+++ b/API/1463_Trend_Following_Moving_Averages/CS/TrendFollowingMovingAveragesStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1464_Trend_Following_Parabolic_Buy_Sell/CS/TrendFollowingParabolicBuySellStrategy.cs
+++ b/API/1464_Trend_Following_Parabolic_Buy_Sell/CS/TrendFollowingParabolicBuySellStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1465_Trend_Following_KNN/CS/TrendFollowingKnnStrategy.cs
+++ b/API/1465_Trend_Following_KNN/CS/TrendFollowingKnnStrategy.cs
@@ -1,5 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/1466_Trend_Following_Candles/CS/TrendFollowingCandlesStrategy.cs
+++ b/API/1466_Trend_Following_Candles/CS/TrendFollowingCandlesStrategy.cs
@@ -1,5 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/1467_Trend_Impulse_Tester/CS/TrendImpulseTesterStrategy.cs
+++ b/API/1467_Trend_Impulse_Tester/CS/TrendImpulseTesterStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1468_Trend_Magic_with_EMA_SMA_and_AutoTrading/CS/TrendMagicWithEmaSmaAndAutoTradingStrategy.cs
+++ b/API/1468_Trend_Magic_with_EMA_SMA_and_AutoTrading/CS/TrendMagicWithEmaSmaAndAutoTradingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1469_Trend_Signals_with_TP_SL_UAlgo/CS/TrendSignalsWithTpSlUAlgoStrategy.cs
+++ b/API/1469_Trend_Signals_with_TP_SL_UAlgo/CS/TrendSignalsWithTpSlUAlgoStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1470_Trend_Trader_Remastered/CS/TrendTraderRemasteredStrategy.cs
+++ b/API/1470_Trend_Trader_Remastered/CS/TrendTraderRemasteredStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1471_Trend_Type_Indicator/CS/TrendTypeIndicatorStrategy.cs
+++ b/API/1471_Trend_Type_Indicator/CS/TrendTypeIndicatorStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1472_Trend_Vanguard/CS/TrendVanguardStrategy.cs
+++ b/API/1472_Trend_Vanguard/CS/TrendVanguardStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1473_TrendGuard_Flag_Finder/CS/TrendGuardFlagFinderStrategy.cs
+++ b/API/1473_TrendGuard_Flag_Finder/CS/TrendGuardFlagFinderStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1474_TrendGuard_Scalper_SSL_Hama_Candle_with_Consolidation_Zones/CS/TrendGuardScalperSslHamaCandleWithConsolidationZonesStrategy.cs
+++ b/API/1474_TrendGuard_Scalper_SSL_Hama_Candle_with_Consolidation_Zones/CS/TrendGuardScalperSslHamaCandleWithConsolidationZonesStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1475_Trendline_Breaks_with_Multi_Fibonacci_Supertrend/CS/TrendlineBreaksWithMultiFibonacciSupertrendStrategy.cs
+++ b/API/1475_Trendline_Breaks_with_Multi_Fibonacci_Supertrend/CS/TrendlineBreaksWithMultiFibonacciSupertrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1476_TrendMaster_Pro_2_3_with_Alerts/CS/TrendMasterPro23WithAlertsStrategy.cs
+++ b/API/1476_TrendMaster_Pro_2_3_with_Alerts/CS/TrendMasterPro23WithAlertsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1477_TrendSync_Pro_SMC/CS/TrendSyncProSmcStrategy.cs
+++ b/API/1477_TrendSync_Pro_SMC/CS/TrendSyncProSmcStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1478_TrendTwisterV1_5_Forex_Ready_Indicators/CS/TrendTwisterV15Strategy.cs
+++ b/API/1478_TrendTwisterV1_5_Forex_Ready_Indicators/CS/TrendTwisterV15Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1479_Trend_Switch/CS/TrendSwitchStrategy.cs
+++ b/API/1479_Trend_Switch/CS/TrendSwitchStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1480_Tri_Monthly_BTC_Swing/CS/TriMonthlyBtcSwingStrategy.cs
+++ b/API/1480_Tri_Monthly_BTC_Swing/CS/TriMonthlyBtcSwingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1481_Triangle_Breakout_for_BTC_MARK804/CS/TriangleBreakoutBtcMark804Strategy.cs
+++ b/API/1481_Triangle_Breakout_for_BTC_MARK804/CS/TriangleBreakoutBtcMark804Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1482_Triangle_Breakout_with_TP_SL_EMA_Filter/CS/TriangleBreakoutTpSlEmaFilterStrategy.cs
+++ b/API/1482_Triangle_Breakout_with_TP_SL_EMA_Filter/CS/TriangleBreakoutTpSlEmaFilterStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1483_Triangular_Hull_Moving_Average/CS/TriangularHullMovingAverageStrategy.cs
+++ b/API/1483_Triangular_Hull_Moving_Average/CS/TriangularHullMovingAverageStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1484_TRIN_Arms_Index/CS/TrinArmsIndexStrategy.cs
+++ b/API/1484_TRIN_Arms_Index/CS/TrinArmsIndexStrategy.cs
@@ -1,4 +1,11 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/1485_Triple_CCI_MFI_Confirmed/CS/TripleCciMfiConfirmedStrategy.cs
+++ b/API/1485_Triple_CCI_MFI_Confirmed/CS/TripleCciMfiConfirmedStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1486_Triple_EMA_QQE_Trend_Following/CS/TripleEmaQqeTrendFollowingStrategy.cs
+++ b/API/1486_Triple_EMA_QQE_Trend_Following/CS/TripleEmaQqeTrendFollowingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1487_Triple_EMA_Crossover/CS/TripleEmaCrossoverStrategy.cs
+++ b/API/1487_Triple_EMA_Crossover/CS/TripleEmaCrossoverStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1488_Triple_MA_HTF_Dynamic_Smoothing/CS/TripleMaHtfDynamicSmoothingStrategy.cs
+++ b/API/1488_Triple_MA_HTF_Dynamic_Smoothing/CS/TripleMaHtfDynamicSmoothingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1489_Tripple_MACD/CS/TrippleMacdStrategy.cs
+++ b/API/1489_Tripple_MACD/CS/TrippleMacdStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1490_TSI_Long_Short_for_BTC_2H/CS/TsiLongShortForBtc2HStrategy.cs
+++ b/API/1490_TSI_Long_Short_for_BTC_2H/CS/TsiLongShortForBtc2HStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1491_TSI_w_SuperTrend_decision_presentTrading/CS/TsiSuperTrendDecisionStrategy.cs
+++ b/API/1491_TSI_w_SuperTrend_decision_presentTrading/CS/TsiSuperTrendDecisionStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1492_TTM_Grid/CS/TTMGridStrategy.cs
+++ b/API/1492_TTM_Grid/CS/TTMGridStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1493_Ttp_Intelligent_Accumulator/CS/TtpIntelligentAccumulatorStrategy.cs
+++ b/API/1493_Ttp_Intelligent_Accumulator/CS/TtpIntelligentAccumulatorStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1494_Tuga_Supertrend/CS/TugaSupertrendStrategy.cs
+++ b/API/1494_Tuga_Supertrend/CS/TugaSupertrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1495_Turn_Around_Tuesday_on_Steroids/CS/TurnAroundTuesdayOnSteroidsStrategy.cs
+++ b/API/1495_Turn_Around_Tuesday_on_Steroids/CS/TurnAroundTuesdayOnSteroidsStrategy.cs
@@ -1,8 +1,13 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
@@ -153,4 +158,3 @@ public class TurnAroundTuesdayOnSteroidsStrategy : Strategy
 		_prevHigh = candle.HighPrice;
 	}
 }
-

--- a/API/1496_Turn_of_the_Month_on_Steroids/CS/TurnOfTheMonthOnSteroidsStrategy.cs
+++ b/API/1496_Turn_of_the_Month_on_Steroids/CS/TurnOfTheMonthOnSteroidsStrategy.cs
@@ -1,8 +1,13 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
@@ -142,4 +147,3 @@ public class TurnOfTheMonthOnSteroidsStrategy : Strategy
 		_prevClose1 = candle.ClosePrice;
 	}
 }
-

--- a/API/1497_Turn_of_the_Month_Honestcowboy/CS/TurnOfTheMonthHonestcowboyStrategy.cs
+++ b/API/1497_Turn_of_the_Month_Honestcowboy/CS/TurnOfTheMonthHonestcowboyStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
@@ -106,4 +112,3 @@ public class TurnOfTheMonthHonestcowboyStrategy : Strategy
 		}
 	}
 }
-

--- a/API/1498_Turtle_Trader/CS/TurtleTraderStrategy.cs
+++ b/API/1498_Turtle_Trader/CS/TurtleTraderStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1499_Turtle_Trading/CS/TurtleTradingStrategy.cs
+++ b/API/1499_Turtle_Trading/CS/TurtleTradingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1500_Tutorial_Adding_Sessions_To_Strategies/CS/TutorialAddingSessionsToStrategiesStrategy.cs
+++ b/API/1500_Tutorial_Adding_Sessions_To_Strategies/CS/TutorialAddingSessionsToStrategiesStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using System.Globalization;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using System.Globalization;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1501_Twisted_SMA_4h/CS/TwistedSma4hStrategy.cs
+++ b/API/1501_Twisted_SMA_4h/CS/TwistedSma4hStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -192,4 +197,3 @@ public class TwistedSma4hStrategy : Strategy
 		_prevKama = kamaValue;
 	}
 }
-

--- a/API/1502_Uhl_MA_Crossover_System/CS/UhlMaCrossoverSystemStrategy.cs
+++ b/API/1502_Uhl_MA_Crossover_System/CS/UhlMaCrossoverSystemStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -151,4 +156,3 @@ public class UhlMaCrossoverSystemStrategy : Strategy
 		}
 	}
 }
-

--- a/API/1503_Ultimate_Balance/CS/UltimateBalanceStrategy.cs
+++ b/API/1503_Ultimate_Balance/CS/UltimateBalanceStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -303,4 +308,3 @@ public class UltimateBalanceStrategy : Strategy
 		};
 	}
 }
-

--- a/API/1504_Ultimate_Oscillator_Trading/CS/UltimateOscillatorStrategy.cs
+++ b/API/1504_Ultimate_Oscillator_Trading/CS/UltimateOscillatorStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1505_Ultimate_Scalping_v2/CS/UltimateScalpingV2Strategy.cs
+++ b/API/1505_Ultimate_Scalping_v2/CS/UltimateScalpingV2Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1506_Ultimate_Stochastics/CS/UltimateStochasticsStrategy.cs
+++ b/API/1506_Ultimate_Stochastics/CS/UltimateStochasticsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1507_Ultimate_Template/CS/UltimateTemplateStrategy.cs
+++ b/API/1507_Ultimate_Template/CS/UltimateTemplateStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1508_Ultimate_Trading_Bot/CS/UltimateTradingBotStrategy.cs
+++ b/API/1508_Ultimate_Trading_Bot/CS/UltimateTradingBotStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1509_Unicode_font_function_-_JD/CS/UnicodeFontFunctionJdStrategy.cs
+++ b/API/1509_Unicode_font_function_-_JD/CS/UnicodeFontFunctionJdStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1510_Unicode_Font_Function_V2_JD/CS/UnicodeFontFunctionV2JdStrategy.cs
+++ b/API/1510_Unicode_Font_Function_V2_JD/CS/UnicodeFontFunctionV2JdStrategy.cs
@@ -1,7 +1,17 @@
 using System;
-using System.Text;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
+using System.Text;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1511_Up_Gap_With_Delay/CS/UpGapWithDelayStrategy.cs
+++ b/API/1511_Up_Gap_With_Delay/CS/UpGapWithDelayStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1512_Uptrick_Intensity_Index/CS/UptrickIntensityIndexStrategy.cs
+++ b/API/1512_Uptrick_Intensity_Index/CS/UptrickIntensityIndexStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1513_Uptrick_X_PineIndicators_Z_Score_Flow/CS/UptrickXPineIndicatorsZScoreFlowStrategy.cs
+++ b/API/1513_Uptrick_X_PineIndicators_Z_Score_Flow/CS/UptrickXPineIndicatorsZScoreFlowStrategy.cs
@@ -1,4 +1,11 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/1514_US_30_Daily_Breakout/CS/Us30DailyBreakoutStrategy.cs
+++ b/API/1514_US_30_Daily_Breakout/CS/Us30DailyBreakoutStrategy.cs
@@ -1,4 +1,12 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1515_US_Index_First_30m_Candle/CS/UsIndexFirst30mCandleStrategy.cs
+++ b/API/1515_US_Index_First_30m_Candle/CS/UsIndexFirst30mCandleStrategy.cs
@@ -1,4 +1,12 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1516_US30_Stealth/CS/Us30StealthStrategy.cs
+++ b/API/1516_US30_Stealth/CS/Us30StealthStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1517_Varanormal_Mac_N_Cheez/CS/VaranormalMacNCheezStrategy.cs
+++ b/API/1517_Varanormal_Mac_N_Cheez/CS/VaranormalMacNCheezStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1518_Vawsi_Trend_Persistance_Reversal/CS/VawsiTrendPersistanceReversalStrategy.cs
+++ b/API/1518_Vawsi_Trend_Persistance_Reversal/CS/VawsiTrendPersistanceReversalStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1519_Vector3/CS/Vector3Strategy.cs
+++ b/API/1519_Vector3/CS/Vector3Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -145,4 +150,3 @@ SellMarket(volume);
 }
 }
 }
-

--- a/API/1520_Vegas_SuperTrend_Enhanced_presentTrading/CS/VegasSuperTrendEnhancedStrategy.cs
+++ b/API/1520_Vegas_SuperTrend_Enhanced_presentTrading/CS/VegasSuperTrendEnhancedStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -199,4 +204,3 @@ SellMarket(volume);
 }
 }
 }
-

--- a/API/1521_Vegas_Tunnel/CS/VegasTunnelStrategy.cs
+++ b/API/1521_Vegas_Tunnel/CS/VegasTunnelStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -191,4 +196,3 @@ SellMarket(volume);
 }
 }
 }
-

--- a/API/1522_Vicious_Mortgage_Rates_V1_0/CS/ViciousMortgageRatesV1Strategy.cs
+++ b/API/1522_Vicious_Mortgage_Rates_V1_0/CS/ViciousMortgageRatesV1Strategy.cs
@@ -1,4 +1,11 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -130,4 +137,3 @@ SellMarket(volume);
 }
 }
 }
-

--- a/API/1523_VIDYA_Auto_Trading_Reversal_Logic/CS/VidyaAutoTradingReversalLogicStrategy.cs
+++ b/API/1523_VIDYA_Auto_Trading_Reversal_Logic/CS/VidyaAutoTradingReversalLogicStrategy.cs
@@ -1,6 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
@@ -100,4 +108,3 @@ _prevLower = lower;
 _prevClose = candle.ClosePrice;
 }
 }
-

--- a/API/1524_VIDYA_ProTrend_Multi_Tier_Profit/CS/VidyaProTrendMultiTierProfitStrategy.cs
+++ b/API/1524_VIDYA_ProTrend_Multi_Tier_Profit/CS/VidyaProTrendMultiTierProfitStrategy.cs
@@ -1,6 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
@@ -278,4 +286,3 @@ _tpShortPlaced = true;
 }
 }
 }
-

--- a/API/1525_Vinicius_Setup_ATR/CS/ViniciusSetupATRStrategy.cs
+++ b/API/1525_Vinicius_Setup_ATR/CS/ViniciusSetupATRStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1526_VisibleChart/CS/VisibleChartStrategy.cs
+++ b/API/1526_VisibleChart/CS/VisibleChartStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1527_VIX_Futures_Basis/CS/VixFuturesBasisStrategy.cs
+++ b/API/1527_VIX_Futures_Basis/CS/VixFuturesBasisStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1528_VIX_Spike/CS/VixSpikeStrategy.cs
+++ b/API/1528_VIX_Spike/CS/VixSpikeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1529_Volatility_Arbitrage_Spread_Oscillator_Model_VASOM/CS/VolatilityArbitrageSpreadOscillatorModelStrategy.cs
+++ b/API/1529_Volatility_Arbitrage_Spread_Oscillator_Model_VASOM/CS/VolatilityArbitrageSpreadOscillatorModelStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1530_Volatility_Bias_Model/CS/VolatilityBiasModelStrategy.cs
+++ b/API/1530_Volatility_Bias_Model/CS/VolatilityBiasModelStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1531_Volatility_Capture_RSI_Bollinger/CS/VolatilityCaptureRsiBollingerStrategy.cs
+++ b/API/1531_Volatility_Capture_RSI_Bollinger/CS/VolatilityCaptureRsiBollingerStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1532_Volatility_Momentum_Breakout/CS/VolatilityMomentumBreakoutStrategy.cs
+++ b/API/1532_Volatility_Momentum_Breakout/CS/VolatilityMomentumBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1533_Volatility_Pulse_with_Dynamic_Exit/CS/VolatilityPulseWithDynamicExitStrategy.cs
+++ b/API/1533_Volatility_Pulse_with_Dynamic_Exit/CS/VolatilityPulseWithDynamicExitStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1534_Volume_and_Volatility_Ratio_Indicator_WODI/CS/VolumeAndVolatilityRatioIndicatorWodiStrategy.cs
+++ b/API/1534_Volume_and_Volatility_Ratio_Indicator_WODI/CS/VolumeAndVolatilityRatioIndicatorWodiStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1535_Volume_Block_Order_Analyzer/CS/VolumeBlockOrderAnalyzerStrategy.cs
+++ b/API/1535_Volume_Block_Order_Analyzer/CS/VolumeBlockOrderAnalyzerStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1536_Volume_by_Session/CS/VolumeBySessionStrategy.cs
+++ b/API/1536_Volume_by_Session/CS/VolumeBySessionStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1537_Volume_per_Point/CS/VolumePerPointStrategy.cs
+++ b/API/1537_Volume_per_Point/CS/VolumePerPointStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1538_Volume_Profile_Makit0/CS/VolumeProfileMakit0Strategy.cs
+++ b/API/1538_Volume_Profile_Makit0/CS/VolumeProfileMakit0Strategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1539_Volume_ValueWhen_Velocity/CS/VolumeValueWhenVelocityStrategy.cs
+++ b/API/1539_Volume_ValueWhen_Velocity/CS/VolumeValueWhenVelocityStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1540_Volume_Supported_Linear_Regression_Trend_Modified/CS/VolumeSupportedLinearRegressionTrendModifiedStrategy.cs
+++ b/API/1540_Volume_Supported_Linear_Regression_Trend_Modified/CS/VolumeSupportedLinearRegressionTrendModifiedStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1541_Volume_Weighted_Supertrend/CS/VolumeWeightedSupertrendStrategy.cs
+++ b/API/1541_Volume_Weighted_Supertrend/CS/VolumeWeightedSupertrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1542_Vortex_Cross_MA_Confirmation/CS/VortexCrossMaConfirmationStrategy.cs
+++ b/API/1542_Vortex_Cross_MA_Confirmation/CS/VortexCrossMaConfirmationStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1543_Vortex_MTF/CS/VortexMtfStrategy.cs
+++ b/API/1543_Vortex_MTF/CS/VortexMtfStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1544_Voss_Predictor/CS/VossPredictorStrategy.cs
+++ b/API/1544_Voss_Predictor/CS/VossPredictorStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1545_VoVix_DEVMA/CS/VoVixDevmaStrategy.cs
+++ b/API/1545_VoVix_DEVMA/CS/VoVixDevmaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1546_VQZL_Z_Score/CS/VqzlZScoreStrategy.cs
+++ b/API/1546_VQZL_Z_Score/CS/VqzlZScoreStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1547_VRS_Vegas_Reversal/CS/VrsVegasReversalStrategy.cs
+++ b/API/1547_VRS_Vegas_Reversal/CS/VrsVegasReversalStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1548_VWAP_EMA_ATR_Pullback/CS/VwapEmaAtrPullbackStrategy.cs
+++ b/API/1548_VWAP_EMA_ATR_Pullback/CS/VwapEmaAtrPullbackStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1549_VWAP_Breakout_EMAs_Clean_Cycle_TP_SL_Plots/CS/VwapBreakoutAtrStrategy.cs
+++ b/API/1549_VWAP_Breakout_EMAs_Clean_Cycle_TP_SL_Plots/CS/VwapBreakoutAtrStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -146,4 +151,3 @@ public class VwapBreakoutAtrStrategy : Strategy
 		}
 	}
 }
-

--- a/API/1550_VWAP_Stdev_Bands_Long_Only/CS/VwapStdevBandsLongStrategy.cs
+++ b/API/1550_VWAP_Stdev_Bands_Long_Only/CS/VwapStdevBandsLongStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
@@ -161,4 +167,3 @@ public class VwapStdevBandsLongStrategy : Strategy
 		_hasPrev = true;
 	}
 }
-

--- a/API/1551_VWAP/CS/VwapStrategy.cs
+++ b/API/1551_VWAP/CS/VwapStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
@@ -269,4 +275,3 @@ public class VwapStrategy : Strategy
 		}
 	}
 }
-

--- a/API/1552_VWAP_RSI_Scalper_FINAL_v1/CS/VwapRsiScalperFinalV1Strategy.cs
+++ b/API/1552_VWAP_RSI_Scalper_FINAL_v1/CS/VwapRsiScalperFinalV1Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1553_Waindrops_Makit0/CS/WaindropsMakit0Strategy.cs
+++ b/API/1553_Waindrops_Makit0/CS/WaindropsMakit0Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1554_Warrior_Trading_Momentum/CS/WarriorTradingMomentumStrategy.cs
+++ b/API/1554_Warrior_Trading_Momentum/CS/WarriorTradingMomentumStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1555_Weighted_Harrell_Davis_Quantile_Estimator_with_AbsoluteDeviation/CS/WeightedHarrellDavisQuantileEstimatorWithAbsoluteDeviationStrategy.cs
+++ b/API/1555_Weighted_Harrell_Davis_Quantile_Estimator_with_AbsoluteDeviation/CS/WeightedHarrellDavisQuantileEstimatorWithAbsoluteDeviationStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1556_Weighted_Ichimoku/CS/WeightedIchimokuStrategy.cs
+++ b/API/1556_Weighted_Ichimoku/CS/WeightedIchimokuStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1557_Williams_R_Cross_with_200_MA_Filter/CS/WilliamsRCrossWith200MaFilterStrategy.cs
+++ b/API/1557_Williams_R_Cross_with_200_MA_Filter/CS/WilliamsRCrossWith200MaFilterStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1558_Williams_R/CS/WilliamsRStrategy.cs
+++ b/API/1558_Williams_R/CS/WilliamsRStrategy.cs
@@ -1,4 +1,10 @@
+using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1559_Williams_Fractal_Trailing_Stops/CS/WilliamsFractalTrailingStopsStrategy.cs
+++ b/API/1559_Williams_Fractal_Trailing_Stops/CS/WilliamsFractalTrailingStopsStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1560_Williams_R_Zone_Scalper/CS/WilliamsRZoneScalperStrategy.cs
+++ b/API/1560_Williams_R_Zone_Scalper/CS/WilliamsRZoneScalperStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1561_WODIsMA_3_MA_Crossover_Bull_Bear_Trend_Confirmation/CS/WodismaTripleMaCrossoverStrategy.cs
+++ b/API/1561_WODIsMA_3_MA_Crossover_Bull_Bear_Trend_Confirmation/CS/WodismaTripleMaCrossoverStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1562_XAU_USD_with_Correct_ADX_and_Bollinger_Bands_Fill/CS/XauUsdAdxBollingerStrategy.cs
+++ b/API/1562_XAU_USD_with_Correct_ADX_and_Bollinger_Bands_Fill/CS/XauUsdAdxBollingerStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1563_XAUUSD_10_Minute/CS/Xauusd10MinuteStrategy.cs
+++ b/API/1563_XAUUSD_10_Minute/CS/Xauusd10MinuteStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1564_XAUUSD_Simple_20_Profit_100_Loss/CS/XauusdSimple20Profit100LossStrategy.cs
+++ b/API/1564_XAUUSD_Simple_20_Profit_100_Loss/CS/XauusdSimple20Profit100LossStrategy.cs
@@ -1,6 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1565_XAUUSD_Trend/CS/XauusdTrendStrategy.cs
+++ b/API/1565_XAUUSD_Trend/CS/XauusdTrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1566_XRP_AI_15_m_Adaptive_v3_1/CS/XrpAi15mAdaptiveV31Strategy.cs
+++ b/API/1566_XRP_AI_15_m_Adaptive_v3_1/CS/XrpAi15mAdaptiveV31Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1567_Yeong_RRG/CS/YeongRrgStrategy.cs
+++ b/API/1567_Yeong_RRG/CS/YeongRrgStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using Ecng.ComponentModel;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using Ecng.ComponentModel;
 
 namespace StockSharp.Samples.Strategies;
 
@@ -216,4 +223,3 @@ public class YeongRrgStrategy : Strategy
 		Blue
 	}
 }
-

--- a/API/1568_Yesterdays_High/CS/YesterdaysHighStrategy.cs
+++ b/API/1568_Yesterdays_High/CS/YesterdaysHighStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1569_YinYang_RSI_Volume_Trend/CS/YinYangRsiVolumeTrendStrategy.cs
+++ b/API/1569_YinYang_RSI_Volume_Trend/CS/YinYangRsiVolumeTrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1570_Z-Score_Normalized_VIX/CS/ZScoreNormalizedVixStrategy.cs
+++ b/API/1570_Z-Score_Normalized_VIX/CS/ZScoreNormalizedVixStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1571_Z-Score_RSI/CS/ZScoreRsiStrategy.cs
+++ b/API/1571_Z-Score_RSI/CS/ZScoreRsiStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1572_Z-Strike_Recovery/CS/ZStrikeRecoveryStrategy.cs
+++ b/API/1572_Z-Strike_Recovery/CS/ZStrikeRecoveryStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1573_Zahorchak_Measure/CS/ZahorchakMeasureStrategy.cs
+++ b/API/1573_Zahorchak_Measure/CS/ZahorchakMeasureStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1574_ZapTeam_Pro_v6_EMA/CS/ZapTeamProV6EmaStrategy.cs
+++ b/API/1574_ZapTeam_Pro_v6_EMA/CS/ZapTeamProV6EmaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1575_Zero_Lag_Macd_Kijun_Sen_Eom/CS/ZeroLagMacdKijunSenEomStrategy.cs
+++ b/API/1575_Zero_Lag_Macd_Kijun_Sen_Eom/CS/ZeroLagMacdKijunSenEomStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1576_Zero_Lag_Ma_Trend_Following/CS/ZeroLagMaTrendFollowingStrategy.cs
+++ b/API/1576_Zero_Lag_Ma_Trend_Following/CS/ZeroLagMaTrendFollowingStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1577_Zero_Lag_Tema_Crosses_Pakun/CS/ZeroLagTemaCrossesPakunStrategy.cs
+++ b/API/1577_Zero_Lag_Tema_Crosses_Pakun/CS/ZeroLagTemaCrossesPakunStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1578_Zero_Lag_Volatility_Breakout_Ema_Trend/CS/ZeroLagVolatilityBreakoutEmaTrendStrategy.cs
+++ b/API/1578_Zero_Lag_Volatility_Breakout_Ema_Trend/CS/ZeroLagVolatilityBreakoutEmaTrendStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1579_Zig_Zag_Aroon/CS/ZigZagAroonStrategy.cs
+++ b/API/1579_Zig_Zag_Aroon/CS/ZigZagAroonStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1580_Zigzag_Candles/CS/ZigzagCandlesStrategy.cs
+++ b/API/1580_Zigzag_Candles/CS/ZigzagCandlesStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1581_3Commas_HA_MA/CS/ThreeCommasHaMaStrategy.cs
+++ b/API/1581_3Commas_HA_MA/CS/ThreeCommasHaMaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1582_3Commas_Turtle/CS/ThreeCommasTurtleStrategy.cs
+++ b/API/1582_3Commas_Turtle/CS/ThreeCommasTurtleStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1583_MartinGale_Scalping/CS/MartinGaleScalpingStrategy.cs
+++ b/API/1583_MartinGale_Scalping/CS/MartinGaleScalpingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1584_Ehlers_SwamiCharts_RSI/CS/EhlersSwamiChartsRsiStrategy.cs
+++ b/API/1584_Ehlers_SwamiCharts_RSI/CS/EhlersSwamiChartsRsiStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1585_Fibonacci_Bands/CS/FibonacciBandsStrategy.cs
+++ b/API/1585_Fibonacci_Bands/CS/FibonacciBandsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1586_Drawing_Library_Horizontal_Ray/CS/HorizontalRayStrategy.cs
+++ b/API/1586_Drawing_Library_Horizontal_Ray/CS/HorizontalRayStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1587_Reflex_Trendflex/CS/ReflexTrendflexStrategy.cs
+++ b/API/1587_Reflex_Trendflex/CS/ReflexTrendflexStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1588_ATR_Exit/CS/AtrExitStrategy.cs
+++ b/API/1588_ATR_Exit/CS/AtrExitStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1589_Post_Earnings_Announcement_Drift/CS/PostEarningsAnnouncementDriftStrategy.cs
+++ b/API/1589_Post_Earnings_Announcement_Drift/CS/PostEarningsAnnouncementDriftStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1590_Tape/CS/TapeStrategy.cs
+++ b/API/1590_Tape/CS/TapeStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1591_Mustang_Algo_Channel/CS/MustangAlgoChannelStrategy.cs
+++ b/API/1591_Mustang_Algo_Channel/CS/MustangAlgoChannelStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -275,4 +280,3 @@ public class MustangAlgoChannelStrategy : Strategy
 		_prevMedian = med;
 	}
 }
-

--- a/API/1592_Breakout_Nifty_BN/CS/BreakoutNiftyBnStrategy.cs
+++ b/API/1592_Breakout_Nifty_BN/CS/BreakoutNiftyBnStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1593_External_Level/CS/ExternalLevelStrategy.cs
+++ b/API/1593_External_Level/CS/ExternalLevelStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1594_Donchian_HL_Width_Cycle_Information/CS/DonchianHlWidthCycleInformationStrategy.cs
+++ b/API/1594_Donchian_HL_Width_Cycle_Information/CS/DonchianHlWidthCycleInformationStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1595_Majors_Volume_Sum/CS/MajorsVolumeSumStrategy.cs
+++ b/API/1595_Majors_Volume_Sum/CS/MajorsVolumeSumStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
@@ -97,4 +104,3 @@ public class MajorsVolumeSumStrategy : Strategy
 		_prevClose = candle.ClosePrice;
 	}
 }
-

--- a/API/1596_Simple_Forecast_Keltner_Worms/CS/SimpleForecastKeltnerWormsStrategy.cs
+++ b/API/1596_Simple_Forecast_Keltner_Worms/CS/SimpleForecastKeltnerWormsStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
@@ -82,4 +89,3 @@ public class SimpleForecastKeltnerWormsStrategy : Strategy
 			SellMarket();
 	}
 }
-

--- a/API/1597_Simplistic_Automatic_Growth_Models/CS/SimplisticAutomaticGrowthModelsStrategy.cs
+++ b/API/1597_Simplistic_Automatic_Growth_Models/CS/SimplisticAutomaticGrowthModelsStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
@@ -86,4 +93,3 @@ public class SimplisticAutomaticGrowthModelsStrategy : Strategy
 			SellMarket();
 	}
 }
-

--- a/API/1598_10_Bar_Low_Pullback/CS/ShortOnly10BarLowPullbackStrategy.cs
+++ b/API/1598_10_Bar_Low_Pullback/CS/ShortOnly10BarLowPullbackStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
@@ -167,4 +174,3 @@ public class ShortOnly10BarLowPullbackStrategy : Strategy
 			BuyMarket();
 	}
 }
-

--- a/API/1599_ATR_Sell_the_Rip_Mean_Reversion/CS/AtrSellTheRipMeanReversionStrategy.cs
+++ b/API/1599_ATR_Sell_the_Rip_Mean_Reversion/CS/AtrSellTheRipMeanReversionStrategy.cs
@@ -1,6 +1,11 @@
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1600_Consecutive_Bars_Above_MA/CS/ConsecutiveBarsAboveMaStrategy.cs
+++ b/API/1600_Consecutive_Bars_Above_MA/CS/ConsecutiveBarsAboveMaStrategy.cs
@@ -1,6 +1,11 @@
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1601_Consecutive_Close_High1_Mean_Reversion/CS/ConsecutiveCloseHigh1MeanReversionStrategy.cs
+++ b/API/1601_Consecutive_Close_High1_Mean_Reversion/CS/ConsecutiveCloseHigh1MeanReversionStrategy.cs
@@ -1,6 +1,11 @@
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1602_Internal_Bar_Strength_IBS_Mean_Reversion/CS/InternalBarStrengthIbsMeanReversionStrategy.cs
+++ b/API/1602_Internal_Bar_Strength_IBS_Mean_Reversion/CS/InternalBarStrengthIbsMeanReversionStrategy.cs
@@ -1,7 +1,13 @@
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1603_Fibonacci_Auto_Trend_Scouter/CS/FibonacciAutoTrendScouterStrategy.cs
+++ b/API/1603_Fibonacci_Auto_Trend_Scouter/CS/FibonacciAutoTrendScouterStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
@@ -71,4 +78,3 @@ public class FibonacciAutoTrendScouterStrategy : Strategy
 		_downTrend = down;
 	}
 }
-

--- a/API/1604_Ema_5_8_13_Adx_Filter/CS/Ema5813AdxFilterStrategy.cs
+++ b/API/1604_Ema_5_8_13_Adx_Filter/CS/Ema5813AdxFilterStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
@@ -88,4 +95,3 @@ public class Ema5813AdxFilterStrategy : Strategy
 			BuyMarket();
 	}
 }
-

--- a/API/1605_Vwap_Mean_Magnet_V2_Vol_Filter/CS/VwapMeanMagnetV2VolFilterStrategy.cs
+++ b/API/1605_Vwap_Mean_Magnet_V2_Vol_Filter/CS/VwapMeanMagnetV2VolFilterStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
@@ -92,4 +99,3 @@ public class VwapMeanMagnetV2VolFilterStrategy : Strategy
 			BuyMarket();
 	}
 }
-

--- a/API/1606_Vwap_Mean_Magnet_V9_Simple_Alert/CS/VwapMeanMagnetV9SimpleAlertStrategy.cs
+++ b/API/1606_Vwap_Mean_Magnet_V9_Simple_Alert/CS/VwapMeanMagnetV9SimpleAlertStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
@@ -74,4 +81,3 @@ public class VwapMeanMagnetV9SimpleAlertStrategy : Strategy
 			BuyMarket();
 	}
 }
-

--- a/API/1607_Renko_Trend_Reversal_V2/CS/RenkoTrendReversalV2Strategy.cs
+++ b/API/1607_Renko_Trend_Reversal_V2/CS/RenkoTrendReversalV2Strategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
@@ -206,4 +213,3 @@ public class RenkoTrendReversalV2Strategy : Strategy
 		_hasPrev = true;
 	}
 }
-

--- a/API/1608_Renko_Trend_Reversal/CS/RenkoTrendReversalStrategy.cs
+++ b/API/1608_Renko_Trend_Reversal/CS/RenkoTrendReversalStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
@@ -215,4 +222,3 @@ public class RenkoTrendReversalStrategy : Strategy
 		_hasPrev = true;
 	}
 }
-

--- a/API/1609_Session_Input_Parser/CS/SessionInputParserStrategy.cs
+++ b/API/1609_Session_Input_Parser/CS/SessionInputParserStrategy.cs
@@ -1,7 +1,12 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
@@ -84,4 +89,3 @@ public class SessionInputParserStrategy : Strategy
 		return (hStart, mStart, hEnd, mEnd, weekdays);
 	}
 }
-

--- a/API/1610_Security_Revisited/CS/SecurityRevisitedStrategy.cs
+++ b/API/1610_Security_Revisited/CS/SecurityRevisitedStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
@@ -99,4 +106,3 @@ public class SecurityRevisitedStrategy : Strategy
 			SellMarket();
 	}
 }
-

--- a/API/1611_Calculation_Position_Size_Based_on_Risk/CS/CalculationPositionSizeBasedOnRiskStrategy.cs
+++ b/API/1611_Calculation_Position_Size_Based_on_Risk/CS/CalculationPositionSizeBasedOnRiskStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1612_BACKTEST_UT_Bot_RSI/CS/BacktestUtBotRsiStrategy.cs
+++ b/API/1612_BACKTEST_UT_Bot_RSI/CS/BacktestUtBotRsiStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1613_Bollinger_RSI_Countertrend_SOL/CS/BollingerRsiCountertrendSolStrategy.cs
+++ b/API/1613_Bollinger_RSI_Countertrend_SOL/CS/BollingerRsiCountertrendSolStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1614_UNMITIGATED_LEVELS_ACCUMULATION/CS/UnmitigatedLevelsAccumulationStrategy.cs
+++ b/API/1614_UNMITIGATED_LEVELS_ACCUMULATION/CS/UnmitigatedLevelsAccumulationStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1615_Hybrid_Scalping_Bot/CS/HybridScalpingBotStrategy.cs
+++ b/API/1615_Hybrid_Scalping_Bot/CS/HybridScalpingBotStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1616_Yuri_Garcia_Smart_Money/CS/YuriGarciaSmartMoneyStrategy.cs
+++ b/API/1616_Yuri_Garcia_Smart_Money/CS/YuriGarciaSmartMoneyStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1617_Ultimate_T3_Fibonacci_BTC_Scalping/CS/UltimateT3FibonacciBtcScalpingStrategy.cs
+++ b/API/1617_Ultimate_T3_Fibonacci_BTC_Scalping/CS/UltimateT3FibonacciBtcScalpingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1618_DNSE_VN301_SMA_EMA_Cross/CS/DnseVn301SmaEmaCrossStrategy.cs
+++ b/API/1618_DNSE_VN301_SMA_EMA_Cross/CS/DnseVn301SmaEmaCrossStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1619_FT_CCI/CS/FtCciStrategy.cs
+++ b/API/1619_FT_CCI/CS/FtCciStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1620_MSL_EA/CS/MsleaStrategy.cs
+++ b/API/1620_MSL_EA/CS/MsleaStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
@@ -189,4 +195,3 @@ public class MsleaStrategy : Strategy
 		return min;
 	}
 }
-

--- a/API/1621_Sea_Dragon2_v1/CS/SeaDragon2Strategy.cs
+++ b/API/1621_Sea_Dragon2_v1/CS/SeaDragon2Strategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1622_TPSL_Insert/CS/TpslInsertStrategy.cs
+++ b/API/1622_TPSL_Insert/CS/TpslInsertStrategy.cs
@@ -1,7 +1,15 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
@@ -48,4 +56,3 @@ public class TpslInsertStrategy : Strategy
 			stopLoss: new Unit(StopLossPips * step, UnitTypes.Point));
 	}
 }
-

--- a/API/1623_Fxscalper/CS/FxscalperStrategy.cs
+++ b/API/1623_Fxscalper/CS/FxscalperStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1624_Parabolic_SAR_MultiTimeframe/CS/ParabolicSarMultiTimeframeStrategy.cs
+++ b/API/1624_Parabolic_SAR_MultiTimeframe/CS/ParabolicSarMultiTimeframeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1625_Scalp_Rsi/CS/ScalpRsiStrategy.cs
+++ b/API/1625_Scalp_Rsi/CS/ScalpRsiStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1626_Parabolic_SAR_Bug5/CS/ParabolicSarBug5Strategy.cs
+++ b/API/1626_Parabolic_SAR_Bug5/CS/ParabolicSarBug5Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -244,4 +249,3 @@ public class ParabolicSarBug5Strategy : Strategy
 		_lowestPrice = 0m;
 	}
 }
-

--- a/API/1627_ZeroLag_MACD/CS/ZeroLagMacdStrategy.cs
+++ b/API/1627_ZeroLag_MACD/CS/ZeroLagMacdStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1628_MAM_Crossover_Trader/CS/MamCrossoverTraderStrategy.cs
+++ b/API/1628_MAM_Crossover_Trader/CS/MamCrossoverTraderStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1629_Move_Cross/CS/MoveCrossStrategy.cs
+++ b/API/1629_Move_Cross/CS/MoveCrossStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1630_EMA_WPR_Retracement/CS/EmaWprRetracementStrategy.cs
+++ b/API/1630_EMA_WPR_Retracement/CS/EmaWprRetracementStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1631_Blonde_Trader/CS/BlondeTraderStrategy.cs
+++ b/API/1631_Blonde_Trader/CS/BlondeTraderStrategy.cs
@@ -1,4 +1,11 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/1632_VisualTrader_Simulator_Edition/CS/VisualTraderSimulatorEditionStrategy.cs
+++ b/API/1632_VisualTrader_Simulator_Edition/CS/VisualTraderSimulatorEditionStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1633_Breakdown_Level_Day/CS/BreakdownLevelDayStrategy.cs
+++ b/API/1633_Breakdown_Level_Day/CS/BreakdownLevelDayStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1634_MTrainer/CS/MTrainerStrategy.cs
+++ b/API/1634_MTrainer/CS/MTrainerStrategy.cs
@@ -1,8 +1,17 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 using StockSharp.Algo.Candles;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1635_Exp_ATR_Trailing/CS/ExpAtrTrailingStrategy.cs
+++ b/API/1635_Exp_ATR_Trailing/CS/ExpAtrTrailingStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1636_Good_Gbbi/CS/GoodGbbiStrategy.cs
+++ b/API/1636_Good_Gbbi/CS/GoodGbbiStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1637_X_Trail/CS/XTrailStrategy.cs
+++ b/API/1637_X_Trail/CS/XTrailStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -118,4 +123,3 @@ public class XTrailStrategy : Strategy
 		_prevMa2 = ma2;
 	}
 }
-

--- a/API/1638_ARD_Order_Management/CS/ArdOrderManagementStrategy.cs
+++ b/API/1638_ARD_Order_Management/CS/ArdOrderManagementStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1639_EMA_WPR_Trend/CS/EmaWprTrendStrategy.cs
+++ b/API/1639_EMA_WPR_Trend/CS/EmaWprTrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1640_OCO_Order/CS/OcoOrderStrategy.cs
+++ b/API/1640_OCO_Order/CS/OcoOrderStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1641_X_Trail_2/CS/XTrail2Strategy.cs
+++ b/API/1641_X_Trail_2/CS/XTrail2Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1643_Contrarian_trade_MA/CS/ContrarianTradeMaStrategy.cs
+++ b/API/1643_Contrarian_trade_MA/CS/ContrarianTradeMaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1644_Artificial_Intelligence/CS/ArtificialIntelligenceStrategy.cs
+++ b/API/1644_Artificial_Intelligence/CS/ArtificialIntelligenceStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1645_Price_Quotes_By_Email/CS/PriceQuotesByEmailStrategy.cs
+++ b/API/1645_Price_Quotes_By_Email/CS/PriceQuotesByEmailStrategy.cs
@@ -1,13 +1,20 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 using System.Net;
 using System.Net.Mail;
 using System.Text;
 using System.Timers;
-
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1646_EMA_SAR_Power/CS/EmaSarPowerStrategy.cs
+++ b/API/1646_EMA_SAR_Power/CS/EmaSarPowerStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1647_Stop_Loss_Mover/CS/StopLossMoverStrategy.cs
+++ b/API/1647_Stop_Loss_Mover/CS/StopLossMoverStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1648_EMA_SAR_Bulls_Bears/CS/EmaSarBullsBearsStrategy.cs
+++ b/API/1648_EMA_SAR_Bulls_Bears/CS/EmaSarBullsBearsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -257,4 +262,3 @@ _bullsPower = new() { Length = BearsBullsPeriod };
 		_prevBullsPower = bullsPower;
 		}
 		}
-

--- a/API/1649_Line_Order/CS/LineOrderStrategy.cs
+++ b/API/1649_Line_Order/CS/LineOrderStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1650_Simple_Ema_Crossover/CS/SimpleEmaCrossoverStrategy.cs
+++ b/API/1650_Simple_Ema_Crossover/CS/SimpleEmaCrossoverStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1651_Godbot/CS/GodbotStrategy.cs
+++ b/API/1651_Godbot/CS/GodbotStrategy.cs
@@ -1,6 +1,11 @@
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1652_AmlCandleCross/CS/AmlCandleCrossStrategy.cs
+++ b/API/1652_AmlCandleCross/CS/AmlCandleCrossStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1653_MACD_EMA_SAR_Bollinger_BullBear/CS/MacdEmaSarBollingerBullBearStrategy.cs
+++ b/API/1653_MACD_EMA_SAR_Bollinger_BullBear/CS/MacdEmaSarBollingerBullBearStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1654_MACD_Sample/CS/MacdSampleStrategy.cs
+++ b/API/1654_MACD_Sample/CS/MacdSampleStrategy.cs
@@ -1,11 +1,16 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-	
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
-	
+
 namespace StockSharp.Samples.Strategies;
 	
 	/// <summary>

--- a/API/1656_EMA_Sticker/CS/EmaStickerStrategy.cs
+++ b/API/1656_EMA_Sticker/CS/EmaStickerStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1657_ZMFX_Stolid_5a_EA/CS/ZmfxStolid5aEaStrategy.cs
+++ b/API/1657_ZMFX_Stolid_5a_EA/CS/ZmfxStolid5aEaStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1658_MTF_RSI_SAR/CS/MtfRsiSarStrategy.cs
+++ b/API/1658_MTF_RSI_SAR/CS/MtfRsiSarStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1659_MA2CCI/CS/MA2CCIStrategy.cs
+++ b/API/1659_MA2CCI/CS/MA2CCIStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1660_Live_Alligator/CS/LiveAlligatorStrategy.cs
+++ b/API/1660_Live_Alligator/CS/LiveAlligatorStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1661_Symr_New_Bar/CS/SymrNewBarStrategy.cs
+++ b/API/1661_Symr_New_Bar/CS/SymrNewBarStrategy.cs
@@ -1,4 +1,12 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1662_Live_RSI/CS/LiveRSIStrategy.cs
+++ b/API/1662_Live_RSI/CS/LiveRSIStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1663_Psi_Proc_Ema_Macd/CS/PsiProcEmaMacdStrategy.cs
+++ b/API/1663_Psi_Proc_Ema_Macd/CS/PsiProcEmaMacdStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1664_Intraday_v2/CS/IntradayV2Strategy.cs
+++ b/API/1664_Intraday_v2/CS/IntradayV2Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1665_Fibo_Avg_001a/CS/FiboAvg001aStrategy.cs
+++ b/API/1665_Fibo_Avg_001a/CS/FiboAvg001aStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1666_AI_Grid/CS/AiGridStrategy.cs
+++ b/API/1666_AI_Grid/CS/AiGridStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1667_Three_Level_Grid/CS/ThreeLevelGridStrategy.cs
+++ b/API/1667_Three_Level_Grid/CS/ThreeLevelGridStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1668_Close_Orders/CS/CloseOrdersStrategy.cs
+++ b/API/1668_Close_Orders/CS/CloseOrdersStrategy.cs
@@ -1,6 +1,12 @@
 using System;
 using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1669_Tester_v0_14/CS/TesterV014Strategy.cs
+++ b/API/1669_Tester_v0_14/CS/TesterV014Strategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1670_Ema_Plus_Wpr_V2/CS/EmaPlusWprV2Strategy.cs
+++ b/API/1670_Ema_Plus_Wpr_V2/CS/EmaPlusWprV2Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -254,4 +259,3 @@ public class EmaPlusWprV2Strategy : Strategy
 		_unprofitBars = 0;
 	}
 }
-

--- a/API/1671_Aver4_Stoch_Post_ZigZag/CS/Aver4StochPostZigZagStrategy.cs
+++ b/API/1671_Aver4_Stoch_Post_ZigZag/CS/Aver4StochPostZigZagStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1672_TradePad/CS/TradePadStrategy.cs
+++ b/API/1672_TradePad/CS/TradePadStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1673_Ride_Alligator/CS/RideAlligatorStrategy.cs
+++ b/API/1673_Ride_Alligator/CS/RideAlligatorStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1674_Shuriken_Lite/CS/ShurikenLiteStrategy.cs
+++ b/API/1674_Shuriken_Lite/CS/ShurikenLiteStrategy.cs
@@ -1,6 +1,15 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1675_Lego_V3/CS/LegoV3Strategy.cs
+++ b/API/1675_Lego_V3/CS/LegoV3Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1676_My_Line_Order/CS/MyLineOrderStrategy.cs
+++ b/API/1676_My_Line_Order/CS/MyLineOrderStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1677_Averaged_Stoch_WPR/CS/AveragedStochWprStrategy.cs
+++ b/API/1677_Averaged_Stoch_WPR/CS/AveragedStochWprStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1678_Status_Mail_and_Alert_On_Order_Close/CS/StatusMailAndAlertOnOrderCloseStrategy.cs
+++ b/API/1678_Status_Mail_and_Alert_On_Order_Close/CS/StatusMailAndAlertOnOrderCloseStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
@@ -150,4 +156,3 @@ public class StatusMailAndAlertOnOrderCloseStrategy : Strategy
 		AddInfo($"Closed {order.Direction} order #{order.Id} at {trade.Trade.Price:0.####}. Balance {Portfolio?.CurrentValue ?? 0m:0.##}. PnL {PnL:0.##}.");
 	}
 }
-

--- a/API/1679_Psar_Bug_6/CS/PsarBug6Strategy.cs
+++ b/API/1679_Psar_Bug_6/CS/PsarBug6Strategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1680_Xbug_Free/CS/XbugFreeStrategy.cs
+++ b/API/1680_Xbug_Free/CS/XbugFreeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1681_MA2CCI/CS/Ma2CciStrategy.cs
+++ b/API/1681_MA2CCI/CS/Ma2CciStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1682_X_Alert_3/CS/XAlert3Strategy.cs
+++ b/API/1682_X_Alert_3/CS/XAlert3Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -223,4 +228,3 @@ public enum PriceTypeEnum
 	/// <summary>Weighted close price (high+low+close*2)/4.</summary>
 	Weighted
 }
-

--- a/API/1683_Parabolic_SAR_Alert/CS/ParabolicSarAlertStrategy.cs
+++ b/API/1683_Parabolic_SAR_Alert/CS/ParabolicSarAlertStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1684_Line_Order/CS/LineOrderStrategy.cs
+++ b/API/1684_Line_Order/CS/LineOrderStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1685_Trade_Channel/CS/TradeChannelStrategy.cs
+++ b/API/1685_Trade_Channel/CS/TradeChannelStrategy.cs
@@ -1,6 +1,11 @@
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1687_Scalping_EA/CS/ScalpingEAStrategy.cs
+++ b/API/1687_Scalping_EA/CS/ScalpingEAStrategy.cs
@@ -1,5 +1,12 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1688_Manager_Trailing/CS/ManagerTrailingStrategy.cs
+++ b/API/1688_Manager_Trailing/CS/ManagerTrailingStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using System.Globalization;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using System.Globalization;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1689_Hybrid_EA/CS/HybridEaStrategy.cs
+++ b/API/1689_Hybrid_EA/CS/HybridEaStrategy.cs
@@ -1,4 +1,10 @@
+using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1690_News_Pending_Orders/CS/NewsPendingOrdersStrategy.cs
+++ b/API/1690_News_Pending_Orders/CS/NewsPendingOrdersStrategy.cs
@@ -1,9 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using StockSharp.Algo;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1691_Lego_4_Beta/CS/Lego4BetaStrategy.cs
+++ b/API/1691_Lego_4_Beta/CS/Lego4BetaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1692_Parabolic_SAR_Bug/CS/ParabolicSarBugStrategy.cs
+++ b/API/1692_Parabolic_SAR_Bug/CS/ParabolicSarBugStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1693_Xbug_Free_V4/CS/XbugFreeV4Strategy.cs
+++ b/API/1693_Xbug_Free_V4/CS/XbugFreeV4Strategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1694_Marneni_Money_Tree/CS/MarneniMoneyTreeStrategy.cs
+++ b/API/1694_Marneni_Money_Tree/CS/MarneniMoneyTreeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1695_Close_vs_Previous_Open/CS/CloseVsPreviousOpenStrategy.cs
+++ b/API/1695_Close_vs_Previous_Open/CS/CloseVsPreviousOpenStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
@@ -166,4 +172,3 @@ public class CloseVsPreviousOpenStrategy : Strategy
 		_isInitialized = true;
 	}
 }
-

--- a/API/1696_EPSI_MultiSET/CS/EPSIMultiSetStrategy.cs
+++ b/API/1696_EPSI_MultiSET/CS/EPSIMultiSetStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1697_Time_Trader/CS/TimeTraderStrategy.cs
+++ b/API/1697_Time_Trader/CS/TimeTraderStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
@@ -195,4 +201,3 @@ public class TimeTraderStrategy : Strategy
 		}
 	}
 }
-

--- a/API/1698_TCPivot_Stop/CS/TcpPivotStopStrategy.cs
+++ b/API/1698_TCPivot_Stop/CS/TcpPivotStopStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1700_TCPivotLimit/CS/TcpPivotLimitStrategy.cs
+++ b/API/1700_TCPivotLimit/CS/TcpPivotLimitStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1701_Geedo/CS/GeedoStrategy.cs
+++ b/API/1701_Geedo/CS/GeedoStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
@@ -307,4 +313,3 @@ public class GeedoStrategy : Strategy
 		_takeProfitPrice = null;
 	}
 }
-

--- a/API/1702_Renko_Scalper/CS/RenkoScalperStrategy.cs
+++ b/API/1702_Renko_Scalper/CS/RenkoScalperStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
@@ -145,4 +151,3 @@ public class RenkoScalperStrategy : Strategy
 		_previousClose = close;
 	}
 }
-

--- a/API/1703_VR_MARS/CS/VRMarsStrategy.cs
+++ b/API/1703_VR_MARS/CS/VRMarsStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1704_Martini_Martingale/CS/MartiniMartingaleStrategy.cs
+++ b/API/1704_Martini_Martingale/CS/MartiniMartingaleStrategy.cs
@@ -1,5 +1,12 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1705_Sophia1_1/CS/Sophia11Strategy.cs
+++ b/API/1705_Sophia1_1/CS/Sophia11Strategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1706_Robot_Danu/CS/RobotDanuStrategy.cs
+++ b/API/1706_Robot_Danu/CS/RobotDanuStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1707_Intraday_Beta/CS/IntradayBetaStrategy.cs
+++ b/API/1707_Intraday_Beta/CS/IntradayBetaStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1708_Disturbed/CS/DisturbedStrategy.cs
+++ b/API/1708_Disturbed/CS/DisturbedStrategy.cs
@@ -1,7 +1,17 @@
 using System;
-using StockSharp.Algo;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1709_MLTrendE/CS/MLTrendEStrategy.cs
+++ b/API/1709_MLTrendE/CS/MLTrendEStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1711_High_Low_MA_Breakout/CS/HighLowMaBreakoutStrategy.cs
+++ b/API/1711_High_Low_MA_Breakout/CS/HighLowMaBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -193,4 +198,3 @@ public class HighLowMaBreakoutStrategy : Strategy
 		_prevMaLow = maLow;
 	}
 }
-

--- a/API/1712_CloseAtProfit/CS/CloseAtProfitStrategy.cs
+++ b/API/1712_CloseAtProfit/CS/CloseAtProfitStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1713_Zig_Dan_Zag_Ultimate_Investment_Long_Term/CS/ZigDanZagUltimateInvestmentLongTermStrategy.cs
+++ b/API/1713_Zig_Dan_Zag_Ultimate_Investment_Long_Term/CS/ZigDanZagUltimateInvestmentLongTermStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1714_LotScalp/CS/LotScalpStrategy.cs
+++ b/API/1714_LotScalp/CS/LotScalpStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1715_Batman_Atr_Trailing_Stop/CS/BatmanAtrTrailingStopStrategy.cs
+++ b/API/1715_Batman_Atr_Trailing_Stop/CS/BatmanAtrTrailingStopStrategy.cs
@@ -1,5 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/1716_Time_Trader/CS/TimeTraderStrategy.cs
+++ b/API/1716_Time_Trader/CS/TimeTraderStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1717_Exp_X2MA/CS/ExpX2MaStrategy.cs
+++ b/API/1717_Exp_X2MA/CS/ExpX2MaStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1719_Adaptive_Cyber_Cycle/CS/AdaptiveCyberCycleStrategy.cs
+++ b/API/1719_Adaptive_Cyber_Cycle/CS/AdaptiveCyberCycleStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -170,4 +175,3 @@ public class AdaptiveCyberCycleIndicator : Indicator<decimal>
 		return new DecimalIndicatorValue(this, cycle, input.Time);
 	}
 }
-

--- a/API/1720_VR_Setka_P2/CS/VrSetkaP2Strategy.cs
+++ b/API/1720_VR_Setka_P2/CS/VrSetkaP2Strategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1721_Volume_EA/CS/VolumeEaStrategy.cs
+++ b/API/1721_Volume_EA/CS/VolumeEaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1722_AMkA_Signal/CS/AmkaSignalStrategy.cs
+++ b/API/1722_AMkA_Signal/CS/AmkaSignalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1723_Candle_Trader/CS/CandleTraderStrategy.cs
+++ b/API/1723_Candle_Trader/CS/CandleTraderStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
@@ -180,4 +186,3 @@ public class CandleTraderStrategy : Strategy
 		}
 	}
 }
-

--- a/API/1724_Pure_Martingale/CS/PureMartingaleStrategy.cs
+++ b/API/1724_Pure_Martingale/CS/PureMartingaleStrategy.cs
@@ -1,11 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1725_Rampok_Scalp/CS/RampokScalpStrategy.cs
+++ b/API/1725_Rampok_Scalp/CS/RampokScalpStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1727_Three_Parabolic_SAR/CS/ThreeParabolicSarStrategy.cs
+++ b/API/1727_Three_Parabolic_SAR/CS/ThreeParabolicSarStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1728_Autostop/CS/AutostopStrategy.cs
+++ b/API/1728_Autostop/CS/AutostopStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1729_Third_Generation_XMA_Reversal/CS/ThirdGenerationXmaReversalStrategy.cs
+++ b/API/1729_Third_Generation_XMA_Reversal/CS/ThirdGenerationXmaReversalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1730_BBands_Stop/CS/BBandsStopStrategy.cs
+++ b/API/1730_BBands_Stop/CS/BBandsStopStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1731_Emagic1/CS/Emagic1Strategy.cs
+++ b/API/1731_Emagic1/CS/Emagic1Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1732_BB_Squeeze/CS/BbSqueezeStrategy.cs
+++ b/API/1732_BB_Squeeze/CS/BbSqueezeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1733_Break_the_Range_Bound/CS/BreakTheRangeBoundStrategy.cs
+++ b/API/1733_Break_the_Range_Bound/CS/BreakTheRangeBoundStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1734_MACD_Cross_AUDUSD_D1/CS/MacdCrossAudusdD1Strategy.cs
+++ b/API/1734_MACD_Cross_AUDUSD_D1/CS/MacdCrossAudusdD1Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1735_Line_Order/CS/LineOrderStrategy.cs
+++ b/API/1735_Line_Order/CS/LineOrderStrategy.cs
@@ -1,9 +1,15 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1736_RGT_EA_RSI/CS/RgtEaRsiStrategy.cs
+++ b/API/1736_RGT_EA_RSI/CS/RgtEaRsiStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1737_RGT_RSI_Bollinger/CS/RgtRsiBollingerStrategy.cs
+++ b/API/1737_RGT_RSI_Bollinger/CS/RgtRsiBollingerStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1738_MACFibo/CS/MacfiboStrategy.cs
+++ b/API/1738_MACFibo/CS/MacfiboStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1739_Channel_Scalper/CS/ChannelScalperStrategy.cs
+++ b/API/1739_Channel_Scalper/CS/ChannelScalperStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1740_Snowieso_EA/CS/SnowiesoStrategy.cs
+++ b/API/1740_Snowieso_EA/CS/SnowiesoStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1741_Trend_Capture/CS/TrendCaptureStrategy.cs
+++ b/API/1741_Trend_Capture/CS/TrendCaptureStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1742_Rsi_Trader_V1/CS/RsiTraderV1Strategy.cs
+++ b/API/1742_Rsi_Trader_V1/CS/RsiTraderV1Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -249,4 +254,3 @@ public class RsiTraderV1Strategy : Strategy
 		_prevRsi = rsiValue;
 	}
 }
-

--- a/API/1743_Universal_Investor/CS/UniversalInvestorStrategy.cs
+++ b/API/1743_Universal_Investor/CS/UniversalInvestorStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1744_Renko_Live_Chart/CS/RenkoLiveChartStrategy.cs
+++ b/API/1744_Renko_Live_Chart/CS/RenkoLiveChartStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1745_Charles/CS/CharlesStrategy.cs
+++ b/API/1745_Charles/CS/CharlesStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -224,4 +229,3 @@ public class CharlesStrategy : Strategy
 		}
 	}
 }
-

--- a/API/1746_Up3x1/CS/Up3x1Strategy.cs
+++ b/API/1746_Up3x1/CS/Up3x1Strategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
@@ -175,4 +182,3 @@ BuyMarket(-Position);
 }
 }
 }
-

--- a/API/1747_Charles_137/CS/Charles137Strategy.cs
+++ b/API/1747_Charles_137/CS/Charles137Strategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1748_EM_VOL/CS/EmVolStrategy.cs
+++ b/API/1748_EM_VOL/CS/EmVolStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1749_Drag_SLTP/CS/DragSlTpStrategy.cs
+++ b/API/1749_Drag_SLTP/CS/DragSlTpStrategy.cs
@@ -1,5 +1,12 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1750_PSAR_Trader/CS/PsarTraderStrategy.cs
+++ b/API/1750_PSAR_Trader/CS/PsarTraderStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1751_Maximus_Vx_Lite/CS/MaximusVxLiteStrategy.cs
+++ b/API/1751_Maximus_Vx_Lite/CS/MaximusVxLiteStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1752_Charles/CS/CharlesStrategy.cs
+++ b/API/1752_Charles/CS/CharlesStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1753_VrSetkaGrid/CS/VrSetkaGridStrategy.cs
+++ b/API/1753_VrSetkaGrid/CS/VrSetkaGridStrategy.cs
@@ -1,7 +1,13 @@
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1754_Up3x1_Krohabor_D/CS/Up3x1KrohaborDStrategy.cs
+++ b/API/1754_Up3x1_Krohabor_D/CS/Up3x1KrohaborDStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1755_X_Trader/CS/XTraderStrategy.cs
+++ b/API/1755_X_Trader/CS/XTraderStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1756_Bullish_Reversal/CS/BullishReversalStrategy.cs
+++ b/API/1756_Bullish_Reversal/CS/BullishReversalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1757_PSAR_Trader/CS/PsarTraderStrategy.cs
+++ b/API/1757_PSAR_Trader/CS/PsarTraderStrategy.cs
@@ -1,5 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/1758_Autostop_Cyriac/CS/AutostopCyriacStrategy.cs
+++ b/API/1758_Autostop_Cyriac/CS/AutostopCyriacStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1759_Time_Trader/CS/TimeTraderStrategy.cs
+++ b/API/1759_Time_Trader/CS/TimeTraderStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1760_Charles_SMA_Trailing/CS/CharlesSmaTrailingStrategy.cs
+++ b/API/1760_Charles_SMA_Trailing/CS/CharlesSmaTrailingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1762_RSI_Trend/CS/RsiTrendStrategy.cs
+++ b/API/1762_RSI_Trend/CS/RsiTrendStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1763_Mma_Breakout_Volume_I/CS/MmaBreakoutVolumeIStrategy.cs
+++ b/API/1763_Mma_Breakout_Volume_I/CS/MmaBreakoutVolumeIStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -152,4 +157,3 @@ public class MmaBreakoutVolumeIStrategy : Strategy
 		_prevSlow = slowValue;
 	}
 }
-

--- a/API/1764_Divergence_Trader/CS/DivergenceTraderStrategy.cs
+++ b/API/1764_Divergence_Trader/CS/DivergenceTraderStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1765_SHE_Kanskigor/CS/SheKanskigorStrategy.cs
+++ b/API/1765_SHE_Kanskigor/CS/SheKanskigorStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1766_Laguerre_CCI_MA/CS/LaguerreCciMaStrategy.cs
+++ b/API/1766_Laguerre_CCI_MA/CS/LaguerreCciMaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1767_Aeron_Robot/CS/AeronRobotStrategy.cs
+++ b/API/1767_Aeron_Robot/CS/AeronRobotStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1769_Follow_Your_Heart/CS/FollowYourHeartStrategy.cs
+++ b/API/1769_Follow_Your_Heart/CS/FollowYourHeartStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1770_Collector_v1_0/CS/CollectorV10Strategy.cs
+++ b/API/1770_Collector_v1_0/CS/CollectorV10Strategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1771_X_Trader_V2/CS/XTraderV2Strategy.cs
+++ b/API/1771_X_Trader_V2/CS/XTraderV2Strategy.cs
@@ -1,11 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 using StockSharp.Algo;
 using StockSharp.Algo.Candles;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1772_PSAR_Trader_v2/CS/PsarTraderV2Strategy.cs
+++ b/API/1772_PSAR_Trader_v2/CS/PsarTraderV2Strategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1773_Breakout_04/CS/Breakout04Strategy.cs
+++ b/API/1773_Breakout_04/CS/Breakout04Strategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1774_MADX07_ADX_MA/CS/Madx07AdxMaStrategy.cs
+++ b/API/1774_MADX07_ADX_MA/CS/Madx07AdxMaStrategy.cs
@@ -1,4 +1,11 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/1776_AntiFragile_EA/CS/AntiFragileStrategy.cs
+++ b/API/1776_AntiFragile_EA/CS/AntiFragileStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1777_Binary_Wave/CS/BinaryWaveStrategy.cs
+++ b/API/1777_Binary_Wave/CS/BinaryWaveStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1778_C_Factor_HLH4_Buy_Only/CS/CFactorHlh4BuyOnlyStrategy.cs
+++ b/API/1778_C_Factor_HLH4_Buy_Only/CS/CFactorHlh4BuyOnlyStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1779_Pz_Reversal_Trend_Following/CS/PzReversalTrendFollowingStrategy.cs
+++ b/API/1779_Pz_Reversal_Trend_Following/CS/PzReversalTrendFollowingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1780_PZ_Parabolic_SAR_EA/CS/PzParabolicSarEaStrategy.cs
+++ b/API/1780_PZ_Parabolic_SAR_EA/CS/PzParabolicSarEaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1781_Xmacd_Modes/CS/XmacdModesStrategy.cs
+++ b/API/1781_Xmacd_Modes/CS/XmacdModesStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1782_Hedger/CS/HedgerStrategy.cs
+++ b/API/1782_Hedger/CS/HedgerStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1783_Arrows_Curves/CS/ArrowsCurvesStrategy.cs
+++ b/API/1783_Arrows_Curves/CS/ArrowsCurvesStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1784_X_trader_v3/CS/XTraderV3Strategy.cs
+++ b/API/1784_X_trader_v3/CS/XTraderV3Strategy.cs
@@ -1,5 +1,14 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1785_Fracture/CS/FractureStrategy.cs
+++ b/API/1785_Fracture/CS/FractureStrategy.cs
@@ -1,6 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1786_EURUSD_V2_0/CS/EurusdV20Strategy.cs
+++ b/API/1786_EURUSD_V2_0/CS/EurusdV20Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -189,4 +194,3 @@ public class EurusdV20Strategy : Strategy
 		return m * 0.01m;
 	}
 }
-

--- a/API/1787_Stop_Loss_To_BreakEven/CS/StopLossToBreakEvenStrategy.cs
+++ b/API/1787_Stop_Loss_To_BreakEven/CS/StopLossToBreakEvenStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1788_Timer/CS/TimerStrategy.cs
+++ b/API/1788_Timer/CS/TimerStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1789_BreakThrough/CS/BreakThroughStrategy.cs
+++ b/API/1789_BreakThrough/CS/BreakThroughStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1790_BrakeExp_Channel/CS/BrakeExpChannelStrategy.cs
+++ b/API/1790_BrakeExp_Channel/CS/BrakeExpChannelStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1791_Stoch_TP_TS_V3103/CS/StochTpTsV3103Strategy.cs
+++ b/API/1791_Stoch_TP_TS_V3103/CS/StochTpTsV3103Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1792_Magna_Rapax_Copper/CS/MagnaRapaxCopperStrategy.cs
+++ b/API/1792_Magna_Rapax_Copper/CS/MagnaRapaxCopperStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1793_News_Trading_EA/CS/NewsTradingEaStrategy.cs
+++ b/API/1793_News_Trading_EA/CS/NewsTradingEaStrategy.cs
@@ -1,5 +1,12 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1794_Brake_Exp/CS/BrakeExpStrategy.cs
+++ b/API/1794_Brake_Exp/CS/BrakeExpStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1795_Close_Positions/CS/ClosePositionsStrategy.cs
+++ b/API/1795_Close_Positions/CS/ClosePositionsStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1796_Straddle_News/CS/StraddleNewsStrategy.cs
+++ b/API/1796_Straddle_News/CS/StraddleNewsStrategy.cs
@@ -1,5 +1,12 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1797_Brake_Parabolic/CS/BrakeParabolicStrategy.cs
+++ b/API/1797_Brake_Parabolic/CS/BrakeParabolicStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1798_Bulls_Bears_Power_Cross/CS/BullsBearsPowerCrossStrategy.cs
+++ b/API/1798_Bulls_Bears_Power_Cross/CS/BullsBearsPowerCrossStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1799_Milestone_Trend/CS/MilestoneTrendStrategy.cs
+++ b/API/1799_Milestone_Trend/CS/MilestoneTrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -234,4 +239,3 @@ _prevSlow = slowValue;
 _prevCandle = candle;
 }
 }
-

--- a/API/1800_Bulls_Bears_Eyes/CS/BullsBearsEyesStrategy.cs
+++ b/API/1800_Bulls_Bears_Eyes/CS/BullsBearsEyesStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -152,4 +157,3 @@ public class BullsBearsEyesStrategy : Strategy {
 		}
 	}
 }
-

--- a/API/1801_Artificial_Intelligence/CS/ArtificialIntelligenceStrategy.cs
+++ b/API/1801_Artificial_Intelligence/CS/ArtificialIntelligenceStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1802_E_TurboFx/CS/ETurboFxStrategy.cs
+++ b/API/1802_E_TurboFx/CS/ETurboFxStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1803_Unseasonalised_ATR_and_Forecast/CS/UnseasonalisedAtrForecastStrategy.cs
+++ b/API/1803_Unseasonalised_ATR_and_Forecast/CS/UnseasonalisedAtrForecastStrategy.cs
@@ -1,7 +1,13 @@
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1804_Coensio_Swing_Trader/CS/CoensioSwingTraderStrategy.cs
+++ b/API/1804_Coensio_Swing_Trader/CS/CoensioSwingTraderStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
@@ -280,4 +286,3 @@ public class CoensioSwingTraderStrategy : Strategy
 		}
 	}
 }
-

--- a/API/1805_X3MA_EA_V2_0/CS/X3MaEaV20Strategy.cs
+++ b/API/1805_X3MA_EA_V2_0/CS/X3MaEaV20Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1806_Hardcore_FX/CS/HardcoreFxStrategy.cs
+++ b/API/1806_Hardcore_FX/CS/HardcoreFxStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1807_GO/CS/GoStrategy.cs
+++ b/API/1807_GO/CS/GoStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1808_Close_Cross_Kijun_Sen/CS/CloseCrossKijunSenStrategy.cs
+++ b/API/1808_Close_Cross_Kijun_Sen/CS/CloseCrossKijunSenStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1809_Lucky_Jump/CS/LuckyJumpStrategy.cs
+++ b/API/1809_Lucky_Jump/CS/LuckyJumpStrategy.cs
@@ -1,5 +1,12 @@
+using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1810_Catcher_Profit_1_0/CS/CatcherProfit10Strategy.cs
+++ b/API/1810_Catcher_Profit_1_0/CS/CatcherProfit10Strategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1811_Obj_Label_Example/CS/ObjLabelExampleStrategy.cs
+++ b/API/1811_Obj_Label_Example/CS/ObjLabelExampleStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1813_Self_Learning_Experts/CS/SelfLearningExpertsStrategy.cs
+++ b/API/1813_Self_Learning_Experts/CS/SelfLearningExpertsStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
@@ -299,4 +305,3 @@ public class SelfLearningExpertsStrategy : Strategy
 		}
 	}
 }
-

--- a/API/1814_A_Informer/CS/AInformerStrategy.cs
+++ b/API/1814_A_Informer/CS/AInformerStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1815_Close_Cross_MA/CS/CloseCrossMaStrategy.cs
+++ b/API/1815_Close_Cross_MA/CS/CloseCrossMaStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1816_BuySell/CS/BuySellStrategy.cs
+++ b/API/1816_BuySell/CS/BuySellStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1817_Liquidex_V1/CS/LiquidexV1Strategy.cs
+++ b/API/1817_Liquidex_V1/CS/LiquidexV1Strategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1818_MadTrader/CS/MadTraderStrategy.cs
+++ b/API/1818_MadTrader/CS/MadTraderStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1819_Perceptron_AC/CS/PerceptronAcStrategy.cs
+++ b/API/1819_Perceptron_AC/CS/PerceptronAcStrategy.cs
@@ -1,6 +1,11 @@
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1820_Price_Action/CS/PriceActionStrategy.cs
+++ b/API/1820_Price_Action/CS/PriceActionStrategy.cs
@@ -1,5 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1822_Elliott_Trader/CS/ElliottTraderStrategy.cs
+++ b/API/1822_Elliott_Trader/CS/ElliottTraderStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1823_Turtle_Trader_V1/CS/TurtleTraderV1Strategy.cs
+++ b/API/1823_Turtle_Trader_V1/CS/TurtleTraderV1Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1824_VR_Overturn/CS/VROverturnStrategy.cs
+++ b/API/1824_VR_Overturn/CS/VROverturnStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1825_Simulator/CS/SimulatorStrategy.cs
+++ b/API/1825_Simulator/CS/SimulatorStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;
@@ -171,4 +184,3 @@ _prevFast = fast;
 _prevSlow = slow;
 }
 }
-

--- a/API/1826_MACD_vs_Signal/CS/MacdVsSignalStrategy.cs
+++ b/API/1826_MACD_vs_Signal/CS/MacdVsSignalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1827_Terminator_V2z0/CS/TerminatorV2z0Strategy.cs
+++ b/API/1827_Terminator_V2z0/CS/TerminatorV2z0Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1828_SwingCyborg/CS/SwingCyborgStrategy.cs
+++ b/API/1828_SwingCyborg/CS/SwingCyborgStrategy.cs
@@ -1,12 +1,18 @@
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1829_Universal_EA/CS/UniversalEaStrategy.cs
+++ b/API/1829_Universal_EA/CS/UniversalEaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1830_CCI_COMA/CS/CciComaStrategy.cs
+++ b/API/1830_CCI_COMA/CS/CciComaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1831_Smart_Ass_Trade/CS/SmartAssTradeStrategy.cs
+++ b/API/1831_Smart_Ass_Trade/CS/SmartAssTradeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1832_Ema_2_35_Cross/CS/Ema235CrossStrategy.cs
+++ b/API/1832_Ema_2_35_Cross/CS/Ema235CrossStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1833_RSI_Value/CS/RsiValueStrategy.cs
+++ b/API/1833_RSI_Value/CS/RsiValueStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1834_Virtual_Stop_Manager/CS/VirtualStopManagerStrategy.cs
+++ b/API/1834_Virtual_Stop_Manager/CS/VirtualStopManagerStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;
@@ -180,4 +193,3 @@ public class VirtualStopManagerStrategy : Strategy
 		_breakevenMoved = false;
 	}
 }
-

--- a/API/1835_SMA_Multi_Hedge2/CS/SmaMultiHedge2Strategy.cs
+++ b/API/1835_SMA_Multi_Hedge2/CS/SmaMultiHedge2Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -244,4 +249,3 @@ public class SmaMultiHedge2Strategy : Strategy
 		return (decimal)(numerator / denominator);
 	}
 }
-

--- a/API/1836_Gap_Fill/CS/GapFillStrategy.cs
+++ b/API/1836_Gap_Fill/CS/GapFillStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1837_BWWiseMan2/CS/BWWiseMan2Strategy.cs
+++ b/API/1837_BWWiseMan2/CS/BWWiseMan2Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1838_Exp_Hull_Trend/CS/ExpHullTrendStrategy.cs
+++ b/API/1838_Exp_Hull_Trend/CS/ExpHullTrendStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1839_TSI_MACD_Crossover/CS/TsiMacdCrossoverStrategy.cs
+++ b/API/1839_TSI_MACD_Crossover/CS/TsiMacdCrossoverStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1840_Exp_TSI_CCI/CS/ExpTsiCciStrategy.cs
+++ b/API/1840_Exp_TSI_CCI/CS/ExpTsiCciStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1841_Order_Manager/CS/OrderManagerStrategy.cs
+++ b/API/1841_Order_Manager/CS/OrderManagerStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1842_TSI_WPR_Cross/CS/TsiWprCrossStrategy.cs
+++ b/API/1842_TSI_WPR_Cross/CS/TsiWprCrossStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1843_Karpenko_Channel/CS/KarpenkoChannelStrategy.cs
+++ b/API/1843_Karpenko_Channel/CS/KarpenkoChannelStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1844_SlopeDirectionLine/CS/SlopeDirectionLineStrategy.cs
+++ b/API/1844_SlopeDirectionLine/CS/SlopeDirectionLineStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;
@@ -185,4 +198,3 @@ public class SlopeDirectionLineStrategy : Strategy
 		_prevSlope = currentSlope;
 	}
 }
-

--- a/API/1845_TSI_DeMarker/CS/TSIDeMarkerStrategy.cs
+++ b/API/1845_TSI_DeMarker/CS/TSIDeMarkerStrategy.cs
@@ -1,10 +1,18 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 using StockSharp.Algo;
 using StockSharp.Algo.Candles;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1846_MaRsi_Trigger/CS/MaRsiTriggerStrategy.cs
+++ b/API/1846_MaRsi_Trigger/CS/MaRsiTriggerStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1847_ADX_Stop_Order_Template/CS/AdxStopOrderTemplateStrategy.cs
+++ b/API/1847_ADX_Stop_Order_Template/CS/AdxStopOrderTemplateStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1848_MaByMa/CS/MaByMaStrategy.cs
+++ b/API/1848_MaByMa/CS/MaByMaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1849_Yuraz_Closeprc_V3/CS/YurazCloseprcV3Strategy.cs
+++ b/API/1849_Yuraz_Closeprc_V3/CS/YurazCloseprcV3Strategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1850_Combo_Right/CS/ComboRightStrategy.cs
+++ b/API/1850_Combo_Right/CS/ComboRightStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1851_Channel_Trailing_Stop/CS/ChannelTrailingStopStrategy.cs
+++ b/API/1851_Channel_Trailing_Stop/CS/ChannelTrailingStopStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1852_Eugene_Candle_Pattern/CS/EugeneCandlePatternStrategy.cs
+++ b/API/1852_Eugene_Candle_Pattern/CS/EugeneCandlePatternStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1853_Exchange_Price/CS/ExchangePriceStrategy.cs
+++ b/API/1853_Exchange_Price/CS/ExchangePriceStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1854_Heiken_Ashi_Simplified_EA/CS/HeikenAshiSimplifiedEaStrategy.cs
+++ b/API/1854_Heiken_Ashi_Simplified_EA/CS/HeikenAshiSimplifiedEaStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1855_Center_Of_Gravity/CS/CenterOfGravityStrategy.cs
+++ b/API/1855_Center_Of_Gravity/CS/CenterOfGravityStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1856_BnB/CS/BnBStrategy.cs
+++ b/API/1856_BnB/CS/BnBStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1857_Signals_Demo/CS/SignalsDemoStrategy.cs
+++ b/API/1857_Signals_Demo/CS/SignalsDemoStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1858_Signals_Demo/CS/SignalsDemoStrategy.cs
+++ b/API/1858_Signals_Demo/CS/SignalsDemoStrategy.cs
@@ -1,6 +1,15 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1859_CMO_Zero_Cross/CS/CmoZeroCrossStrategy.cs
+++ b/API/1859_CMO_Zero_Cross/CS/CmoZeroCrossStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1862_Bulls_vs_Bears_Crossover/CS/BullsVsBearsCrossoverStrategy.cs
+++ b/API/1862_Bulls_vs_Bears_Crossover/CS/BullsVsBearsCrossoverStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1863_Kauf_WMA_Cross/CS/KaufWmaCrossStrategy.cs
+++ b/API/1863_Kauf_WMA_Cross/CS/KaufWmaCrossStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;
@@ -155,4 +168,3 @@ public class KaufWmaCrossStrategy : Strategy
 		_prevWma = wmaValue;
 	}
 }
-

--- a/API/1864_Simple_Bars/CS/SimpleBarsStrategy.cs
+++ b/API/1864_Simple_Bars/CS/SimpleBarsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1865_Liquidex/CS/LiquidexStrategy.cs
+++ b/API/1865_Liquidex/CS/LiquidexStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1867_MA_SAR_ADX/CS/MaSarAdxStrategy.cs
+++ b/API/1867_MA_SAR_ADX/CS/MaSarAdxStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1868_MA_L_World/CS/MaLWorldStrategy.cs
+++ b/API/1868_MA_L_World/CS/MaLWorldStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1869_Bollinger_Breakout/CS/BollingerBreakoutStrategy.cs
+++ b/API/1869_Bollinger_Breakout/CS/BollingerBreakoutStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using StockSharp.Algo.Indicators;

--- a/API/1870_Close_At_Profit/CS/CloseAtProfitStrategy.cs
+++ b/API/1870_Close_At_Profit/CS/CloseAtProfitStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1871_Tiger_EMA_ADX_RSI/CS/TigerEmaAdxRsiStrategy.cs
+++ b/API/1871_Tiger_EMA_ADX_RSI/CS/TigerEmaAdxRsiStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1872_T3MA_Alarm/CS/T3MaAlarmStrategy.cs
+++ b/API/1872_T3MA_Alarm/CS/T3MaAlarmStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1873_CoeffofLineTrue/CS/CoeffofLineTrueStrategy.cs
+++ b/API/1873_CoeffofLineTrue/CS/CoeffofLineTrueStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
@@ -144,4 +150,3 @@ public class CoeffofLineTrueStrategy : Strategy
 		}
 	}
 }
-

--- a/API/1874_Color_BB_Candles/CS/ColorBbCandlesStrategy.cs
+++ b/API/1874_Color_BB_Candles/CS/ColorBbCandlesStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1875_Genie/CS/GenieStrategy.cs
+++ b/API/1875_Genie/CS/GenieStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1876_ProfitTrailing/CS/ProfitTrailingStrategy.cs
+++ b/API/1876_ProfitTrailing/CS/ProfitTrailingStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1877_Two_Direction_Martin_Stylized/CS/TwoDirectionMartinStylizedStrategy.cs
+++ b/API/1877_Two_Direction_Martin_Stylized/CS/TwoDirectionMartinStylizedStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1878_Two_Pole_Ideal_MA/CS/TwoPoleIdealMaStrategy.cs
+++ b/API/1878_Two_Pole_Ideal_MA/CS/TwoPoleIdealMaStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1879_Ilan_1_6_Dynamic/CS/Ilan16DynamicStrategy.cs
+++ b/API/1879_Ilan_1_6_Dynamic/CS/Ilan16DynamicStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1880_Genie_Pivot/CS/GeniePivotStrategy.cs
+++ b/API/1880_Genie_Pivot/CS/GeniePivotStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1881_Genie_Pivot/CS/GeniePivotStrategy.cs
+++ b/API/1881_Genie_Pivot/CS/GeniePivotStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1882_20_200_Expert/CS/Twenty200ExpertStrategy.cs
+++ b/API/1882_20_200_Expert/CS/Twenty200ExpertStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1884_Kloss/CS/KlossStrategy.cs
+++ b/API/1884_Kloss/CS/KlossStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1885_Genie_RSI/CS/GenieRsiStrategy.cs
+++ b/API/1885_Genie_RSI/CS/GenieRsiStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1886_Sma_Trend_Filter/CS/SmaTrendFilterStrategy.cs
+++ b/API/1886_Sma_Trend_Filter/CS/SmaTrendFilterStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1887_Vlt_Trader/CS/VltTraderStrategy.cs
+++ b/API/1887_Vlt_Trader/CS/VltTraderStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1888_Genie_Stoch_RSI/CS/GenieStochRsiStrategy.cs
+++ b/API/1888_Genie_Stoch_RSI/CS/GenieStochRsiStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1889_Analyze_History/CS/AnalyzeHistoryStrategy.cs
+++ b/API/1889_Analyze_History/CS/AnalyzeHistoryStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1890_RoNz_Auto_SL_TS_TP/CS/RoNzAutoSlTsTpStrategy.cs
+++ b/API/1890_RoNz_Auto_SL_TS_TP/CS/RoNzAutoSlTsTpStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1891_2pbIdealXOSMA/CS/TwoPbIdealXosmaStrategy.cs
+++ b/API/1891_2pbIdealXOSMA/CS/TwoPbIdealXosmaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1892_Auto_Pending_By_RSI/CS/AutoPendingByRsiStrategy.cs
+++ b/API/1892_Auto_Pending_By_RSI/CS/AutoPendingByRsiStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1893_EA_Template/CS/EaTemplateStrategy.cs
+++ b/API/1893_EA_Template/CS/EaTemplateStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1894_Liquidex_Keltner/CS/LiquidexKeltnerStrategy.cs
+++ b/API/1894_Liquidex_Keltner/CS/LiquidexKeltnerStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1895_Renko_Live_Charts_Pimped/CS/RenkoLiveChartsPimpedStrategy.cs
+++ b/API/1895_Renko_Live_Charts_Pimped/CS/RenkoLiveChartsPimpedStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
@@ -216,4 +222,3 @@ public class RenkoLiveChartsPimpedStrategy : Strategy
 		_hasPrev = true;
 	}
 }
-

--- a/API/1896_Double_Trading/CS/DoubleTradingStrategy.cs
+++ b/API/1896_Double_Trading/CS/DoubleTradingStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1897_ExpOracle/CS/ExpOracleStrategy.cs
+++ b/API/1897_ExpOracle/CS/ExpOracleStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1898_Roboti_ADX_Profit/CS/RobotiAdxProfitStrategy.cs
+++ b/API/1898_Roboti_ADX_Profit/CS/RobotiAdxProfitStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1899_AdaptiveRenko/CS/AdaptiveRenkoStrategy.cs
+++ b/API/1899_AdaptiveRenko/CS/AdaptiveRenkoStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1900_JBrainUltraRsi/CS/JBrainUltraRsiStrategy.cs
+++ b/API/1900_JBrainUltraRsi/CS/JBrainUltraRsiStrategy.cs
@@ -1,6 +1,11 @@
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1901_Coensio_Swing_Trader_V06/CS/CoensioSwingTraderV06Strategy.cs
+++ b/API/1901_Coensio_Swing_Trader_V06/CS/CoensioSwingTraderV06Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -208,4 +213,3 @@ public class CoensioSwingTraderV06Strategy : Strategy
 		}
 	}
 }
-

--- a/API/1902_Exp_Candles_XSmoothed/CS/ExpCandlesXSmoothedStrategy.cs
+++ b/API/1902_Exp_Candles_XSmoothed/CS/ExpCandlesXSmoothedStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1903_Spread_Info/CS/SpreadInfoStrategy.cs
+++ b/API/1903_Spread_Info/CS/SpreadInfoStrategy.cs
@@ -1,6 +1,15 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1904_Bleris/CS/BlerisStrategy.cs
+++ b/API/1904_Bleris/CS/BlerisStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;
@@ -132,4 +145,3 @@ public class BlerisStrategy : Strategy
 	_lastSellPrice = price;
 }
 }
-

--- a/API/1905_Stufic_Stoch/CS/StuficStochStrategy.cs
+++ b/API/1905_Stufic_Stoch/CS/StuficStochStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
@@ -237,4 +244,3 @@ public class StuficStochStrategy : Strategy
 		_prevD = d;
 	}
 }
-

--- a/API/1906_Auto_Trailing_Stop/CS/AutoTrailingStopStrategy.cs
+++ b/API/1906_Auto_Trailing_Stop/CS/AutoTrailingStopStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1907_Malr_Channel_Breakout/CS/MalrChannelBreakoutStrategy.cs
+++ b/API/1907_Malr_Channel_Breakout/CS/MalrChannelBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1908_Random_Trailing_Stop/CS/RandomTrailingStopStrategy.cs
+++ b/API/1908_Random_Trailing_Stop/CS/RandomTrailingStopStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
@@ -170,4 +176,3 @@ public class RandomTrailingStopStrategy : Strategy
 			return rnd == 1 ? Sides.Buy : Sides.Sell;
 	}
 }
-

--- a/API/1909_SmartAssTrade_V2/CS/SmartAssTradeV2Strategy.cs
+++ b/API/1909_SmartAssTrade_V2/CS/SmartAssTradeV2Strategy.cs
@@ -1,12 +1,18 @@
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1910_Knux_Multi_Indicator/CS/KnuxStrategy.cs
+++ b/API/1910_Knux_Multi_Indicator/CS/KnuxStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1911_Exp_MAMA/CS/ExpMamaStrategy.cs
+++ b/API/1911_Exp_MAMA/CS/ExpMamaStrategy.cs
@@ -1,5 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1912_Auto_SLTP_Setter/CS/AutoSlTpSetterStrategy.cs
+++ b/API/1912_Auto_SLTP_Setter/CS/AutoSlTpSetterStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1913_Fibo_Stop/CS/FiboStopStrategy.cs
+++ b/API/1913_Fibo_Stop/CS/FiboStopStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1914_RMACD_Reversal/CS/RmacdReversalStrategy.cs
+++ b/API/1914_RMACD_Reversal/CS/RmacdReversalStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1915_Kolier_SuperTrend/CS/KolierSuperTrendStrategy.cs
+++ b/API/1915_Kolier_SuperTrend/CS/KolierSuperTrendStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1916_Order_Expert/CS/OrderExpertStrategy.cs
+++ b/API/1916_Order_Expert/CS/OrderExpertStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
@@ -219,4 +225,3 @@ public class OrderExpertStrategy : Strategy
 		}
 	}
 }
-

--- a/API/1918_Trend_Collector/CS/TrendCollectorStrategy.cs
+++ b/API/1918_Trend_Collector/CS/TrendCollectorStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1919_Murrey_BBand_Stochastic/CS/MurreyBBandStochasticStrategy.cs
+++ b/API/1919_Murrey_BBand_Stochastic/CS/MurreyBBandStochasticStrategy.cs
@@ -1,6 +1,11 @@
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1920_ZPF_Filter/CS/ZpfStrategy.cs
+++ b/API/1920_ZPF_Filter/CS/ZpfStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1921_Trailing_Stop_EA/CS/TrailingStopEAStrategy.cs
+++ b/API/1921_Trailing_Stop_EA/CS/TrailingStopEAStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1922_Exp_MA_Rounding_Channel/CS/ExpMaRoundingChannelStrategy.cs
+++ b/API/1922_Exp_MA_Rounding_Channel/CS/ExpMaRoundingChannelStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1923_RoNz_Rapid_Fire/CS/RoNzRapidFireStrategy.cs
+++ b/API/1923_RoNz_Rapid_Fire/CS/RoNzRapidFireStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1925_FMOne_Scalping/CS/FmOneScalpingStrategy.cs
+++ b/API/1925_FMOne_Scalping/CS/FmOneScalpingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1926_Ilan_Dynamic_HT/CS/IlanDynamicHtStrategy.cs
+++ b/API/1926_Ilan_Dynamic_HT/CS/IlanDynamicHtStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1927_Knux_Martingale/CS/KnuxMartingaleStrategy.cs
+++ b/API/1927_Knux_Martingale/CS/KnuxMartingaleStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -174,4 +179,3 @@ public class KnuxMartingaleStrategy : Strategy
 		}
 	}
 }
-

--- a/API/1928_Exp_TrendValue/CS/ExpTrendValueStrategy.cs
+++ b/API/1928_Exp_TrendValue/CS/ExpTrendValueStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1929_Trailing_Stop/CS/TrailingStopStrategy.cs
+++ b/API/1929_Trailing_Stop/CS/TrailingStopStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
@@ -157,4 +163,3 @@ public class TrailingStopStrategy : Strategy
 		}
 	}
 }
-

--- a/API/1931_SVM_Trader/CS/SvmTraderStrategy.cs
+++ b/API/1931_SVM_Trader/CS/SvmTraderStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1932_Hybrid_Scalper/CS/HybridScalperStrategy.cs
+++ b/API/1932_Hybrid_Scalper/CS/HybridScalperStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1933_Simple_MA_ADX_EA/CS/SimpleMaAdxEaStrategy.cs
+++ b/API/1933_Simple_MA_ADX_EA/CS/SimpleMaAdxEaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -194,4 +199,3 @@ public class SimpleMaAdxEaStrategy : Strategy
 		}
 	}
 }
-

--- a/API/1934_Linear_Regression_Slope_Trigger/CS/LinearRegressionSlopeTriggerStrategy.cs
+++ b/API/1934_Linear_Regression_Slope_Trigger/CS/LinearRegressionSlopeTriggerStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1935_Vortex_Indicator_Cross/CS/VortexIndicatorCrossStrategy.cs
+++ b/API/1935_Vortex_Indicator_Cross/CS/VortexIndicatorCrossStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1936_Exp_Extremum/CS/ExpExtremumStrategy.cs
+++ b/API/1936_Exp_Extremum/CS/ExpExtremumStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1937_Syndicate_Trader/CS/SyndicateTraderStrategy.cs
+++ b/API/1937_Syndicate_Trader/CS/SyndicateTraderStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1938_Range_EA/CS/RangeEaStrategy.cs
+++ b/API/1938_Range_EA/CS/RangeEaStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;
@@ -338,4 +351,3 @@ public class RangeEaStrategy : Strategy
 		}
 	}
 }
-

--- a/API/1939_Ultra_WPR_Cross/CS/UltraWprCrossStrategy.cs
+++ b/API/1939_Ultra_WPR_Cross/CS/UltraWprCrossStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1940_CSPA_143/CS/Cspa143Strategy.cs
+++ b/API/1940_CSPA_143/CS/Cspa143Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1941_MPM/CS/MpmStrategy.cs
+++ b/API/1941_MPM/CS/MpmStrategy.cs
@@ -1,6 +1,11 @@
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1942_Close_By_Equity_Percent/CS/CloseByEquityPercentStrategy.cs
+++ b/API/1942_Close_By_Equity_Percent/CS/CloseByEquityPercentStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1943_Back_To_The_Future/CS/BackToTheFutureStrategy.cs
+++ b/API/1943_Back_To_The_Future/CS/BackToTheFutureStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1944_AnchoredMomentum/CS/AnchoredMomentumStrategy.cs
+++ b/API/1944_AnchoredMomentum/CS/AnchoredMomentumStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1946_Fisher_Cyber_Cycle/CS/FisherCyberCycleStrategy.cs
+++ b/API/1946_Fisher_Cyber_Cycle/CS/FisherCyberCycleStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -243,4 +248,3 @@ public class FisherCyberCycleValue : ComplexIndicatorValue
 	/// </summary>
 	public decimal Trigger => (decimal)GetValue(nameof(Trigger));
 }
-

--- a/API/1947_Range_Expansion_Index/CS/RangeExpansionIndexStrategy.cs
+++ b/API/1947_Range_Expansion_Index/CS/RangeExpansionIndexStrategy.cs
@@ -1,4 +1,17 @@
 
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1948_GG_RSI_CCI/CS/GgRsiCciStrategy.cs
+++ b/API/1948_GG_RSI_CCI/CS/GgRsiCciStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1949_OzymandiaTrend/CS/OzymandiasStrategy.cs
+++ b/API/1949_OzymandiaTrend/CS/OzymandiasStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1950_Elder_Impulse_System/CS/ElderImpulseSystemStrategy.cs
+++ b/API/1950_Elder_Impulse_System/CS/ElderImpulseSystemStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1951_Modified_Optimum_Elliptic_Filter/CS/ModifiedOptimumEllipticFilterStrategy.cs
+++ b/API/1951_Modified_Optimum_Elliptic_Filter/CS/ModifiedOptimumEllipticFilterStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1952_DSS_Bressert/CS/DssBressertStrategy.cs
+++ b/API/1952_DSS_Bressert/CS/DssBressertStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1953_UltraFatl/CS/UltraFatlStrategy.cs
+++ b/API/1953_UltraFatl/CS/UltraFatlStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1954_Exp_Leading/CS/ExpLeadingStrategy.cs
+++ b/API/1954_Exp_Leading/CS/ExpLeadingStrategy.cs
@@ -1,9 +1,17 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/1955_Exp_HLRSign/CS/ExpHlrSignStrategy.cs
+++ b/API/1955_Exp_HLRSign/CS/ExpHlrSignStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;
@@ -249,4 +262,3 @@ public class ExpHlrSignStrategy : Strategy
 		_previousHlr = hlr;
 	}
 }
-

--- a/API/1956_FatlSatlOsma/CS/FatlSatlOsmaStrategy.cs
+++ b/API/1956_FatlSatlOsma/CS/FatlSatlOsmaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -105,4 +110,3 @@ public class FatlSatlOsmaStrategy : Strategy
 		_prev1 = val;
 	}
 }
-

--- a/API/1957_Simple_Trading_System/CS/SimpleTradingSystemStrategy.cs
+++ b/API/1957_Simple_Trading_System/CS/SimpleTradingSystemStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1958_Trendless_AG_Hist/CS/TrendlessAgHistStrategy.cs
+++ b/API/1958_Trendless_AG_Hist/CS/TrendlessAgHistStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1959_NRatio_Sign/CS/NRatioSignStrategy.cs
+++ b/API/1959_NRatio_Sign/CS/NRatioSignStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1960_Trendline_Alert/CS/TrendlineAlertStrategy.cs
+++ b/API/1960_Trendline_Alert/CS/TrendlineAlertStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1961_Auto_KD_Crossover/CS/AutoKdStrategy.cs
+++ b/API/1961_Auto_KD_Crossover/CS/AutoKdStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1962_AFL_Winner_Sign/CS/AflWinnerSignStrategy.cs
+++ b/API/1962_AFL_Winner_Sign/CS/AflWinnerSignStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1963_Risk_Manager/CS/RiskManagerStrategy.cs
+++ b/API/1963_Risk_Manager/CS/RiskManagerStrategy.cs
@@ -1,5 +1,12 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1964_XMA_Ichimoku_Channel/CS/XmaIchimokuChannelStrategy.cs
+++ b/API/1964_XMA_Ichimoku_Channel/CS/XmaIchimokuChannelStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1965_ForexProfitBoost/CS/ForexProfitBoostStrategy.cs
+++ b/API/1965_ForexProfitBoost/CS/ForexProfitBoostStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -222,4 +227,3 @@ public class ForexProfitBoostStrategy : Strategy
 		}
 	}
 }
-

--- a/API/1967_ExpXmaRangeBands/CS/ExpXmaRangeBandsStrategy.cs
+++ b/API/1967_ExpXmaRangeBands/CS/ExpXmaRangeBandsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1968_Smoothing_Average/CS/SmoothingAverageStrategy.cs
+++ b/API/1968_Smoothing_Average/CS/SmoothingAverageStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1969_Asimmetric_Stoch_NR/CS/AsimmetricStochNrStrategy.cs
+++ b/API/1969_Asimmetric_Stoch_NR/CS/AsimmetricStochNrStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
@@ -291,4 +297,3 @@ public class AsimmetricStochNrStrategy : Strategy
 		_prevD = d;
 	}
 }
-

--- a/API/1971_ADX_Crossing/CS/AdxCrossingStrategy.cs
+++ b/API/1971_ADX_Crossing/CS/AdxCrossingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -217,4 +222,3 @@ public class AdxCrossingStrategy : Strategy
 		_prevMinusDi = minusDi;
 	}
 }
-

--- a/API/1972_Stop_Level_Counter/CS/StopLevelCounterStrategy.cs
+++ b/API/1972_Stop_Level_Counter/CS/StopLevelCounterStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1973_Angrybird_xScalpingn/CS/AngrybirdXScalpingnStrategy.cs
+++ b/API/1973_Angrybird_xScalpingn/CS/AngrybirdXScalpingnStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1974_Jpalonso_Modoki/CS/JpalonsoModokiStrategy.cs
+++ b/API/1974_Jpalonso_Modoki/CS/JpalonsoModokiStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;
@@ -151,4 +164,3 @@ public class JpalonsoModokiStrategy : Strategy
 		}
 	}
 }
-

--- a/API/1975_Parallel_Strategies/CS/ParallelStrategiesStrategy.cs
+++ b/API/1975_Parallel_Strategies/CS/ParallelStrategiesStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1976_Exp_3XMA_Ishimoku/CS/Exp3XmaIshimokuStrategy.cs
+++ b/API/1976_Exp_3XMA_Ishimoku/CS/Exp3XmaIshimokuStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1977_ADX_Smoothed_Cross/CS/AdxSmoothedCrossStrategy.cs
+++ b/API/1977_ADX_Smoothed_Cross/CS/AdxSmoothedCrossStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1979_Grid_Trading/CS/GridStrategy.cs
+++ b/API/1979_Grid_Trading/CS/GridStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1980_Adaptive_Market_Level/CS/AdaptiveMarketLevelStrategy.cs
+++ b/API/1980_Adaptive_Market_Level/CS/AdaptiveMarketLevelStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1981_ColorNonLagDotMACD/CS/ColorNonLagDotMacdStrategy.cs
+++ b/API/1981_ColorNonLagDotMACD/CS/ColorNonLagDotMacdStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -310,4 +315,3 @@ public class ColorNonLagDotMacdStrategy : Strategy
 	    _prevSignal = signal;
 	}
 }
-

--- a/API/1982_Color_METRO/CS/ColorMetroStrategy.cs
+++ b/API/1982_Color_METRO/CS/ColorMetroStrategy.cs
@@ -1,6 +1,11 @@
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1983_Aeron_JJN/CS/AeronJjnStrategy.cs
+++ b/API/1983_Aeron_JJN/CS/AeronJjnStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1984_BlauTvi/CS/BlauTviStrategy.cs
+++ b/API/1984_BlauTvi/CS/BlauTviStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1985_XRVI_Crossover/CS/XrviCrossoverStrategy.cs
+++ b/API/1985_XRVI_Crossover/CS/XrviCrossoverStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1986_Four_Screens/CS/FourScreensStrategy.cs
+++ b/API/1986_Four_Screens/CS/FourScreensStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1987_Color_Step_Xccx/CS/ColorStepXccxStrategy.cs
+++ b/API/1987_Color_Step_Xccx/CS/ColorStepXccxStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1988_SuperTake/CS/SuperTakeStrategy.cs
+++ b/API/1988_SuperTake/CS/SuperTakeStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1989_Trailing_Stop/CS/TrailingStopStrategy.cs
+++ b/API/1989_Trailing_Stop/CS/TrailingStopStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/1990_Color_J_Variation/CS/ColorJVariationStrategy.cs
+++ b/API/1990_Color_J_Variation/CS/ColorJVariationStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1991_Binario_31/CS/Binario31Strategy.cs
+++ b/API/1991_Binario_31/CS/Binario31Strategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1992_Exp_MovingAverage_FN/CS/ExpMovingAverageFnStrategy.cs
+++ b/API/1992_Exp_MovingAverage_FN/CS/ExpMovingAverageFnStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1993_Lacust_Stop_and_BE/CS/LacustStopAndBeStrategy.cs
+++ b/API/1993_Lacust_Stop_and_BE/CS/LacustStopAndBeStrategy.cs
@@ -1,6 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1994_Heiken_Ashi_No_Wick/CS/HeikenAshiNoWickStrategy.cs
+++ b/API/1994_Heiken_Ashi_No_Wick/CS/HeikenAshiNoWickStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/1995_Color_ZeroLag_MA/CS/ColorZeroLagMaStrategy.cs
+++ b/API/1995_Color_ZeroLag_MA/CS/ColorZeroLagMaStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/1996_Color_Zerolag_RVI/CS/ColorZerolagRviStrategy.cs
+++ b/API/1996_Color_Zerolag_RVI/CS/ColorZerolagRviStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1997_ColorZerolagTrix/CS/ColorZerolagTrixStrategy.cs
+++ b/API/1997_ColorZerolagTrix/CS/ColorZerolagTrixStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
@@ -303,4 +310,3 @@ _prevFast = fast;
 _prevSlow = _slowLine;
 }
 }
-

--- a/API/1998_Center_Of_Gravity_OSMA/CS/CenterOfGravityOsmaStrategy.cs
+++ b/API/1998_Center_Of_Gravity_OSMA/CS/CenterOfGravityOsmaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/1999_Color_Zerolag_TriX_OSMA/CS/ColorZerolagTrixOsmaStrategy.cs
+++ b/API/1999_Color_Zerolag_TriX_OSMA/CS/ColorZerolagTrixOsmaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2000_HFT_Spreader_for_FORTS/CS/HftSpreaderForFortsStrategy.cs
+++ b/API/2000_HFT_Spreader_for_FORTS/CS/HftSpreaderForFortsStrategy.cs
@@ -1,5 +1,12 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;


### PR DESCRIPTION
## Summary
- add the required System, Ecng, and StockSharp using directives to every C# strategy in the API folders numbered 1001 through 2000

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d80946c07083239dcb524712221f1b