### PR TITLE
Add missing using directives to API strategies 2001-3000

### DIFF
--- a/API/2001_Color_Zerolag_RSI_OSMA/CS/ColorZerolagRsiOsmaStrategy.cs
+++ b/API/2001_Color_Zerolag_RSI_OSMA/CS/ColorZerolagRsiOsmaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2002_WellMartin/CS/WellMartinStrategy.cs
+++ b/API/2002_WellMartin/CS/WellMartinStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2003_Calc_Profit_Loss_On_LinePrice/CS/CalcProfitLossOnLinePriceStrategy.cs
+++ b/API/2003_Calc_Profit_Loss_On_LinePrice/CS/CalcProfitLossOnLinePriceStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2004_Color_Zerolag_Momentum_OSMA/CS/ColorZerolagMomentumOsmaStrategy.cs
+++ b/API/2004_Color_Zerolag_Momentum_OSMA/CS/ColorZerolagMomentumOsmaStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2005_OsHma_Breakdown_Twist/CS/OsHmaStrategy.cs
+++ b/API/2005_OsHma_Breakdown_Twist/CS/OsHmaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -210,4 +215,3 @@ public class OsHmaStrategy : Strategy
 	_prevValue = current;
 	}
 }
-

--- a/API/2006_Color_Zerolag_X10_Ma/CS/ColorZerolagX10MaStrategy.cs
+++ b/API/2006_Color_Zerolag_X10_Ma/CS/ColorZerolagX10MaStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2007_ColorJMomentum/CS/ColorJMomentumStrategy.cs
+++ b/API/2007_ColorJMomentum/CS/ColorJMomentumStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2008_Color_JLaguerre/CS/ColorJLaguerreStrategy.cs
+++ b/API/2008_Color_JLaguerre/CS/ColorJLaguerreStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2009_Color_Stoch_NR/CS/ColorStochNrStrategy.cs
+++ b/API/2009_Color_Stoch_NR/CS/ColorStochNrStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2010_ColorMaRsi_Trigger/CS/ColorMaRsiTriggerStrategy.cs
+++ b/API/2010_ColorMaRsi_Trigger/CS/ColorMaRsiTriggerStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2011_Escort_Trend/CS/EscortTrendStrategy.cs
+++ b/API/2011_Escort_Trend/CS/EscortTrendStrategy.cs
@@ -1,9 +1,16 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 /// <summary>
 /// Escort Trend strategy combining WMA crossover with MACD and CCI confirmation.

--- a/API/2012_Random_Trader/CS/RandomTraderStrategy.cs
+++ b/API/2012_Random_Trader/CS/RandomTraderStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2013_Mava_Xonax/CS/MavaXonaxStrategy.cs
+++ b/API/2013_Mava_Xonax/CS/MavaXonaxStrategy.cs
@@ -1,4 +1,10 @@
+using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2014_ColorSchaffMfiTrendCycle/CS/ColorSchaffMfiTrendCycleStrategy.cs
+++ b/API/2014_ColorSchaffMfiTrendCycle/CS/ColorSchaffMfiTrendCycleStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2015_Color_Schaff_Momentum_Trend_Cycle/CS/ColorSchaffMomentumTrendCycleStrategy.cs
+++ b/API/2015_Color_Schaff_Momentum_Trend_Cycle/CS/ColorSchaffMomentumTrendCycleStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;
@@ -209,4 +222,3 @@ public class ColorSchaffMomentumTrendCycleStrategy : Strategy
 		_prevStc = stc;
 	}
 }
-

--- a/API/2016_ColorSchaffRsiTrendCycle/CS/ColorSchaffRsiTrendCycleStrategy.cs
+++ b/API/2016_ColorSchaffRsiTrendCycle/CS/ColorSchaffRsiTrendCycleStrategy.cs
@@ -1,9 +1,14 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2017_ColorMomentum_Ama/CS/ColorMomentumAmaStrategy.cs
+++ b/API/2017_ColorMomentum_Ama/CS/ColorMomentumAmaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2018_ColorSchaffRVITrendCycle/CS/ColorSchaffRviTrendCycleStrategy.cs
+++ b/API/2018_ColorSchaffRVITrendCycle/CS/ColorSchaffRviTrendCycleStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2019_Color_SchaffTrix_Trend_Cycle/CS/ColorSchaffTrixTrendCycleStrategy.cs
+++ b/API/2019_Color_SchaffTrix_Trend_Cycle/CS/ColorSchaffTrixTrendCycleStrategy.cs
@@ -1,9 +1,17 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2020_Color_Schaff_WPR_Trend_Cycle/CS/ColorSchaffWprTrendCycleStrategy.cs
+++ b/API/2020_Color_Schaff_WPR_Trend_Cycle/CS/ColorSchaffWprTrendCycleStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2021_News_Hour_Trade/CS/NewsHourTradeStrategy.cs
+++ b/API/2021_News_Hour_Trade/CS/NewsHourTradeStrategy.cs
@@ -1,5 +1,12 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2022_Color_XXDPO/CS/ColorXXDPOStrategy.cs
+++ b/API/2022_Color_XXDPO/CS/ColorXXDPOStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2023_ColorXdinMA/CS/ColorXdinMAStrategy.cs
+++ b/API/2023_ColorXdinMA/CS/ColorXdinMAStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2024_ExpMartinV2/CS/ExpMartinV2Strategy.cs
+++ b/API/2024_ExpMartinV2/CS/ExpMartinV2Strategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2025_Coppock_Histogram/CS/CoppockHistogramStrategy.cs
+++ b/API/2025_Coppock_Histogram/CS/CoppockHistogramStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2026_Cronex_CCI/CS/CronexCciStrategy.cs
+++ b/API/2026_Cronex_CCI/CS/CronexCciStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2027_Exp_CyclePeriod/CS/ExpCyclePeriodStrategy.cs
+++ b/API/2027_Exp_CyclePeriod/CS/ExpCyclePeriodStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2028_Color_LeMan_Trend/CS/ColorLemanTrendStrategy.cs
+++ b/API/2028_Color_LeMan_Trend/CS/ColorLemanTrendStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2029_DiNapoli_Stochastic/CS/DiNapoliStochasticStrategy.cs
+++ b/API/2029_DiNapoli_Stochastic/CS/DiNapoliStochasticStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2030_ColorTrend_CF/CS/ColorTrendCfStrategy.cs
+++ b/API/2030_ColorTrend_CF/CS/ColorTrendCfStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2031_DigVariation/CS/DigVariationStrategy.cs
+++ b/API/2031_DigVariation/CS/DigVariationStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
@@ -154,4 +161,3 @@ public class DigVariationStrategy : Strategy
 		_prev = smaValue;
 	}
 }
-

--- a/API/2032_Previous_HighLow_Breakout/CS/PreviousHighLowBreakoutStrategy.cs
+++ b/API/2032_Previous_HighLow_Breakout/CS/PreviousHighLowBreakoutStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
@@ -139,4 +145,3 @@ public class PreviousHighLowBreakoutStrategy : Strategy
 		_previousLow = candle.LowPrice;
 	}
 }
-

--- a/API/2033_Ema_Crossover_Signal/CS/EmaCrossoverSignalStrategy.cs
+++ b/API/2033_Ema_Crossover_Signal/CS/EmaCrossoverSignalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2034_Ema_Prediction/CS/EmaPredictionStrategy.cs
+++ b/API/2034_Ema_Prediction/CS/EmaPredictionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2035_Personal_Assistant/CS/PersonalAssistantStrategy.cs
+++ b/API/2035_Personal_Assistant/CS/PersonalAssistantStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2036_Ergodic_Ticks_Volume_Indicator/CS/ErgodicTicksVolumeIndicatorStrategy.cs
+++ b/API/2036_Ergodic_Ticks_Volume_Indicator/CS/ErgodicTicksVolumeIndicatorStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2037_Ergodic_Ticks_Volume_OSMA/CS/ErgodicTicksVolumeOsmaStrategy.cs
+++ b/API/2037_Ergodic_Ticks_Volume_OSMA/CS/ErgodicTicksVolumeOsmaStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2038_MovingUp_MA/CS/MovingUpStrategy.cs
+++ b/API/2038_MovingUp_MA/CS/MovingUpStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2039_Fast2_Crossover/CS/Fast2CrossoverStrategy.cs
+++ b/API/2039_Fast2_Crossover/CS/Fast2CrossoverStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 // Fast2CrossoverStrategy.cs
 // -----------------------------------------------------------------------------
 // Implements crossover trading based on the Fast2 indicator.

--- a/API/2040_Personal_Assistant/CS/PersonalAssistantStrategy.cs
+++ b/API/2040_Personal_Assistant/CS/PersonalAssistantStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2041_RSI_EA/CS/RsiEaStrategy.cs
+++ b/API/2041_RSI_EA/CS/RsiEaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2042_Fatl_Macd/CS/FatlMacdStrategy.cs
+++ b/API/2042_Fatl_Macd/CS/FatlMacdStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2043_Fine_Tuning_MA/CS/FineTuningMaStrategy.cs
+++ b/API/2043_Fine_Tuning_MA/CS/FineTuningMaStrategy.cs
@@ -1,9 +1,15 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
-using System;
-using System.Collections.Generic;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2044_CorrectedAverage_Breakout/CS/CorrectedAverageBreakoutStrategy.cs
+++ b/API/2044_CorrectedAverage_Breakout/CS/CorrectedAverageBreakoutStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2045_Force_DiverSign/CS/ForceDiverSignStrategy.cs
+++ b/API/2045_Force_DiverSign/CS/ForceDiverSignStrategy.cs
@@ -1,9 +1,16 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 /// <summary>
 /// Force DiverSign strategy.

--- a/API/2046_Forecast_Oscillator/CS/ForecastOscillatorStrategy.cs
+++ b/API/2046_Forecast_Oscillator/CS/ForecastOscillatorStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2047_Forex_Fraus_4_For_M1s/CS/ForexFraus4ForM1sStrategy.cs
+++ b/API/2047_Forex_Fraus_4_For_M1s/CS/ForexFraus4ForM1sStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2048_Fractal_Ama_Mbk/CS/FractalAmaMbkStrategy.cs
+++ b/API/2048_Fractal_Ama_Mbk/CS/FractalAmaMbkStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2049_VininI_Trend/CS/VininITrendStrategy.cs
+++ b/API/2049_VininI_Trend/CS/VininITrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2050_VininI_Trend_LRMA/CS/VininITrendLrmaStrategy.cs
+++ b/API/2050_VininI_Trend_LRMA/CS/VininITrendLrmaStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2051_Trend_Catcher/CS/TrendCatcherStrategy.cs
+++ b/API/2051_Trend_Catcher/CS/TrendCatcherStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2052_Negative_Spread/CS/NegativeSpreadStrategy.cs
+++ b/API/2052_Negative_Spread/CS/NegativeSpreadStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2053_Schnick_Demo/CS/SchnickDemoStrategy.cs
+++ b/API/2053_Schnick_Demo/CS/SchnickDemoStrategy.cs
@@ -1,6 +1,15 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2054_Color_HMA_Reversal/CS/ColorHmaReversalStrategy.cs
+++ b/API/2054_Color_HMA_Reversal/CS/ColorHmaReversalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2055_HVR/CS/HvrStrategy.cs
+++ b/API/2055_HVR/CS/HvrStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2056_DecEMA/CS/DecEmaStrategy.cs
+++ b/API/2056_DecEMA/CS/DecEmaStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2057_BandsPrice/CS/BandsPriceStrategy.cs
+++ b/API/2057_BandsPrice/CS/BandsPriceStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2058_KlPrice_Reversal/CS/KlPriceReversalStrategy.cs
+++ b/API/2058_KlPrice_Reversal/CS/KlPriceReversalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2059_Simple_Trailing_Stop/CS/SimpleTrailingStopStrategy.cs
+++ b/API/2059_Simple_Trailing_Stop/CS/SimpleTrailingStopStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
@@ -97,4 +103,3 @@ public class SimpleTrailingStopStrategy : Strategy
 		}
 	}
 }
-

--- a/API/2060_Order_Time_Alert/CS/OrderTimeAlertStrategy.cs
+++ b/API/2060_Order_Time_Alert/CS/OrderTimeAlertStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2061_I_Trend/CS/ITrendStrategy.cs
+++ b/API/2061_I_Trend/CS/ITrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2062_Anchored_Momentum/CS/AnchoredMomentumStrategy.cs
+++ b/API/2062_Anchored_Momentum/CS/AnchoredMomentumStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2063_Ichimoku_Oscillator/CS/IchimokuOscillatorStrategy.cs
+++ b/API/2063_Ichimoku_Oscillator/CS/IchimokuOscillatorStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2064_Hull_Trend_OSMA/CS/HullTrendOsmaStrategy.cs
+++ b/API/2064_Hull_Trend_OSMA/CS/HullTrendOsmaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2065_Color_Zerolag_HLR/CS/ColorZerolagHlrStrategy.cs
+++ b/API/2065_Color_Zerolag_HLR/CS/ColorZerolagHlrStrategy.cs
@@ -1,8 +1,13 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 

--- a/API/2066_AMMA_Trend/CS/AmmaTrendStrategy.cs
+++ b/API/2066_AMMA_Trend/CS/AmmaTrendStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2067_Puria/CS/PuriaStrategy.cs
+++ b/API/2067_Puria/CS/PuriaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2068_Traffic_Light/CS/TrafficLightStrategy.cs
+++ b/API/2068_Traffic_Light/CS/TrafficLightStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2070_RSI_Expert/CS/RsiExpertStrategy.cs
+++ b/API/2070_RSI_Expert/CS/RsiExpertStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -194,4 +199,3 @@ public class RsiExpertStrategy : Strategy
 		_prevRsi = rsiValue;
 	}
 }
-

--- a/API/2071_Daily_Breakpoint/CS/DailyBreakpointStrategy.cs
+++ b/API/2071_Daily_Breakpoint/CS/DailyBreakpointStrategy.cs
@@ -1,4 +1,12 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2072_InstantaneousTrendFilter/CS/InstantaneousTrendFilterStrategy.cs
+++ b/API/2072_InstantaneousTrendFilter/CS/InstantaneousTrendFilterStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2073_ColorXADX/CS/ColorXAdxStrategy.cs
+++ b/API/2073_ColorXADX/CS/ColorXAdxStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -178,4 +183,3 @@ public class ColorXAdxStrategy : Strategy
 		_prevMinusDi = minusDi;
 	}
 }
-

--- a/API/2074_ColorSchaffJJRSXTrendCycle/CS/ColorSchaffJjrsxTrendCycleStrategy.cs
+++ b/API/2074_ColorSchaffJJRSXTrendCycle/CS/ColorSchaffJjrsxTrendCycleStrategy.cs
@@ -1,6 +1,14 @@
 using System;
-using StockSharp.Algo.Strategies;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2075_Virtual_Trailing_Stop/CS/VirtualTrailingStopStrategy.cs
+++ b/API/2075_Virtual_Trailing_Stop/CS/VirtualTrailingStopStrategy.cs
@@ -1,10 +1,15 @@
-
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2076_ColorZerolagJJRSX/CS/ColorZerolagJjrsxStrategy.cs
+++ b/API/2076_ColorZerolagJJRSX/CS/ColorZerolagJjrsxStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -214,4 +220,3 @@ public class ColorZerolagJjrsxStrategy : Strategy
 		_prevSlow = slow;
 	}
 }
-

--- a/API/2077_Bill_Williams/CS/BillWilliamsStrategy.cs
+++ b/API/2077_Bill_Williams/CS/BillWilliamsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2079_Color_Zerolag_JCCX/CS/ColorZerolagJccxStrategy.cs
+++ b/API/2079_Color_Zerolag_JCCX/CS/ColorZerolagJccxStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2080_ColorSchaffJCCX_Trend_Cycle/CS/ColorSchaffJccxTrendCycleStrategy.cs
+++ b/API/2080_ColorSchaffJCCX_Trend_Cycle/CS/ColorSchaffJccxTrendCycleStrategy.cs
@@ -1,6 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2081_EF_Distance/CS/EfDistanceStrategy.cs
+++ b/API/2081_EF_Distance/CS/EfDistanceStrategy.cs
@@ -1,6 +1,10 @@
-
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2082_Kalman_Filter_Signal/CS/KalmanFilterSignalStrategy.cs
+++ b/API/2082_Kalman_Filter_Signal/CS/KalmanFilterSignalStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2083_Volatile_Action/CS/VolatileActionStrategy.cs
+++ b/API/2083_Volatile_Action/CS/VolatileActionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2084_Basic_Trailing_Stop/CS/BasicTrailingStopStrategy.cs
+++ b/API/2084_Basic_Trailing_Stop/CS/BasicTrailingStopStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2085_Rijfie_Pyramid/CS/RijfiePyramidStrategy.cs
+++ b/API/2085_Rijfie_Pyramid/CS/RijfiePyramidStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2086_Derivative_Zero_Cross/CS/DerivativeZeroCrossStrategy.cs
+++ b/API/2086_Derivative_Zero_Cross/CS/DerivativeZeroCrossStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2087_Exp_Multitrend_Signal_Kvn/CS/ExpMultitrendSignalKvnStrategy.cs
+++ b/API/2087_Exp_Multitrend_Signal_Kvn/CS/ExpMultitrendSignalKvnStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2088_KPrmSt_Cross/CS/KPrmStCrossStrategy.cs
+++ b/API/2088_KPrmSt_Cross/CS/KPrmStCrossStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2090_Instant_Execution/CS/InstantExecutionStrategy.cs
+++ b/API/2090_Instant_Execution/CS/InstantExecutionStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2091_Robust_EA_Template/CS/RobustEaTemplateStrategy.cs
+++ b/API/2091_Robust_EA_Template/CS/RobustEaTemplateStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2092_Tema_Custom_Slope/CS/TemaCustomSlopeStrategy.cs
+++ b/API/2092_Tema_Custom_Slope/CS/TemaCustomSlopeStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2093_XDerivative/CS/XDerivativeStrategy.cs
+++ b/API/2093_XDerivative/CS/XDerivativeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2094_RSI_Stochastic_MA/CS/RsiStochasticMaStrategy.cs
+++ b/API/2094_RSI_Stochastic_MA/CS/RsiStochasticMaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2095_XKRI_Histogram/CS/XkriHistogramStrategy.cs
+++ b/API/2095_XKRI_Histogram/CS/XkriHistogramStrategy.cs
@@ -1,9 +1,17 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2096_Breakout_Bars_Trend/CS/BreakoutBarsTrendStrategy.cs
+++ b/API/2096_Breakout_Bars_Trend/CS/BreakoutBarsTrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2097_Laguerre_Filter/CS/LaguerreFilterStrategy.cs
+++ b/API/2097_Laguerre_Filter/CS/LaguerreFilterStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2098_Millenium_Code/CS/MilleniumCodeStrategy.cs
+++ b/API/2098_Millenium_Code/CS/MilleniumCodeStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2099_Laguerre_ADX/CS/LaguerreAdxStrategy.cs
+++ b/API/2099_Laguerre_ADX/CS/LaguerreAdxStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2101_Linear_Regression_Slope_V1/CS/LinearRegressionSlopeV1Strategy.cs
+++ b/API/2101_Linear_Regression_Slope_V1/CS/LinearRegressionSlopeV1Strategy.cs
@@ -1,5 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/2102_LSMA_Angle/CS/LsmaAngleStrategy.cs
+++ b/API/2102_LSMA_Angle/CS/LsmaAngleStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2103_ColorSchaffDeMarkerTrendCycle/CS/ColorSchaffDeMarkerTrendCycleStrategy.cs
+++ b/API/2103_ColorSchaffDeMarkerTrendCycle/CS/ColorSchaffDeMarkerTrendCycleStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2104_Color_Zerolag_DeMarker/CS/ColorZerolagDeMarkerStrategy.cs
+++ b/API/2104_Color_Zerolag_DeMarker/CS/ColorZerolagDeMarkerStrategy.cs
@@ -1,9 +1,17 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2105_Ha_MaZi/CS/HaMaZiStrategy.cs
+++ b/API/2105_Ha_MaZi/CS/HaMaZiStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2106_CandleStop_Trailing/CS/CandleStopTrailingStrategy.cs
+++ b/API/2106_CandleStop_Trailing/CS/CandleStopTrailingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2107_TP_SL_Panel/CS/TpSlPanelStrategy.cs
+++ b/API/2107_TP_SL_Panel/CS/TpSlPanelStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2109_RD_Trend_Trigger/CS/RdTrendTriggerStrategy.cs
+++ b/API/2109_RD_Trend_Trigger/CS/RdTrendTriggerStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2110_MA_Rounding_Candle/CS/MaRoundingCandleStrategy.cs
+++ b/API/2110_MA_Rounding_Candle/CS/MaRoundingCandleStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2111_Frama_Candle_Trend/CS/FramaCandleTrendStrategy.cs
+++ b/API/2111_Frama_Candle_Trend/CS/FramaCandleTrendStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2112_Trix_Candle/CS/TrixCandleStrategy.cs
+++ b/API/2112_Trix_Candle/CS/TrixCandleStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2113_CHO_With_Flat/CS/ChoWithFlatStrategy.cs
+++ b/API/2113_CHO_With_Flat/CS/ChoWithFlatStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2114_Universal_Trailing_Stop/CS/UniversalTrailingStopStrategy.cs
+++ b/API/2114_Universal_Trailing_Stop/CS/UniversalTrailingStopStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2115_Digital_Filter_T01/CS/DigitalFilterT01Strategy.cs
+++ b/API/2115_Digital_Filter_T01/CS/DigitalFilterT01Strategy.cs
@@ -1,12 +1,17 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
-using StockSharp.Algo.Storages;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Storages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2116_Simple_Levels/CS/SimpleLevelsStrategy.cs
+++ b/API/2116_Simple_Levels/CS/SimpleLevelsStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2117_Step_Stochastic_Cross/CS/StepStochasticCrossStrategy.cs
+++ b/API/2117_Step_Stochastic_Cross/CS/StepStochasticCrossStrategy.cs
@@ -1,6 +1,10 @@
-
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2118_Nevalyashka/CS/NevalyashkaStrategy.cs
+++ b/API/2118_Nevalyashka/CS/NevalyashkaStrategy.cs
@@ -1,3 +1,15 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2119_Simple_News/CS/SimpleNewsStrategy.cs
+++ b/API/2119_Simple_News/CS/SimpleNewsStrategy.cs
@@ -1,5 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2120_Levels_With_Revolve/CS/LevelsWithRevolveStrategy.cs
+++ b/API/2120_Levels_With_Revolve/CS/LevelsWithRevolveStrategy.cs
@@ -1,6 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
@@ -191,4 +199,3 @@ public class LevelsWithRevolveStrategy : Strategy
         }
     }
 }
