### PR TITLE
Remove duplicate using directives from strategies

### DIFF
--- a/API/0113_Bullish_Abandoned_Baby/CS/BullishAbandonedBabyStrategy.cs
+++ b/API/0113_Bullish_Abandoned_Baby/CS/BullishAbandonedBabyStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
-using StockSharp.BusinessEntities;
 
 /// <summary>
 /// Strategy based on Bullish Abandoned Baby candlestick pattern.

--- a/API/0114_Bearish_Abandoned_Baby/CS/BearishAbandonedBabyStrategy.cs
+++ b/API/0114_Bearish_Abandoned_Baby/CS/BearishAbandonedBabyStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
-using StockSharp.BusinessEntities;
 
 /// <summary>
 /// Strategy based on Bearish Abandoned Baby candlestick pattern.

--- a/API/0115_Volume_Climax_Reversal/CS/VolumeClimaxReversalStrategy.cs
+++ b/API/0115_Volume_Climax_Reversal/CS/VolumeClimaxReversalStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.Algo.Indicators;
-using StockSharp.Messages;
-using StockSharp.BusinessEntities;
 
 /// <summary>
 /// Volume Climax Reversal strategy.

--- a/API/0130_Lunch_Break_Fade/CS/LunchBreakFadeStrategy.cs
+++ b/API/0130_Lunch_Break_Fade/CS/LunchBreakFadeStrategy.cs
@@ -1,28 +1,20 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using Ecng.Common;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy that trades on the price movement fade during the lunch break.

--- a/API/0131_MACD_RSI/CS/MacdRsiStrategy.cs
+++ b/API/0131_MACD_RSI/CS/MacdRsiStrategy.cs
@@ -1,29 +1,20 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using Ecng.Common;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy that combines MACD and RSI indicators to identify potential trading opportunities.

--- a/API/0132_Bollinger_Stochastic/CS/BollingerStochasticStrategy.cs
+++ b/API/0132_Bollinger_Stochastic/CS/BollingerStochasticStrategy.cs
@@ -1,29 +1,20 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using Ecng.Common;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy that combines Bollinger Bands and Stochastic oscillator to identify

--- a/API/0133_MA_Volume/CS/MaVolumeStrategy.cs
+++ b/API/0133_MA_Volume/CS/MaVolumeStrategy.cs
@@ -1,29 +1,20 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using Ecng.Common;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy that combines moving average and volume indicators to identify

--- a/API/0134_ADX_MACD/CS/AdxMacdStrategy.cs
+++ b/API/0134_ADX_MACD/CS/AdxMacdStrategy.cs
@@ -1,29 +1,20 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using Ecng.Common;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy that combines ADX and MACD indicators to identify strong trends

--- a/API/0135_Ichimoku_RSI/CS/IchimokuRsiStrategy.cs
+++ b/API/0135_Ichimoku_RSI/CS/IchimokuRsiStrategy.cs
@@ -1,29 +1,20 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using Ecng.Common;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy that combines Ichimoku Cloud and RSI indicators to identify

--- a/API/0136_Supertrend_Volume/CS/SupertrendVolumeStrategy.cs
+++ b/API/0136_Supertrend_Volume/CS/SupertrendVolumeStrategy.cs
@@ -1,29 +1,20 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using Ecng.Common;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy that combines the Supertrend indicator with volume analysis to identify

--- a/API/0527_Arpeet_Macd/CS/ArpeetMacdStrategy.cs
+++ b/API/0527_Arpeet_Macd/CS/ArpeetMacdStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Arpeet MACD strategy - trades MACD crossovers with zero-line filter.

--- a/API/0538_Automatic_Trendlines/CS/AutomaticTrendlinesStrategy.cs
+++ b/API/0538_Automatic_Trendlines/CS/AutomaticTrendlinesStrategy.cs
@@ -1,25 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Automatic Trendlines Strategy

--- a/API/0541_Average_High_Low_Range_IBS_Reversal/CS/AverageHighLowRangeIbsReversalStrategy.cs
+++ b/API/0541_Average_High_Low_Range_IBS_Reversal/CS/AverageHighLowRangeIbsReversalStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Average high-low range with IBS reversal strategy.

--- a/API/0547_Bar_Balance/CS/BarBalanceStrategy.cs
+++ b/API/0547_Bar_Balance/CS/BarBalanceStrategy.cs
@@ -1,28 +1,19 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using Ecng.Common;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Bar balance strategy.

--- a/API/0554_BB_Heikin_Ashi_Entry/CS/BollingerHeikinAshiEntryStrategy.cs
+++ b/API/0554_BB_Heikin_Ashi_Entry/CS/BollingerHeikinAshiEntryStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy using Bollinger Bands with Heikin Ashi entries.

--- a/API/0589_Bollinger_Bands_RSI/CS/BollingerBandsRsiStrategy.cs
+++ b/API/0589_Bollinger_Bands_RSI/CS/BollingerBandsRsiStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on Bollinger Bands and RSI.

--- a/API/0593_Bollinger_Bands_Modified/CS/BollingerBandsModifiedStrategy.cs
+++ b/API/0593_Bollinger_Bands_Modified/CS/BollingerBandsModifiedStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Bollinger Bands Modified strategy.

--- a/API/0595_Bollinger_Bands/CS/BollingerBandsStrategy.cs
+++ b/API/0595_Bollinger_Bands/CS/BollingerBandsStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy trading Bollinger Bands breakouts.

--- a/API/0601_Captain_Backtest_Model/CS/CaptainBacktestModelStrategy.cs
+++ b/API/0601_Captain_Backtest_Model/CS/CaptainBacktestModelStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,11 +11,6 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Captain Backtest Model strategy.

--- a/API/0603_CC_Trend_Downtrend_Short/CS/CCTrend2DowntrendShortStrategy.cs
+++ b/API/0603_CC_Trend_Downtrend_Short/CS/CCTrend2DowntrendShortStrategy.cs
@@ -1,26 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Short-only strategy based on EMA trend filters and Fibonacci levels.

--- a/API/0604_CCI_Support_Resistance/CS/CciSupportResistanceStrategy.cs
+++ b/API/0604_CCI_Support_Resistance/CS/CciSupportResistanceStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy that trades breakouts of CCI based support and resistance levels.

--- a/API/0609_Ce_Zlsma_5Min_Candlechart/CS/CeZlsma5MinCandlechartStrategy.cs
+++ b/API/0609_Ce_Zlsma_5Min_Candlechart/CS/CeZlsma5MinCandlechartStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// CE ZLSMA 5MIN Candlechart Strategy.