-

--- a/API/2121_Levels_With_Trail/CS/LevelsWithTrailStrategy.cs
+++ b/API/2121_Levels_With_Trail/CS/LevelsWithTrailStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2122_Auto_Trade_With_Bollinger_Bands/CS/AutoTradeWithBollingerBandsStrategy.cs
+++ b/API/2122_Auto_Trade_With_Bollinger_Bands/CS/AutoTradeWithBollingerBandsStrategy.cs
@@ -1,10 +1,18 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 using StockSharp.Algo;
 using StockSharp.Algo.Candles;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
@@ -221,4 +229,3 @@ public class AutoTradeWithBollingerBandsStrategy : Strategy
 		}
 	}
 }
-

--- a/API/2124_JMA_Candle_Sign/CS/JmaCandleSignStrategy.cs
+++ b/API/2124_JMA_Candle_Sign/CS/JmaCandleSignStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2125_XMA_Range_Channel/CS/XmaRangeChannelStrategy.cs
+++ b/API/2125_XMA_Range_Channel/CS/XmaRangeChannelStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2126_Last_Price/CS/LastPriceStrategy.cs
+++ b/API/2126_Last_Price/CS/LastPriceStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2127_Trend_Envelopes/CS/TrendEnvelopesStrategy.cs
+++ b/API/2127_Trend_Envelopes/CS/TrendEnvelopesStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -279,4 +284,3 @@ public class TrendEnvelopesStrategy : Strategy
 		SellMarket(Volume + Math.Abs(Position));
 	}
 }
-

--- a/API/2128_Momentum_Candle_Sign/CS/MomentumCandleSignStrategy.cs
+++ b/API/2128_Momentum_Candle_Sign/CS/MomentumCandleSignStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2129_Color_Schaff_Trend_Cycle/CS/ColorSchaffTrendCycleStrategy.cs
+++ b/API/2129_Color_Schaff_Trend_Cycle/CS/ColorSchaffTrendCycleStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2130_Color_XCCX_Candle/CS/ColorXccxCandleStrategy.cs
+++ b/API/2130_Color_XCCX_Candle/CS/ColorXccxCandleStrategy.cs
@@ -1,8 +1,13 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 

--- a/API/2131_Cidomo_V1/CS/CidomoV1Strategy.cs
+++ b/API/2131_Cidomo_V1/CS/CidomoV1Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -274,4 +279,3 @@ public class CidomoV1Strategy : Strategy
 		}
 	}
 }
-

--- a/API/2132_Exp_Super_Trend/CS/ExpSuperTrendStrategy.cs
+++ b/API/2132_Exp_Super_Trend/CS/ExpSuperTrendStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2133_Dots/CS/DotsStrategy.cs
+++ b/API/2133_Dots/CS/DotsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2134_Divergence_Expert/CS/DivergenceExpertStrategy.cs
+++ b/API/2134_Divergence_Expert/CS/DivergenceExpertStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;
@@ -179,4 +192,3 @@ public class DivergenceExpertStrategy : Strategy
 			ClosePosition();
 	}
 }
-

--- a/API/2135_Breakeven_Trailing_Stop/CS/BreakevenTrailingStopStrategy.cs
+++ b/API/2135_Breakeven_Trailing_Stop/CS/BreakevenTrailingStopStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2136_Coin_Flip/CS/CoinFlipStrategy.cs
+++ b/API/2136_Coin_Flip/CS/CoinFlipStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2137_Close_At_Time/CS/CloseAtTimeStrategy.cs
+++ b/API/2137_Close_At_Time/CS/CloseAtTimeStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using System.Threading.Tasks;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2138_Session_Order_Sentiment/CS/SessionOrderSentimentStrategy.cs
+++ b/API/2138_Session_Order_Sentiment/CS/SessionOrderSentimentStrategy.cs
@@ -1,5 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2139_MacdWaterlineCross/CS/MacdWaterlineCrossExpectatorStrategy.cs
+++ b/API/2139_MacdWaterlineCross/CS/MacdWaterlineCrossExpectatorStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2140_Volatility_Quality/CS/VolatilityQualityStrategy.cs
+++ b/API/2140_Volatility_Quality/CS/VolatilityQualityStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2141_Color_Bears/CS/ColorBearsStrategy.cs
+++ b/API/2141_Color_Bears/CS/ColorBearsStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2142_Color_Bulls/CS/ColorBullsStrategy.cs
+++ b/API/2142_Color_Bulls/CS/ColorBullsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2143_Kositbablo_10/CS/Kositbablo10Strategy.cs
+++ b/API/2143_Kositbablo_10/CS/Kositbablo10Strategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2144_PA_Oscillator/CS/PaOscillatorStrategy.cs
+++ b/API/2144_PA_Oscillator/CS/PaOscillatorStrategy.cs
@@ -1,4 +1,10 @@
+using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -206,4 +212,3 @@ public class PaOscillatorStrategy : Strategy
 		_prevColor = color;
 	}
 }
-

--- a/API/2145_I_Gap/CS/IGapStrategy.cs
+++ b/API/2145_I_Gap/CS/IGapStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;
@@ -164,4 +177,3 @@ public class IGapStrategy : Strategy
 		_prevClose = candle.ClosePrice;
 	}
 }
-

--- a/API/2146_LeMan_Trend/CS/LeManTrendStrategy.cs
+++ b/API/2146_LeMan_Trend/CS/LeManTrendStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2147_Labouchere_EA/CS/LabouchereEaStrategy.cs
+++ b/API/2147_Labouchere_EA/CS/LabouchereEaStrategy.cs
@@ -1,12 +1,17 @@
 using System;
-using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using System.Globalization;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2148_Buy_Sell_Grid/CS/BuySellGridStrategy.cs
+++ b/API/2148_Buy_Sell_Grid/CS/BuySellGridStrategy.cs
@@ -1,5 +1,12 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2149_Leman_Trend_Hist/CS/LeManTrendHistStrategy.cs
+++ b/API/2149_Leman_Trend_Hist/CS/LeManTrendHistStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2150_Laguerre_ROC/CS/LaguerreRocStrategy.cs
+++ b/API/2150_Laguerre_ROC/CS/LaguerreRocStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -202,4 +207,3 @@ public class LaguerreRocStrategy : Strategy
 		_l3 = l3;
 	}
 }
-

--- a/API/2151_MACD_Candle/CS/MacdCandleStrategy.cs
+++ b/API/2151_MACD_Candle/CS/MacdCandleStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2152_Kalman_Filter_Candles/CS/KalmanFilterCandlesStrategy.cs
+++ b/API/2152_Kalman_Filter_Candles/CS/KalmanFilterCandlesStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2153_Anchored_Momentum_Candle/CS/AnchoredMomentumCandleStrategy.cs
+++ b/API/2153_Anchored_Momentum_Candle/CS/AnchoredMomentumCandleStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2154_MACD_Trend_Mode/CS/MacdTrendModeStrategy.cs
+++ b/API/2154_MACD_Trend_Mode/CS/MacdTrendModeStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2155_Loco/CS/LocoStrategy.cs
+++ b/API/2155_Loco/CS/LocoStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 

--- a/API/2156_Beginner_Breakout/CS/BeginnerBreakoutStrategy.cs
+++ b/API/2156_Beginner_Breakout/CS/BeginnerBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2157_Color_Bears_Gap/CS/ColorBearsGapStrategy.cs
+++ b/API/2157_Color_Bears_Gap/CS/ColorBearsGapStrategy.cs
@@ -1,10 +1,15 @@
-
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2158_Color_Bulls_Gap/CS/ColorBullsGapStrategy.cs
+++ b/API/2158_Color_Bulls_Gap/CS/ColorBullsGapStrategy.cs
@@ -1,10 +1,16 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 /// <summary>
 /// Strategy based on a simplified ColorBullsGap indicator.

--- a/API/2159_ColorMetro_DeMarker/CS/ColorMetroDeMarkerStrategy.cs
+++ b/API/2159_ColorMetro_DeMarker/CS/ColorMetroDeMarkerStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2160_ColorMETRO_Stochastic/CS/ColorMetroStochasticStrategy.cs
+++ b/API/2160_ColorMETRO_Stochastic/CS/ColorMetroStochasticStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2161_Forex_Fraus_Slogger/CS/ForexFrausSloggerStrategy.cs
+++ b/API/2161_Forex_Fraus_Slogger/CS/ForexFrausSloggerStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2162_CCI_Normalized_Reversal/CS/CciNormalizedReversalStrategy.cs
+++ b/API/2162_CCI_Normalized_Reversal/CS/CciNormalizedReversalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -164,4 +169,3 @@ public class CciNormalizedReversalStrategy : Strategy
 		return 2;
 	}
 }
-

--- a/API/2163_RSI_MA_Trend/CS/RsiMaTrendStrategy.cs
+++ b/API/2163_RSI_MA_Trend/CS/RsiMaTrendStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2164_Super_Woodies_CCI/CS/SuperWoodiesCciStrategy.cs
+++ b/API/2164_Super_Woodies_CCI/CS/SuperWoodiesCciStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2165_S7_Up_Bot/CS/S7UpBotStrategy.cs
+++ b/API/2165_S7_Up_Bot/CS/S7UpBotStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2166_Digital_CCI_Woodies/CS/DigitalCciWoodiesStrategy.cs
+++ b/API/2166_Digital_CCI_Woodies/CS/DigitalCciWoodiesStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2167_ColorMETRO_WPR/CS/ColorMetroWprStrategy.cs
+++ b/API/2167_ColorMETRO_WPR/CS/ColorMetroWprStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2168_AfterEffects/CS/AfterEffectsStrategy.cs
+++ b/API/2168_AfterEffects/CS/AfterEffectsStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2169_ScalpWiz_Bollinger/CS/ScalpWizBollingerStrategy.cs
+++ b/API/2169_ScalpWiz_Bollinger/CS/ScalpWizBollingerStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2170_Zonal_Trading/CS/ZonalTradingStrategy.cs
+++ b/API/2170_Zonal_Trading/CS/ZonalTradingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2172_ColorMETRO_XRSX/CS/ColorMetroXrsxStrategy.cs
+++ b/API/2172_ColorMETRO_XRSX/CS/ColorMetroXrsxStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2173_TMA_Breakout/CS/TmaBreakoutStrategy.cs
+++ b/API/2173_TMA_Breakout/CS/TmaBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2174_Hidden_SL/CS/HiddenSlStrategy.cs
+++ b/API/2174_Hidden_SL/CS/HiddenSlStrategy.cs
@@ -1,5 +1,12 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2175_Drawdown_Close_All/CS/DdCloseAllStrategy.cs
+++ b/API/2175_Drawdown_Close_All/CS/DdCloseAllStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2176_MBkasctrend3/CS/Mbkasctrend3Strategy.cs
+++ b/API/2176_MBkasctrend3/CS/Mbkasctrend3Strategy.cs
@@ -1,5 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/2177_Zakryvator/CS/ZakryvatorStrategy.cs
+++ b/API/2177_Zakryvator/CS/ZakryvatorStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
@@ -106,4 +113,3 @@ public class ZakryvatorStrategy : Strategy
 			ClosePosition();
 	}
 }
-

--- a/API/2178_Lossless_MA/CS/LosslessMaStrategy.cs
+++ b/API/2178_Lossless_MA/CS/LosslessMaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2179_Quantum_Stochastic/CS/QuantumStochasticStrategy.cs
+++ b/API/2179_Quantum_Stochastic/CS/QuantumStochasticStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2180_FrakTrak_XonaX/CS/FraktrakXonaxStrategy.cs
+++ b/API/2180_FrakTrak_XonaX/CS/FraktrakXonaxStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2181_RSI_Bollinger_Bands/CS/RsiBollingerBandsStrategy.cs
+++ b/API/2181_RSI_Bollinger_Bands/CS/RsiBollingerBandsStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;
@@ -92,4 +105,3 @@ public class RsiBollingerBandsStrategy : Strategy
 		}
 	}
 }
-

--- a/API/2182_Exp_Adx_Cross_Hull_Style/CS/ExpAdxCrossHullStyleStrategy.cs
+++ b/API/2182_Exp_Adx_Cross_Hull_Style/CS/ExpAdxCrossHullStyleStrategy.cs
@@ -1,9 +1,16 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 /// <summary>
 /// Strategy based on ADX directional cross and Hull moving averages.

--- a/API/2183_Night/CS/NightStrategy.cs
+++ b/API/2183_Night/CS/NightStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2184_Order_Example/CS/OrderExampleStrategy.cs
+++ b/API/2184_Order_Example/CS/OrderExampleStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2185_Simple_Multiple_Time_Frame_Moving_Average/CS/SimpleMultipleTimeFrameMovingAverageStrategy.cs
+++ b/API/2185_Simple_Multiple_Time_Frame_Moving_Average/CS/SimpleMultipleTimeFrameMovingAverageStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2186_Droneox_Equity_Guardian/CS/DroneoxEquityGuardianStrategy.cs
+++ b/API/2186_Droneox_Equity_Guardian/CS/DroneoxEquityGuardianStrategy.cs
@@ -1,6 +1,15 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2187_Hawaiian_Tsunami_Surfer/CS/HawaiianTsunamiSurferStrategy.cs
+++ b/API/2187_Hawaiian_Tsunami_Surfer/CS/HawaiianTsunamiSurferStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
@@ -162,4 +168,3 @@ public class HawaiianTsunamiSurferStrategy : Strategy
 		}
 	}
 }
-

--- a/API/2188_RSI_Automated/CS/RsiAutomatedStrategy.cs
+++ b/API/2188_RSI_Automated/CS/RsiAutomatedStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2189_Bounce_Strength_Index/CS/BounceStrengthIndexStrategy.cs
+++ b/API/2189_Bounce_Strength_Index/CS/BounceStrengthIndexStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2190_Color_Coppock/CS/ColorCoppockStrategy.cs
+++ b/API/2190_Color_Coppock/CS/ColorCoppockStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2192_Stochastic_Automated/CS/StochasticAutomatedStrategy.cs
+++ b/API/2192_Stochastic_Automated/CS/StochasticAutomatedStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2194_Pending_Order/CS/PendingOrderStrategy.cs
+++ b/API/2194_Pending_Order/CS/PendingOrderStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2195_Extrem_N/CS/ExtremNStrategy.cs
+++ b/API/2195_Extrem_N/CS/ExtremNStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2196_ForexLine/CS/ForexLineStrategy.cs
+++ b/API/2196_ForexLine/CS/ForexLineStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2197_Ima_Expert/CS/ImaExpertStrategy.cs
+++ b/API/2197_Ima_Expert/CS/ImaExpertStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
@@ -180,4 +187,3 @@ public class ImaExpertStrategy : Strategy
 		return volume;
 	}
 }
-

--- a/API/2198_Exp_Multic/CS/ExpMulticStrategy.cs
+++ b/API/2198_Exp_Multic/CS/ExpMulticStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2199_RSI_Histogram/CS/RsiHistogramStrategy.cs
+++ b/API/2199_RSI_Histogram/CS/RsiHistogramStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2200_MFI_Histogram/CS/MfiHistogramStrategy.cs
+++ b/API/2200_MFI_Histogram/CS/MfiHistogramStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2201_Wpr_Histogram/CS/WprHistogramStrategy.cs
+++ b/API/2201_Wpr_Histogram/CS/WprHistogramStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -154,4 +159,3 @@ public class WprHistogramStrategy : Strategy
 		_previousZone = currentZone;
 	}
 }
-

--- a/API/2202_MA_Oscillator_Histogram/CS/MaOscillatorHistogramStrategy.cs
+++ b/API/2202_MA_Oscillator_Histogram/CS/MaOscillatorHistogramStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 // MaOscillatorHistogramStrategy.cs
 // -----------------------------------------------------------------------------
 // Strategy based on a moving average oscillator with histogram-like turning points.

--- a/API/2203_Rvi_Histogram_Reversal/CS/RviHistogramReversalStrategy.cs
+++ b/API/2203_Rvi_Histogram_Reversal/CS/RviHistogramReversalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2204_Color_XMACD_Candle/CS/ColorXMacdCandleStrategy.cs
+++ b/API/2204_Color_XMACD_Candle/CS/ColorXMacdCandleStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2205_Stochastic_Histogram/CS/StochasticHistogramStrategy.cs
+++ b/API/2205_Stochastic_Histogram/CS/StochasticHistogramStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2206_Adam_and_Eve/CS/AdamAndEveStrategy.cs
+++ b/API/2206_Adam_and_Eve/CS/AdamAndEveStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2207_Bollinger_Bands_Automated/CS/BollingerBandsAutomatedStrategy.cs
+++ b/API/2207_Bollinger_Bands_Automated/CS/BollingerBandsAutomatedStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2208_Hedge_Average/CS/HedgeAverageStrategy.cs
+++ b/API/2208_Hedge_Average/CS/HedgeAverageStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2209_CCI_Histogram/CS/CciHistogramStrategy.cs
+++ b/API/2209_CCI_Histogram/CS/CciHistogramStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2210_RoBoost/CS/RoBoostStrategy.cs
+++ b/API/2210_RoBoost/CS/RoBoostStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2211_Positions_Change_Informer/CS/PositionsChangeInformerStrategy.cs
+++ b/API/2211_Positions_Change_Informer/CS/PositionsChangeInformerStrategy.cs
@@ -1,5 +1,12 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
@@ -150,4 +157,3 @@ public class PositionsChangeInformerStrategy : Strategy
 			: (Language == MessageLanguage.Russian ? "продажа" : "sell");
 	}
 }
-

--- a/API/2212_One_Click_Close_All/CS/OneClickCloseAllStrategy.cs
+++ b/API/2212_One_Click_Close_All/CS/OneClickCloseAllStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;
@@ -123,4 +136,3 @@ private void CloseFor(Security security)
 	}
 }
 }
-

--- a/API/2213_Color_Laguerre/CS/ColorLaguerreStrategy.cs
+++ b/API/2213_Color_Laguerre/CS/ColorLaguerreStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -235,4 +240,3 @@ public class ColorLaguerreStrategy : Strategy
 			BuyMarket(Math.Abs(Position));
 	}
 }
-

--- a/API/2214_Auto_Trade_With_RSI/CS/AutoTradeWithRsiStrategy.cs
+++ b/API/2214_Auto_Trade_With_RSI/CS/AutoTradeWithRsiStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2215_Three_Line_Break/CS/ThreeLineBreakStrategy.cs
+++ b/API/2215_Three_Line_Break/CS/ThreeLineBreakStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2216_ASCtrend/CS/ASCtrendStrategy.cs
+++ b/API/2216_ASCtrend/CS/ASCtrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2217_BykovTrend/CS/BykovTrendStrategy.cs
+++ b/API/2217_BykovTrend/CS/BykovTrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2218_Candles_Smoothed/CS/CandlesSmoothedStrategy.cs
+++ b/API/2218_Candles_Smoothed/CS/CandlesSmoothedStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.BusinessEntities;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2219_Fibo_Candles_Trend/CS/FiboCandlesTrendStrategy.cs
+++ b/API/2219_Fibo_Candles_Trend/CS/FiboCandlesTrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -220,4 +225,3 @@ public class FiboCandlesTrendStrategy : Strategy
 		};
 	}
 }
-

--- a/API/2220_Go_Candle_Body_Reversal/CS/GoCandleBodyReversalStrategy.cs
+++ b/API/2220_Go_Candle_Body_Reversal/CS/GoCandleBodyReversalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -122,4 +127,3 @@ public class GoCandleBodyReversalStrategy : Strategy
 		_prevSign = sign;
 	}
 }
-

--- a/API/2221_Cci_Automated/CS/CciAutomatedStrategy.cs
+++ b/API/2221_Cci_Automated/CS/CciAutomatedStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -203,4 +208,3 @@ public class CciAutomatedStrategy : Strategy
 			_trailPrice = null;
 	}
 }
-

--- a/API/2222_Heiken_Ashi_Smoothed_Trend/CS/HeikenAshiSmoothedTrendStrategy.cs
+++ b/API/2222_Heiken_Ashi_Smoothed_Trend/CS/HeikenAshiSmoothedTrendStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2223_Karacatica/CS/KaracaticaStrategy.cs
+++ b/API/2223_Karacatica/CS/KaracaticaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2224_LeMan_Signal/CS/LeManSignalStrategy.cs
+++ b/API/2224_LeMan_Signal/CS/LeManSignalStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2225_NonLagDot/CS/NonLagDotStrategy.cs
+++ b/API/2225_NonLagDot/CS/NonLagDotStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2226_PriceChannel_Stop/CS/PriceChannelStopStrategy.cs
+++ b/API/2226_PriceChannel_Stop/CS/PriceChannelStopStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2228_Sidus/CS/SidusStrategy.cs
+++ b/API/2228_Sidus/CS/SidusStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2229_Silver_Trend/CS/SilverTrendStrategy.cs
+++ b/API/2229_Silver_Trend/CS/SilverTrendStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2230_Doctor/CS/DoctorStrategy.cs
+++ b/API/2230_Doctor/CS/DoctorStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2231_Stalin/CS/StalinStrategy.cs
+++ b/API/2231_Stalin/CS/StalinStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2232_StepMA_NRTR/CS/StepMaNrtrStrategy.cs
+++ b/API/2232_StepMA_NRTR/CS/StepMaNrtrStrategy.cs
@@ -1,8 +1,14 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2233_Supertrend_Signal/CS/SupertrendSignalStrategy.cs
+++ b/API/2233_Supertrend_Signal/CS/SupertrendSignalStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;
@@ -124,4 +137,3 @@ public class SupertrendSignalStrategy : Strategy
 		_prevTrend = trend;
 	}
 }
-

--- a/API/2234_JMA_Slope/CS/JmaSlopeStrategy.cs
+++ b/API/2234_JMA_Slope/CS/JmaSlopeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2235_WPRSI_Signal/CS/WprsiSignalStrategy.cs
+++ b/API/2235_WPRSI_Signal/CS/WprsiSignalStrategy.cs
@@ -1,9 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using StockSharp.BusinessEntities;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2236_Panel_Joke/CS/PanelJokeStrategy.cs
+++ b/API/2236_Panel_Joke/CS/PanelJokeStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2237_NRTR_Trailing_Stop/CS/NrtrTrailingStopStrategy.cs
+++ b/API/2237_NRTR_Trailing_Stop/CS/NrtrTrailingStopStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2238_NRTR_Extr/CS/NrtrExtrStrategy.cs
+++ b/API/2238_NRTR_Extr/CS/NrtrExtrStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2239_Elliott_Wave_Oscillator/CS/ElliottWaveOscillatorStrategy.cs
+++ b/API/2239_Elliott_Wave_Oscillator/CS/ElliottWaveOscillatorStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2240_XDPO_Histogram/CS/XdpoHistogramStrategy.cs
+++ b/API/2240_XDPO_Histogram/CS/XdpoHistogramStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2241_ColorXdinMA_StDev/CS/ColorXdinMAStDevStrategy.cs
+++ b/API/2241_ColorXdinMA_StDev/CS/ColorXdinMAStDevStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2242_Bezier_StDev/CS/BezierStDevStrategy.cs
+++ b/API/2242_Bezier_StDev/CS/BezierStDevStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2243_Binary_Wave_StDev/CS/BinaryWaveStdDevStrategy.cs
+++ b/API/2243_Binary_Wave_StDev/CS/BinaryWaveStdDevStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
@@ -312,4 +318,3 @@ public class BinaryWaveStdDevStrategy : Strategy
 		}
 	}
 }
-

--- a/API/2244_Color_HMA_StDev/CS/ColorHmaStDevStrategy.cs
+++ b/API/2244_Color_HMA_StDev/CS/ColorHmaStDevStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2245_Color_J2JMA_StdDev/CS/ColorJ2JmaStdDevStrategy.cs
+++ b/API/2245_Color_J2JMA_StdDev/CS/ColorJ2JmaStdDevStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2246_ColorJFatlStDev/CS/ColorJFatlStDevStrategy.cs
+++ b/API/2246_ColorJFatlStDev/CS/ColorJFatlStDevStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
@@ -270,4 +277,3 @@ public enum SignalMode
     /// </summary>
     Without
 }
-

--- a/API/2247_Aroon_Horn_Sign/CS/AroonHornSignStrategy.cs
+++ b/API/2247_Aroon_Horn_Sign/CS/AroonHornSignStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
@@ -141,4 +147,3 @@ public class AroonHornSignStrategy : Strategy
 		_prevTrend = trend;
 	}
 }
-

--- a/API/2248_Exp_To_Close_Profit/CS/ExpToCloseProfitStrategy.cs
+++ b/API/2248_Exp_To_Close_Profit/CS/ExpToCloseProfitStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2249_Multicurrency_Trading_Panel/CS/MulticurrencyTradingPanelStrategy.cs
+++ b/API/2249_Multicurrency_Trading_Panel/CS/MulticurrencyTradingPanelStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2250_Close_On_Loss/CS/CloseOnLossStrategy.cs
+++ b/API/2250_Close_On_Loss/CS/CloseOnLossStrategy.cs
@@ -1,9 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2251_Forex_Fraus_Portfolio/CS/ForexFrausPortfolioStrategy.cs
+++ b/API/2251_Forex_Fraus_Portfolio/CS/ForexFrausPortfolioStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2252_Reco_RSI_Grid/CS/RecoRsiGridStrategy.cs
+++ b/API/2252_Reco_RSI_Grid/CS/RecoRsiGridStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2253_Color_Xtrix_Histogram/CS/ColorXtrixHistogramStrategy.cs
+++ b/API/2253_Color_Xtrix_Histogram/CS/ColorXtrixHistogramStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2254_Martingale_MACD/CS/MartingaleMacdStrategy.cs
+++ b/API/2254_Martingale_MACD/CS/MartingaleMacdStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2256_XDPO_Candle/CS/XdpoCandleStrategy.cs
+++ b/API/2256_XDPO_Candle/CS/XdpoCandleStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2258_Sar_Automated/CS/SarAutomatedStrategy.cs
+++ b/API/2258_Sar_Automated/CS/SarAutomatedStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2259_MaDelta/CS/MaDeltaStrategy.cs
+++ b/API/2259_MaDelta/CS/MaDeltaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2260_Trend_Arrows/CS/TrendArrowsStrategy.cs
+++ b/API/2260_Trend_Arrows/CS/TrendArrowsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2261_VWAP_Close/CS/VwapCloseStrategy.cs
+++ b/API/2261_VWAP_Close/CS/VwapCloseStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -179,4 +184,3 @@ public class VwapCloseStrategy : Strategy
 		_prev1 = vwmaValue;
 	}
 }
-

--- a/API/2262_Directed_Movement/CS/DirectedMovementStrategy.cs
+++ b/API/2262_Directed_Movement/CS/DirectedMovementStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -159,4 +165,3 @@ public enum MaType
 		WMA,
 		HMA,
 }
-

--- a/API/2263_CCI_Woodies/CS/CCI_WoodiesStrategy.cs
+++ b/API/2263_CCI_Woodies/CS/CCI_WoodiesStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2264_Indicator_Buffers/CS/IndicatorBuffersStrategy.cs
+++ b/API/2264_Indicator_Buffers/CS/IndicatorBuffersStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2265_Q2MA_Cross/CS/Q2maCrossStrategy.cs
+++ b/API/2265_Q2MA_Cross/CS/Q2maCrossStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2266_Ma_Channel/CS/MaChannelStrategy.cs
+++ b/API/2266_Ma_Channel/CS/MaChannelStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2267_ROC2_VG/CS/Roc2VgStrategy.cs
+++ b/API/2267_ROC2_VG/CS/Roc2VgStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2268_TSI_Cloud_Cross/CS/TsiCloudCrossStrategy.cs
+++ b/API/2268_TSI_Cloud_Cross/CS/TsiCloudCrossStrategy.cs
@@ -1,3 +1,15 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2269_AutoTraderRus/CS/AutoTraderRusStrategy.cs
+++ b/API/2269_AutoTraderRus/CS/AutoTraderRusStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;
@@ -145,4 +158,3 @@ public class AutoTraderRusStrategy : Strategy
 		return current >= start && current < stop;
 	}
 }
-

--- a/API/2270_Arb_Synthetic/CS/ArbSyntheticStrategy.cs
+++ b/API/2270_Arb_Synthetic/CS/ArbSyntheticStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2273_Color_Rsi_Macd/CS/ColorRsiMacdStrategy.cs
+++ b/API/2273_Color_Rsi_Macd/CS/ColorRsiMacdStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2274_Directed_Movement_Candle/CS/DirectedMovementCandleStrategy.cs
+++ b/API/2274_Directed_Movement_Candle/CS/DirectedMovementCandleStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2275_RSI_Sign/CS/RsiSignStrategy.cs
+++ b/API/2275_RSI_Sign/CS/RsiSignStrategy.cs
@@ -1,10 +1,15 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2277_Chaikin_Volatility_Stochastic/CS/ChaikinVolatilityStochasticStrategy.cs
+++ b/API/2277_Chaikin_Volatility_Stochastic/CS/ChaikinVolatilityStochasticStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2278_StochKomposter/CS/StochKomposterStrategy.cs
+++ b/API/2278_StochKomposter/CS/StochKomposterStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2279_ColorJFatl_Digit/CS/ColorJFatlDigitStrategy.cs
+++ b/API/2279_ColorJFatl_Digit/CS/ColorJFatlDigitStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2280_ColorX2MA_Digit/CS/ColorX2MaDigitStrategy.cs
+++ b/API/2280_ColorX2MA_Digit/CS/ColorX2MaDigitStrategy.cs
@@ -1,5 +1,11 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -146,4 +152,3 @@ public class ColorX2MaDigitStrategy : Strategy
 		_prevSlow = slowMa;
 	}
 }
-

--- a/API/2281_Multik_SMA_Exp/CS/MultikSmaExpStrategy.cs
+++ b/API/2281_Multik_SMA_Exp/CS/MultikSmaExpStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2282_DeMarker_Sign/CS/DeMarkerSignStrategy.cs
+++ b/API/2282_DeMarker_Sign/CS/DeMarkerSignStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2283_FRASMAv2/CS/FrasmaV2Strategy.cs
+++ b/API/2283_FRASMAv2/CS/FrasmaV2Strategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2284_Jupiter_M/CS/JupiterMStrategy.cs
+++ b/API/2284_Jupiter_M/CS/JupiterMStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2285_Volume_Weighted_MA_Slope/CS/VolumeWeightedMaSlopeStrategy.cs
+++ b/API/2285_Volume_Weighted_MA_Slope/CS/VolumeWeightedMaSlopeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2286_Nevalyashka_Stopup/CS/NevalyashkaStopupStrategy.cs
+++ b/API/2286_Nevalyashka_Stopup/CS/NevalyashkaStopupStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2287_Universal_Trailing_Stop_Hedge/CS/UniversalTrailingStopHedgeStrategy.cs
+++ b/API/2287_Universal_Trailing_Stop_Hedge/CS/UniversalTrailingStopHedgeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2288_Timer_Trade/CS/TimerTradeStrategy.cs
+++ b/API/2288_Timer_Trade/CS/TimerTradeStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2289_Volume_Weighted_MA_StDev/CS/VolumeWeightedMaStDevStrategy.cs
+++ b/API/2289_Volume_Weighted_MA_StDev/CS/VolumeWeightedMaStDevStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2290_AcceleratorBot_USDJPYH4/CS/AcceleratorBotUsdJpyH4Strategy.cs
+++ b/API/2290_AcceleratorBot_USDJPYH4/CS/AcceleratorBotUsdJpyH4Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2291_Fisher_Org_V1/CS/FisherOrgV1Strategy.cs
+++ b/API/2291_Fisher_Org_V1/CS/FisherOrgV1Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2292_Fisher_Org_Sign/CS/FisherOrgSignStrategy.cs
+++ b/API/2292_Fisher_Org_Sign/CS/FisherOrgSignStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2293_JFatl_Digit_System/CS/JfatlDigitSystemStrategy.cs
+++ b/API/2293_JFatl_Digit_System/CS/JfatlDigitSystemStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2294_Volume_Weighted_MA_Digit_System/CS/VolumeWeightedMaDigitSystemStrategy.cs
+++ b/API/2294_Volume_Weighted_MA_Digit_System/CS/VolumeWeightedMaDigitSystemStrategy.cs
@@ -1,4 +1,11 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;

--- a/API/2295_Trade_Panel_With_Autopilot/CS/TradePanelWithAutopilotStrategy.cs
+++ b/API/2295_Trade_Panel_With_Autopilot/CS/TradePanelWithAutopilotStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2296_Volume_Weighted_MA_Candle/CS/VolumeWeightedMaCandleStrategy.cs
+++ b/API/2296_Volume_Weighted_MA_Candle/CS/VolumeWeightedMaCandleStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2297_Random_Coin_Toss/CS/RandomCoinTossStrategy.cs
+++ b/API/2297_Random_Coin_Toss/CS/RandomCoinTossStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2298_Donchian_Channels_System/CS/DonchianChannelsSystemStrategy.cs
+++ b/API/2298_Donchian_Channels_System/CS/DonchianChannelsSystemStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2299_PChannel_System/CS/PChannelSystemStrategy.cs
+++ b/API/2299_PChannel_System/CS/PChannelSystemStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2300_DarvasBoxes_System/CS/DarvasBoxesSystemStrategy.cs
+++ b/API/2300_DarvasBoxes_System/CS/DarvasBoxesSystemStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2302_Trade_Panel_Autopilot/CS/TradePanelAutopilotStrategy.cs
+++ b/API/2302_Trade_Panel_Autopilot/CS/TradePanelAutopilotStrategy.cs
@@ -1,6 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2303_ADX_DMI/CS/AdxDmiStrategy.cs
+++ b/API/2303_ADX_DMI/CS/AdxDmiStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2304_Aroon_Oscillator_Sign_Alert/CS/AroonOscillatorSignAlertStrategy.cs
+++ b/API/2304_Aroon_Oscillator_Sign_Alert/CS/AroonOscillatorSignAlertStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2305_SAW_System_1/CS/SawSystem1Strategy.cs
+++ b/API/2305_SAW_System_1/CS/SawSystem1Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2306_Cm_Fishing/CS/CmFishingStrategy.cs
+++ b/API/2306_Cm_Fishing/CS/CmFishingStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2307_Trend_Continuation/CS/TrendContinuationStrategy.cs
+++ b/API/2307_Trend_Continuation/CS/TrendContinuationStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2308_ICAi/CS/ICaiStrategy.cs
+++ b/API/2308_ICAi/CS/ICaiStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -195,4 +200,3 @@ public class ICaiStrategy : Strategy
 		}
 	}
 }
-

--- a/API/2310_SMI_Correct/CS/SmiCorrectStrategy.cs
+++ b/API/2310_SMI_Correct/CS/SmiCorrectStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2312_CAi_Standard_Deviation/CS/CaiStandardDeviationStrategy.cs
+++ b/API/2312_CAi_Standard_Deviation/CS/CaiStandardDeviationStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2313_ZZFiboTrader/CS/ZZFiboTraderStrategy.cs
+++ b/API/2313_ZZFiboTrader/CS/ZZFiboTraderStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2314_CAiChannel_System_Digit/CS/CaiChannelSystemDigitStrategy.cs
+++ b/API/2314_CAiChannel_System_Digit/CS/CaiChannelSystemDigitStrategy.cs
@@ -1,9 +1,15 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using StockSharp.Algo.Strategies;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
-using StockSharp.Messages;
+using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2315_Limits_Martin/CS/LimitsMartinStrategy.cs
+++ b/API/2315_Limits_Martin/CS/LimitsMartinStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2316_Polarized_Fractal_Efficiency/CS/PolarizedFractalEfficiencyStrategy.cs
+++ b/API/2316_Polarized_Fractal_Efficiency/CS/PolarizedFractalEfficiencyStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -140,4 +145,3 @@ public class PolarizedFractalEfficiencyStrategy : Strategy
 		}
 	}
 }
-

--- a/API/2317_PFE_Extremes/CS/PfeExtremesStrategy.cs
+++ b/API/2317_PFE_Extremes/CS/PfeExtremesStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2318_ASCTrendND/CS/AscTrendNdStrategy.cs
+++ b/API/2318_ASCTrendND/CS/AscTrendNdStrategy.cs
@@ -1,9 +1,17 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2319_PPO_Cloud/CS/PpoCloudStrategy.cs
+++ b/API/2319_PPO_Cloud/CS/PpoCloudStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -174,4 +179,3 @@ _prevSignal = signalValue;
 _hasPrev = true;
 }
 }
-

--- a/API/2320_Cm_RSI/CS/CmRsiStrategy.cs
+++ b/API/2320_Cm_RSI/CS/CmRsiStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2321_CandlesticksBW/CS/CandlesticksBwStrategy.cs
+++ b/API/2321_CandlesticksBW/CS/CandlesticksBwStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2322_SAR_Trailing_System/CS/SarTrailingSystemStrategy.cs
+++ b/API/2322_SAR_Trailing_System/CS/SarTrailingSystemStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2323_Cm_Manual_Grid/CS/CmManualGridStrategy.cs
+++ b/API/2323_Cm_Manual_Grid/CS/CmManualGridStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2324_RAVI_Histogram/CS/RaviHistogramStrategy.cs
+++ b/API/2324_RAVI_Histogram/CS/RaviHistogramStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2325_Spectral_RVI_Crossover/CS/SpectralRviStrategy.cs
+++ b/API/2325_Spectral_RVI_Crossover/CS/SpectralRviStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2326_SpectrAnalysis_WPR/CS/SpectrAnalysisWprStrategy.cs
+++ b/API/2326_SpectrAnalysis_WPR/CS/SpectrAnalysisWprStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2327_WlxBW5Zone/CS/WlxBw5ZoneStrategy.cs
+++ b/API/2327_WlxBW5Zone/CS/WlxBw5ZoneStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2328_Trailing_Master/CS/TrailingMasterStrategy.cs
+++ b/API/2328_Trailing_Master/CS/TrailingMasterStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2329_Break_Even_Master/CS/BreakEvenMasterStrategy.cs
+++ b/API/2329_Break_Even_Master/CS/BreakEvenMasterStrategy.cs
@@ -1,6 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2332_Balance_Of_Power_Histogram/CS/BalanceOfPowerHistogramStrategy.cs
+++ b/API/2332_Balance_Of_Power_Histogram/CS/BalanceOfPowerHistogramStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2333_SpectrAnalysis_Chaikin/CS/SpectrAnalysisChaikinStrategy.cs
+++ b/API/2333_SpectrAnalysis_Chaikin/CS/SpectrAnalysisChaikinStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2334_RVI_Diff_Reversal/CS/RviDiffReversalStrategy.cs
+++ b/API/2334_RVI_Diff_Reversal/CS/RviDiffReversalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2335_Fibonacci_Retracement/CS/FibonacciRetracementStrategy.cs
+++ b/API/2335_Fibonacci_Retracement/CS/FibonacciRetracementStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2336_STLMCandle/CS/StlmCandleStrategy.cs
+++ b/API/2336_STLMCandle/CS/StlmCandleStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2337_Stochastic_Diff/CS/StochasticDiffStrategy.cs
+++ b/API/2337_Stochastic_Diff/CS/StochasticDiffStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -179,4 +185,3 @@ public class StochasticDiffStrategy : Strategy
 		_prevDiff = current;
 	}
 }
-

--- a/API/2338_Limits_Bot/CS/LimitsBotStrategy.cs
+++ b/API/2338_Limits_Bot/CS/LimitsBotStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
@@ -226,4 +232,3 @@ public class LimitsBotStrategy : Strategy
 		_lastPosition = Position;
 	}
 }
-

--- a/API/2339_News_EA/CS/NewsEAStrategy.cs
+++ b/API/2339_News_EA/CS/NewsEAStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2340_Sync_Charts/CS/SyncChartsStrategy.cs
+++ b/API/2340_Sync_Charts/CS/SyncChartsStrategy.cs
@@ -1,8 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using System.Timers;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
+using System.Timers;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2341_ColorXvaMA_Digit/CS/ColorXvaMADigitStrategy.cs
+++ b/API/2341_ColorXvaMA_Digit/CS/ColorXvaMADigitStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2342_HelloSmart/CS/HelloSmartStrategy.cs
+++ b/API/2342_HelloSmart/CS/HelloSmartStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2343_Night_Scalper/CS/NightScalperStrategy.cs
+++ b/API/2343_Night_Scalper/CS/NightScalperStrategy.cs
@@ -1,9 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2344_AFL_Winner_V2/CS/AflWinnerV2Strategy.cs
+++ b/API/2344_AFL_Winner_V2/CS/AflWinnerV2Strategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2345_JSatl_Digit_System/CS/JSatlDigitSystemStrategy.cs
+++ b/API/2345_JSatl_Digit_System/CS/JSatlDigitSystemStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2346_JSatl_Digit_System/CS/JsAtlDigitSystemStrategy.cs
+++ b/API/2346_JSatl_Digit_System/CS/JsAtlDigitSystemStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2347_Renko_Chart_From_Ticks/CS/RenkoChartFromTicksStrategy.cs
+++ b/API/2347_Renko_Chart_From_Ticks/CS/RenkoChartFromTicksStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2348_TralingLine/CS/TralingLineStrategy.cs
+++ b/API/2348_TralingLine/CS/TralingLineStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2349_Candle_Trend/CS/CandleTrendStrategy.cs
+++ b/API/2349_Candle_Trend/CS/CandleTrendStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2350_ColorJSatl_Digit/CS/ColorJsatlDigitStrategy.cs
+++ b/API/2350_ColorJSatl_Digit/CS/ColorJsatlDigitStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -139,4 +145,3 @@ public class ColorJsatlDigitStrategy : Strategy
 		_prevJma = jmaValue;
 	}
 }
-

--- a/API/2351_Waddah_Attar_Trend/CS/WaddahAttarTrendStrategy.cs
+++ b/API/2351_Waddah_Attar_Trend/CS/WaddahAttarTrendStrategy.cs
@@ -1,10 +1,18 @@
 using System;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2352_Figurelli_Series/CS/FigurelliSeriesStrategy.cs
+++ b/API/2352_Figurelli_Series/CS/FigurelliSeriesStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2353_I4_DRF_v2/CS/I4DrfV2Strategy.cs
+++ b/API/2353_I4_DRF_v2/CS/I4DrfV2Strategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;
@@ -339,4 +352,3 @@ _sum = 0;
 }
 }
 }
-

--- a/API/2355_JSatl_Candle/CS/JSatlCandleStrategy.cs
+++ b/API/2355_JSatl_Candle/CS/JSatlCandleStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2356_Bear_Bulls_Power/CS/BearBullsPowerStrategy.cs
+++ b/API/2356_Bear_Bulls_Power/CS/BearBullsPowerStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2357_I4_DRF/CS/I4DrfStrategy.cs
+++ b/API/2357_I4_DRF/CS/I4DrfStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2358_Exp_QqeCloud/CS/ExpQqeCloudStrategy.cs
+++ b/API/2358_Exp_QqeCloud/CS/ExpQqeCloudStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2360_ColorXvaMA_Digit_StDev/CS/ColorXvaMaDigitStDevStrategy.cs
+++ b/API/2360_ColorXvaMA_Digit_StDev/CS/ColorXvaMaDigitStDevStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2361_Color_3rdGen_XMA/CS/Color3rdGenXmaStrategy.cs
+++ b/API/2361_Color_3rdGen_XMA/CS/Color3rdGenXmaStrategy.cs
@@ -1,6 +1,10 @@
-
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2362_Delta_RSI/CS/DeltaRsiStrategy.cs
+++ b/API/2362_Delta_RSI/CS/DeltaRsiStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 

--- a/API/2363_Rock_Trader_Neuro/CS/RockTraderNeuroStrategy.cs
+++ b/API/2363_Rock_Trader_Neuro/CS/RockTraderNeuroStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2364_Trix_Crossover/CS/TrixCrossoverStrategy.cs
+++ b/API/2364_Trix_Crossover/CS/TrixCrossoverStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2365_Delta_MFI/CS/DeltaMfiStrategy.cs
+++ b/API/2365_Delta_MFI/CS/DeltaMfiStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2366_Delta_Wpr/CS/DeltaWprStrategy.cs
+++ b/API/2366_Delta_Wpr/CS/DeltaWprStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2367_RSI_Slowdown/CS/RsiSlowdownStrategy.cs
+++ b/API/2367_RSI_Slowdown/CS/RsiSlowdownStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2368_F2a_Ao/CS/F2aAoStrategy.cs
+++ b/API/2368_F2a_Ao/CS/F2aAoStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2369_WPR_Slowdown/CS/WprSlowdownStrategy.cs
+++ b/API/2369_WPR_Slowdown/CS/WprSlowdownStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -212,4 +217,3 @@ public class WprSlowdownStrategy : Strategy
 		_prevWpr = wpr;
 	}
 }
-