--- a/API/0622_Cnagda_Fixed_Swing/CS/CnagdaFixedSwingStrategy.cs
+++ b/API/0622_Cnagda_Fixed_Swing/CS/CnagdaFixedSwingStrategy.cs
@@ -1,28 +1,19 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using Ecng.Common;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 public class CnagdaFixedSwingStrategy : Strategy
 {

--- a/API/0649_CVD_Divergence_Volume_HMA_RSI_MACD/CS/CvdDivergenceVolumeHmaRsiMacdStrategy.cs
+++ b/API/0649_CVD_Divergence_Volume_HMA_RSI_MACD/CS/CvdDivergenceVolumeHmaRsiMacdStrategy.cs
@@ -1,23 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
-using StockSharp.Algo.Indicators;
-using StockSharp.Messages;
 
 public class CvdDivergenceVolumeHmaRsiMacdStrategy : Strategy
 {

--- a/API/0652_D-BoT_Alpha_Short_SMA_and_RSI/CS/DBoTAlphaShortSmaAndRsiStrategy.cs
+++ b/API/0652_D-BoT_Alpha_Short_SMA_and_RSI/CS/DBoTAlphaShortSmaAndRsiStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Short strategy based on SMA and RSI.

--- a/API/0668_DebugConsole/CS/DebugConsoleStrategy.cs
+++ b/API/0668_DebugConsole/CS/DebugConsoleStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
-using StockSharp.BusinessEntities;
 
 /// <summary>
 /// Demonstrates a console that queues messages for debugging.

--- a/API/0672_Delta_RSI_Oscillator/CS/DeltaRsiOscillatorStrategy.cs
+++ b/API/0672_Delta_RSI_Oscillator/CS/DeltaRsiOscillatorStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 public enum SignalCondition
 {

--- a/API/0677_Distance_to_Demand_Vector/CS/DistanceToDemandVectorStrategy.cs
+++ b/API/0677_Distance_to_Demand_Vector/CS/DistanceToDemandVectorStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on Distance to Demand Vector indicator.

--- a/API/0685_Donchian_Breakout/CS/DonchianBreakoutStrategy.cs
+++ b/API/0685_Donchian_Breakout/CS/DonchianBreakoutStrategy.cs
@@ -1,26 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Donchian Breakout Strategy.

--- a/API/0692_Double_Bollinger_Bands_Signals/CS/DoubleBollingerBandsSignalsStrategy.cs
+++ b/API/0692_Double_Bollinger_Bands_Signals/CS/DoubleBollingerBandsSignalsStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy trading double Bollinger Bands with entry and exit signals.

--- a/API/0694_Double_CCI_Confirmed_Hull_Moving_Average_Reversal/CS/DoubleCciConfirmedHullMovingAverageReversalStrategy.cs
+++ b/API/0694_Double_CCI_Confirmed_Hull_Moving_Average_Reversal/CS/DoubleCciConfirmedHullMovingAverageReversalStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy that trades when price crosses above Hull MA confirmed by two CCI indicators.

--- a/API/0705_DSL/CS/DslStrategy.cs
+++ b/API/0705_DSL/CS/DslStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 public class DslStrategy : Strategy
 {

--- a/API/0715_Dynamic_Breakout_Master/CS/DynamicBreakoutMasterStrategy.cs
+++ b/API/0715_Dynamic_Breakout_Master/CS/DynamicBreakoutMasterStrategy.cs
@@ -1,12 +1,9 @@
-
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -14,15 +11,8 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using Ecng.Common;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Dynamic Breakout Master strategy with multiple filters.

--- a/API/0727_Elliott_Wave_Supertrend_Exit/CS/ElliottWaveSupertrendExitStrategy.cs
+++ b/API/0727_Elliott_Wave_Supertrend_Exit/CS/ElliottWaveSupertrendExitStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Elliott Wave strategy with Supertrend exits and fixed percentage stop-loss.

--- a/API/0742_EMA_Crossover_Volume_Stacked_TP_Trailing_SL/CS/EmaCrossoverVolumeStackedTpTrailingSlStrategy.cs
+++ b/API/0742_EMA_Crossover_Volume_Stacked_TP_Trailing_SL/CS/EmaCrossoverVolumeStackedTpTrailingSlStrategy.cs
@@ -1,28 +1,20 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using Ecng.Common;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// EMA crossover strategy with volume filter.

--- a/API/0749_EMATrend_Heikin_Ashi_Entry/CS/EmaTrendHeikinAshiEntryStrategy.cs
+++ b/API/0749_EMATrend_Heikin_Ashi_Entry/CS/EmaTrendHeikinAshiEntryStrategy.cs
@@ -1,12 +1,9 @@
-
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -14,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy using Bollinger Bands on Heikin Ashi with higher timeframe EMA trend.

--- a/API/0754_Enhanced_BarUpDn/CS/EnhancedBarUpDnStrategy.cs
+++ b/API/0754_Enhanced_BarUpDn/CS/EnhancedBarUpDnStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on Enhanced BarUpDn signals with Bollinger Bands filter.

--- a/API/0760_Enhanced_Time_Segmented_Volume/CS/EnhancedTimeSegmentedVolumeStrategy.cs
+++ b/API/0760_Enhanced_Time_Segmented_Volume/CS/EnhancedTimeSegmentedVolumeStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Enhanced Time Segmented Volume strategy

--- a/API/0776_Extrapolated_Pivot_Connector/CS/ExtrapolatedPivotConnectorStrategy.cs
+++ b/API/0776_Extrapolated_Pivot_Connector/CS/ExtrapolatedPivotConnectorStrategy.cs
@@ -1,25 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 public class ExtrapolatedPivotConnectorStrategy : Strategy
 {

--- a/API/0781_Fibonacci_Bollinger_Bands/CS/FibonacciBollingerBandsStrategy.cs
+++ b/API/0781_Fibonacci_Bollinger_Bands/CS/FibonacciBollingerBandsStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Fibonacci & Bollinger Bands Strategy.

--- a/API/0783_Fibonacci_ATR_Fusion/CS/FibonacciAtrFusionStrategy.cs
+++ b/API/0783_Fibonacci_ATR_Fusion/CS/FibonacciAtrFusionStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Integrates weighted buying pressure ratios and ATR thresholds.

--- a/API/0789_Fibonacci_Trend_Reversal/CS/FibonacciTrendReversalStrategy.cs
+++ b/API/0789_Fibonacci_Trend_Reversal/CS/FibonacciTrendReversalStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Fibonacci trend reversal strategy with ATR based risk management.

--- a/API/0793_Financial_Ratios_Fundamental/CS/FinancialRatiosFundamentalStrategy.cs
+++ b/API/0793_Financial_Ratios_Fundamental/CS/FinancialRatiosFundamentalStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Fundamental strategy based on financial ratios.

--- a/API/0796_Fine_tune_Inputs_Gann_Laplace_Smooth_Volume_Zone_Oscillator/CS/FineTuneGannLaplaceVzoStrategy.cs
+++ b/API/0796_Fine_tune_Inputs_Gann_Laplace_Smooth_Volume_Zone_Oscillator/CS/FineTuneGannLaplaceVzoStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Volume oscillator strategy with EMA smoothing.

--- a/API/0799_Flex_ATR/CS/FlexAtrStrategy.cs
+++ b/API/0799_Flex_ATR/CS/FlexAtrStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Flex ATR strategy using EMA crossover with RSI filter and ATR-based stops.

--- a/API/0800_Flexible_Moving_Average/CS/FlexibleMovingAverageStrategy.cs
+++ b/API/0800_Flexible_Moving_Average/CS/FlexibleMovingAverageStrategy.cs
@@ -1,26 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 public class FlexibleMovingAverageStrategy : Strategy
 {

--- a/API/0801_FlexiMA_Variance_Tracker/CS/FlexiMaVarianceTrackerStrategy.cs
+++ b/API/0801_FlexiMA_Variance_Tracker/CS/FlexiMaVarianceTrackerStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 public class FlexiMaVarianceTrackerStrategy : Strategy
 {

--- a/API/0804_Follow_Line/CS/FollowLineStrategy.cs
+++ b/API/0804_Follow_Line/CS/FollowLineStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Follow Line strategy with optional higher timeframe confirmation.

--- a/API/0817_Function_Simple_Markov_Chain_Monte_Carlo_Simulation/CS/FunctionSimpleMarkovChainMonteCarloSimulationStrategy.cs
+++ b/API/0817_Function_Simple_Markov_Chain_Monte_Carlo_Simulation/CS/FunctionSimpleMarkovChainMonteCarloSimulationStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,10 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
 
 /// <summary>
 /// Generates a path using a simple Markov Chain Monte Carlo simulation.

--- a/API/0834_Gaussian_Channel/CS/GaussianChannelStrategy.cs
+++ b/API/0834_Gaussian_Channel/CS/GaussianChannelStrategy.cs
@@ -1,24 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 public enum LineSelection
 {

--- a/API/0849_Gold_Scalping_BOS_CHoCH/CS/GoldScalpingBosChochStrategy.cs
+++ b/API/0849_Gold_Scalping_BOS_CHoCH/CS/GoldScalpingBosChochStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Gold scalping strategy based on Break of Structure (BOS) and Change of Character (CHoCH).

--- a/API/0853_Golden_Cross_VWMA_EMA/CS/GoldenCrossVwmaEmaStrategy.cs
+++ b/API/0853_Golden_Cross_VWMA_EMA/CS/GoldenCrossVwmaEmaStrategy.cs
@@ -1,24 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 /// <summary>
 /// Golden Cross VWMA & EMA Strategy.

--- a/API/0856_Volume_Support_Resistance_Zones/CS/VolumeSupportResistanceZonesStrategy.cs
+++ b/API/0856_Volume_Support_Resistance_Zones/CS/VolumeSupportResistanceZonesStrategy.cs
@@ -1,24 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 /// <summary>
 /// Volume-based Support & Resistance Zones V2.

--- a/API/0857_Gradient_Trend_Filter/CS/GradientTrendFilterStrategy.cs
+++ b/API/0857_Gradient_Trend_Filter/CS/GradientTrendFilterStrategy.cs
@@ -1,24 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 /// <summary>
 /// Gradient Trend Filter strategy.

--- a/API/0859_Grid_Bot_Backtesting/CS/GridBotBacktestingStrategy.cs
+++ b/API/0859_Grid_Bot_Backtesting/CS/GridBotBacktestingStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Grid Bot Backtesting Strategy.

--- a/API/0860_Grid_Like/CS/GridLikeStrategy.cs
+++ b/API/0860_Grid_Like/CS/GridLikeStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Grid like strategy using martingale or anti-martingale position sizing.

--- a/API/0871_HarmonicPattern/CS/HarmonicPatternStrategy.cs
+++ b/API/0871_HarmonicPattern/CS/HarmonicPatternStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,9 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo.Strategies;
 
 /// <summary>
 /// Harmonic pattern detection helper methods.

--- a/API/0872_Harmony_Signal_Flow_By_Arun/CS/HarmonySignalFlowByArunStrategy.cs
+++ b/API/0872_Harmony_Signal_Flow_By_Arun/CS/HarmonySignalFlowByArunStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,6 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 public class HarmonySignalFlowByArunStrategy : Strategy {
 	private readonly StrategyParam<int> _rsiPeriod;

--- a/API/0877_Heikin_Ashi_ROC_Percentile/CS/HeikinAshiRocPercentileStrategy.cs
+++ b/API/0877_Heikin_Ashi_ROC_Percentile/CS/HeikinAshiRocPercentileStrategy.cs
@@ -1,26 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Heikin Ashi ROC Percentile Strategy.

--- a/API/0882_Higher_Order_Pivots/CS/HigherOrderPivotsStrategy.cs
+++ b/API/0882_Higher_Order_Pivots/CS/HigherOrderPivotsStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,11 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Detects 1st, 2nd and 3rd order pivot highs and lows.

--- a/API/0895_HTF_Candles_Lib/CS/HtfCandlesLibStrategy.cs
+++ b/API/0895_HTF_Candles_Lib/CS/HtfCandlesLibStrategy.cs
@@ -1,25 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Utility strategy that reconstructs higher timeframe candles from lower timeframe data.

--- a/API/0903_Hybrid_RSI_Breakout_Dashboard/CS/HybridRsiBreakoutDashboardStrategy.cs
+++ b/API/0903_Hybrid_RSI_Breakout_Dashboard/CS/HybridRsiBreakoutDashboardStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Hybrid strategy combining RSI mean reversion and breakout entries with dashboard tracking.

--- a/API/0906_Ichimoku_Rsi_Macd/CS/IchimokuRsiMacdStrategy.cs
+++ b/API/0906_Ichimoku_Rsi_Macd/CS/IchimokuRsiMacdStrategy.cs
@@ -1,29 +1,20 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using Ecng.Common;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy combining Ichimoku Cloud with RSI and MACD crossover.

--- a/API/0907_Ichimoku_by_FarmerBTC/CS/IchimokuByFarmerBtcStrategy.cs
+++ b/API/0907_Ichimoku_by_FarmerBTC/CS/IchimokuByFarmerBtcStrategy.cs
@@ -1,26 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on Ichimoku cloud with high timeframe SMA and volume filter.

--- a/API/0908_Ichimoku_Cloud_Breakout_Only_Long/CS/IchimokuCloudBreakoutOnlyLongStrategy.cs
+++ b/API/0908_Ichimoku_Cloud_Breakout_Only_Long/CS/IchimokuCloudBreakoutOnlyLongStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Ichimoku cloud breakout strategy trading only long.

--- a/API/0927_Internal_Bar_Strength_IBS/CS/InternalBarStrengthIbsStrategy.cs
+++ b/API/0927_Internal_Bar_Strength_IBS/CS/InternalBarStrengthIbsStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Internal bar strength mean reversion strategy.

--- a/API/0928_Intra_Bullish_Profit_Ping_v4_0/CS/IntraBullishProfitPingV40Strategy.cs
+++ b/API/0928_Intra_Bullish_Profit_Ping_v4_0/CS/IntraBullishProfitPingV40Strategy.cs
@@ -1,26 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Intra Bullish Strategy - Profit Ping v4.0.

--- a/API/0940_IU_Gap_Fill/CS/IUGapFillStrategy.cs
+++ b/API/0940_IU_Gap_Fill/CS/IUGapFillStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Trades when a session gap of a given size is filled.

--- a/API/0941_IU_Higher_Timeframe_MA_Cross/CS/IUHigherTimeframeMACrossStrategy.cs
+++ b/API/0941_IU_Higher_Timeframe_MA_Cross/CS/IUHigherTimeframeMACrossStrategy.cs
@@ -1,26 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 public class IUHigherTimeframeMACrossStrategy : Strategy
 {

--- a/API/0945_JLines_Ribbon_4_Cycle_Engine/CS/JLinesRibbon4CycleEngineStrategy.cs
+++ b/API/0945_JLines_Ribbon_4_Cycle_Engine/CS/JLinesRibbon4CycleEngineStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// J-Lines Ribbon 4-Cycle Engine strategy.

--- a/API/0965_Lanz_6_0_Backtest/CS/Lanz60BacktestStrategy.cs
+++ b/API/0965_Lanz_6_0_Backtest/CS/Lanz60BacktestStrategy.cs
@@ -1,25 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// LANZ Strategy 6.0: trades the 09:00 New York hour candle with risk management.

--- a/API/0993_Long_Short_Exit_Risk_Management/CS/LongShortExitRiskManagementStrategy.cs
+++ b/API/0993_Long_Short_Exit_Risk_Management/CS/LongShortExitRiskManagementStrategy.cs
@@ -1,25 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 public enum TradingDirection
 {

--- a/API/0997_Long_Only_Opening_Range_Breakout_ORB_with_Pivot_Points/CS/LongOnlyOpeningRangeBreakoutWithPivotPointsStrategy.cs
+++ b/API/0997_Long_Only_Opening_Range_Breakout_ORB_with_Pivot_Points/CS/LongOnlyOpeningRangeBreakoutWithPivotPointsStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 public enum SlType
 {

--- a/API/0998_LSMA_Fast_Simple_Alternative_Calculation/CS/LsmaFastSimpleAlternativeCalculationStrategy.cs
+++ b/API/0998_LSMA_Fast_Simple_Alternative_Calculation/CS/LsmaFastSimpleAlternativeCalculationStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// LSMA Fast And Simple Alternative Calculation Strategy.

--- a/API/1004_MA_MACD_BB_BackTester/CS/MaMacdBbBackTesterStrategy.cs
+++ b/API/1004_MA_MACD_BB_BackTester/CS/MaMacdBbBackTesterStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy that trades using either MA, MACD or Bollinger Bands signals.

--- a/API/1009_MACD_Enhanced_MTF_With_Stop_Loss/CS/MacdEnhancedMtfWithStopLossStrategy.cs
+++ b/API/1009_MACD_Enhanced_MTF_With_Stop_Loss/CS/MacdEnhancedMtfWithStopLossStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// MACD Enhanced Strategy MTF with Stop Loss.

--- a/API/1019_Markdown_The_Pine_Editors_Hidden_Gem/CS/MarkdownThePineEditorsHiddenGemStrategy.cs
+++ b/API/1019_Markdown_The_Pine_Editors_Hidden_Gem/CS/MarkdownThePineEditorsHiddenGemStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Bollinger Bands breakout strategy based on a simple moving average.

--- a/API/1026_Mateos_Time_of_Day_Analysis_LE/CS/MateosTimeOfDayAnalysisLeStrategy.cs
+++ b/API/1026_Mateos_Time_of_Day_Analysis_LE/CS/MateosTimeOfDayAnalysisLeStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Mateo's Time of Day Analysis LE strategy.

--- a/API/1031_Function_Matrix_Library/CS/FunctionMatrixLibraryStrategy.cs
+++ b/API/1031_Function_Matrix_Library/CS/FunctionMatrixLibraryStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Demonstrates multiple linear regression using two SMA inputs.

--- a/API/1039_MCOTs_Intuition/CS/McotsIntuitionStrategy.cs
+++ b/API/1039_MCOTs_Intuition/CS/McotsIntuitionStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// MCOTs Intuition Strategy.

--- a/API/1057_MOC_Delta_MOO_Entry_V2_REVERSE/CS/MocDeltaMooEntryV2ReverseStrategy.cs
+++ b/API/1057_MOC_Delta_MOO_Entry_V2_REVERSE/CS/MocDeltaMooEntryV2ReverseStrategy.cs
@@ -1,26 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 public class MocDeltaMooEntryV2ReverseStrategy : Strategy
 {

--- a/API/1086_Multi_Conditions_Curve_Fitting/CS/MultiConditionsCurveFittingStrategy.cs
+++ b/API/1086_Multi_Conditions_Curve_Fitting/CS/MultiConditionsCurveFittingStrategy.cs
@@ -1,27 +1,19 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy combining EMA crossover, RSI and Stochastic oscillator.

--- a/API/1087_Multi_Time_Frame_Candles_with_Volume_Info_3D/CS/MultiTimeFrameCandlesWithVolumeInfo3DStrategy.cs
+++ b/API/1087_Multi_Time_Frame_Candles_with_Volume_Info_3D/CS/MultiTimeFrameCandlesWithVolumeInfo3DStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Displays higher time frame candles with volume information.

--- a/API/1099_Multi-Step_Vegas_SuperTrend/CS/MultiStepVegasSuperTrendStrategy.cs
+++ b/API/1099_Multi-Step_Vegas_SuperTrend/CS/MultiStepVegasSuperTrendStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// SuperTrend strategy adjusted by Vegas channel with multi-step take profits.

--- a/API/1102_Multi_Timeframe_Parabolic_SAR/CS/MultiTimeframeParabolicSarStrategy.cs
+++ b/API/1102_Multi_Timeframe_Parabolic_SAR/CS/MultiTimeframeParabolicSarStrategy.cs
@@ -1,29 +1,20 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using Ecng.Common;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Multi-timeframe Parabolic SAR strategy.

--- a/API/1106_MultiLayer_Awesome_Oscillator_Saucer/CS/MultiLayerAwesomeOscillatorSaucerStrategy.cs
+++ b/API/1106_MultiLayer_Awesome_Oscillator_Saucer/CS/MultiLayerAwesomeOscillatorSaucerStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// MultiLayer Awesome Oscillator Saucer strategy.

--- a/API/1110_Narrow_Range/CS/NarrowRangeStrategy.cs
+++ b/API/1110_Narrow_Range/CS/NarrowRangeStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy trading breakouts after a narrow range bar.

--- a/API/1136_Optimized_Auto_Detect/CS/OptimizedAutoDetectStrategy.cs
+++ b/API/1136_Optimized_Auto_Detect/CS/OptimizedAutoDetectStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Moving average crossover strategy with optional trend, RSI filters and ATR-based exit.

--- a/API/1138_Optimized_Heikin_Ashi_Buy_Sell/CS/OptimizedHeikinAshiBuySellStrategy.cs
+++ b/API/1138_Optimized_Heikin_Ashi_Buy_Sell/CS/OptimizedHeikinAshiBuySellStrategy.cs
@@ -1,25 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Heikin-Ashi strategy trading a single direction with optional stop-loss and take-profit.

--- a/API/1156_Parabolic_SAR_Early_Buy_MA_Exit/CS/ParabolicSarEarlyBuyMaExitStrategy.cs
+++ b/API/1156_Parabolic_SAR_Early_Buy_MA_Exit/CS/ParabolicSarEarlyBuyMaExitStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Parabolic SAR strategy with early buy and MA-based exit.

--- a/API/1161_PEAD/CS/PeadStrategy.cs
+++ b/API/1161_PEAD/CS/PeadStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Post-earnings announcement drift strategy with gap and EMA exit.

--- a/API/1201_Pullback_Pro_Dow/CS/PullbackProDowStrategy.cs
+++ b/API/1201_Pullback_Pro_Dow/CS/PullbackProDowStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Pullback strategy based on Dow Theory pivots with optional ADX filter and two-step profit targets.

--- a/API/1204_Pure_Price_Action/CS/PurePriceActionStrategy.cs
+++ b/API/1204_Pure_Price_Action/CS/PurePriceActionStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Pure price action strategy using Break of Structure (BOS) and Market Structure Shift (MSS).

--- a/API/1212_Quantum_Reversal/CS/QuantumReversalStrategy.cs
+++ b/API/1212_Quantum_Reversal/CS/QuantumReversalStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 public class QuantumReversalStrategy : Strategy
 {

--- a/API/1215_Rally_Base_Drop_SND_Pivots/CS/RallyBaseDropSndPivotsStrategy.cs
+++ b/API/1215_Rally_Base_Drop_SND_Pivots/CS/RallyBaseDropSndPivotsStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Rally Base Drop SND Pivots strategy.

--- a/API/1255_Risk_to_Reward_FIXED_SL_Backtester/CS/RiskToRewardFixedSlBacktesterStrategy.cs
+++ b/API/1255_Risk_to_Reward_FIXED_SL_Backtester/CS/RiskToRewardFixedSlBacktesterStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Risk to Reward - Fixed SL Backtester strategy.

--- a/API/1270_Rsi_Long_Term_15min/CS/RsiLongTerm15minStrategy.cs
+++ b/API/1270_Rsi_Long_Term_15min/CS/RsiLongTerm15minStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,10 +11,6 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// RSI Long-Term strategy using 15-minute candles.

--- a/API/1290_Scalping_By_TradingConToto/CS/ScalpingByTradingConTotoStrategy.cs
+++ b/API/1290_Scalping_By_TradingConToto/CS/ScalpingByTradingConTotoStrategy.cs
@@ -1,26 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 public class ScalpingByTradingConTotoStrategy : Strategy
 {

--- a/API/1310_SMA_RSI_Volume_ATR/CS/SmaRsiVolumeAtrStrategy.cs
+++ b/API/1310_SMA_RSI_Volume_ATR/CS/SmaRsiVolumeAtrStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,15 +11,8 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using Ecng.Common;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 public class SmaRsiVolumeAtrStrategy : Strategy
 {

--- a/API/1323_Smoothed_Heiken_Ashi_Long_Only/CS/SmoothedHeikenAshiLongOnlyStrategy.cs
+++ b/API/1323_Smoothed_Heiken_Ashi_Long_Only/CS/SmoothedHeikenAshiLongOnlyStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Long-only strategy based on smoothed Heikin-Ashi candles.

--- a/API/1325_SMU_STDEV_Candles/CS/SmuStdevCandlesStrategy.cs
+++ b/API/1325_SMU_STDEV_Candles/CS/SmuStdevCandlesStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,6 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// SMU STDEV Candles Strategy.

--- a/API/1399_MADH_Moving_Average_Difference_Hann/CS/MadhMovingAverageDifferenceHannStrategy.cs
+++ b/API/1399_MADH_Moving_Average_Difference_Hann/CS/MadhMovingAverageDifferenceHannStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on the MADH (Moving Average Difference, Hann) indicator.

--- a/API/1400_The_Weekly_Factor/CS/TheWeeklyFactorStrategy.cs
+++ b/API/1400_The_Weekly_Factor/CS/TheWeeklyFactorStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on the Weekly Factor pattern.

--- a/API/1401_Gap_Momentum_System/CS/GapMomentumSystemStrategy.cs
+++ b/API/1401_Gap_Momentum_System/CS/GapMomentumSystemStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
-using StockSharp.Algo.Indicators;
 
 /// <summary>
 /// Strategy using the Gap Momentum System by Perry Kaufman.

--- a/API/1403_Volume_Confirmation_For_A_Trend_System/CS/VolumeConfirmationForATrendSystemStrategy.cs
+++ b/API/1403_Volume_Confirmation_For_A_Trend_System/CS/VolumeConfirmationForATrendSystemStrategy.cs
@@ -1,25 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Long-only strategy using ADX, Trend Thrust Indicator (TTI) and Volume Price Confirmation Indicator (VPCI).

--- a/API/1485_Triple_CCI_MFI_Confirmed/CS/TripleCciMfiConfirmedStrategy.cs
+++ b/API/1485_Triple_CCI_MFI_Confirmed/CS/TripleCciMfiConfirmedStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy using triple CCI confirmed by MFI and EMA with ATR based trailing exit.

--- a/API/1489_Tripple_MACD/CS/TrippleMacdStrategy.cs
+++ b/API/1489_Tripple_MACD/CS/TrippleMacdStrategy.cs
@@ -1,25 +1,19 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 /// <summary>
 /// Combines four MACD indicators and an RSI filter.

--- a/API/1490_TSI_Long_Short_for_BTC_2H/CS/TsiLongShortForBtc2HStrategy.cs
+++ b/API/1490_TSI_Long_Short_for_BTC_2H/CS/TsiLongShortForBtc2HStrategy.cs
@@ -1,25 +1,19 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 /// <summary>
 /// True Strength Index breakout strategy.

--- a/API/1491_TSI_w_SuperTrend_decision_presentTrading/CS/TsiSuperTrendDecisionStrategy.cs
+++ b/API/1491_TSI_w_SuperTrend_decision_presentTrading/CS/TsiSuperTrendDecisionStrategy.cs
@@ -1,25 +1,19 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 /// <summary>
 /// Correlation-based TSI with SuperTrend direction.

--- a/API/1507_Ultimate_Template/CS/UltimateTemplateStrategy.cs
+++ b/API/1507_Ultimate_Template/CS/UltimateTemplateStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,6 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Basic crossover template with stop loss and take profit.

--- a/API/1508_Ultimate_Trading_Bot/CS/UltimateTradingBotStrategy.cs
+++ b/API/1508_Ultimate_Trading_Bot/CS/UltimateTradingBotStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,6 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// RSI, MA, MACD and Stochastic based long-only bot.

--- a/API/1509_Unicode_font_function_-_JD/CS/UnicodeFontFunctionJdStrategy.cs
+++ b/API/1509_Unicode_font_function_-_JD/CS/UnicodeFontFunctionJdStrategy.cs
@@ -1,24 +1,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using System.Text;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Demonstrates Unicode font conversion utilities.

--- a/API/1533_Volatility_Pulse_with_Dynamic_Exit/CS/VolatilityPulseWithDynamicExitStrategy.cs
+++ b/API/1533_Volatility_Pulse_with_Dynamic_Exit/CS/VolatilityPulseWithDynamicExitStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy using ATR volatility expansion with momentum confirmation and delayed exits.

--- a/API/1593_External_Level/CS/ExternalLevelStrategy.cs
+++ b/API/1593_External_Level/CS/ExternalLevelStrategy.cs
@@ -1,25 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Draws horizontal levels based on external signals.

--- a/API/1632_VisualTrader_Simulator_Edition/CS/VisualTraderSimulatorEditionStrategy.cs
+++ b/API/1632_VisualTrader_Simulator_Edition/CS/VisualTraderSimulatorEditionStrategy.cs
@@ -1,21 +1,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using StockSharp.Algo;
-using StockSharp.Algo.Strategies;
 
 /// <summary>
 /// Simplified Visual Trader order manager.

--- a/API/1657_ZMFX_Stolid_5a_EA/CS/ZmfxStolid5aEaStrategy.cs
+++ b/API/1657_ZMFX_Stolid_5a_EA/CS/ZmfxStolid5aEaStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,10 +11,6 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 /// <summary>
 /// ZMFX Stolid 5a strategy converted from MQL.

--- a/API/1683_Parabolic_SAR_Alert/CS/ParabolicSarAlertStrategy.cs
+++ b/API/1683_Parabolic_SAR_Alert/CS/ParabolicSarAlertStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Parabolic SAR Alert Strategy.

--- a/API/1693_Xbug_Free_V4/CS/XbugFreeV4Strategy.cs
+++ b/API/1693_Xbug_Free_V4/CS/XbugFreeV4Strategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Xbug Free v4 strategy based on moving average crossing median price.

--- a/API/1703_VR_MARS/CS/VRMarsStrategy.cs
+++ b/API/1703_VR_MARS/CS/VRMarsStrategy.cs
@@ -1,21 +1,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using StockSharp.Algo;
-using StockSharp.Algo.Strategies;
 
 public class VRMarsStrategy : Strategy
 {

--- a/API/1707_Intraday_Beta/CS/IntradayBetaStrategy.cs
+++ b/API/1707_Intraday_Beta/CS/IntradayBetaStrategy.cs
@@ -1,26 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Intraday strategy based on moving average slope changes and RSI.

--- a/API/1709_MLTrendE/CS/MLTrendEStrategy.cs
+++ b/API/1709_MLTrendE/CS/MLTrendEStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Weighted moving average trend strategy with position pyramiding.

--- a/API/1717_Exp_X2MA/CS/ExpX2MaStrategy.cs
+++ b/API/1717_Exp_X2MA/CS/ExpX2MaStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on turning points of double smoothed moving average.

--- a/API/1728_Autostop/CS/AutostopStrategy.cs
+++ b/API/1728_Autostop/CS/AutostopStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,9 +11,6 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 /// <summary>
 /// Automatically applies take-profit and stop-loss to existing positions.

--- a/API/1739_Channel_Scalper/CS/ChannelScalperStrategy.cs
+++ b/API/1739_Channel_Scalper/CS/ChannelScalperStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,11 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 /// <summary>
 /// ATR based channel breakout scalping strategy.

--- a/API/1770_Collector_v1_0/CS/CollectorV10Strategy.cs
+++ b/API/1770_Collector_v1_0/CS/CollectorV10Strategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,10 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 /// <summary>
 /// Grid strategy that opens trades when price crosses dynamic levels.

--- a/API/1783_Arrows_Curves/CS/ArrowsCurvesStrategy.cs
+++ b/API/1783_Arrows_Curves/CS/ArrowsCurvesStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on Arrows & Curves indicator.

--- a/API/1787_Stop_Loss_To_BreakEven/CS/StopLossToBreakEvenStrategy.cs
+++ b/API/1787_Stop_Loss_To_BreakEven/CS/StopLossToBreakEvenStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy that moves stop loss to break-even after reaching a profit in pips.

--- a/API/1810_Catcher_Profit_1_0/CS/CatcherProfit10Strategy.cs
+++ b/API/1810_Catcher_Profit_1_0/CS/CatcherProfit10Strategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Closes all positions when profit exceeds a fixed amount or percentage.

--- a/API/1825_Simulator/CS/SimulatorStrategy.cs
+++ b/API/1825_Simulator/CS/SimulatorStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,11 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 /// <summary>
 /// Simple EMA crossover strategy with optional stop loss and take profit.

--- a/API/1834_Virtual_Stop_Manager/CS/VirtualStopManagerStrategy.cs
+++ b/API/1834_Virtual_Stop_Manager/CS/VirtualStopManagerStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,11 +11,6 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy managing virtual stop loss, take profit, trailing stop and breakeven levels.

--- a/API/1839_TSI_MACD_Crossover/CS/TsiMacdCrossoverStrategy.cs
+++ b/API/1839_TSI_MACD_Crossover/CS/TsiMacdCrossoverStrategy.cs
@@ -1,26 +1,19 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 /// <summary>
 /// True Strength Index MACD crossover strategy.

--- a/API/1840_Exp_TSI_CCI/CS/ExpTsiCciStrategy.cs
+++ b/API/1840_Exp_TSI_CCI/CS/ExpTsiCciStrategy.cs
@@ -1,26 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on True Strength Index calculated from Commodity Channel Index.

--- a/API/1843_Karpenko_Channel/CS/KarpenkoChannelStrategy.cs
+++ b/API/1843_Karpenko_Channel/CS/KarpenkoChannelStrategy.cs
@@ -1,26 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Karpenko Channel strategy.

--- a/API/1844_SlopeDirectionLine/CS/SlopeDirectionLineStrategy.cs
+++ b/API/1844_SlopeDirectionLine/CS/SlopeDirectionLineStrategy.cs
@@ -1,26 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy that trades on changes in the slope of a linear regression line.

--- a/API/1852_Eugene_Candle_Pattern/CS/EugeneCandlePatternStrategy.cs
+++ b/API/1852_Eugene_Candle_Pattern/CS/EugeneCandlePatternStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,11 +11,6 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 public class EugeneCandlePatternStrategy : Strategy
 {

--- a/API/1855_Center_Of_Gravity/CS/CenterOfGravityStrategy.cs
+++ b/API/1855_Center_Of_Gravity/CS/CenterOfGravityStrategy.cs
@@ -1,24 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 /// <summary>
 /// Center of Gravity Strategy.

--- a/API/1856_BnB/CS/BnBStrategy.cs
+++ b/API/1856_BnB/CS/BnBStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on smoothed bull and bear power comparison.

--- a/API/1863_Kauf_WMA_Cross/CS/KaufWmaCrossStrategy.cs
+++ b/API/1863_Kauf_WMA_Cross/CS/KaufWmaCrossStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Trades when Kaufman Adaptive Moving Average crosses Weighted Moving Average.

--- a/API/1867_MA_SAR_ADX/CS/MaSarAdxStrategy.cs
+++ b/API/1867_MA_SAR_ADX/CS/MaSarAdxStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy combining Moving Average, Parabolic SAR and ADX indicators.

--- a/API/1869_Bollinger_Breakout_Momentum/CS/BollingerBreakoutMomentumStrategy.cs
+++ b/API/1869_Bollinger_Breakout_Momentum/CS/BollingerBreakoutMomentumStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,10 +11,6 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy trading Bollinger Band breakouts with additional RSI, EMA and MACD filters.

--- a/API/1880_Genie_Pivot/CS/GeniePivotStrategy.cs
+++ b/API/1880_Genie_Pivot/CS/GeniePivotStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Pivot point reversal scalping strategy.

--- a/API/1887_Vlt_Trader/CS/VltTraderStrategy.cs
+++ b/API/1887_Vlt_Trader/CS/VltTraderStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,14 +11,8 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using Ecng.Common;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 /// <summary>
 /// Places breakout stop orders after detecting low volatility periods.

--- a/API/1889_Analyze_History/CS/AnalyzeHistoryStrategy.cs
+++ b/API/1889_Analyze_History/CS/AnalyzeHistoryStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy that analyzes historical bar data and logs gaps in the series.

--- a/API/1893_EA_Template/CS/EaTemplateStrategy.cs
+++ b/API/1893_EA_Template/CS/EaTemplateStrategy.cs
@@ -1,25 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Simple candle color strategy converted from a MetaTrader expert advisor.

--- a/API/1898_Roboti_ADX_Profit/CS/RobotiAdxProfitStrategy.cs
+++ b/API/1898_Roboti_ADX_Profit/CS/RobotiAdxProfitStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy that trades when DMI's +DI crosses above -DI and vice versa.

--- a/API/1904_Bleris/CS/BlerisStrategy.cs
+++ b/API/1904_Bleris/CS/BlerisStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,11 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 /// <summary>
 /// Bleris strategy based on comparisons of consecutive highest highs and lowest lows.

--- a/API/1926_Ilan_Dynamic_HT/CS/IlanDynamicHtStrategy.cs
+++ b/API/1926_Ilan_Dynamic_HT/CS/IlanDynamicHtStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Ilan Dynamic HT Strategy.

--- a/API/1934_Linear_Regression_Slope_Trigger/CS/LinearRegressionSlopeTriggerStrategy.cs
+++ b/API/1934_Linear_Regression_Slope_Trigger/CS/LinearRegressionSlopeTriggerStrategy.cs
@@ -1,25 +1,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on linear regression slope and trigger line.

--- a/API/1938_Range_EA/CS/RangeEaStrategy.cs
+++ b/API/1938_Range_EA/CS/RangeEaStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Range breakout strategy with optional step-down averaging and turn reversal.

--- a/API/1947_Range_Expansion_Index/CS/RangeExpansionIndexStrategy.cs
+++ b/API/1947_Range_Expansion_Index/CS/RangeExpansionIndexStrategy.cs
@@ -1,12 +1,9 @@
-
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -14,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on the Range Expansion Index (REI).

--- a/API/1948_GG_RSI_CCI/CS/GgRsiCciStrategy.cs
+++ b/API/1948_GG_RSI_CCI/CS/GgRsiCciStrategy.cs
@@ -1,26 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on the GG-RSI-CCI indicator.

--- a/API/1955_Exp_HLRSign/CS/ExpHlrSignStrategy.cs
+++ b/API/1955_Exp_HLRSign/CS/ExpHlrSignStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,11 +11,6 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// HLRSign based strategy.

--- a/API/1964_XMA_Ichimoku_Channel/CS/XmaIchimokuChannelStrategy.cs
+++ b/API/1964_XMA_Ichimoku_Channel/CS/XmaIchimokuChannelStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on the XMA Ichimoku channel concept.

--- a/API/1973_Angrybird_xScalpingn/CS/AngrybirdXScalpingnStrategy.cs
+++ b/API/1973_Angrybird_xScalpingn/CS/AngrybirdXScalpingnStrategy.cs
@@ -1,27 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 public class AngrybirdXScalpingnStrategy : Strategy
 {

--- a/API/1974_Jpalonso_Modoki/CS/JpalonsoModokiStrategy.cs
+++ b/API/1974_Jpalonso_Modoki/CS/JpalonsoModokiStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,15 +11,8 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using Ecng.Common;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on price position relative to SMA envelopes.

--- a/API/1976_Exp_3XMA_Ishimoku/CS/Exp3XmaIshimokuStrategy.cs
+++ b/API/1976_Exp_3XMA_Ishimoku/CS/Exp3XmaIshimokuStrategy.cs
@@ -1,26 +1,19 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Contrarian strategy based on Ichimoku cloud and Kijun line.

--- a/API/1987_Color_Step_Xccx/CS/ColorStepXccxStrategy.cs
+++ b/API/1987_Color_Step_Xccx/CS/ColorStepXccxStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on Color Step XCCX indicator.

--- a/API/1991_Binario_31/CS/Binario31Strategy.cs
+++ b/API/1991_Binario_31/CS/Binario31Strategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Breakout strategy based on EMA channel from binario_31 script.

--- a/API/1994_Heiken_Ashi_No_Wick/CS/HeikenAshiNoWickStrategy.cs
+++ b/API/1994_Heiken_Ashi_No_Wick/CS/HeikenAshiNoWickStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy trading opposite Heiken Ashi candles without wicks.

--- a/API/2009_Color_Stoch_NR/CS/ColorStochNrStrategy.cs
+++ b/API/2009_Color_Stoch_NR/CS/ColorStochNrStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on the stochastic oscillator with multiple signal modes.

--- a/API/2015_Color_Schaff_Momentum_Trend_Cycle/CS/ColorSchaffMomentumTrendCycleStrategy.cs
+++ b/API/2015_Color_Schaff_Momentum_Trend_Cycle/CS/ColorSchaffMomentumTrendCycleStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,11 +11,6 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 public class ColorSchaffMomentumTrendCycleStrategy : Strategy
 {

--- a/API/2035_Personal_Assistant/CS/PersonalAssistantStrategy.cs
+++ b/API/2035_Personal_Assistant/CS/PersonalAssistantStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Manual trading helper that displays basic account info.

--- a/API/2036_Ergodic_Ticks_Volume_Indicator/CS/ErgodicTicksVolumeIndicatorStrategy.cs
+++ b/API/2036_Ergodic_Ticks_Volume_Indicator/CS/ErgodicTicksVolumeIndicatorStrategy.cs
@@ -1,26 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on True Strength Index crossovers of the signal line.

--- a/API/2037_Ergodic_Ticks_Volume_OSMA/CS/ErgodicTicksVolumeOsmaStrategy.cs
+++ b/API/2037_Ergodic_Ticks_Volume_OSMA/CS/ErgodicTicksVolumeOsmaStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
-using StockSharp.BusinessEntities;
 
 /// <summary>
 /// Strategy based on MACD histogram as an approximation of the Ergodic Ticks Volume OSMA indicator.

--- a/API/2044_CorrectedAverage_Breakout/CS/CorrectedAverageBreakoutStrategy.cs
+++ b/API/2044_CorrectedAverage_Breakout/CS/CorrectedAverageBreakoutStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on the Corrected Average breakout.

--- a/API/2056_DecEMA/CS/DecEmaStrategy.cs
+++ b/API/2056_DecEMA/CS/DecEmaStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on DecEMA indicator slope.

--- a/API/2063_Ichimoku_Oscillator/CS/IchimokuOscillatorStrategy.cs
+++ b/API/2063_Ichimoku_Oscillator/CS/IchimokuOscillatorStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on Ichimoku oscillator smoothed by Jurik moving average.

--- a/API/2066_AMMA_Trend/CS/AmmaTrendStrategy.cs
+++ b/API/2066_AMMA_Trend/CS/AmmaTrendStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 public class AmmaTrendStrategy : Strategy
 {

--- a/API/2072_InstantaneousTrendFilter/CS/InstantaneousTrendFilterStrategy.cs
+++ b/API/2072_InstantaneousTrendFilter/CS/InstantaneousTrendFilterStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,10 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 public class InstantaneousTrendFilterStrategy : Strategy
 {

--- a/API/2107_TP_SL_Panel/CS/TpSlPanelStrategy.cs
+++ b/API/2107_TP_SL_Panel/CS/TpSlPanelStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy that closes existing positions when price reaches specified take-profit or stop-loss levels.

--- a/API/2109_RD_Trend_Trigger/CS/RdTrendTriggerStrategy.cs
+++ b/API/2109_RD_Trend_Trigger/CS/RdTrendTriggerStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// RD Trend Trigger oscillator based strategy.

--- a/API/2113_CHO_With_Flat/CS/ChoWithFlatStrategy.cs
+++ b/API/2113_CHO_With_Flat/CS/ChoWithFlatStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 /// <summary>
 /// Chaikin Oscillator strategy with flat filter.

--- a/API/2116_Simple_Levels/CS/SimpleLevelsStrategy.cs
+++ b/API/2116_Simple_Levels/CS/SimpleLevelsStrategy.cs
@@ -1,25 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Trades when price crosses user defined trend lines.

--- a/API/2118_Nevalyashka/CS/NevalyashkaStrategy.cs
+++ b/API/2118_Nevalyashka/CS/NevalyashkaStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,10 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 /// <summary>
 /// Alternating long/short strategy with martingale sizing.

--- a/API/2121_Levels_With_Trail/CS/LevelsWithTrailStrategy.cs
+++ b/API/2121_Levels_With_Trail/CS/LevelsWithTrailStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,11 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy trading price level breakouts with optional trailing stop loss.

--- a/API/2134_Divergence_Expert/CS/DivergenceExpertStrategy.cs
+++ b/API/2134_Divergence_Expert/CS/DivergenceExpertStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy trading RSI price divergences.

--- a/API/2141_Color_Bears/CS/ColorBearsStrategy.cs
+++ b/API/2141_Color_Bears/CS/ColorBearsStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on a double-smoothed Bears Power indicator.

--- a/API/2145_I_Gap/CS/IGapStrategy.cs
+++ b/API/2145_I_Gap/CS/IGapStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on gap between previous close and current open.

--- a/API/2146_LeMan_Trend/CS/LeManTrendStrategy.cs
+++ b/API/2146_LeMan_Trend/CS/LeManTrendStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Leman Trend strategy using high/low differences smoothed by EMA.

--- a/API/2152_Kalman_Filter_Candles/CS/KalmanFilterCandlesStrategy.cs
+++ b/API/2152_Kalman_Filter_Candles/CS/KalmanFilterCandlesStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on Kalman filtered candle colors.

--- a/API/2153_Anchored_Momentum_Candle/CS/AnchoredMomentumCandleStrategy.cs
+++ b/API/2153_Anchored_Momentum_Candle/CS/AnchoredMomentumCandleStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.Algo.Indicators;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on the Anchored Momentum Candle indicator.

--- a/API/2154_MACD_Trend_Mode/CS/MacdTrendModeStrategy.cs
+++ b/API/2154_MACD_Trend_Mode/CS/MacdTrendModeStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// MACD strategy with selectable trend detection modes.

--- a/API/2155_Loco/CS/LocoStrategy.cs
+++ b/API/2155_Loco/CS/LocoStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -14,13 +12,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies;
 
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on the Loco indicator.

--- a/API/2166_Digital_CCI_Woodies/CS/DigitalCciWoodiesStrategy.cs
+++ b/API/2166_Digital_CCI_Woodies/CS/DigitalCciWoodiesStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on crossover of fast and slow CCI indicators.

--- a/API/2181_RSI_Bollinger_Bands/CS/RsiBollingerBandsStrategy.cs
+++ b/API/2181_RSI_Bollinger_Bands/CS/RsiBollingerBandsStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// RSI combined with Bollinger Bands strategy.

--- a/API/2185_Simple_Multiple_Time_Frame_Moving_Average/CS/SimpleMultipleTimeFrameMovingAverageStrategy.cs
+++ b/API/2185_Simple_Multiple_Time_Frame_Moving_Average/CS/SimpleMultipleTimeFrameMovingAverageStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,11 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 /// <summary>
 /// Simple multiple time frame moving average strategy.

--- a/API/2190_Color_Coppock/CS/ColorCoppockStrategy.cs
+++ b/API/2190_Color_Coppock/CS/ColorCoppockStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on the Color Coppock oscillator.

--- a/API/2195_Extrem_N/CS/ExtremNStrategy.cs
+++ b/API/2195_Extrem_N/CS/ExtremNStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy trading reversals after alternating price extremes.

--- a/API/2200_MFI_Histogram/CS/MfiHistogramStrategy.cs
+++ b/API/2200_MFI_Histogram/CS/MfiHistogramStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Money Flow Index histogram strategy.

--- a/API/2212_One_Click_Close_All/CS/OneClickCloseAllStrategy.cs
+++ b/API/2212_One_Click_Close_All/CS/OneClickCloseAllStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy that closes all positions and optionally cancels pending orders on start.

--- a/API/2222_Heiken_Ashi_Smoothed_Trend/CS/HeikenAshiSmoothedTrendStrategy.cs
+++ b/API/2222_Heiken_Ashi_Smoothed_Trend/CS/HeikenAshiSmoothedTrendStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Heiken-Ashi strategy using EMA-smoothed candles.

--- a/API/2233_Supertrend_Signal/CS/SupertrendSignalStrategy.cs
+++ b/API/2233_Supertrend_Signal/CS/SupertrendSignalStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Simple SuperTrend crossover strategy.

--- a/API/2238_NRTR_Extr/CS/NrtrExtrStrategy.cs
+++ b/API/2238_NRTR_Extr/CS/NrtrExtrStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// NRTR Extr strategy based on NRTR indicator with extra signals.

--- a/API/2241_ColorXdinMA_StDev/CS/ColorXdinMAStDevStrategy.cs
+++ b/API/2241_ColorXdinMA_StDev/CS/ColorXdinMAStDevStrategy.cs
@@ -1,26 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on difference of two moving averages with standard deviation filter.

--- a/API/2251_Forex_Fraus_Portfolio/CS/ForexFrausPortfolioStrategy.cs
+++ b/API/2251_Forex_Fraus_Portfolio/CS/ForexFrausPortfolioStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Williams %R based multi-currency strategy with trailing stop logic.

--- a/API/2256_XDPO_Candle/CS/XdpoCandleStrategy.cs
+++ b/API/2256_XDPO_Candle/CS/XdpoCandleStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// XDPO candle strategy that trades on color changes of double smoothed candles.

--- a/API/2263_CCI_Woodies/CS/CCI_WoodiesStrategy.cs
+++ b/API/2263_CCI_Woodies/CS/CCI_WoodiesStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// CCI Woodies crossover strategy.

--- a/API/2268_TSI_Cloud_Cross/CS/TsiCloudCrossStrategy.cs
+++ b/API/2268_TSI_Cloud_Cross/CS/TsiCloudCrossStrategy.cs
@@ -1,26 +1,19 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 /// <summary>
 /// True Strength Index cross with delayed line.

--- a/API/2269_AutoTraderRus/CS/AutoTraderRusStrategy.cs
+++ b/API/2269_AutoTraderRus/CS/AutoTraderRusStrategy.cs
@@ -1,26 +1,19 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy that enables trading only during specified session times.

--- a/API/2273_Color_Rsi_Macd/CS/ColorRsiMacdStrategy.cs
+++ b/API/2273_Color_Rsi_Macd/CS/ColorRsiMacdStrategy.cs
@@ -1,27 +1,19 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Candles;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on MACD turning points and zero line breakdowns.

--- a/API/2274_Directed_Movement_Candle/CS/DirectedMovementCandleStrategy.cs
+++ b/API/2274_Directed_Movement_Candle/CS/DirectedMovementCandleStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,10 +11,6 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 /// <summary>
 /// Directed Movement Candle strategy.

--- a/API/2289_Volume_Weighted_MA_StDev/CS/VolumeWeightedMaStDevStrategy.cs
+++ b/API/2289_Volume_Weighted_MA_StDev/CS/VolumeWeightedMaStDevStrategy.cs
@@ -1,24 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 /// <summary>
 /// Volume Weighted Moving Average with Standard Deviation filter.

--- a/API/2303_ADX_DMI/CS/AdxDmiStrategy.cs
+++ b/API/2303_ADX_DMI/CS/AdxDmiStrategy.cs
@@ -1,26 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Directional Movement Index crossover strategy.

--- a/API/2310_SMI_Correct/CS/SmiCorrectStrategy.cs
+++ b/API/2310_SMI_Correct/CS/SmiCorrectStrategy.cs
@@ -1,26 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on Stochastic Momentum Index crossings.

--- a/API/2315_Limits_Martin/CS/LimitsMartinStrategy.cs
+++ b/API/2315_Limits_Martin/CS/LimitsMartinStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 public class LimitsMartinStrategy : Strategy
 {

--- a/API/2322_SAR_Trailing_System/CS/SarTrailingSystemStrategy.cs
+++ b/API/2322_SAR_Trailing_System/CS/SarTrailingSystemStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy that opens random trades and uses Parabolic SAR for trailing exits.

--- a/API/2323_Cm_Manual_Grid/CS/CmManualGridStrategy.cs
+++ b/API/2323_Cm_Manual_Grid/CS/CmManualGridStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,9 +11,6 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 /// <summary>
 /// Simplified manual grid strategy.

--- a/API/2333_SpectrAnalysis_Chaikin/CS/SpectrAnalysisChaikinStrategy.cs
+++ b/API/2333_SpectrAnalysis_Chaikin/CS/SpectrAnalysisChaikinStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on Chaikin oscillator with linear weighted moving averages.

--- a/API/2344_AFL_Winner_V2/CS/AflWinnerV2Strategy.cs
+++ b/API/2344_AFL_Winner_V2/CS/AflWinnerV2Strategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,11 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.Algo.Indicators;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on the AFL Winner indicator approximation using a stochastic oscillator.

--- a/API/2353_I4_DRF_v2/CS/I4DrfV2Strategy.cs
+++ b/API/2353_I4_DRF_v2/CS/I4DrfV2Strategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// I4 DRF v2 strategy.

--- a/API/2362_Delta_RSI/CS/DeltaRsiStrategy.cs
+++ b/API/2362_Delta_RSI/CS/DeltaRsiStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -14,13 +12,7 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies;
 
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on Delta RSI indicator.

--- a/API/2363_Rock_Trader_Neuro/CS/RockTraderNeuroStrategy.cs
+++ b/API/2363_Rock_Trader_Neuro/CS/RockTraderNeuroStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,11 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy using Bollinger Bands and a simple neuron to generate signals.

--- a/API/2373_Trigger_Line/CS/TriggerLineStrategy.cs
+++ b/API/2373_Trigger_Line/CS/TriggerLineStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Trigger Line cross strategy based on weighted trend line and LSMA.

--- a/API/2378_X2MA_Digit_DM_361/CS/X2MADigitDm361Strategy.cs
+++ b/API/2378_X2MA_Digit_DM_361/CS/X2MADigitDm361Strategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on two moving averages and directional movement index.

--- a/API/2383_The_MasterMind_2/CS/TheMasterMind2Strategy.cs
+++ b/API/2383_The_MasterMind_2/CS/TheMasterMind2Strategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on Stochastic Oscillator and Williams %R.

--- a/API/2399_Zero_Filling_Stop/CS/ZeroFillingStopStrategy.cs
+++ b/API/2399_Zero_Filling_Stop/CS/ZeroFillingStopStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Moves stop loss to breakeven after reaching specified profit in points.

--- a/API/2400_DVD_Level/CS/DvdLevelStrategy.cs
+++ b/API/2400_DVD_Level/CS/DvdLevelStrategy.cs
@@ -1,24 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo.Candles;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 /// <summary>
 /// RAVI based level strategy. Opens long when the RAVI goes negative and short when it becomes positive.

--- a/API/2403_ReOpen_Positions/CS/ReOpenPositionsStrategy.cs
+++ b/API/2403_ReOpen_Positions/CS/ReOpenPositionsStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy that reopens positions once profit reaches a target in points.

--- a/API/2407_MFI_Level_Cross/CS/MfiLevelCrossStrategy.cs
+++ b/API/2407_MFI_Level_Cross/CS/MfiLevelCrossStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Money Flow Index based strategy that opens positions when the indicator crosses predefined levels.

--- a/API/2416_DoubleUp2/CS/DoubleUp2Strategy.cs
+++ b/API/2416_DoubleUp2/CS/DoubleUp2Strategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// DoubleUp2 strategy combining CCI and MACD with volume doubling.

--- a/API/2418_VR_Setka_3/CS/VRSetka3Strategy.cs
+++ b/API/2418_VR_Setka_3/CS/VRSetka3Strategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Grid strategy inspired by VR SETKA 3.

--- a/API/2425_Adaptive_CG_Oscillator_X2/CS/AdaptiveCgOscillatorX2Strategy.cs
+++ b/API/2425_Adaptive_CG_Oscillator_X2/CS/AdaptiveCgOscillatorX2Strategy.cs
@@ -1,26 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on Adaptive CG Oscillator crossovers on two timeframes.

--- a/API/2438_Bollinger_Bands_Distance/CS/BollingerBandsDistanceStrategy.cs
+++ b/API/2438_Bollinger_Bands_Distance/CS/BollingerBandsDistanceStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,11 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy trading reversals from Bollinger Bands with extra distance.

--- a/API/2450_Trend_Alexcud/CS/TrendAlexcudStrategy.cs
+++ b/API/2450_Trend_Alexcud/CS/TrendAlexcudStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,11 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 /// <summary>
 /// Multi-timeframe trend strategy based on multiple simple moving averages

--- a/API/2457_Breakdown_Level_Intraday/CS/BreakdownLevelIntradayStrategy.cs
+++ b/API/2457_Breakdown_Level_Intraday/CS/BreakdownLevelIntradayStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Breakout strategy that trades previous day's high/low levels.

--- a/API/2459_SilverTrend_Signal_ReOpen/CS/SilverTrendSignalReOpenStrategy.cs
+++ b/API/2459_SilverTrend_Signal_ReOpen/CS/SilverTrendSignalReOpenStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy using SilverTrend indicator with optional position re-opening.

--- a/API/2480_10_Pips_EURUSD/CS/TenPipsEurusdStrategy.cs
+++ b/API/2480_10_Pips_EURUSD/CS/TenPipsEurusdStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,11 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Breakout strategy based on pending stop orders around the previous candle range.

--- a/API/2515_Proper_Bot/CS/ProperBotStrategy.cs
+++ b/API/2515_Proper_Bot/CS/ProperBotStrategy.cs
@@ -1,27 +1,19 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using System.Globalization;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
-using System.Globalization;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Grid strategy converted from the "Proper Bot" MQL expert advisor.

--- a/API/2533_Polish_Layer/CS/PolishLayerStrategy.cs
+++ b/API/2533_Polish_Layer/CS/PolishLayerStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Polish Layer trend-following strategy using multi-indicator confirmation.

--- a/API/2540_Rabbit3/CS/Rabbit3Strategy.cs
+++ b/API/2540_Rabbit3/CS/Rabbit3Strategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,6 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 public class Rabbit3Strategy : Strategy
 {

--- a/API/2547_UmnickTrader/CS/UmnickTraderStrategy.cs
+++ b/API/2547_UmnickTrader/CS/UmnickTraderStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Adaptive mean-reversion strategy converted from the UmnickTrader MQL5 expert advisor.

--- a/API/2556_Currencyprofits_HighLow_Channel/CS/CurrencyprofitsHighLowChannelStrategy.cs
+++ b/API/2556_Currencyprofits_HighLow_Channel/CS/CurrencyprofitsHighLowChannelStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Currencyprofits strategy that trades trend pullbacks into the recent channel extremes.

--- a/API/2560_IBS_RSI_CCI_v4_X2/CS/IbsRsiCciV4X2Strategy.cs
+++ b/API/2560_IBS_RSI_CCI_v4_X2/CS/IbsRsiCciV4X2Strategy.cs
@@ -1,26 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 public class IbsRsiCciV4X2Strategy : Strategy
 {

--- a/API/2589_Bollinger_Breakout_DC2008/CS/BollingerBreakoutDc2008Strategy.cs
+++ b/API/2589_Bollinger_Breakout_DC2008/CS/BollingerBreakoutDc2008Strategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 public enum AppliedPriceType
 {

--- a/API/2601_Ma_Sar_Adx_Bind/CS/MaSarAdxBindStrategy.cs
+++ b/API/2601_Ma_Sar_Adx_Bind/CS/MaSarAdxBindStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Conversion of the MaSarADX MetaTrader strategy to StockSharp high level API.

--- a/API/2614_Bollinger_Bands_N_Positions/CS/BollingerBandsNPositionsStrategy.cs
+++ b/API/2614_Bollinger_Bands_N_Positions/CS/BollingerBandsNPositionsStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 /// <summary>
 /// Bollinger Bands breakout strategy translated from the MQL5 version with N-position control.

--- a/API/2640_ExpertClor_Close_Manager/CS/ExpertClorCloseManagerStrategy.cs
+++ b/API/2640_ExpertClor_Close_Manager/CS/ExpertClorCloseManagerStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy that manages existing positions using moving average cross exits and ATR based trailing stops.

--- a/API/2648_Multi_Arbitration_1_1xx/CS/MultiArbitration11xxStrategy.cs
+++ b/API/2648_Multi_Arbitration_1_1xx/CS/MultiArbitration11xxStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Adaptive grid strategy that trades two correlated instruments using breakout levels.

--- a/API/2649_Stop_Loss_Take_Profit/CS/StopLossTakeProfitStrategy.cs
+++ b/API/2649_Stop_Loss_Take_Profit/CS/StopLossTakeProfitStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Random direction strategy with pip-based stop loss and take profit that doubles the volume after losses.

--- a/API/2657_OzFx_Accelerator_Stochastic/CS/OzFxAcceleratorStochasticStrategy.cs
+++ b/API/2657_OzFx_Accelerator_Stochastic/CS/OzFxAcceleratorStochasticStrategy.cs
@@ -1,26 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// OzFx strategy converted from MetaTrader 5 to the StockSharp high-level API.

--- a/API/2668_Button_Close_Buy_Sell/CS/ButtonCloseBuySellStrategy.cs
+++ b/API/2668_Button_Close_Buy_Sell/CS/ButtonCloseBuySellStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Utility strategy that closes open long or short positions on demand.

--- a/API/2670_Burg_Extrapolator/CS/BurgExtrapolatorStrategy.cs
+++ b/API/2670_Burg_Extrapolator/CS/BurgExtrapolatorStrategy.cs
@@ -1,25 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Localization;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Localization;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy that extrapolates future prices using the Burg autoregressive model and opens trades when forecasted swings exceed thresholds.

--- a/API/2672_Open_Two_Pending_Orders/CS/OpenTwoPendingOrdersStrategy.cs
+++ b/API/2672_Open_Two_Pending_Orders/CS/OpenTwoPendingOrdersStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,11 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy that places both buy stop and sell stop orders around the current spread.

--- a/API/2681_Multi_Stochastic/CS/MultiStochasticStrategy.cs
+++ b/API/2681_Multi_Stochastic/CS/MultiStochasticStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// StockSharp port of the Multi Stochastic MT5 expert advisor.

--- a/API/2701_Jims_Close_Positions/CS/JimsClosePositionsStrategy.cs
+++ b/API/2701_Jims_Close_Positions/CS/JimsClosePositionsStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,11 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 /// <summary>
 /// Closes existing positions according to user defined rules.

--- a/API/2728_Exp_Blau_CSI/CS/ExpBlauCsiStrategy.cs
+++ b/API/2728_Exp_Blau_CSI/CS/ExpBlauCsiStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Blau Candle Stochastic Index strategy converted from MetaTrader 5.

--- a/API/2749_Galactic_Explosion/CS/GalacticExplosionStrategy.cs
+++ b/API/2749_Galactic_Explosion/CS/GalacticExplosionStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy that recreates the Galactic Explosion grid behavior using a moving average bias and distance based scaling.

--- a/API/2754_ZigZag_EvgeTrofi/CS/ZigZagEvgeTrofiStrategy.cs
+++ b/API/2754_ZigZag_EvgeTrofi/CS/ZigZagEvgeTrofiStrategy.cs
@@ -1,26 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// ZigZag pivot strategy based on the original ZigZagEvgeTrofi expert advisor.

--- a/API/2773_Channels_Envelope_Cross/CS/ChannelsEnvelopeCrossStrategy.cs
+++ b/API/2773_Channels_Envelope_Cross/CS/ChannelsEnvelopeCrossStrategy.cs
@@ -1,26 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Channels envelope crossover strategy converted from the MetaTrader Channels expert advisor.

--- a/API/2795_Two_MA_RSI/CS/TwoMaRsiStrategy.cs
+++ b/API/2795_Two_MA_RSI/CS/TwoMaRsiStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,11 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 /// <summary>
 /// Moving average crossover strategy with RSI confirmation and martingale sizing.

--- a/API/2805_Channel_EA_Limits/CS/ChannelEaLimitsStrategy.cs
+++ b/API/2805_Channel_EA_Limits/CS/ChannelEaLimitsStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Channel trading strategy that places limit orders at the end of the monitored session.

--- a/API/2815_Poker_Show/CS/PokerShowStrategy.cs
+++ b/API/2815_Poker_Show/CS/PokerShowStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy that emulates the Poker_SHOW MetaTrader 5 expert advisor.

--- a/API/2820_NCandlesSequence_Streak/CS/NCandlesSequenceStreakStrategy.cs
+++ b/API/2820_NCandlesSequence_Streak/CS/NCandlesSequenceStreakStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy that searches for N identical candles in a row and trades in the direction of the streak.

--- a/API/2826_Blau_Ergodic/CS/BlauErgodicStrategy.cs
+++ b/API/2826_Blau_Ergodic/CS/BlauErgodicStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Blau Ergodic oscillator strategy with multiple signal modes.

--- a/API/2842_Binary_Option_Symbol_Scanner/CS/BinaryOptionSymbolScannerStrategy.cs
+++ b/API/2842_Binary_Option_Symbol_Scanner/CS/BinaryOptionSymbolScannerStrategy.cs
@@ -1,26 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using System.Globalization;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy that scans provided securities and reports binary option symbols based on metadata filters.

--- a/API/2854_Rsi_Bollinger_Bands_Ea/CS/RsiBollingerBandsEaStrategy.cs
+++ b/API/2854_Rsi_Bollinger_Bands_Ea/CS/RsiBollingerBandsEaStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// RSI Bollinger Bands strategy converted from the MetaTrader 5 expert adviser.

--- a/API/2868_ATR_Normalize_Histogram/CS/AtrNormalizeHistogramStrategy.cs
+++ b/API/2868_ATR_Normalize_Histogram/CS/AtrNormalizeHistogramStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy that trades on normalized ATR histogram color transitions.

--- a/API/2870_Binario/CS/BinarioStrategy.cs
+++ b/API/2870_Binario/CS/BinarioStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Binario strategy converted from MetaTrader 5.

--- a/API/2872_Trading_Boxing/CS/TradingBoxingStrategy.cs
+++ b/API/2872_Trading_Boxing/CS/TradingBoxingStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Manual order management strategy that mirrors the TradingBoxing expert panel.

--- a/API/2880_Two_MA_One_RSI/CS/TwoMaOneRsiStrategy.cs
+++ b/API/2880_Two_MA_One_RSI/CS/TwoMaOneRsiStrategy.cs
@@ -1,26 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Port of the “Two MA one RSI” MetaTrader 5 strategy.

--- a/API/2888_Exp_ColorX2MA_X2/CS/ExpColorX2MaX2Strategy.cs
+++ b/API/2888_Exp_ColorX2MA_X2/CS/ExpColorX2MaX2Strategy.cs
@@ -1,26 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using System.Reflection;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
-using System.Reflection;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Exp ColorX2MA X2 dual timeframe trend-following strategy.

--- a/API/2893_Volume_Trader/CS/VolumeTraderStrategy.cs
+++ b/API/2893_Volume_Trader/CS/VolumeTraderStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Volume based reversal strategy that reacts to increasing or decreasing tick volume.

--- a/API/2904_BrainTrend2_AbsolutelyNoLagLwma/CS/BrainTrend2AbsolutelyNoLagLwmaStrategy.cs
+++ b/API/2904_BrainTrend2_AbsolutelyNoLagLwma/CS/BrainTrend2AbsolutelyNoLagLwmaStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,13 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Combined strategy that trades BrainTrend2 and AbsolutelyNoLagLWMA signals.

--- a/API/2909_Bollinger_Band_Two_MA_ZigZag/CS/BollingerBandTwoMaZigZagStrategy.cs
+++ b/API/2909_Bollinger_Band_Two_MA_ZigZag/CS/BollingerBandTwoMaZigZagStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy combining Bollinger Bands, two moving averages, and swing points from a ZigZag-like detector.

--- a/API/2929_Absolutely_NoLag_Lwma_Digit_MMRec/CS/AbsolutelyNoLagLwmaDigitMmRecStrategy.cs
+++ b/API/2929_Absolutely_NoLag_Lwma_Digit_MMRec/CS/AbsolutelyNoLagLwmaDigitMmRecStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.Messages;
 
 public class AbsolutelyNoLagLwmaDigitMmRecStrategy : Strategy
 {

--- a/API/2943_CandleStop_System_Tm_Plus/CS/CandleStopSystemTmPlusStrategy.cs
+++ b/API/2943_CandleStop_System_Tm_Plus/CS/CandleStopSystemTmPlusStrategy.cs
@@ -1,26 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// CandleStop breakout system with trailing high/low channels and optional time-based exits.

--- a/API/2958_Dematus/CS/DematusStrategy.cs
+++ b/API/2958_Dematus/CS/DematusStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
 
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Strategy based on the Dematus expert advisor with DeMarker crossovers and equity protection.

--- a/API/2972_RSI_Expert_Breakout/CS/RsiExpertBreakoutStrategy.cs
+++ b/API/2972_RSI_Expert_Breakout/CS/RsiExpertBreakoutStrategy.cs
@@ -1,26 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// RSI Expert strategy converted from MetaTrader 5.

--- a/API/2986_The_20s_Breakout/CS/The20sBreakoutStrategy.cs
+++ b/API/2986_The_20s_Breakout/CS/The20sBreakoutStrategy.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
@@ -13,12 +11,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Indicator mode options for the The 20s breakout strategy.

--- a/API/2987_Renko_Chart/CS/RenkoChartStrategy.cs
+++ b/API/2987_Renko_Chart/CS/RenkoChartStrategy.cs
@@ -1,25 +1,18 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Builds a Renko candle stream from trade or bid ticks and mirrors the custom symbol generator from the original MQL expert.

--- a/API/2988_Flat_Trend_EA/CS/FlatTrendEaStrategy.cs
+++ b/API/2988_Flat_Trend_EA/CS/FlatTrendEaStrategy.cs
@@ -1,27 +1,19 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
+using StockSharp.Algo.Candles;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using StockSharp.Algo;
-using System.Collections.Generic;
 
-using StockSharp.Algo.Candles;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Port of the MQL5 "Flat Trend EA" that combines Parabolic SAR with ADX directional movement.

--- a/API/2997_AMA_Trader/CS/AmaTraderStrategy.cs
+++ b/API/2997_AMA_Trader/CS/AmaTraderStrategy.cs
@@ -1,28 +1,19 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Ecng.Common;
 using Ecng.Collections;
 using Ecng.Serialization;
-
 using StockSharp.Algo.Indicators;
 using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
+using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-using System;
-using System.Collections.Generic;
 
-using Ecng.Common;
 
-using StockSharp.Algo;
-using StockSharp.Algo.Indicators;
-using StockSharp.Algo.Strategies;
-using StockSharp.BusinessEntities;
-using StockSharp.Messages;
 
 /// <summary>
 /// Adaptive moving average and RSI based averaging strategy.


### PR DESCRIPTION
## Summary
- remove duplicated using directives across the strategy sources so each file has a single import block ahead of the namespace
- normalize spacing between the using block and the file-scoped namespace declarations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8339fd9608323b2ce3ad2d397aafe