--- a/API/2370_MFI_Slowdown/CS/MfiSlowdownStrategy.cs
+++ b/API/2370_MFI_Slowdown/CS/MfiSlowdownStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2371_Limits_Rsi_Momentum_Bot/CS/LimitsRsiMomentumBotStrategy.cs
+++ b/API/2371_Limits_Rsi_Momentum_Bot/CS/LimitsRsiMomentumBotStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2372_Bollinger_Bands_DEMA/CS/BollingerBandsDemaStrategy.cs
+++ b/API/2372_Bollinger_Bands_DEMA/CS/BollingerBandsDemaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2373_Trigger_Line/CS/TriggerLineStrategy.cs
+++ b/API/2373_Trigger_Line/CS/TriggerLineStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2374_XMACandles/CS/XMACandlesStrategy.cs
+++ b/API/2374_XMACandles/CS/XMACandlesStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2375_X2MA_JFatl/CS/X2MaJfatlStrategy.cs
+++ b/API/2375_X2MA_JFatl/CS/X2MaJfatlStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2377_X2MA_JJRSX/CS/X2maJjrsxStrategy.cs
+++ b/API/2377_X2MA_JJRSX/CS/X2maJjrsxStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2378_X2MA_Digit_DM_361/CS/X2MADigitDm361Strategy.cs
+++ b/API/2378_X2MA_Digit_DM_361/CS/X2MADigitDm361Strategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;
@@ -180,4 +193,3 @@ public class X2MADigitDm361Strategy : Strategy
 		}
 	}
 }
-

--- a/API/2379_CyberiaTrader/CS/CyberiaTraderStrategy.cs
+++ b/API/2379_CyberiaTrader/CS/CyberiaTraderStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2380_Day_Trading/CS/DayTradingStrategy.cs
+++ b/API/2380_Day_Trading/CS/DayTradingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2381_20_200_Expert_V4_2_AntS/CS/Twenty200ExpertStrategy.cs
+++ b/API/2381_20_200_Expert_V4_2_AntS/CS/Twenty200ExpertStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2382_Regression_Channel_Breakout/CS/RegressionChannelBreakoutStrategy.cs
+++ b/API/2382_Regression_Channel_Breakout/CS/RegressionChannelBreakoutStrategy.cs
@@ -1,5 +1,14 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2383_The_MasterMind_2/CS/TheMasterMind2Strategy.cs
+++ b/API/2383_The_MasterMind_2/CS/TheMasterMind2Strategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2384_Artificial_Intelligence/CS/ArtificialIntelligenceStrategy.cs
+++ b/API/2384_Artificial_Intelligence/CS/ArtificialIntelligenceStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2385_Opening_Closing_On_Time/CS/OpeningClosingOnTimeStrategy.cs
+++ b/API/2385_Opening_Closing_On_Time/CS/OpeningClosingOnTimeStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2386_TripleStochasticMTF/CS/Exp3StoStrategy.cs
+++ b/API/2386_TripleStochasticMTF/CS/Exp3StoStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2387_Triple_RVI/CS/TripleRviStrategy.cs
+++ b/API/2387_Triple_RVI/CS/TripleRviStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2388_RobotPowerM5/CS/RobotPowerM5Strategy.cs
+++ b/API/2388_RobotPowerM5/CS/RobotPowerM5Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2390_Exp_MUV_NorDIFF_Cloud/CS/ExpMuvNorDiffCloudStrategy.cs
+++ b/API/2390_Exp_MUV_NorDIFF_Cloud/CS/ExpMuvNorDiffCloudStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2391_Global_Take_Profit/CS/GlobalTakeProfitStrategy.cs
+++ b/API/2391_Global_Take_Profit/CS/GlobalTakeProfitStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2392_MTC_Combo_v2/CS/MtcComboV2Strategy.cs
+++ b/API/2392_MTC_Combo_v2/CS/MtcComboV2Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2393_Pivot_Heiken/CS/PivotHeikenStrategy.cs
+++ b/API/2393_Pivot_Heiken/CS/PivotHeikenStrategy.cs
@@ -1,9 +1,15 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2394_Exp_GStop/CS/ExpGStopStrategy.cs
+++ b/API/2394_Exp_GStop/CS/ExpGStopStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2395_2MA_Bunny_Cross_Expert/CS/TwoMaBunnyCrossStrategy.cs
+++ b/API/2395_2MA_Bunny_Cross_Expert/CS/TwoMaBunnyCrossStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2396_CenterOfGravityCandle/CS/CenterOfGravityCandleStrategy.cs
+++ b/API/2396_CenterOfGravityCandle/CS/CenterOfGravityCandleStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
-using StockSharp.Localization;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Localization;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2398_Times_Direction/CS/TimesDirectionStrategy.cs
+++ b/API/2398_Times_Direction/CS/TimesDirectionStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2399_Zero_Filling_Stop/CS/ZeroFillingStopStrategy.cs
+++ b/API/2399_Zero_Filling_Stop/CS/ZeroFillingStopStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2400_DVD_Level/CS/DvdLevelStrategy.cs
+++ b/API/2400_DVD_Level/CS/DvdLevelStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2401_Scalpel_EA/CS/ScalpelEaStrategy.cs
+++ b/API/2401_Scalpel_EA/CS/ScalpelEaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2402_Trailing_Stop/CS/TrailingStopStrategy.cs
+++ b/API/2402_Trailing_Stop/CS/TrailingStopStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2403_ReOpen_Positions/CS/ReOpenPositionsStrategy.cs
+++ b/API/2403_ReOpen_Positions/CS/ReOpenPositionsStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2404_EMA_Cross/CS/EmaCrossStrategy.cs
+++ b/API/2404_EMA_Cross/CS/EmaCrossStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2405_Fibo_iSAR/CS/FiboIsarStrategy.cs
+++ b/API/2405_Fibo_iSAR/CS/FiboIsarStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2406_RSIThreshold/CS/RsiThresholdStrategy.cs
+++ b/API/2406_RSIThreshold/CS/RsiThresholdStrategy.cs
@@ -1,4 +1,10 @@
+using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2407_MFI_Level_Cross/CS/MfiLevelCrossStrategy.cs
+++ b/API/2407_MFI_Level_Cross/CS/MfiLevelCrossStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2408_Candels_High_Open/CS/CandelsHighOpenStrategy.cs
+++ b/API/2408_Candels_High_Open/CS/CandelsHighOpenStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2409_Turtle_Trader_SAR/CS/TurtleTraderSarStrategy.cs
+++ b/API/2409_Turtle_Trader_SAR/CS/TurtleTraderSarStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2410_Wpr_Level_Cross/CS/WprLevelCrossStrategy.cs
+++ b/API/2410_Wpr_Level_Cross/CS/WprLevelCrossStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2411_Exp_Fishing/CS/ExpFishingStrategy.cs
+++ b/API/2411_Exp_Fishing/CS/ExpFishingStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2412_ColorJFatl_Digit_ReOpen/CS/ColorJFatlDigitReOpenStrategy.cs
+++ b/API/2412_ColorJFatl_Digit_ReOpen/CS/ColorJFatlDigitReOpenStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2413_Simple_FX/CS/SimpleFxStrategy.cs
+++ b/API/2413_Simple_FX/CS/SimpleFxStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2414_Bezier_ReOpen/CS/BezierReOpenStrategy.cs
+++ b/API/2414_Bezier_ReOpen/CS/BezierReOpenStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2415_Opening_and_Closing_on_time_v2/CS/OpeningAndClosingOnTimeV2Strategy.cs
+++ b/API/2415_Opening_and_Closing_on_time_v2/CS/OpeningAndClosingOnTimeV2Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2416_DoubleUp2/CS/DoubleUp2Strategy.cs
+++ b/API/2416_DoubleUp2/CS/DoubleUp2Strategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2417_JBrainTrend_ReOpen/CS/JBrainTrendReopenStrategy.cs
+++ b/API/2417_JBrainTrend_ReOpen/CS/JBrainTrendReopenStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2418_VR_Setka_3/CS/VRSetka3Strategy.cs
+++ b/API/2418_VR_Setka_3/CS/VRSetka3Strategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2419_Expert_NEWS/CS/ExpertNewsStrategy.cs
+++ b/API/2419_Expert_NEWS/CS/ExpertNewsStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2420_MACD_Stochastic_2/CS/MacdStochastic2Strategy.cs
+++ b/API/2420_MACD_Stochastic_2/CS/MacdStochastic2Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2423_Frank_Ud/CS/FrankUdStrategy.cs
+++ b/API/2423_Frank_Ud/CS/FrankUdStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2424_Limit_Orders_Control/CS/LimitOrdersControlStrategy.cs
+++ b/API/2424_Limit_Orders_Control/CS/LimitOrdersControlStrategy.cs
@@ -1,7 +1,12 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
@@ -106,4 +111,3 @@ public class LimitOrdersControlStrategy : Strategy
 		}
 	}
 }
-

--- a/API/2425_Adaptive_CG_Oscillator_X2/CS/AdaptiveCgOscillatorX2Strategy.cs
+++ b/API/2425_Adaptive_CG_Oscillator_X2/CS/AdaptiveCgOscillatorX2Strategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2426_Fractal_RSI/CS/FractalRsiStrategy.cs
+++ b/API/2426_Fractal_RSI/CS/FractalRsiStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2427_Fisher_Transform_X2/CS/FisherTransformX2Strategy.cs
+++ b/API/2427_Fisher_Transform_X2/CS/FisherTransformX2Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2428_CrossMA/CS/CrossMAStrategy.cs
+++ b/API/2428_CrossMA/CS/CrossMAStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2429_JS_MA_Day/CS/JsMaDayStrategy.cs
+++ b/API/2429_JS_MA_Day/CS/JsMaDayStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2430_2pbIdealMA_ReOpen/CS/TwoPbIdealMaReOpenStrategy.cs
+++ b/API/2430_2pbIdealMA_ReOpen/CS/TwoPbIdealMaReOpenStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2431_Expert_MACD_EURUSD_1_Hour/CS/ExpertMacdEurusd1HourStrategy.cs
+++ b/API/2431_Expert_MACD_EURUSD_1_Hour/CS/ExpertMacdEurusd1HourStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2432_GO/CS/GoStrategy.cs
+++ b/API/2432_GO/CS/GoStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2433_Ichimoku_Chinkou_Cross/CS/IchimokuChinkouCrossStrategy.cs
+++ b/API/2433_Ichimoku_Chinkou_Cross/CS/IchimokuChinkouCrossStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2434_Color_Zerolag_Momentum_X2/CS/ColorZerolagMomentumX2Strategy.cs
+++ b/API/2434_Color_Zerolag_Momentum_X2/CS/ColorZerolagMomentumX2Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2435_H4L4Breakout/CS/H4L4BreakoutStrategy.cs
+++ b/API/2435_H4L4Breakout/CS/H4L4BreakoutStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2436_Stochastic_Three_Periods/CS/StochasticThreePeriodsStrategy.cs
+++ b/API/2436_Stochastic_Three_Periods/CS/StochasticThreePeriodsStrategy.cs
@@ -1,9 +1,16 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 /// <summary>
 /// Stochastic alignment across three timeframes.

--- a/API/2437_Zonal_Trading/CS/ZonalTradingStrategy.cs
+++ b/API/2437_Zonal_Trading/CS/ZonalTradingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2438_Bollinger_Bands_Distance/CS/BollingerBandsDistanceStrategy.cs
+++ b/API/2438_Bollinger_Bands_Distance/CS/BollingerBandsDistanceStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2439_MasterMind/CS/TheMasterMindStrategy.cs
+++ b/API/2439_MasterMind/CS/TheMasterMindStrategy.cs
@@ -1,9 +1,17 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2440_VR_Steals_2/CS/VRSteals2Strategy.cs
+++ b/API/2440_VR_Steals_2/CS/VRSteals2Strategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2441_MasterMind_3/CS/MasterMind3Strategy.cs
+++ b/API/2441_MasterMind_3/CS/MasterMind3Strategy.cs
@@ -1,4 +1,10 @@
+using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -152,4 +158,3 @@ public class MasterMind3Strategy : Strategy
 		}
 	}
 }
-

--- a/API/2442_Fractal_WPR/CS/FractalWprStrategy.cs
+++ b/API/2442_Fractal_WPR/CS/FractalWprStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2443_Escape/CS/EscapeStrategy.cs
+++ b/API/2443_Escape/CS/EscapeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2444_Very_Blonde_System/CS/VeryBlondeSystemStrategy.cs
+++ b/API/2444_Very_Blonde_System/CS/VeryBlondeSystemStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2445_EliteEFiboTrader/CS/EliteEFiboTraderStrategy.cs
+++ b/API/2445_EliteEFiboTrader/CS/EliteEFiboTraderStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2446_MA_Cross/CS/MaCrossStrategy.cs
+++ b/API/2446_MA_Cross/CS/MaCrossStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2447_PROphet/CS/PROphetStrategy.cs
+++ b/API/2447_PROphet/CS/PROphetStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2448_Fractal_ADX_Cloud/CS/FractalAdxCloudStrategy.cs
+++ b/API/2448_Fractal_ADX_Cloud/CS/FractalAdxCloudStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2449_ADX_System/CS/AdxSystemStrategy.cs
+++ b/API/2449_ADX_System/CS/AdxSystemStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -256,4 +261,3 @@ public class AdxSystemStrategy : Strategy
 		_prevMinusDi = currentMinusDi;
 	}
 }
-

--- a/API/2450_Trend_Alexcud/CS/TrendAlexcudStrategy.cs
+++ b/API/2450_Trend_Alexcud/CS/TrendAlexcudStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2451_10_Pips/CS/TenPipsStrategy.cs
+++ b/API/2451_10_Pips/CS/TenPipsStrategy.cs
@@ -1,5 +1,12 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2452_Fractal_Force_Index/CS/FractalForceIndexStrategy.cs
+++ b/API/2452_Fractal_Force_Index/CS/FractalForceIndexStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2453_Exp_Price_Position/CS/ExpPricePositionStrategy.cs
+++ b/API/2453_Exp_Price_Position/CS/ExpPricePositionStrategy.cs
@@ -1,4 +1,11 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -201,4 +208,3 @@ public class ExpPricePositionStrategy : Strategy
 		_prevSlow = slow;
 	}
 }
-

--- a/API/2454_Exp_RSIOMA/CS/ExpRsiomaStrategy.cs
+++ b/API/2454_Exp_RSIOMA/CS/ExpRsiomaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2455_EMA_WMA_Crossover/CS/EmaWmaCrossoverStrategy.cs
+++ b/API/2455_EMA_WMA_Crossover/CS/EmaWmaCrossoverStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2457_Breakdown_Level_Day/CS/BreakdownLevelDayStrategy.cs
+++ b/API/2457_Breakdown_Level_Day/CS/BreakdownLevelDayStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2458_BykovTrend_ReOpen/CS/BykovTrendReOpenStrategy.cs
+++ b/API/2458_BykovTrend_ReOpen/CS/BykovTrendReOpenStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2459_SilverTrend_Signal_ReOpen/CS/SilverTrendSignalReOpenStrategy.cs
+++ b/API/2459_SilverTrend_Signal_ReOpen/CS/SilverTrendSignalReOpenStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2460_Price_Rollback/CS/PriceRollbackStrategy.cs
+++ b/API/2460_Price_Rollback/CS/PriceRollbackStrategy.cs
@@ -1,6 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2461_Ilan14/CS/Ilan14Strategy.cs
+++ b/API/2461_Ilan14/CS/Ilan14Strategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2462_Weight_Oscillator/CS/WeightOscillatorStrategy.cs
+++ b/API/2462_Weight_Oscillator/CS/WeightOscillatorStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2463_Universum_3_0/CS/Universum30Strategy.cs
+++ b/API/2463_Universum_3_0/CS/Universum30Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2464_MACD_Signal/CS/MacdSignalStrategy.cs
+++ b/API/2464_MACD_Signal/CS/MacdSignalStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2465_Stochastic_Martingale/CS/StochasticMartingaleStrategy.cs
+++ b/API/2465_Stochastic_Martingale/CS/StochasticMartingaleStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2466_Heiken_Ashi_Waves/CS/HeikenAshiWavesStrategy.cs
+++ b/API/2466_Heiken_Ashi_Waves/CS/HeikenAshiWavesStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2467_Bill_Williams_Trader/CS/BillWilliamsTraderStrategy.cs
+++ b/API/2467_Bill_Williams_Trader/CS/BillWilliamsTraderStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2468_ZeroLag_MACD_Crossover/CS/ZeroLagMacdCrossoverStrategy.cs
+++ b/API/2468_ZeroLag_MACD_Crossover/CS/ZeroLagMacdCrossoverStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2469_MACD_CCI_Lotfy/CS/MacdCciLotfyStrategy.cs
+++ b/API/2469_MACD_CCI_Lotfy/CS/MacdCciLotfyStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2470_Ride_Alligator/CS/RideAlligatorStrategy.cs
+++ b/API/2470_Ride_Alligator/CS/RideAlligatorStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2471_Fractal_MFI/CS/FractalMfiStrategy.cs
+++ b/API/2471_Fractal_MFI/CS/FractalMfiStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2472_Angry_Bird_Scalping/CS/AngryBirdScalpingStrategy.cs
+++ b/API/2472_Angry_Bird_Scalping/CS/AngryBirdScalpingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2473_Macd_Pattern_Trader_All/CS/MacdPatternTraderAllStrategy.cs
+++ b/API/2473_Macd_Pattern_Trader_All/CS/MacdPatternTraderAllStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2474_Neural_Network_MACD/CS/NeuralNetworkMacdStrategy.cs
+++ b/API/2474_Neural_Network_MACD/CS/NeuralNetworkMacdStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2475_ExpBuySellSide/CS/ExpBuySellSideStrategy.cs
+++ b/API/2475_ExpBuySellSide/CS/ExpBuySellSideStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2476_Straddle_Trail_Manager/CS/StraddleTrailStrategy.cs
+++ b/API/2476_Straddle_Trail_Manager/CS/StraddleTrailStrategy.cs
@@ -1,10 +1,17 @@
 using System;
-using System.Globalization;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using System.Globalization;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2477_Alligator_Fractal_Martingale/CS/AlligatorFractalMartingaleStrategy.cs
+++ b/API/2477_Alligator_Fractal_Martingale/CS/AlligatorFractalMartingaleStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2478_WOC012Momentum/CS/Woc012Strategy.cs
+++ b/API/2478_WOC012Momentum/CS/Woc012Strategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2479_Pipsover/CS/PipsoverStrategy.cs
+++ b/API/2479_Pipsover/CS/PipsoverStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2480_10_Pips_EURUSD/CS/TenPipsEurusdStrategy.cs
+++ b/API/2480_10_Pips_EURUSD/CS/TenPipsEurusdStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2481_CashMachine_5min/CS/CashMachine5minStrategy.cs
+++ b/API/2481_CashMachine_5min/CS/CashMachine5minStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
@@ -390,4 +396,3 @@ public class CashMachine5minStrategy : Strategy
 		return step * adjust;
 	}
 }
-

--- a/API/2482_JK_BullPower_AutoTrader/CS/JkBullPowerAutoTraderStrategy.cs
+++ b/API/2482_JK_BullPower_AutoTrader/CS/JkBullPowerAutoTraderStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2483_Gandalf_Pro/CS/GandalfProStrategy.cs
+++ b/API/2483_Gandalf_Pro/CS/GandalfProStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2484_The_Puncher/CS/PuncherStrategy.cs
+++ b/API/2484_The_Puncher/CS/PuncherStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2485_Hercules_ATC_2006/CS/HerculesATC2006Strategy.cs
+++ b/API/2485_Hercules_ATC_2006/CS/HerculesATC2006Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2486_MoneyFixedRisk/CS/MoneyFixedRiskStrategy.cs
+++ b/API/2486_MoneyFixedRisk/CS/MoneyFixedRiskStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2487_Example_of_MACD_Automated/CS/ExampleOfMacdAutomatedStrategy.cs
+++ b/API/2487_Example_of_MACD_Automated/CS/ExampleOfMacdAutomatedStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2488_Big_Bar_Sound/CS/BigBarSoundStrategy.cs
+++ b/API/2488_Big_Bar_Sound/CS/BigBarSoundStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2489_Master_MM_Droid/CS/MasterMmDroidStrategy.cs
+++ b/API/2489_Master_MM_Droid/CS/MasterMmDroidStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2490_Forex_Profit/CS/ForexProfitStrategy.cs
+++ b/API/2490_Forex_Profit/CS/ForexProfitStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2491_SendClose/CS/SendCloseStrategy.cs
+++ b/API/2491_SendClose/CS/SendCloseStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2492_Gazonkos_Rollback/CS/GazonkosStrategy.cs
+++ b/API/2492_Gazonkos_Rollback/CS/GazonkosStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2493_Altarius_RSI_Stochastic/CS/AltariusRsiStochasticStrategy.cs
+++ b/API/2493_Altarius_RSI_Stochastic/CS/AltariusRsiStochasticStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2494_Two_MA_Four_Level/CS/TwoMaFourLevelStrategy.cs
+++ b/API/2494_Two_MA_Four_Level/CS/TwoMaFourLevelStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2495_Autotrade_Pending_Stops/CS/AutotradePendingStopsStrategy.cs
+++ b/API/2495_Autotrade_Pending_Stops/CS/AutotradePendingStopsStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2496_Big_Dog/CS/BigDogStrategy.cs
+++ b/API/2496_Big_Dog/CS/BigDogStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2497_Trailing_Stop_Manager/CS/TrailingStopManagerStrategy.cs
+++ b/API/2497_Trailing_Stop_Manager/CS/TrailingStopManagerStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2498_AIS1_EURUSD_Breakout/CS/Ais1EurUsdBreakoutStrategy.cs
+++ b/API/2498_AIS1_EURUSD_Breakout/CS/Ais1EurUsdBreakoutStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2499_SimpleTrade/CS/SimpleTradeStrategy.cs
+++ b/API/2499_SimpleTrade/CS/SimpleTradeStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2500_YenTrader051/CS/YenTrader051Strategy.cs
+++ b/API/2500_YenTrader051/CS/YenTrader051Strategy.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
 using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2501_Lucky/CS/LuckyStrategy.cs
+++ b/API/2501_Lucky/CS/LuckyStrategy.cs
@@ -1,7 +1,17 @@
 using System;
-using StockSharp.Algo;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2502_21Hour_Session_Breakout/CS/TwentyOneHourSessionBreakoutStrategy.cs
+++ b/API/2502_21Hour_Session_Breakout/CS/TwentyOneHourSessionBreakoutStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2503_Money_Fixed_Margin/CS/MoneyFixedMarginStrategy.cs
+++ b/API/2503_Money_Fixed_Margin/CS/MoneyFixedMarginStrategy.cs
@@ -1,9 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2504_RSI_EA/CS/RsiEaStrategy.cs
+++ b/API/2504_RSI_EA/CS/RsiEaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2506_e_TurboFx/CS/ETurboFxStrategy.cs
+++ b/API/2506_e_TurboFx/CS/ETurboFxStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2507_Previous_Candle_Breakout/CS/PreviousCandleBreakoutStrategy.cs
+++ b/API/2507_Previous_Candle_Breakout/CS/PreviousCandleBreakoutStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2508_Waddah_Attar_Win/CS/WaddahAttarWinStrategy.cs
+++ b/API/2508_Waddah_Attar_Win/CS/WaddahAttarWinStrategy.cs
@@ -1,5 +1,12 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2509_Up3x1_Premium/CS/Up3x1PremiumStrategy.cs
+++ b/API/2509_Up3x1_Premium/CS/Up3x1PremiumStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2510_Bull_vs_Medved/CS/BullVsMedvedStrategy.cs
+++ b/API/2510_Bull_vs_Medved/CS/BullVsMedvedStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2511_True_Scalper_Profit_Lock/CS/TrueScalperProfitLockStrategy.cs
+++ b/API/2511_True_Scalper_Profit_Lock/CS/TrueScalperProfitLockStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2512_Up3x1/CS/Up3x1Strategy.cs
+++ b/API/2512_Up3x1/CS/Up3x1Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2513_MACD_Parabolic_SAR_Wizard/CS/MacdParabolicSarWizardStrategy.cs
+++ b/API/2513_MACD_Parabolic_SAR_Wizard/CS/MacdParabolicSarWizardStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2514_MACD_Zero_Filter_Take_Profit/CS/MacdZeroFilterTakeProfitStrategy.cs
+++ b/API/2514_MACD_Zero_Filter_Take_Profit/CS/MacdZeroFilterTakeProfitStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2515_Proper_Bot/CS/ProperBotStrategy.cs
+++ b/API/2515_Proper_Bot/CS/ProperBotStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2516_Trend_Catcher/CS/TrendCatcherStrategy.cs
+++ b/API/2516_Trend_Catcher/CS/TrendCatcherStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2517_BollTradeBreakout/CS/BollTradeStrategy.cs
+++ b/API/2517_BollTradeBreakout/CS/BollTradeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2518_Moving_Average_Trade_System/CS/MovingAverageTradeSystemStrategy.cs
+++ b/API/2518_Moving_Average_Trade_System/CS/MovingAverageTradeSystemStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2520_TDS_Global/CS/TdsGlobalStrategy.cs
+++ b/API/2520_TDS_Global/CS/TdsGlobalStrategy.cs
@@ -1,6 +1,10 @@
-
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2521_Simple_MACD/CS/SimpleMacdStrategy.cs
+++ b/API/2521_Simple_MACD/CS/SimpleMacdStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2522_MARE51_Shifted_MA/CS/Mare51Strategy.cs
+++ b/API/2522_MARE51_Shifted_MA/CS/Mare51Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2523_Fractal_Weight_Oscillator/CS/FractalWeightOscillatorStrategy.cs
+++ b/API/2523_Fractal_Weight_Oscillator/CS/FractalWeightOscillatorStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2524_New_Martin/CS/NewMartinStrategy.cs
+++ b/API/2524_New_Martin/CS/NewMartinStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2525_Silver_Trend_V3/CS/SilverTrendV3Strategy.cs
+++ b/API/2525_Silver_Trend_V3/CS/SilverTrendV3Strategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2526_TDI_2_ReOpen/CS/Tdi2ReOpenStrategy.cs
+++ b/API/2526_TDI_2_ReOpen/CS/Tdi2ReOpenStrategy.cs
@@ -1,9 +1,17 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2527_Kijun_Sen_Robot/CS/KijunSenRobotStrategy.cs
+++ b/API/2527_Kijun_Sen_Robot/CS/KijunSenRobotStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2528_5_8_MA_Cross/CS/FiveEightMaCrossStrategy.cs
+++ b/API/2528_5_8_MA_Cross/CS/FiveEightMaCrossStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2529_V1N1_Lonny_Breakout/CS/V1n1LonnyBreakoutStrategy.cs
+++ b/API/2529_V1N1_Lonny_Breakout/CS/V1n1LonnyBreakoutStrategy.cs
@@ -1,14 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
 using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2531_E_Skoch_Open/CS/ESkochOpenStrategy.cs
+++ b/API/2531_E_Skoch_Open/CS/ESkochOpenStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2532_e-Smart_Trailing/CS/ESmartTrailingStrategy.cs
+++ b/API/2532_e-Smart_Trailing/CS/ESmartTrailingStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2533_Polish_Layer/CS/PolishLayerStrategy.cs
+++ b/API/2533_Polish_Layer/CS/PolishLayerStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2534_MA_RSI_Wizard/CS/MaRsiWizardStrategy.cs
+++ b/API/2534_MA_RSI_Wizard/CS/MaRsiWizardStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2535_Backbone/CS/BackboneStrategy.cs
+++ b/API/2535_Backbone/CS/BackboneStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using System.Globalization;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using System.Globalization;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2536_Currency_Strength_v1_1/CS/CurrencyStrengthV11Strategy.cs
+++ b/API/2536_Currency_Strength_v1_1/CS/CurrencyStrengthV11Strategy.cs
@@ -1,7 +1,12 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2537_FuzzyLogic/CS/FuzzyLogicStrategy.cs
+++ b/API/2537_FuzzyLogic/CS/FuzzyLogicStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2538_ADX_MA_Crossover/CS/AdxMaCrossoverStrategy.cs
+++ b/API/2538_ADX_MA_Crossover/CS/AdxMaCrossoverStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using System.Globalization;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using System.Globalization;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2539_Ma2Cci/CS/Ma2CciStrategy.cs
+++ b/API/2539_Ma2Cci/CS/Ma2CciStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2540_Rabbit3/CS/Rabbit3Strategy.cs
+++ b/API/2540_Rabbit3/CS/Rabbit3Strategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2541_IBS_RSI_CCI_v4/CS/IbsRsiCciV4Strategy.cs
+++ b/API/2541_IBS_RSI_CCI_v4/CS/IbsRsiCciV4Strategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2542_High_and_Low_Last_24_Hours/CS/HighAndLowLast24HoursStrategy.cs
+++ b/API/2542_High_and_Low_Last_24_Hours/CS/HighAndLowLast24HoursStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using System.Globalization;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using System.Globalization;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2543_Weight_Oscillator_Direct/CS/WeightOscillatorDirectStrategy.cs
+++ b/API/2543_Weight_Oscillator_Direct/CS/WeightOscillatorDirectStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2544_Order_Escort/CS/OrderEscortStrategy.cs
+++ b/API/2544_Order_Escort/CS/OrderEscortStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2545_Eugene_Inside_Breakout/CS/EugeneInsideBreakoutStrategy.cs
+++ b/API/2545_Eugene_Inside_Breakout/CS/EugeneInsideBreakoutStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2546_MacdPatternTrader/2546/CS/MacdPatternTraderStrategy.cs
+++ b/API/2546_MacdPatternTrader/2546/CS/MacdPatternTraderStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -1995,4 +2000,3 @@ public class MacdPatternTraderStrategy : Strategy
 		_shortTake = null;
 	}
 }
-

--- a/API/2546_MacdPatternTrader/CS/MacdPatternTraderStrategy.cs
+++ b/API/2546_MacdPatternTrader/CS/MacdPatternTraderStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -1977,4 +1982,3 @@ public class MacdPatternTraderStrategy : Strategy
 		_shortTake = null;
 	}
 }
-

--- a/API/2546_Macd_Pattern_Trader/CS/MacdPatternTraderStrategy.cs
+++ b/API/2546_Macd_Pattern_Trader/CS/MacdPatternTraderStrategy.cs
@@ -1,13 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
 using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
-using StockSharp.Algo;
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2547_UmnickTrader/CS/UmnickTraderStrategy.cs
+++ b/API/2547_UmnickTrader/CS/UmnickTraderStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2548_Get_Trend/CS/GetTrendStrategy.cs
+++ b/API/2548_Get_Trend/CS/GetTrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2549_Money_Rain/CS/MoneyRainStrategy.cs
+++ b/API/2549_Money_Rain/CS/MoneyRainStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2550_SupportResistTrade/CS/SupportResistTradeStrategy.cs
+++ b/API/2550_SupportResistTrade/CS/SupportResistTradeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2551_T3MA_Direction_Change/CS/T3MaDirectionChangeStrategy.cs
+++ b/API/2551_T3MA_Direction_Change/CS/T3MaDirectionChangeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2552_BrakeoutTraderV1/CS/BrakeoutTraderV1Strategy.cs
+++ b/API/2552_BrakeoutTraderV1/CS/BrakeoutTraderV1Strategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2553_Order_Notify/CS/OrderNotifyStrategy.cs
+++ b/API/2553_Order_Notify/CS/OrderNotifyStrategy.cs
@@ -1,10 +1,19 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 using System.Net;
 using System.Net.Mail;
 using System.Text;
-
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2554_TypePendingOrderTriggered/CS/TypePendingOrderTriggeredStrategy.cs
+++ b/API/2554_TypePendingOrderTriggered/CS/TypePendingOrderTriggeredStrategy.cs
@@ -1,5 +1,12 @@
+using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2555_ChandelExit_ReOpen/CS/ChandelExitReopenStrategy.cs
+++ b/API/2555_ChandelExit_ReOpen/CS/ChandelExitReopenStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2556_Currencyprofits_HighLow_Channel/CS/CurrencyprofitsHighLowChannelStrategy.cs
+++ b/API/2556_Currencyprofits_HighLow_Channel/CS/CurrencyprofitsHighLowChannelStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2557_Ttm_Trend_Reopen/CS/TtmTrendReopenStrategy.cs
+++ b/API/2557_Ttm_Trend_Reopen/CS/TtmTrendReopenStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2558_CGOscillator_X2/CS/CGOscillatorX2Strategy.cs
+++ b/API/2558_CGOscillator_X2/CS/CGOscillatorX2Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2559_XOSignal_ReOpen/CS/XoSignalReopenStrategy.cs
+++ b/API/2559_XOSignal_ReOpen/CS/XoSignalReopenStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2560_IBS_RSI_CCI_v4_X2/CS/IbsRsiCciV4X2Strategy.cs
+++ b/API/2560_IBS_RSI_CCI_v4_X2/CS/IbsRsiCciV4X2Strategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2561_Three_Candles_Reversal/CS/ThreeCandlesReversalStrategy.cs
+++ b/API/2561_Three_Candles_Reversal/CS/ThreeCandlesReversalStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2562_Ivan_CCI_Averaging/CS/IvanCciAveragingStrategy.cs
+++ b/API/2562_Ivan_CCI_Averaging/CS/IvanCciAveragingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2563_Simple_Hedge_Panel/CS/SimpleHedgePanelStrategy.cs
+++ b/API/2563_Simple_Hedge_Panel/CS/SimpleHedgePanelStrategy.cs
@@ -1,8 +1,17 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2564_Ichi_Oscillator/CS/IchiOscillatorStrategy.cs
+++ b/API/2564_Ichi_Oscillator/CS/IchiOscillatorStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2565_Renko_LineBreak_vs_RSI/CS/RenkoLineBreakVsRsiStrategy.cs
+++ b/API/2565_Renko_LineBreak_vs_RSI/CS/RenkoLineBreakVsRsiStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2566_EMA_Barabashkakvn_Edition/CS/EmaBarabashkakvnEditionStrategy.cs
+++ b/API/2566_EMA_Barabashkakvn_Edition/CS/EmaBarabashkakvnEditionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2567_Pinball_Machine/CS/PinballMachineStrategy.cs
+++ b/API/2567_Pinball_Machine/CS/PinballMachineStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2568_DoubleMA_Crossover/CS/DoubleMaCrossoverStrategy.cs
+++ b/API/2568_DoubleMA_Crossover/CS/DoubleMaCrossoverStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2569_ElliIchimokuADX/CS/ElliIchimokuAdxStrategy.cs
+++ b/API/2569_ElliIchimokuADX/CS/ElliIchimokuAdxStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2570_Multi_Hedging_Scheduler/CS/MultiHedgingSchedulerStrategy.cs
+++ b/API/2570_Multi_Hedging_Scheduler/CS/MultiHedgingSchedulerStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2571_MACD_AO_Pattern/CS/MacdAoPatternStrategy.cs
+++ b/API/2571_MACD_AO_Pattern/CS/MacdAoPatternStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2572_Nevalyashka_Martingale/CS/NevalyashkaMartingaleStrategy.cs
+++ b/API/2572_Nevalyashka_Martingale/CS/NevalyashkaMartingaleStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2573_eRP250ReversePoint/CS/ERp250Strategy.cs
+++ b/API/2573_eRP250ReversePoint/CS/ERp250Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2574_NUp1Down/CS/NUp1DownStrategy.cs
+++ b/API/2574_NUp1Down/CS/NUp1DownStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using System.Globalization;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using System.Globalization;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2575_RSI_Trader/CS/RsiTraderStrategy.cs
+++ b/API/2575_RSI_Trader/CS/RsiTraderStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2578_Trade_on_Qualified_RSI/CS/TradeOnQualifiedRSIStrategy.cs
+++ b/API/2578_Trade_on_Qualified_RSI/CS/TradeOnQualifiedRSIStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2579_20PRExp_3/CS/TwentyPrExpThreeStrategy.cs
+++ b/API/2579_20PRExp_3/CS/TwentyPrExpThreeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2581_ClosePositionsByTime/CS/ClosePositionsByTimeStrategy.cs
+++ b/API/2581_ClosePositionsByTime/CS/ClosePositionsByTimeStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2582_Close_All_Positions_By_Time/CS/CloseAllPositionsByTimeStrategy.cs
+++ b/API/2582_Close_All_Positions_By_Time/CS/CloseAllPositionsByTimeStrategy.cs
@@ -1,7 +1,12 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2584_Time_Object_Text_Display/CS/TimeObjectTextDisplayStrategy.cs
+++ b/API/2584_Time_Object_Text_Display/CS/TimeObjectTextDisplayStrategy.cs
@@ -1,7 +1,17 @@
 using System;
-using System.Globalization;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
+using System.Globalization;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2585_Candle_Shadow_Percent/CS/CandleShadowPercentStrategy.cs
+++ b/API/2585_Candle_Shadow_Percent/CS/CandleShadowPercentStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2586_Pending_Order_Grid/CS/PendingOrderGridStrategy.cs
+++ b/API/2586_Pending_Order_Grid/CS/PendingOrderGridStrategy.cs
@@ -1,5 +1,12 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2587_List_Positions/CS/ListPositionsStrategy.cs
+++ b/API/2587_List_Positions/CS/ListPositionsStrategy.cs
@@ -1,10 +1,19 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 using System.Reflection;
 using System.Text;
 using System.Threading;
-
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2588_Candle/CS/CandleStrategy.cs
+++ b/API/2588_Candle/CS/CandleStrategy.cs
@@ -1,9 +1,17 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
 using Ecng.Common;
-using StockSharp.Algo.Candles;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2589_Bollinger_Breakout_DC2008/CS/BollingerBreakoutDc2008Strategy.cs
+++ b/API/2589_Bollinger_Breakout_DC2008/CS/BollingerBreakoutDc2008Strategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2590_Heiken_Ashi_Idea/CS/HeikenAshiIdeaStrategy.cs
+++ b/API/2590_Heiken_Ashi_Idea/CS/HeikenAshiIdeaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2591_N_Candles/CS/NCandlesStrategy.cs
+++ b/API/2591_N_Candles/CS/NCandlesStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2592_Exp_Breakout_Signals/CS/ExpBreakoutSignalsStrategy.cs
+++ b/API/2592_Exp_Breakout_Signals/CS/ExpBreakoutSignalsStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using System.Globalization;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using System.Globalization;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2593_Stochastic_Chaikins_Volatility/CS/StochasticChaikinsVolatilityStrategy.cs
+++ b/API/2593_Stochastic_Chaikins_Volatility/CS/StochasticChaikinsVolatilityStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2595_Inverse_Reaction/CS/InverseReactionStrategy.cs
+++ b/API/2595_Inverse_Reaction/CS/InverseReactionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2596_Max_Lot_Size_Display/CS/MaxLotSizeDisplayStrategy.cs
+++ b/API/2596_Max_Lot_Size_Display/CS/MaxLotSizeDisplayStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2597_Morse_Code/CS/MorseCodeStrategy.cs
+++ b/API/2597_Morse_Code/CS/MorseCodeStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2598_Sound_Alert_Entry_Out/CS/SoundAlertEntryOutStrategy.cs
+++ b/API/2598_Sound_Alert_Entry_Out/CS/SoundAlertEntryOutStrategy.cs
@@ -1,5 +1,12 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2599_Trailing_Stop_Manager/CS/TrailingStopManagerStrategy.cs
+++ b/API/2599_Trailing_Stop_Manager/CS/TrailingStopManagerStrategy.cs
@@ -1,9 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using StockSharp.Algo;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2600_Simple_Trade_Copier/CS/TradeCopierStrategy.cs
+++ b/API/2600_Simple_Trade_Copier/CS/TradeCopierStrategy.cs
@@ -1,7 +1,12 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2601_Ma_Sar_Adx/CS/MaSarAdxStrategy.cs
+++ b/API/2601_Ma_Sar_Adx/CS/MaSarAdxStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2602_XFatl_XSatl_Cloud/CS/XFatlXSatlCloudStrategy.cs
+++ b/API/2602_XFatl_XSatl_Cloud/CS/XFatlXSatlCloudStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2603_Dual_MA_Trend_Confirmation/CS/DualMaTrendConfirmationStrategy.cs
+++ b/API/2603_Dual_MA_Trend_Confirmation/CS/DualMaTrendConfirmationStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2604_Piano_Multi_Timeframe_Bar_State/CS/PianoMultiTimeframeBarStateStrategy.cs
+++ b/API/2604_Piano_Multi_Timeframe_Bar_State/CS/PianoMultiTimeframeBarStateStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using System.Text;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using System.Text;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2605_Kolier_SuperTrend_X2/CS/KolierSuperTrendX2Strategy.cs
+++ b/API/2605_Kolier_SuperTrend_X2/CS/KolierSuperTrendX2Strategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2606_Statistics_Repeating_Behavior/CS/StatisticsRepeatingBehaviorStrategy.cs
+++ b/API/2606_Statistics_Repeating_Behavior/CS/StatisticsRepeatingBehaviorStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2607_N_Candles_v2/CS/NCandlesV2Strategy.cs
+++ b/API/2607_N_Candles_v2/CS/NCandlesV2Strategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2608_Breakthrough_BB/CS/BreakthroughBbStrategy.cs
+++ b/API/2608_Breakthrough_BB/CS/BreakthroughBbStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2609_HTH_Trader/CS/HthTraderStrategy.cs
+++ b/API/2609_HTH_Trader/CS/HthTraderStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2610_Vector/CS/VectorStrategy.cs
+++ b/API/2610_Vector/CS/VectorStrategy.cs
@@ -1,6 +1,10 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2611_RSI_Bollinger_Fractal_Breakout/CS/RsiBollingerFractalBreakoutStrategy.cs
+++ b/API/2611_RSI_Bollinger_Fractal_Breakout/CS/RsiBollingerFractalBreakoutStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2613_Cheduecoglioni_Alternating/CS/CheduecoglioniAlternatingStrategy.cs
+++ b/API/2613_Cheduecoglioni_Alternating/CS/CheduecoglioniAlternatingStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2614_Bollinger_Bands_N_Positions/CS/BollingerBandsNPositionsStrategy.cs
+++ b/API/2614_Bollinger_Bands_N_Positions/CS/BollingerBandsNPositionsStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2615_Total_Power_Indicator_X/CS/TotalPowerIndicatorXStrategy.cs
+++ b/API/2615_Total_Power_Indicator_X/CS/TotalPowerIndicatorXStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2616_Percentage_Crossover/CS/PercentageCrossoverStrategy.cs
+++ b/API/2616_Percentage_Crossover/CS/PercentageCrossoverStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2617_Fractals_Minimum_Distance/CS/FractalsMinimumDistanceStrategy.cs
+++ b/API/2617_Fractals_Minimum_Distance/CS/FractalsMinimumDistanceStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2618_Pipso_Range_Reversal/CS/PipsoStrategy.cs
+++ b/API/2618_Pipso_Range_Reversal/CS/PipsoStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2619_Percentage_Crossover_Channel_System/CS/PercentageCrossoverChannelSystemStrategy.cs
+++ b/API/2619_Percentage_Crossover_Channel_System/CS/PercentageCrossoverChannelSystemStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2620_Color_JFatl_Digit_Tm/CS/ColorJfatlDigitTmStrategy.cs
+++ b/API/2620_Color_JFatl_Digit_Tm/CS/ColorJfatlDigitTmStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using System.Reflection;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using System.Reflection;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2621_Color_Xmuv_Time/CS/ColorXmuvTimeStrategy.cs
+++ b/API/2621_Color_Xmuv_Time/CS/ColorXmuvTimeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2622_Crossing_of_Two_iMA/CS/CrossingOfTwoIMAStrategy.cs
+++ b/API/2622_Crossing_of_Two_iMA/CS/CrossingOfTwoIMAStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2623_Amstell_Grid_Manager/CS/AmstellGridManagerStrategy.cs
+++ b/API/2623_Amstell_Grid_Manager/CS/AmstellGridManagerStrategy.cs
@@ -1,5 +1,12 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2624_NRTR_ATR_Stop/CS/NRTRATRStopStrategy.cs
+++ b/API/2624_NRTR_ATR_Stop/CS/NRTRATRStopStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2625_VLT_Trader/CS/VltTraderStrategy.cs
+++ b/API/2625_VLT_Trader/CS/VltTraderStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
@@ -359,4 +365,3 @@ public class VltTraderStrategy : Strategy
 		return step <= 0.001m ? step * 10m : step;
 	}
 }
-

--- a/API/2626_Bullish_Bearish_Engulfing/CS/BullishBearishEngulfingStrategy.cs
+++ b/API/2626_Bullish_Bearish_Engulfing/CS/BullishBearishEngulfingStrategy.cs
@@ -1,7 +1,12 @@
-
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2627_EES_Hedger/CS/EesHedgerStrategy.cs
+++ b/API/2627_EES_Hedger/CS/EesHedgerStrategy.cs
@@ -1,12 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using System.Globalization;
 
 using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using System.Globalization;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2628_Evening_Star/CS/EveningStarStrategy.cs
+++ b/API/2628_Evening_Star/CS/EveningStarStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2629_XROC2_VG_Tm/CS/Xroc2VgTmStrategy.cs
+++ b/API/2629_XROC2_VG_Tm/CS/Xroc2VgTmStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2630_XROC2_VG_X2/CS/Xroc2VgX2Strategy.cs
+++ b/API/2630_XROC2_VG_X2/CS/Xroc2VgX2Strategy.cs
@@ -1,10 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
 using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
@@ -730,4 +734,3 @@ public class Xroc2VgX2Strategy : Strategy
 		};
 	}
 }
-

--- a/API/2631_N_Candles_v3/CS/NCandlesV3Strategy.cs
+++ b/API/2631_N_Candles_v3/CS/NCandlesV3Strategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2632_Ema_Crossover_Trailing/CS/EmaCrossoverTrailingStrategy.cs
+++ b/API/2632_Ema_Crossover_Trailing/CS/EmaCrossoverTrailingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2633_IStochastic_Trading/CS/IStochasticTradingStrategy.cs
+++ b/API/2633_IStochastic_Trading/CS/IStochasticTradingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2634_ProMart_MACD_Martingale/CS/ProMartMacdMartingaleStrategy.cs
+++ b/API/2634_ProMart_MACD_Martingale/CS/ProMartMacdMartingaleStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2635_N_Candles/CS/NCandlesStrategy.cs
+++ b/API/2635_N_Candles/CS/NCandlesStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using StockSharp.Algo;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2636_MultiCurrEA/CS/MultiCurrEAStrategy.cs
+++ b/API/2636_MultiCurrEA/CS/MultiCurrEAStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2637_Double_ZigZag_Alignment/CS/DoubleZigZagStrategy.cs
+++ b/API/2637_Double_ZigZag_Alignment/CS/DoubleZigZagStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2638_Rabbit_M2/CS/RabbitM2Strategy.cs
+++ b/API/2638_Rabbit_M2/CS/RabbitM2Strategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2639_Expert_RSI_Stochastic_MA/CS/ExpertRsiStochasticMaStrategy.cs
+++ b/API/2639_Expert_RSI_Stochastic_MA/CS/ExpertRsiStochasticMaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2640_ExpertClor_Close_Manager/CS/ExpertClorCloseManagerStrategy.cs
+++ b/API/2640_ExpertClor_Close_Manager/CS/ExpertClorCloseManagerStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2641_EurUsd_Session_Breakout/CS/EurUsdSessionBreakoutStrategy.cs
+++ b/API/2641_EurUsd_Session_Breakout/CS/EurUsdSessionBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
@@ -377,4 +382,3 @@ public class EurUsdSessionBreakoutStrategy : Strategy
 		return step;
 	}
 }
-

--- a/API/2642_Trailing_Profit/CS/TrailingProfitStrategy.cs
+++ b/API/2642_Trailing_Profit/CS/TrailingProfitStrategy.cs
@@ -1,7 +1,12 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2643_Get_Rich_or_Die_Trying_GBP/CS/GetRichOrDieTryingGbpStrategy.cs
+++ b/API/2643_Get_Rich_or_Die_Trying_GBP/CS/GetRichOrDieTryingGbpStrategy.cs
@@ -1,7 +1,12 @@
-
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2644_Multi_Arbitration/CS/MultiArbitrationStrategy.cs
+++ b/API/2644_Multi_Arbitration/CS/MultiArbitrationStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2646_Color_Pema_Envelopes_Digit_System/CS/ColorPemaEnvelopesDigitSystemStrategy.cs
+++ b/API/2646_Color_Pema_Envelopes_Digit_System/CS/ColorPemaEnvelopesDigitSystemStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2647_Omni_Trend/CS/OmniTrendStrategy.cs
+++ b/API/2647_Omni_Trend/CS/OmniTrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2648_Multi_Arbitration_1_1xx/CS/MultiArbitration11xxStrategy.cs
+++ b/API/2648_Multi_Arbitration_1_1xx/CS/MultiArbitration11xxStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2649_Stop_Loss_Take_Profit/CS/StopLossTakeProfitStrategy.cs
+++ b/API/2649_Stop_Loss_Take_Profit/CS/StopLossTakeProfitStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2650_iCCI_iMA/CS/IcciImaStrategy.cs
+++ b/API/2650_iCCI_iMA/CS/IcciImaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2651_AFStar/CS/AfStarStrategy.cs
+++ b/API/2651_AFStar/CS/AfStarStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2652_ColorFisher_M11/CS/ColorFisherM11Strategy.cs
+++ b/API/2652_ColorFisher_M11/CS/ColorFisherM11Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2653_Martin_Martingale/CS/MartinMartingaleStrategy.cs
+++ b/API/2653_Martin_Martingale/CS/MartinMartingaleStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2654_Tipu_EA/CS/TipuEaStrategy.cs
+++ b/API/2654_Tipu_EA/CS/TipuEaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2655_Force_Trend/CS/ForceTrendStrategy.cs
+++ b/API/2655_Force_Trend/CS/ForceTrendStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using StockSharp.Algo;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2656_Trade_in_Channel/CS/TradeInChannelStrategy.cs
+++ b/API/2656_Trade_in_Channel/CS/TradeInChannelStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2657_OzFx_Accelerator_Stochastic/CS/OzFxAcceleratorStochasticStrategy.cs
+++ b/API/2657_OzFx_Accelerator_Stochastic/CS/OzFxAcceleratorStochasticStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2658_Nevalyashka/CS/NevalyashkaStrategy.cs
+++ b/API/2658_Nevalyashka/CS/NevalyashkaStrategy.cs
@@ -1,5 +1,12 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2659_Last_ZZ50/CS/LastZz50Strategy.cs
+++ b/API/2659_Last_ZZ50/CS/LastZz50Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2661_New_Random/CS/NewRandomStrategy.cs
+++ b/API/2661_New_Random/CS/NewRandomStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2662_Up3x1_Investor/CS/Up3x1InvestorStrategy.cs
+++ b/API/2662_Up3x1_Investor/CS/Up3x1InvestorStrategy.cs
@@ -1,6 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2664_Stopreversal_Trailing/CS/StopreversalTrailingStrategy.cs
+++ b/API/2664_Stopreversal_Trailing/CS/StopreversalTrailingStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2665_Long_Short_Expert_MACD/CS/LongShortExpertMacdStrategy.cs
+++ b/API/2665_Long_Short_Expert_MACD/CS/LongShortExpertMacdStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2666_Hidden_StopLoss_TakeProfit_Manager/CS/HiddenStopLossTakeProfitStrategy.cs
+++ b/API/2666_Hidden_StopLoss_TakeProfit_Manager/CS/HiddenStopLossTakeProfitStrategy.cs
@@ -1,5 +1,12 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2667_Slime_Mold_RSI/CS/SlimeMoldRsiStrategy.cs
+++ b/API/2667_Slime_Mold_RSI/CS/SlimeMoldRsiStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2668_Button_Close_Buy_Sell/CS/ButtonCloseBuySellStrategy.cs
+++ b/API/2668_Button_Close_Buy_Sell/CS/ButtonCloseBuySellStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2669_ChaosTraderLite/CS/ChaosTraderLiteStrategy.cs
+++ b/API/2669_ChaosTraderLite/CS/ChaosTraderLiteStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2670_Burg_Extrapolator/CS/BurgExtrapolatorStrategy.cs
+++ b/API/2670_Burg_Extrapolator/CS/BurgExtrapolatorStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2671_Carbophos_Grid/CS/CarbophosGridStrategy.cs
+++ b/API/2671_Carbophos_Grid/CS/CarbophosGridStrategy.cs
@@ -1,7 +1,12 @@
-
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2672_Open_Two_Pending_Orders/CS/OpenTwoPendingOrdersStrategy.cs
+++ b/API/2672_Open_Two_Pending_Orders/CS/OpenTwoPendingOrdersStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2673_EA_Trix/CS/EaTrixStrategy.cs
+++ b/API/2673_EA_Trix/CS/EaTrixStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2674_Pending_Orders_By_Time/CS/PendingOrdersByTimeStrategy.cs
+++ b/API/2674_Pending_Orders_By_Time/CS/PendingOrdersByTimeStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2675_Open_Time/CS/OpenTimeStrategy.cs
+++ b/API/2675_Open_Time/CS/OpenTimeStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2676_Anubis/CS/AnubisStrategy.cs
+++ b/API/2676_Anubis/CS/AnubisStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2677_II_Outbreak/CS/IiOutbreakStrategy.cs
+++ b/API/2677_II_Outbreak/CS/IiOutbreakStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2678_MT45/CS/MT45Strategy.cs
+++ b/API/2678_MT45/CS/MT45Strategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2679_Multicurrency_Overlay_Hedge/CS/MulticurrencyOverlayHedgeStrategy.cs
+++ b/API/2679_Multicurrency_Overlay_Hedge/CS/MulticurrencyOverlayHedgeStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2680_Multi_Time_Frame_Trader/CS/MultiTimeFrameTraderStrategy.cs
+++ b/API/2680_Multi_Time_Frame_Trader/CS/MultiTimeFrameTraderStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2681_Multi_Stochastic/CS/MultiStochasticStrategy.cs
+++ b/API/2681_Multi_Stochastic/CS/MultiStochasticStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2682_Vortex_Indicator_System/CS/VortexIndicatorSystemStrategy.cs
+++ b/API/2682_Vortex_Indicator_System/CS/VortexIndicatorSystemStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2683_TradeEATemplateNews/CS/TradeEaTemplateForNewsStrategy.cs
+++ b/API/2683_TradeEATemplateNews/CS/TradeEaTemplateForNewsStrategy.cs
@@ -1,9 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using System.Globalization;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using System.Globalization;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2684_Flat_Channel/CS/FlatChannelStrategy.cs
+++ b/API/2684_Flat_Channel/CS/FlatChannelStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2685_HarVesteR/CS/HarVesteRStrategy.cs
+++ b/API/2685_HarVesteR/CS/HarVesteRStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2686_Alligator_Trend/CS/AlligatorTrendStrategy.cs
+++ b/API/2686_Alligator_Trend/CS/AlligatorTrendStrategy.cs
@@ -1,6 +1,10 @@
-
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2687_Locker/CS/LockerStrategy.cs
+++ b/API/2687_Locker/CS/LockerStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2688_Super_Simple_RSI_Engulfing/CS/SuperSimpleRsiEngulfingStrategy.cs
+++ b/API/2688_Super_Simple_RSI_Engulfing/CS/SuperSimpleRsiEngulfingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2689_E_Skoch_Pending_Orders/CS/ESkochPendingOrdersStrategy.cs
+++ b/API/2689_E_Skoch_Pending_Orders/CS/ESkochPendingOrdersStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2690_Moving_Averages/CS/MovingAveragesStrategy.cs
+++ b/API/2690_Moving_Averages/CS/MovingAveragesStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2691_Nova/CS/NovaStrategy.cs
+++ b/API/2691_Nova/CS/NovaStrategy.cs
@@ -1,9 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using StockSharp.Algo;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2692_MACD_Stochastic/CS/MacdStochasticStrategy.cs
+++ b/API/2692_MACD_Stochastic/CS/MacdStochasticStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2693_Pattern_Template/CS/PatternTemplateStrategy.cs
+++ b/API/2693_Pattern_Template/CS/PatternTemplateStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2694_Perceptron_Adaptive/CS/PerceptronAdaptiveStrategy.cs
+++ b/API/2694_Perceptron_Adaptive/CS/PerceptronAdaptiveStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2695_Exp_BlauCMI/CS/ExpBlauCmiStrategy.cs
+++ b/API/2695_Exp_BlauCMI/CS/ExpBlauCmiStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2696_MAMACD/CS/MamAcdStrategy.cs
+++ b/API/2696_MAMACD/CS/MamAcdStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2698_NRTR_ATR_Stop/CS/NrtrAtrStopStrategy.cs
+++ b/API/2698_NRTR_ATR_Stop/CS/NrtrAtrStopStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2699_ColorJFatl_Digit_Duplex/CS/ColorJfatlDigitDuplexStrategy.cs
+++ b/API/2699_ColorJFatl_Digit_Duplex/CS/ColorJfatlDigitDuplexStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2700_Blau_C_Momentum/CS/BlauCMomentumStrategy.cs
+++ b/API/2700_Blau_C_Momentum/CS/BlauCMomentumStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2701_Jims_Close_Positions/CS/JimsClosePositionsStrategy.cs
+++ b/API/2701_Jims_Close_Positions/CS/JimsClosePositionsStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2702_JS_Chaos/CS/JSChaosStrategy.cs
+++ b/API/2702_JS_Chaos/CS/JSChaosStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2703_Self_Optimizing_RSI_or_MFI_Trader_v3/CS/SelfOptimizingRsiOrMfiTraderV3Strategy.cs
+++ b/API/2703_Self_Optimizing_RSI_or_MFI_Trader_v3/CS/SelfOptimizingRsiOrMfiTraderV3Strategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2704_N_Seconds_N_Points/CS/NSecondsNPointsStrategy.cs
+++ b/API/2704_N_Seconds_N_Points/CS/NSecondsNPointsStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2705_Spreader_2/CS/Spreader2Strategy.cs
+++ b/API/2705_Spreader_2/CS/Spreader2Strategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using Ecng.ComponentModel;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using Ecng.ComponentModel;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2706_OsMaSter_v0/CS/OsMaSterV0Strategy.cs
+++ b/API/2706_OsMaSter_v0/CS/OsMaSterV0Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2707_RSI_Eraser/CS/RsiEraserStrategy.cs
+++ b/API/2707_RSI_Eraser/CS/RsiEraserStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2708_Stopreversal_Tm/CS/StopreversalTmStrategy.cs
+++ b/API/2708_Stopreversal_Tm/CS/StopreversalTmStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2709_Risk_Fixed_Margin/CS/RiskFixedMarginStrategy.cs
+++ b/API/2709_Risk_Fixed_Margin/CS/RiskFixedMarginStrategy.cs
@@ -1,11 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using System.Globalization;
-using System.Text;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using System.Globalization;
+using System.Text;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2710_VR_Overturn/CS/VrOverturnStrategy.cs
+++ b/API/2710_VR_Overturn/CS/VrOverturnStrategy.cs
@@ -1,9 +1,17 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2711_Bollinger_Bands_Rsi/CS/BollingerBandsRsiStrategy.cs
+++ b/API/2711_Bollinger_Bands_Rsi/CS/BollingerBandsRsiStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2712_Vortex_Oscillator_System/CS/VortexOscillatorSystemStrategy.cs
+++ b/API/2712_Vortex_Oscillator_System/CS/VortexOscillatorSystemStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2713_Martin_1/CS/Martin1Strategy.cs
+++ b/API/2713_Martin_1/CS/Martin1Strategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2714_Billy_Expert/CS/BillyExpertStrategy.cs
+++ b/API/2714_Billy_Expert/CS/BillyExpertStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2715_GreenTrade/CS/GreenTradeStrategy.cs
+++ b/API/2715_GreenTrade/CS/GreenTradeStrategy.cs
@@ -1,6 +1,10 @@
-
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2716_KDJ_Expert_Advisor/CS/KdjExpertAdvisorStrategy.cs
+++ b/API/2716_KDJ_Expert_Advisor/CS/KdjExpertAdvisorStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2717_Daily_BreakPoint/CS/DailyBreakPointStrategy.cs
+++ b/API/2717_Daily_BreakPoint/CS/DailyBreakPointStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2718_20_Pips_Opposite_Last_N_Hour_Trend/CS/20PipsOppositeLastNHourTrendStrategy.cs
+++ b/API/2718_20_Pips_Opposite_Last_N_Hour_Trend/CS/20PipsOppositeLastNHourTrendStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2720_CMO_Duplex/CS/CmoDuplexStrategy.cs
+++ b/API/2720_CMO_Duplex/CS/CmoDuplexStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2721_Larry_Conners_RSI2/CS/LarryConnersRsi2Strategy.cs
+++ b/API/2721_Larry_Conners_RSI2/CS/LarryConnersRsi2Strategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2722_N_Candles_v5/CS/NCandlesV5Strategy.cs
+++ b/API/2722_N_Candles_v5/CS/NCandlesV5Strategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2723_BeerGod_EMA_Timing/CS/BeerGodEmaTimingStrategy.cs
+++ b/API/2723_BeerGod_EMA_Timing/CS/BeerGodEmaTimingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2724_Precipice_Martin/CS/PrecipiceMartinStrategy.cs
+++ b/API/2724_Precipice_Martin/CS/PrecipiceMartinStrategy.cs
@@ -1,5 +1,12 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2725_Triple_MA_Channel_Crossover/CS/TripleMaChannelCrossoverStrategy.cs
+++ b/API/2725_Triple_MA_Channel_Crossover/CS/TripleMaChannelCrossoverStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2726_EA_Breakeven_Stop_Manager/CS/EaBreakevenStopManagerStrategy.cs
+++ b/API/2726_EA_Breakeven_Stop_Manager/CS/EaBreakevenStopManagerStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 // -----------------------------------------------------------------------------
 // EaBreakevenStopManagerStrategy.cs
 // -----------------------------------------------------------------------------

--- a/API/2727_Dealers_Trade_MACD/CS/DealersTradeMacdStrategy.cs
+++ b/API/2727_Dealers_Trade_MACD/CS/DealersTradeMacdStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2728_Exp_Blau_CSI/CS/ExpBlauCsiStrategy.cs
+++ b/API/2728_Exp_Blau_CSI/CS/ExpBlauCsiStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2729_Show_Pips/CS/ShowPipsStrategy.cs
+++ b/API/2729_Show_Pips/CS/ShowPipsStrategy.cs
@@ -1,11 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
-using StockSharp.Charting;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Charting;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2730_VR_ZVER/CS/VrZverStrategy.cs
+++ b/API/2730_VR_ZVER/CS/VrZverStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2731_Dual_Lot_Step_Hedge/CS/DualLotStepHedgeStrategy.cs
+++ b/API/2731_Dual_Lot_Step_Hedge/CS/DualLotStepHedgeStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2732_Forex_Currency_Power/CS/ForexCurrencyPowerStrategy.cs
+++ b/API/2732_Forex_Currency_Power/CS/ForexCurrencyPowerStrategy.cs
@@ -1,13 +1,18 @@
-
 using System;
-using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
-using Ecng.ComponentModel;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using System.Globalization;
+using Ecng.ComponentModel;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2733_FORTS_Currency_Power/CS/FortsCurrencyPowerStrategy.cs
+++ b/API/2733_FORTS_Currency_Power/CS/FortsCurrencyPowerStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2734_EMA_612_Crossover/CS/Ema612CrossoverStrategy.cs
+++ b/API/2734_EMA_612_Crossover/CS/Ema612CrossoverStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2735_Starter_V6Mod/CS/StarterV6ModStrategy.cs
+++ b/API/2735_Starter_V6Mod/CS/StarterV6ModStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2736_Ichimoku_Cloud_Retrace/CS/IchimokuCloudRetraceStrategy.cs
+++ b/API/2736_Ichimoku_Cloud_Retrace/CS/IchimokuCloudRetraceStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2737_Momo_Trades/CS/MomoTradesStrategy.cs
+++ b/API/2737_Momo_Trades/CS/MomoTradesStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2738_Ma_Shift_Puria_Method/CS/MaShiftPuriaMethodStrategy.cs
+++ b/API/2738_Ma_Shift_Puria_Method/CS/MaShiftPuriaMethodStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2739_DealersTradeZeroLagMACD/CS/DealersTradeZeroLagMacdStrategy.cs
+++ b/API/2739_DealersTradeZeroLagMACD/CS/DealersTradeZeroLagMacdStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2740_Doji_Trader/CS/DojiTraderStrategy.cs
+++ b/API/2740_Doji_Trader/CS/DojiTraderStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2741_SAR_Trading_v2_0/CS/SarTradingV20Strategy.cs
+++ b/API/2741_SAR_Trading_v2_0/CS/SarTradingV20Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2742_XFatlXSatlCloud_Duplex/CS/XFatlXSatlCloudDuplexStrategy.cs
+++ b/API/2742_XFatlXSatlCloud_Duplex/CS/XFatlXSatlCloudDuplexStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2743_JS_Sistem_2/CS/JsSistem2Strategy.cs
+++ b/API/2743_JS_Sistem_2/CS/JsSistem2Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2744_Martin_For_Small_Deposits/CS/MartinForSmallDepositsStrategy.cs
+++ b/API/2744_Martin_For_Small_Deposits/CS/MartinForSmallDepositsStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2745_Arrows_and_Curves/CS/ArrowsAndCurvesStrategy.cs
+++ b/API/2745_Arrows_and_Curves/CS/ArrowsAndCurvesStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2746_Expert_ZZLWA/CS/ExpertZzlwaStrategy.cs
+++ b/API/2746_Expert_ZZLWA/CS/ExpertZzlwaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2747_XDidi_Index_Cloud_Duplex/CS/XDidiIndexCloudDuplexStrategy.cs
+++ b/API/2747_XDidi_Index_Cloud_Duplex/CS/XDidiIndexCloudDuplexStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2748_ColorJFatl_Digit_Tm_Plus/CS/ColorJfatlDigitTmPlusStrategy.cs
+++ b/API/2748_ColorJFatl_Digit_Tm_Plus/CS/ColorJfatlDigitTmPlusStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2749_Galactic_Explosion/CS/GalacticExplosionStrategy.cs
+++ b/API/2749_Galactic_Explosion/CS/GalacticExplosionStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2750_ColorJjrsxTimePlus/CS/ColorJjrsxTimePlusStrategy.cs
+++ b/API/2750_ColorJjrsxTimePlus/CS/ColorJjrsxTimePlusStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2751_Ytg_Adx_Level_Cross/CS/YtgAdxLevelCrossStrategy.cs
+++ b/API/2751_Ytg_Adx_Level_Cross/CS/YtgAdxLevelCrossStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2752_Reduce_Risks/CS/ReduceRisksStrategy.cs
+++ b/API/2752_Reduce_Risks/CS/ReduceRisksStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2753_Trade_Panel/CS/TradePanelStrategy.cs
+++ b/API/2753_Trade_Panel/CS/TradePanelStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2754_ZigZag_EvgeTrofi/CS/ZigZagEvgeTrofiStrategy.cs
+++ b/API/2754_ZigZag_EvgeTrofi/CS/ZigZagEvgeTrofiStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2755_Lacus_Trailing_Stop_and_Breakeven/CS/LacusTrailingStopAndBreakevenStrategy.cs
+++ b/API/2755_Lacus_Trailing_Stop_and_Breakeven/CS/LacusTrailingStopAndBreakevenStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2756_VR_ZVER_v2/CS/VrZverV2Strategy.cs
+++ b/API/2756_VR_ZVER_v2/CS/VrZverV2Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2757_Price_Extreme/CS/PriceExtremeStrategy.cs
+++ b/API/2757_Price_Extreme/CS/PriceExtremeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2758_Fractals_At_Close_Prices/CS/FractalsAtClosePricesStrategy.cs
+++ b/API/2758_Fractals_At_Close_Prices/CS/FractalsAtClosePricesStrategy.cs
@@ -1,5 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2759_Coin_Flipping/CS/CoinFlippingStrategy.cs
+++ b/API/2759_Coin_Flipping/CS/CoinFlippingStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2760_Blau_Ergodic_MDI/CS/BlauErgodicMdiStrategy.cs
+++ b/API/2760_Blau_Ergodic_MDI/CS/BlauErgodicMdiStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2761_Diff_TF_MA/CS/DiffTfMaStrategy.cs
+++ b/API/2761_Diff_TF_MA/CS/DiffTfMaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2762_Percentage_Crossover_Channel_EA/CS/PercentageCrossoverChannelStrategy.cs
+++ b/API/2762_Percentage_Crossover_Channel_EA/CS/PercentageCrossoverChannelStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2763_NTK_07_Range_Trader/CS/Ntk07RangeTraderStrategy.cs
+++ b/API/2763_NTK_07_Range_Trader/CS/Ntk07RangeTraderStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2764_TimeEA/CS/TimeEaStrategy.cs
+++ b/API/2764_TimeEA/CS/TimeEaStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2765_Trailing_Take_Profit/CS/TrailingTakeProfitStrategy.cs
+++ b/API/2765_Trailing_Take_Profit/CS/TrailingTakeProfitStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2766_Rnd_Trade/CS/RndTradeStrategy.cs
+++ b/API/2766_Rnd_Trade/CS/RndTradeStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2767_Ambush/CS/AmbushStrategy.cs
+++ b/API/2767_Ambush/CS/AmbushStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2768_SAR_RSI_MTS/CS/SarRsiMtsStrategy.cs
+++ b/API/2768_SAR_RSI_MTS/CS/SarRsiMtsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2769_EMA_Cross_Contest_Hedged/CS/EmaCrossContestHedgedStrategy.cs
+++ b/API/2769_EMA_Cross_Contest_Hedged/CS/EmaCrossContestHedgedStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2770_Trend_Me_Leave_Me/CS/TrendMeLeaveMeStrategy.cs
+++ b/API/2770_Trend_Me_Leave_Me/CS/TrendMeLeaveMeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2771_Trailing_Stop_And_Take/CS/TrailingStopAndTakeStrategy.cs
+++ b/API/2771_Trailing_Stop_And_Take/CS/TrailingStopAndTakeStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2772_Invest_System_45/CS/InvestSystem45Strategy.cs
+++ b/API/2772_Invest_System_45/CS/InvestSystem45Strategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
-using StockSharp.Localization;
 using StockSharp.Messages;
+
+using StockSharp.Localization;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2773_Channels_Envelope_Cross/CS/ChannelsEnvelopeCrossStrategy.cs
+++ b/API/2773_Channels_Envelope_Cross/CS/ChannelsEnvelopeCrossStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2774_MACD_Simple_Reshetov/CS/MacdSimpleReshetovStrategy.cs
+++ b/API/2774_MACD_Simple_Reshetov/CS/MacdSimpleReshetovStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2775_Pipsover_Chaikin_Hedge/CS/PipsoverChaikinHedgeStrategy.cs
+++ b/API/2775_Pipsover_Chaikin_Hedge/CS/PipsoverChaikinHedgeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2776_CH2010_Structure/CS/Ch2010StructureStrategy.cs
+++ b/API/2776_CH2010_Structure/CS/Ch2010StructureStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2777_N_Candles_v6/CS/NCandlesV6Strategy.cs
+++ b/API/2777_N_Candles_v6/CS/NCandlesV6Strategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2779_MACD_EA/CS/MacdEaStrategy.cs
+++ b/API/2779_MACD_EA/CS/MacdEaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2780_Patterns_EA/CS/PatternsEaStrategy.cs
+++ b/API/2780_Patterns_EA/CS/PatternsEaStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2781_Open_Time_Two_Sessions/CS/OpenTimeTwoStrategy.cs
+++ b/API/2781_Open_Time_Two_Sessions/CS/OpenTimeTwoStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2782_Serial_MA_Swing/CS/SerialMASwingStrategy.cs
+++ b/API/2782_Serial_MA_Swing/CS/SerialMASwingStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2783_Blau_TStoch_Indicator/CS/BlauTStochIndicatorStrategy.cs
+++ b/API/2783_Blau_TStoch_Indicator/CS/BlauTStochIndicatorStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2784_MA_Crossover/CS/MaCrossoverMultiTimeframeStrategy.cs
+++ b/API/2784_MA_Crossover/CS/MaCrossoverMultiTimeframeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2785_Fractured_Fractals/CS/FracturedFractalsStrategy.cs
+++ b/API/2785_Fractured_Fractals/CS/FracturedFractalsStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2786_BHS_System/CS/BhsSystemStrategy.cs
+++ b/API/2786_BHS_System/CS/BhsSystemStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2787_Blau_SM_Stochastic/CS/BlauSmStochasticStrategy.cs
+++ b/API/2787_Blau_SM_Stochastic/CS/BlauSmStochasticStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2788_Ichimoku_Barabashkakvn/CS/IchimokuBarabashkakvnStrategy.cs
+++ b/API/2788_Ichimoku_Barabashkakvn/CS/IchimokuBarabashkakvnStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2789_Hans123_Trader/CS/Hans123TraderStrategy.cs
+++ b/API/2789_Hans123_Trader/CS/Hans123TraderStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2790_AlexavSpeedUpM1/CS/AlexavSpeedUpM1Strategy.cs
+++ b/API/2790_AlexavSpeedUpM1/CS/AlexavSpeedUpM1Strategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2791_Cross_Line_Trader/CS/CrossLineTraderStrategy.cs
+++ b/API/2791_Cross_Line_Trader/CS/CrossLineTraderStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using System.Globalization;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using System.Globalization;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2792_FarhadCrab1/CS/FarhadCrab1Strategy.cs
+++ b/API/2792_FarhadCrab1/CS/FarhadCrab1Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2793_Trend_RDS/CS/TrendRdsStrategy.cs
+++ b/API/2793_Trend_RDS/CS/TrendRdsStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2794_Aeron_JJN_Scalper_EA/CS/AeronJjnScalperEaStrategy.cs
+++ b/API/2794_Aeron_JJN_Scalper_EA/CS/AeronJjnScalperEaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2795_Two_MA_RSI/CS/TwoMaRsiStrategy.cs
+++ b/API/2795_Two_MA_RSI/CS/TwoMaRsiStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2796_Parabolic_Trailing_Stop/CS/ParabolicTrailingStopStrategy.cs
+++ b/API/2796_Parabolic_Trailing_Stop/CS/ParabolicTrailingStopStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2797_SV_Daily_Breakout/CS/SvDailyBreakoutStrategy.cs
+++ b/API/2797_SV_Daily_Breakout/CS/SvDailyBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2798_Improve_MA_RSI_Hedge/CS/ImproveMaRsiHedgeStrategy.cs
+++ b/API/2798_Improve_MA_RSI_Hedge/CS/ImproveMaRsiHedgeStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2799_MACD_Multi_Timeframe_Expert/CS/MacdMultiTimeframeExpertStrategy.cs
+++ b/API/2799_MACD_Multi_Timeframe_Expert/CS/MacdMultiTimeframeExpertStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2800_CoensioTrader1V06/CS/CoensioTrader1V06Strategy.cs
+++ b/API/2800_CoensioTrader1V06/CS/CoensioTrader1V06Strategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
@@ -259,4 +265,3 @@ public class CoensioTrader1V06Strategy : Strategy
 		_prevHigh = candle.HighPrice;
 	}
 }
-

--- a/API/2801_Martingale_Bone_Crusher/CS/MartingaleBoneCrusherStrategy.cs
+++ b/API/2801_Martingale_Bone_Crusher/CS/MartingaleBoneCrusherStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2802_Zone_Recovery_Area/CS/ZoneRecoveryAreaStrategy.cs
+++ b/API/2802_Zone_Recovery_Area/CS/ZoneRecoveryAreaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2804_ADX_Expert/CS/AdxExpertStrategy.cs
+++ b/API/2804_ADX_Expert/CS/AdxExpertStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2805_Channel_EA_Limits/CS/ChannelEaLimitsStrategy.cs
+++ b/API/2805_Channel_EA_Limits/CS/ChannelEaLimitsStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2806_Blau_TS_Stochastic/CS/BlauTsStochasticStrategy.cs
+++ b/API/2806_Blau_TS_Stochastic/CS/BlauTsStochasticStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2807_Bollinger_Bands_N_Positions_V2/CS/BollingerBandsNPositionsV2Strategy.cs
+++ b/API/2807_Bollinger_Bands_N_Positions_V2/CS/BollingerBandsNPositionsV2Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2808_Multi_Pair_Closer/CS/MultiPairCloserStrategy.cs
+++ b/API/2808_Multi_Pair_Closer/CS/MultiPairCloserStrategy.cs
@@ -1,11 +1,17 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using System.Text;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2809_Hans123_Trader_v2/CS/Hans123TraderV2Strategy.cs
+++ b/API/2809_Hans123_Trader_v2/CS/Hans123TraderV2Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2810_Crossing_of_two_iMA_v2/CS/CrossingOfTwoIMaV2Strategy.cs
+++ b/API/2810_Crossing_of_two_iMA_v2/CS/CrossingOfTwoIMaV2Strategy.cs
@@ -1,6 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
 using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2811_UniversalTrailingManager/CS/UniversalTrailingManagerStrategy.cs
+++ b/API/2811_UniversalTrailingManager/CS/UniversalTrailingManagerStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2812_Donchain_Counter/CS/DonchainCounterStrategy.cs
+++ b/API/2812_Donchain_Counter/CS/DonchainCounterStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2813_FuturesPortfolioControlExpiration/CS/FuturesPortfolioControlExpirationStrategy.cs
+++ b/API/2813_FuturesPortfolioControlExpiration/CS/FuturesPortfolioControlExpirationStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using System.Globalization;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using System.Globalization;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2814_Maximus_VX_Lite/CS/MaximusVXLiteStrategy.cs
+++ b/API/2814_Maximus_VX_Lite/CS/MaximusVXLiteStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2815_Poker_Show/CS/PokerShowStrategy.cs
+++ b/API/2815_Poker_Show/CS/PokerShowStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2816_True_Sort_Trend/CS/TrueSortTrendStrategy.cs
+++ b/API/2816_True_Sort_Trend/CS/TrueSortTrendStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2817_EMA_WMA_Contrarian/CS/EmaWmaContrarianStrategy.cs
+++ b/API/2817_EMA_WMA_Contrarian/CS/EmaWmaContrarianStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2818_ChannelEA2/CS/ChannelEa2Strategy.cs
+++ b/API/2818_ChannelEA2/CS/ChannelEa2Strategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2819_Small_Inside_Bar/CS/SmallInsideBarStrategy.cs
+++ b/API/2819_Small_Inside_Bar/CS/SmallInsideBarStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2820_NCandlesSequence/CS/NCandlesSequenceStrategy.cs
+++ b/API/2820_NCandlesSequence/CS/NCandlesSequenceStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2821_Price_Impulse/CS/PriceImpulseStrategy.cs
+++ b/API/2821_Price_Impulse/CS/PriceImpulseStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2822_FX_CHAOS_SCALP/CS/FxChaosScalpStrategy.cs
+++ b/API/2822_FX_CHAOS_SCALP/CS/FxChaosScalpStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2823_Momentum_M15/CS/MomentumM15Strategy.cs
+++ b/API/2823_Momentum_M15/CS/MomentumM15Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2824_Brandy/CS/BrandyStrategy.cs
+++ b/API/2824_Brandy/CS/BrandyStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2825_Firebird_Channel_Averaging/CS/FirebirdChannelAveragingStrategy.cs
+++ b/API/2825_Firebird_Channel_Averaging/CS/FirebirdChannelAveragingStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2826_Blau_Ergodic/CS/BlauErgodicStrategy.cs
+++ b/API/2826_Blau_Ergodic/CS/BlauErgodicStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2827_Absorption/CS/AbsorptionStrategy.cs
+++ b/API/2827_Absorption/CS/AbsorptionStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2828_Gold_Warrior02b/CS/GoldWarrior02bStrategy.cs
+++ b/API/2828_Gold_Warrior02b/CS/GoldWarrior02bStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2829_Doji_Arrows/CS/DojiArrowsStrategy.cs
+++ b/API/2829_Doji_Arrows/CS/DojiArrowsStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2830_BSS_Triple_EMA_Separation/CS/BssTripleEmaSeparationStrategy.cs
+++ b/API/2830_BSS_Triple_EMA_Separation/CS/BssTripleEmaSeparationStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2831_VR_Moving_Distance/CS/VrMovingDistanceStrategy.cs
+++ b/API/2831_VR_Moving_Distance/CS/VrMovingDistanceStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2832_Universal_MA_Cross/CS/UniversalMaCrossStrategy.cs
+++ b/API/2832_Universal_MA_Cross/CS/UniversalMaCrossStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2833_EAMovingAverage/CS/EaMovingAverageStrategy.cs
+++ b/API/2833_EAMovingAverage/CS/EaMovingAverageStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2835_Exp_Sar_Tm_Plus/CS/ExpSarTmPlusStrategy.cs
+++ b/API/2835_Exp_Sar_Tm_Plus/CS/ExpSarTmPlusStrategy.cs
@@ -1,6 +1,10 @@
-
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2836_Amstell_Grid/CS/AmstellGridStrategy.cs
+++ b/API/2836_Amstell_Grid/CS/AmstellGridStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2838_Breakeven_Trailing_Stop/CS/BreakevenTrailingStopStrategy.cs
+++ b/API/2838_Breakeven_Trailing_Stop/CS/BreakevenTrailingStopStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2839_E_News_Lucky/CS/ENewsLuckyStrategy.cs
+++ b/API/2839_E_News_Lucky/CS/ENewsLuckyStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2841_Static_Arrow_EA/CS/StaticArrowEaStrategy.cs
+++ b/API/2841_Static_Arrow_EA/CS/StaticArrowEaStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2842_Binary_Option_Symbol_Scanner/CS/BinaryOptionSymbolScannerStrategy.cs
+++ b/API/2842_Binary_Option_Symbol_Scanner/CS/BinaryOptionSymbolScannerStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2844_Timed_Buy_Order/CS/TimedBuyOrderStrategy.cs
+++ b/API/2844_Timed_Buy_Order/CS/TimedBuyOrderStrategy.cs
@@ -1,6 +1,15 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2845_KWAN_NRP/CS/ExpKwanNrpStrategy.cs
+++ b/API/2845_KWAN_NRP/CS/ExpKwanNrpStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2846_PLC/CS/PlcStrategy.cs
+++ b/API/2846_PLC/CS/PlcStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2847_Kwan_Ccc/CS/KwanCccStrategy.cs
+++ b/API/2847_Kwan_Ccc/CS/KwanCccStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2848_Kwan_Rdp/CS/KwanRdpStrategy.cs
+++ b/API/2848_Kwan_Rdp/CS/KwanRdpStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2849_Spasm/CS/SpasmStrategy.cs
+++ b/API/2849_Spasm/CS/SpasmStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2850_AO_Lightning/CS/AoLightningStrategy.cs
+++ b/API/2850_AO_Lightning/CS/AoLightningStrategy.cs
@@ -1,10 +1,18 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 using StockSharp.Algo;
 using StockSharp.Algo.Candles;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2851_Expotest/CS/ExpotestStrategy.cs
+++ b/API/2851_Expotest/CS/ExpotestStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2852_Surefirething/CS/SurefirethingStrategy.cs
+++ b/API/2852_Surefirething/CS/SurefirethingStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2853_AlliHeik/CS/AlliHeikStrategy.cs
+++ b/API/2853_AlliHeik/CS/AlliHeikStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2854_Rsi_Bollinger_Bands_Ea/CS/RsiBollingerBandsEaStrategy.cs
+++ b/API/2854_Rsi_Bollinger_Bands_Ea/CS/RsiBollingerBandsEaStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2855_NeuroNirvaman/CS/NeuroNirvamanStrategy.cs
+++ b/API/2855_NeuroNirvaman/CS/NeuroNirvamanStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2856_Rollback_Rebound/CS/RollbackReboundStrategy.cs
+++ b/API/2856_Rollback_Rebound/CS/RollbackReboundStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2857_Exp_2XMA_Ichimoku_Oscillator/CS/Exp2XmaIchimokuOscillatorStrategy.cs
+++ b/API/2857_Exp_2XMA_Ichimoku_Oscillator/CS/Exp2XmaIchimokuOscillatorStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2858_XRSIDeMarker_Histogram/CS/XrsidDeMarkerHistogramStrategy.cs
+++ b/API/2858_XRSIDeMarker_Histogram/CS/XrsidDeMarkerHistogramStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2859_Average_Change_Candle/CS/AverageChangeCandleStrategy.cs
+++ b/API/2859_Average_Change_Candle/CS/AverageChangeCandleStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2860_Bands_Pending_Breakout/CS/BandsPendingBreakoutStrategy.cs
+++ b/API/2860_Bands_Pending_Breakout/CS/BandsPendingBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2861_Martingale_MA_Breakout/CS/MartingaleMaBreakoutStrategy.cs
+++ b/API/2861_Martingale_MA_Breakout/CS/MartingaleMaBreakoutStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2862_AIS2_Trading_Robot/CS/Ais2TradingRobotStrategy.cs
+++ b/API/2862_AIS2_Trading_Robot/CS/Ais2TradingRobotStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2863_Lock/CS/LockStrategy.cs
+++ b/API/2863_Lock/CS/LockStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2864_Absolutely_No_Lag_LWMA/CS/AbsolutelyNoLagLwmaStrategy.cs
+++ b/API/2864_Absolutely_No_Lag_LWMA/CS/AbsolutelyNoLagLwmaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2865_Night_Flat_Trade/CS/NightFlatTradeStrategy.cs
+++ b/API/2865_Night_Flat_Trade/CS/NightFlatTradeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2866_Executor_Candles/CS/ExecutorCandlesStrategy.cs
+++ b/API/2866_Executor_Candles/CS/ExecutorCandlesStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2867_MACD_and_SAR/CS/MacdAndSarStrategy.cs
+++ b/API/2867_MACD_and_SAR/CS/MacdAndSarStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2868_ATR_Normalize_Histogram/CS/AtrNormalizeHistogramStrategy.cs
+++ b/API/2868_ATR_Normalize_Histogram/CS/AtrNormalizeHistogramStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2869_Coin_Flip/CS/CoinFlipStrategy.cs
+++ b/API/2869_Coin_Flip/CS/CoinFlipStrategy.cs
@@ -1,6 +1,12 @@
 using System;
 using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2870_Binario/CS/BinarioStrategy.cs
+++ b/API/2870_Binario/CS/BinarioStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2872_Trading_Boxing/CS/TradingBoxingStrategy.cs
+++ b/API/2872_Trading_Boxing/CS/TradingBoxingStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2873_BrainTrend2_V2_Duplex/CS/BrainTrend2V2DuplexStrategy.cs
+++ b/API/2873_BrainTrend2_V2_Duplex/CS/BrainTrend2V2DuplexStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2874_Deep_Drawdown_MA/CS/DeepDrawdownMaStrategy.cs
+++ b/API/2874_Deep_Drawdown_MA/CS/DeepDrawdownMaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2875_Previous_Candle_Breakdown/CS/PreviousCandleBreakdownStrategy.cs
+++ b/API/2875_Previous_Candle_Breakdown/CS/PreviousCandleBreakdownStrategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2876_Close_By_Equity_Percent/CS/CloseByEquityPercentStrategy.cs
+++ b/API/2876_Close_By_Equity_Percent/CS/CloseByEquityPercentStrategy.cs
@@ -1,11 +1,17 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2877_EA_Stochastic/CS/EaStochasticStrategy.cs
+++ b/API/2877_EA_Stochastic/CS/EaStochasticStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2878_Martingale_VI_Hybrid/CS/MartingaleViHybridStrategy.cs
+++ b/API/2878_Martingale_VI_Hybrid/CS/MartingaleViHybridStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2879_SilverTrend_CrazyChart/CS/SilverTrendCrazyChartStrategy.cs
+++ b/API/2879_SilverTrend_CrazyChart/CS/SilverTrendCrazyChartStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2880_Two_MA_One_RSI/CS/TwoMaOneRsiStrategy.cs
+++ b/API/2880_Two_MA_One_RSI/CS/TwoMaOneRsiStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2881_On_Tick_Market_Watch/CS/OnTickMarketWatchStrategy.cs
+++ b/API/2881_On_Tick_Market_Watch/CS/OnTickMarketWatchStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using System.Globalization;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using System.Globalization;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2882_Exp_CandlesticksBW_Tm/CS/ExpCandlesticksBwTimeStrategy.cs
+++ b/API/2882_Exp_CandlesticksBW_Tm/CS/ExpCandlesticksBwTimeStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2883_Interceptor/CS/InterceptorStrategy.cs
+++ b/API/2883_Interceptor/CS/InterceptorStrategy.cs
@@ -1,6 +1,10 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2884_SilverTrend_Duplex/CS/SilverTrendDuplexStrategy.cs
+++ b/API/2884_SilverTrend_Duplex/CS/SilverTrendDuplexStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2885_Exp_Sinewave2_X2/CS/ExpSinewave2X2Strategy.cs
+++ b/API/2885_Exp_Sinewave2_X2/CS/ExpSinewave2X2Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2887_Renko_Level/CS/RenkoLevelStrategy.cs
+++ b/API/2887_Renko_Level/CS/RenkoLevelStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2887_Renko_Level_EA/CS/RenkoLevelEaStrategy.cs
+++ b/API/2887_Renko_Level_EA/CS/RenkoLevelEaStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2888_Exp_ColorX2MA_X2/CS/ExpColorX2MaX2Strategy.cs
+++ b/API/2888_Exp_ColorX2MA_X2/CS/ExpColorX2MaX2Strategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2889_BlauErgodicMDITime/CS/BlauErgodicMdiTimeStrategy.cs
+++ b/API/2889_BlauErgodicMDITime/CS/BlauErgodicMdiTimeStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2890_Blau_TVI_Timed_Reversal/CS/BlauTviTimedReversalStrategy.cs
+++ b/API/2890_Blau_TVI_Timed_Reversal/CS/BlauTviTimedReversalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2891_FullDump_BBands_RSI/CS/FullDumpBbRsiStrategy.cs
+++ b/API/2891_FullDump_BBands_RSI/CS/FullDumpBbRsiStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2892_UltraAbsolutelyNoLagLwma/CS/UltraAbsolutelyNoLagLwmaStrategy.cs
+++ b/API/2892_UltraAbsolutelyNoLagLwma/CS/UltraAbsolutelyNoLagLwmaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2893_Volume_Trader/CS/VolumeTraderStrategy.cs
+++ b/API/2893_Volume_Trader/CS/VolumeTraderStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2894_Color_X_Derivative/CS/ColorXDerivativeStrategy.cs
+++ b/API/2894_Color_X_Derivative/CS/ColorXDerivativeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2895_ExFractals/CS/ExFractalsStrategy.cs
+++ b/API/2895_ExFractals/CS/ExFractalsStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2896_WAMI_Cloud_X2/CS/WamiCloudX2Strategy.cs
+++ b/API/2896_WAMI_Cloud_X2/CS/WamiCloudX2Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2897_Caudate_X_Period_Candle_TM_Plus/CS/CaudateXPeriodCandleTmPlusStrategy.cs
+++ b/API/2897_Caudate_X_Period_Candle_TM_Plus/CS/CaudateXPeriodCandleTmPlusStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2898_Exp_XPeriodCandle/CS/ExpXPeriodCandleStrategy.cs
+++ b/API/2898_Exp_XPeriodCandle/CS/ExpXPeriodCandleStrategy.cs
@@ -1,9 +1,15 @@
-	using System;
-	using System.Collections.Generic;
+using System;
+using System.Linq;
+using System.Collections.Generic;
 
-	using StockSharp.Algo.Strategies;
-	using StockSharp.BusinessEntities;
-	using StockSharp.Messages;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
 
 	namespace StockSharp.Samples.Strategies;
 

--- a/API/2900_Area_MACD/CS/AreaMacdStrategy.cs
+++ b/API/2900_Area_MACD/CS/AreaMacdStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2901_Exp_XPeriodCandle_X2/CS/ExpXPeriodCandleX2Strategy.cs
+++ b/API/2901_Exp_XPeriodCandle_X2/CS/ExpXPeriodCandleX2Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2902_Candle_Shadows_V1/CS/CandleShadowsV1Strategy.cs
+++ b/API/2902_Candle_Shadows_V1/CS/CandleShadowsV1Strategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2903_Alexav_D1_Profit_GBPUSD/CS/AlexavD1ProfitGbpUsdStrategy.cs
+++ b/API/2903_Alexav_D1_Profit_GBPUSD/CS/AlexavD1ProfitGbpUsdStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2904_BrainTrend2_AbsolutelyNoLagLwma/CS/BrainTrend2AbsolutelyNoLagLwmaStrategy.cs
+++ b/API/2904_BrainTrend2_AbsolutelyNoLagLwma/CS/BrainTrend2AbsolutelyNoLagLwmaStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2905_SilverTrend_ColorJFatl_Digit/CS/SilverTrendColorJFatlDigitStrategy.cs
+++ b/API/2905_SilverTrend_ColorJFatl_Digit/CS/SilverTrendColorJFatlDigitStrategy.cs
@@ -1,6 +1,10 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2906_BykovTrend_ColorX2MA/CS/BykovTrendColorX2MaStrategy.cs
+++ b/API/2906_BykovTrend_ColorX2MA/CS/BykovTrendColorX2MaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2907_CCFp_Currency_Strength/CS/CcfpCurrencyStrengthStrategy.cs
+++ b/API/2907_CCFp_Currency_Strength/CS/CcfpCurrencyStrengthStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2908_Auto_ADX/CS/AutoAdxStrategy.cs
+++ b/API/2908_Auto_ADX/CS/AutoAdxStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2909_Bollinger_Band_Two_MA_ZigZag/CS/BollingerBandTwoMaZigZagStrategy.cs
+++ b/API/2909_Bollinger_Band_Two_MA_ZigZag/CS/BollingerBandTwoMaZigZagStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2910_Urdala_Trol/CS/UrdalaTrolStrategy.cs
+++ b/API/2910_Urdala_Trol/CS/UrdalaTrolStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2911_Martingail_Expert/CS/MartingailExpertStrategy.cs
+++ b/API/2911_Martingail_Expert/CS/MartingailExpertStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2912_Global_Stop_Loss_Time/CS/GlobalStopLossTimeStrategy.cs
+++ b/API/2912_Global_Stop_Loss_Time/CS/GlobalStopLossTimeStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2913_TakeProfitTimeGuard/CS/TakeProfitTimeGuardStrategy.cs
+++ b/API/2913_TakeProfitTimeGuard/CS/TakeProfitTimeGuardStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2914_Global_Stop_Timer/CS/GlobalStopTimerStrategy.cs
+++ b/API/2914_Global_Stop_Timer/CS/GlobalStopTimerStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2915_AOCCI/CS/AocciStrategy.cs
+++ b/API/2915_AOCCI/CS/AocciStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2916_Clouds_Trade_2/CS/CloudsTrade2Strategy.cs
+++ b/API/2916_Clouds_Trade_2/CS/CloudsTrade2Strategy.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2917_BykovTrend_ColorX2MA_MMRec/CS/BykovTrendColorX2MaMmRecStrategy.cs
+++ b/API/2917_BykovTrend_ColorX2MA_MMRec/CS/BykovTrendColorX2MaMmRecStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2918_SilverTrendColorJFatlDigitMMRec/CS/SilverTrendColorJfatlDigitMmrecStrategy.cs
+++ b/API/2918_SilverTrendColorJFatlDigitMMRec/CS/SilverTrendColorJfatlDigitMmrecStrategy.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
 using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2919_Virtual_Trailing_Stop/CS/VirtualTrailingStopStrategy.cs
+++ b/API/2919_Virtual_Trailing_Stop/CS/VirtualTrailingStopStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2920_BrainTrend2_AbsolutelyNoLagLwma_MMRec/CS/BrainTrend2AbsolutelyNoLagLwmaMmrecStrategy.cs
+++ b/API/2920_BrainTrend2_AbsolutelyNoLagLwma_MMRec/CS/BrainTrend2AbsolutelyNoLagLwmaMmrecStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2921_Simple_Pivot/CS/SimplePivotStrategy.cs
+++ b/API/2921_Simple_Pivot/CS/SimplePivotStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2922_CloseProfit_v2/CS/CloseProfitV2Strategy.cs
+++ b/API/2922_CloseProfit_v2/CS/CloseProfitV2Strategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2923_Arttrader_v1_5/CS/ArttraderV15Strategy.cs
+++ b/API/2923_Arttrader_v1_5/CS/ArttraderV15Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2924_MostasHar15_Pivot/CS/MostasHar15PivotStrategy.cs
+++ b/API/2924_MostasHar15_Pivot/CS/MostasHar15PivotStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2925_Twenty_200_Pips/CS/Twenty200PipsStrategy.cs
+++ b/API/2925_Twenty_200_Pips/CS/Twenty200PipsStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2926_ColorJFatl_Digit_NN3_MMRec/CS/ColorJFatlDigitNn3MmRecStrategy.cs
+++ b/API/2926_ColorJFatl_Digit_NN3_MMRec/CS/ColorJFatlDigitNn3MmRecStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2927_ColorX2MA_Digit_NN3_MMRec/CS/ColorX2MaDigitNn3MmrecStrategy.cs
+++ b/API/2927_ColorX2MA_Digit_NN3_MMRec/CS/ColorX2MaDigitNn3MmrecStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2928_OverHedgeV2/CS/OverHedgeV2Strategy.cs
+++ b/API/2928_OverHedgeV2/CS/OverHedgeV2Strategy.cs
@@ -1,6 +1,10 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2929_Absolutely_NoLag_Lwma_Digit_MMRec/CS/AbsolutelyNoLagLwmaDigitMmRecStrategy.cs
+++ b/API/2929_Absolutely_NoLag_Lwma_Digit_MMRec/CS/AbsolutelyNoLagLwmaDigitMmRecStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2930_Ang_Zad_C_Time_MM_Recovery/CS/AngZadCTimeMMRecoveryStrategy.cs
+++ b/API/2930_Ang_Zad_C_Time_MM_Recovery/CS/AngZadCTimeMMRecoveryStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2931_Return/CS/ReturnStrategy.cs
+++ b/API/2931_Return/CS/ReturnStrategy.cs
@@ -1,7 +1,12 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2932_ZigZag_EA/CS/ZigZagEAStrategy.cs
+++ b/API/2932_ZigZag_EA/CS/ZigZagEAStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2933_Breakdown_Pending_Stop/CS/BreakdownPendingStopStrategy.cs
+++ b/API/2933_Breakdown_Pending_Stop/CS/BreakdownPendingStopStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2934_Triple_SMA_Spread/CS/TripleSmaSpreadStrategy.cs
+++ b/API/2934_Triple_SMA_Spread/CS/TripleSmaSpreadStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2935_One_MA_Channel_Breakout/CS/OneMaChannelBreakoutStrategy.cs
+++ b/API/2935_One_MA_Channel_Breakout/CS/OneMaChannelBreakoutStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2936_MCM_Control_Panel/CS/McmControlPanelStrategy.cs
+++ b/API/2936_MCM_Control_Panel/CS/McmControlPanelStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2937_CCI_and_Martin/CS/CCIAndMartinStrategy.cs
+++ b/API/2937_CCI_and_Martin/CS/CCIAndMartinStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2938_Crossing_Moving_Average/CS/CrossingMovingAverageStrategy.cs
+++ b/API/2938_Crossing_Moving_Average/CS/CrossingMovingAverageStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2939_Separate_Trade/CS/SeparateTradeStrategy.cs
+++ b/API/2939_Separate_Trade/CS/SeparateTradeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2940_XPeriodCandleSystem_Tm_Plus/CS/XPeriodCandleSystemTmPlusStrategy.cs
+++ b/API/2940_XPeriodCandleSystem_Tm_Plus/CS/XPeriodCandleSystemTmPlusStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2941_MACD_Sample/CS/MacdSampleStrategy.cs
+++ b/API/2941_MACD_Sample/CS/MacdSampleStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2942_AbsolutelyNoLagLwma_Range_Channel_Tm_Plus/CS/AbsolutelyNoLagLwmaRangeChannelTmPlusStrategy.cs
+++ b/API/2942_AbsolutelyNoLagLwma_Range_Channel_Tm_Plus/CS/AbsolutelyNoLagLwmaRangeChannelTmPlusStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2943_CandleStop_System_Tm_Plus/CS/CandleStopSystemTmPlusStrategy.cs
+++ b/API/2943_CandleStop_System_Tm_Plus/CS/CandleStopSystemTmPlusStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2944_Rj_SlidingRange_Digit_System_Tm_Plus/CS/ExpRjSlidingRangeRjDigitSystemTmPlusStrategy.cs
+++ b/API/2944_Rj_SlidingRange_Digit_System_Tm_Plus/CS/ExpRjSlidingRangeRjDigitSystemTmPlusStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2945_Exp_Dema_Range_Channel_Tm_Plus/CS/ExpDemaRangeChannelTmPlusStrategy.cs
+++ b/API/2945_Exp_Dema_Range_Channel_Tm_Plus/CS/ExpDemaRangeChannelTmPlusStrategy.cs
@@ -1,6 +1,10 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2946_Exp_T3_TRIX/CS/ExpT3TrixStrategy.cs
+++ b/API/2946_Exp_T3_TRIX/CS/ExpT3TrixStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2947_Market_Capture/CS/MarketCaptureStrategy.cs
+++ b/API/2947_Market_Capture/CS/MarketCaptureStrategy.cs
@@ -1,7 +1,12 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2948_Exp_RSIOMA_V2/CS/ExpRsiomaV2Strategy.cs
+++ b/API/2948_Exp_RSIOMA_V2/CS/ExpRsiomaV2Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2949_Exp_Digital_MACD/CS/ExpDigitalMacdStrategy.cs
+++ b/API/2949_Exp_Digital_MACD/CS/ExpDigitalMacdStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2950_GBP_9AM_Breakout/CS/Gbp9AmBreakoutStrategy.cs
+++ b/API/2950_GBP_9AM_Breakout/CS/Gbp9AmBreakoutStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2951_Open_Oscillator_Cloud_MMRec/CS/OpenOscillatorCloudMmrecStrategy.cs
+++ b/API/2951_Open_Oscillator_Cloud_MMRec/CS/OpenOscillatorCloudMmrecStrategy.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2952_Wajdyss_Ichimoku_Candle_MMRec/CS/WajdyssIchimokuCandleMmrecStrategy.cs
+++ b/API/2952_Wajdyss_Ichimoku_Candle_MMRec/CS/WajdyssIchimokuCandleMmrecStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2953_Freeman/CS/FreemanStrategy.cs
+++ b/API/2953_Freeman/CS/FreemanStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2954_Gaps/CS/GapsStrategy.cs
+++ b/API/2954_Gaps/CS/GapsStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2955_MARSIEA/CS/MaRsiEaStrategy.cs
+++ b/API/2955_MARSIEA/CS/MaRsiEaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2956_Exp_XWAMI_MMRec/CS/ExpXwamiMmRecStrategy.cs
+++ b/API/2956_Exp_XWAMI_MMRec/CS/ExpXwamiMmRecStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2957_Sidus/CS/SidusStrategy.cs
+++ b/API/2957_Sidus/CS/SidusStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2958_Dematus/CS/DematusStrategy.cs
+++ b/API/2958_Dematus/CS/DematusStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2959_AltrTrend_Signal/CS/AltrTrendSignalStrategy.cs
+++ b/API/2959_AltrTrend_Signal/CS/AltrTrendSignalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2960_OHLC_Check/CS/OhlcCheckStrategy.cs
+++ b/API/2960_OHLC_Check/CS/OhlcCheckStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2961_XAng_Zad_C_Tm_MMRec/CS/XAngZadCTmMmRecStrategy.cs
+++ b/API/2961_XAng_Zad_C_Tm_MMRec/CS/XAngZadCTmMmRecStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2962_Xwami_MultiLayer_Mmrec/CS/XwamiMultiLayerMmrecStrategy.cs
+++ b/API/2962_Xwami_MultiLayer_Mmrec/CS/XwamiMultiLayerMmrecStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2963_Expert_Ichimoku/CS/ExpertIchimokuStrategy.cs
+++ b/API/2963_Expert_Ichimoku/CS/ExpertIchimokuStrategy.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2964_1H_EUR_USD/CS/OneHourEurUsdStrategy.cs
+++ b/API/2964_1H_EUR_USD/CS/OneHourEurUsdStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2965_Forex_Fraus_M1/CS/ForexFrausM1Strategy.cs
+++ b/API/2965_Forex_Fraus_M1/CS/ForexFrausM1Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2966_Xit_Three_Ma_Cross/CS/XitThreeMaCrossStrategy.cs
+++ b/API/2966_Xit_Three_Ma_Cross/CS/XitThreeMaCrossStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2967_Bw_Wiseman_1/CS/BwWiseman1Strategy.cs
+++ b/API/2967_Bw_Wiseman_1/CS/BwWiseman1Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2968_ColorXPWMA_Digit_MMRec/CS/ColorXpWmaDigitMmRecStrategy.cs
+++ b/API/2968_ColorXPWMA_Digit_MMRec/CS/ColorXpWmaDigitMmRecStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2969_Avalanche_AV/CS/AvalancheAvStrategy.cs
+++ b/API/2969_Avalanche_AV/CS/AvalancheAvStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2970_Above_Below_MA/CS/AboveBelowMaStrategy.cs
+++ b/API/2970_Above_Below_MA/CS/AboveBelowMaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2971_55_MA_Bar_Comparison/CS/FiftyFiveMaBarComparisonStrategy.cs
+++ b/API/2971_55_MA_Bar_Comparison/CS/FiftyFiveMaBarComparisonStrategy.cs
@@ -1,6 +1,10 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
 using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2972_RSI_Expert/CS/RsiExpertStrategy.cs
+++ b/API/2972_RSI_Expert/CS/RsiExpertStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2973_Renko_Fractals_Grid/CS/RenkoFractalsGridStrategy.cs
+++ b/API/2973_Renko_Fractals_Grid/CS/RenkoFractalsGridStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2974_DLMv_FX_Fish_Grid/CS/DlmvFxFishGridStrategy.cs
+++ b/API/2974_DLMv_FX_Fish_Grid/CS/DlmvFxFishGridStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2975_NextBar_Momentum/CS/NextBarMomentumStrategy.cs
+++ b/API/2975_NextBar_Momentum/CS/NextBarMomentumStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using System.Globalization;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using System.Globalization;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2976_Ultra_MFI_MMRec/CS/UltraMfiMmRecStrategy.cs
+++ b/API/2976_Ultra_MFI_MMRec/CS/UltraMfiMmRecStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2977_ColorXPWMA_Digit_MTF/CS/ColorXpWmaDigitMultiTimeframeStrategy.cs
+++ b/API/2977_ColorXPWMA_Digit_MTF/CS/ColorXpWmaDigitMultiTimeframeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2978_FatPanel_Visual_Builder/CS/FatPanelVisualBuilderStrategy.cs
+++ b/API/2978_FatPanel_Visual_Builder/CS/FatPanelVisualBuilderStrategy.cs
@@ -1,15 +1,20 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using System.Globalization;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
-using StockSharp.Algo;
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2979_Exp_Trend_Intensity_Index/CS/ExpTrendIntensityIndexStrategy.cs
+++ b/API/2979_Exp_Trend_Intensity_Index/CS/ExpTrendIntensityIndexStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2980_Exp_Trading_Channel_Index/CS/ExpTradingChannelIndexStrategy.cs
+++ b/API/2980_Exp_Trading_Channel_Index/CS/ExpTradingChannelIndexStrategy.cs
@@ -1,6 +1,10 @@
-
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2981_Slow_Stochastic_Mode/CS/SlowStochasticModeStrategy.cs
+++ b/API/2981_Slow_Stochastic_Mode/CS/SlowStochasticModeStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2982_Russian20_Momentum_MA/CS/Russian20MomentumMaStrategy.cs
+++ b/API/2982_Russian20_Momentum_MA/CS/Russian20MomentumMaStrategy.cs
@@ -1,7 +1,14 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;

--- a/API/2983_AnyRange_Cloud_Tail_System_Tm_Plus/CS/AnyRangeCloudTailSystemTmPlusStrategy.cs
+++ b/API/2983_AnyRange_Cloud_Tail_System_Tm_Plus/CS/AnyRangeCloudTailSystemTmPlusStrategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2984_Gordago_EA/CS/GordagoEaStrategy.cs
+++ b/API/2984_Gordago_EA/CS/GordagoEaStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2985_Iin_MA_Signal/CS/IinMaSignalStrategy.cs
+++ b/API/2985_Iin_MA_Signal/CS/IinMaSignalStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2986_The_20s_Breakout/CS/The20sBreakoutStrategy.cs
+++ b/API/2986_The_20s_Breakout/CS/The20sBreakoutStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2987_Renko_Chart/CS/RenkoChartStrategy.cs
+++ b/API/2987_Renko_Chart/CS/RenkoChartStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2988_Flat_Trend_EA/CS/FlatTrendEaStrategy.cs
+++ b/API/2988_Flat_Trend_EA/CS/FlatTrendEaStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2989_Trendline_Cross_Alert/CS/TrendlineCrossAlertStrategy.cs
+++ b/API/2989_Trendline_Cross_Alert/CS/TrendlineCrossAlertStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using System.Globalization;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using System.Globalization;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2990_SSB5_123/CS/Ssb5123Strategy.cs
+++ b/API/2990_SSB5_123/CS/Ssb5123Strategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2991_Pending_Orders_By_Time/CS/PendingOrdersByTime2Strategy.cs
+++ b/API/2991_Pending_Orders_By_Time/CS/PendingOrdersByTime2Strategy.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;

--- a/API/2992_XCCI_Histogram_Vol/CS/XcciHistogramVolStrategy.cs
+++ b/API/2992_XCCI_Histogram_Vol/CS/XcciHistogramVolStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2993_Exp_XRSI_Histogram_Vol/CS/ExpXrsiHistogramVolStrategy.cs
+++ b/API/2993_Exp_XRSI_Histogram_Vol/CS/ExpXrsiHistogramVolStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2994_Ravi_AO/CS/RaviAoStrategy.cs
+++ b/API/2994_Ravi_AO/CS/RaviAoStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2995_VR_BUCH/CS/VrBuchStrategy.cs
+++ b/API/2995_VR_BUCH/CS/VrBuchStrategy.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 

--- a/API/2996_ExpIinMASignalMMRec/CS/ExpIinMaSignalMmrecStrategy.cs
+++ b/API/2996_ExpIinMASignalMMRec/CS/ExpIinMaSignalMmrecStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2997_AMA_Trader/CS/AmaTraderStrategy.cs
+++ b/API/2997_AMA_Trader/CS/AmaTraderStrategy.cs
@@ -1,3 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
+using StockSharp.Algo.Indicators;
+using StockSharp.Algo.Strategies;
+using StockSharp.BusinessEntities;
+using StockSharp.Messages;
+
 namespace StockSharp.Samples.Strategies;
 
 using System;

--- a/API/2998_Basic_CCI_RSI/CS/BasicCciRsiStrategy.cs
+++ b/API/2998_Basic_CCI_RSI/CS/BasicCciRsiStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/2999_XRSI_Histogram_Vol_Direct/CS/XrsiHistogramVolDirectStrategy.cs
+++ b/API/2999_XRSI_Histogram_Vol_Direct/CS/XrsiHistogramVolDirectStrategy.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
 
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;

--- a/API/3000_XCCI_Histogram_Vol_Direct/CS/XcciHistogramVolDirectStrategy.cs
+++ b/API/3000_XCCI_Histogram_Vol_Direct/CS/XcciHistogramVolDirectStrategy.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
-using StockSharp.Algo;
+using Ecng.Common;
+using Ecng.Collections;
+using Ecng.Serialization;
+
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 


### PR DESCRIPTION
## Summary
- add the shared System, Ecng, and StockSharp using directives to every API strategy numbered 2001-3000

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d80950d2e48323b617dfbbbf9d6e70