### PR TITLE
Rename early API strategy enums to plural forms

### DIFF
--- a/API/0108_Wyckoff_Accumulation/CS/WyckoffAccumulationStrategy.cs
+++ b/API/0108_Wyckoff_Accumulation/CS/WyckoffAccumulationStrategy.cs
@@ -33,7 +33,7 @@ public class WyckoffAccumulationStrategy : Strategy
 	private Highest _highest;
 	private Lowest _lowest;
 	
-	private enum WyckoffPhase
+	private enum WyckoffPhases
 	{
 		None,
 		PhaseA,  // Selling climax, automatic rally, secondary test
@@ -43,7 +43,7 @@ public class WyckoffAccumulationStrategy : Strategy
 		PhaseE   // Markup, price rise
 	}
 	
-	private WyckoffPhase _currentPhase = WyckoffPhase.None;
+	private WyckoffPhases _currentPhase = WyckoffPhases.None;
 	private decimal _lastRangeHigh;
 	private decimal _lastRangeLow;
 	private int _sidewaysCount;
@@ -136,7 +136,7 @@ public class WyckoffAccumulationStrategy : Strategy
 		_highest = default;
 		_lowest = default;
 
-		_currentPhase = WyckoffPhase.None;
+_currentPhase = WyckoffPhases.None;
 		_lastRangeHigh = 0;
 		_lastRangeLow = 0;
 		_sidewaysCount = 0;
@@ -200,26 +200,26 @@ public class WyckoffAccumulationStrategy : Strategy
 		// State machine for Wyckoff Accumulation phases
 		switch (_currentPhase)
 		{
-			case WyckoffPhase.None:
+case WyckoffPhases.None:
 				// Look for Phase A: Selling climax (high volume, wide range down bar)
 				if (!isBullish && highVolume && candle.ClosePrice < lowest)
 				{
-					_currentPhase = WyckoffPhase.PhaseA;
+_currentPhase = WyckoffPhases.PhaseA;
 					LogInfo($"Wyckoff Phase A detected: Selling climax at {candle.ClosePrice}");
 				}
 				break;
 				
-			case WyckoffPhase.PhaseA:
+case WyckoffPhases.PhaseA:
 				// Look for automatic rally (rebound from selling climax)
 				if (isBullish && candle.ClosePrice > ma)
 				{
-					_currentPhase = WyckoffPhase.PhaseB;
+_currentPhase = WyckoffPhases.PhaseB;
 					LogInfo($"Entering Wyckoff Phase B: Automatic rally at {candle.ClosePrice}");
 					_sidewaysCount = 0;
 				}
 				break;
 				
-			case WyckoffPhase.PhaseB:
+case WyckoffPhases.PhaseB:
 				// Phase B is characterized by sideways movement (accumulation)
 				if (isNarrowRange && candle.ClosePrice > _lastRangeLow && candle.ClosePrice < _lastRangeHigh)
 				{
@@ -228,7 +228,7 @@ public class WyckoffAccumulationStrategy : Strategy
 					// After sufficient sideways movement, look for Phase C
 					if (_sidewaysCount >= 5)
 					{
-						_currentPhase = WyckoffPhase.PhaseC;
+_currentPhase = WyckoffPhases.PhaseC;
 						LogInfo($"Entering Wyckoff Phase C: Accumulation complete after {_sidewaysCount} sideways candles");
 					}
 				}
@@ -238,26 +238,26 @@ public class WyckoffAccumulationStrategy : Strategy
 				}
 				break;
 				
-			case WyckoffPhase.PhaseC:
+case WyckoffPhases.PhaseC:
 				// Phase C includes a spring (price briefly goes below support)
 				if (candle.LowPrice < _lastRangeLow && candle.ClosePrice > _lastRangeLow)
 				{
 					_springLow = candle.LowPrice;
-					_currentPhase = WyckoffPhase.PhaseD;
+_currentPhase = WyckoffPhases.PhaseD;
 					LogInfo($"Entering Wyckoff Phase D: Spring detected at {_springLow}");
 				}
 				break;
 				
-			case WyckoffPhase.PhaseD:
+case WyckoffPhases.PhaseD:
 				// Phase D shows sign of strength (strong move up with volume)
 				if (isBullish && highVolume && priceAboveMA)
 				{
-					_currentPhase = WyckoffPhase.PhaseE;
+_currentPhase = WyckoffPhases.PhaseE;
 					LogInfo($"Entering Wyckoff Phase E: Sign of strength detected at {candle.ClosePrice}");
 				}
 				break;
 				
-			case WyckoffPhase.PhaseE:
+case WyckoffPhases.PhaseE:
 				// Phase E is the markup phase where we enter our position
 				if (isBullish && priceAboveMA && !_positionOpened)
 				{
@@ -279,7 +279,7 @@ public class WyckoffAccumulationStrategy : Strategy
 			{
 				SellMarket(Math.Abs(Position));
 				_positionOpened = false;
-				_currentPhase = WyckoffPhase.None; // Reset the pattern detection
+_currentPhase = WyckoffPhases.None; // Reset the pattern detection
 				
 				LogInfo($"Exit signal: Price broke above range high ({_lastRangeHigh}). Closed long position at {candle.ClosePrice}");
 			}
@@ -288,7 +288,7 @@ public class WyckoffAccumulationStrategy : Strategy
 			{
 				SellMarket(Math.Abs(Position));
 				_positionOpened = false;
-				_currentPhase = WyckoffPhase.None; // Reset the pattern detection
+_currentPhase = WyckoffPhases.None; // Reset the pattern detection
 				
 				LogInfo($"Exit signal: Price fell below MA. Pattern may have failed. Closed long position at {candle.ClosePrice}");
 			}

--- a/API/0109_Wyckoff_Distribution/CS/WyckoffDistributionStrategy.cs
+++ b/API/0109_Wyckoff_Distribution/CS/WyckoffDistributionStrategy.cs
@@ -33,7 +33,7 @@ public class WyckoffDistributionStrategy : Strategy
 	private Highest _highest;
 	private Lowest _lowest;
 	
-	private enum WyckoffPhase
+	private enum WyckoffPhases
 	{
 		None,
 		PhaseA,  // Buying climax, automatic reaction, secondary test
@@ -43,7 +43,7 @@ public class WyckoffDistributionStrategy : Strategy
 		PhaseE   // Markdown, price decline
 	}
 	
-	private WyckoffPhase _currentPhase = WyckoffPhase.None;
+	private WyckoffPhases _currentPhase = WyckoffPhases.None;
 	private decimal _lastRangeHigh;
 	private decimal _lastRangeLow;
 	private int _sidewaysCount;
@@ -136,7 +136,7 @@ public class WyckoffDistributionStrategy : Strategy
 		_highest = default;
 		_lowest = default;
 
-		_currentPhase = WyckoffPhase.None;
+_currentPhase = WyckoffPhases.None;
 		_lastRangeHigh = 0;
 		_lastRangeLow = 0;
 		_sidewaysCount = 0;
@@ -201,26 +201,26 @@ public class WyckoffDistributionStrategy : Strategy
 		// State machine for Wyckoff Distribution phases
 		switch (_currentPhase)
 		{
-			case WyckoffPhase.None:
+case WyckoffPhases.None:
 				// Look for Phase A: Buying climax (high volume, wide range up bar)
 				if (isBullish && highVolume && candle.ClosePrice > highest)
 				{
-					_currentPhase = WyckoffPhase.PhaseA;
+_currentPhase = WyckoffPhases.PhaseA;
 					LogInfo($"Wyckoff Phase A detected: Buying climax at {candle.ClosePrice}");
 				}
 				break;
 				
-			case WyckoffPhase.PhaseA:
+case WyckoffPhases.PhaseA:
 				// Look for automatic reaction (pullback from buying climax)
 				if (isBearish && candle.ClosePrice < ma)
 				{
-					_currentPhase = WyckoffPhase.PhaseB;
+_currentPhase = WyckoffPhases.PhaseB;
 					LogInfo($"Entering Wyckoff Phase B: Automatic reaction at {candle.ClosePrice}");
 					_sidewaysCount = 0;
 				}
 				break;
 				
-			case WyckoffPhase.PhaseB:
+case WyckoffPhases.PhaseB:
 				// Phase B is characterized by sideways movement (distribution)
 				if (isNarrowRange && candle.ClosePrice > _lastRangeLow && candle.ClosePrice < _lastRangeHigh)
 				{
@@ -229,7 +229,7 @@ public class WyckoffDistributionStrategy : Strategy
 					// After sufficient sideways movement, look for Phase C
 					if (_sidewaysCount >= 5)
 					{
-						_currentPhase = WyckoffPhase.PhaseC;
+_currentPhase = WyckoffPhases.PhaseC;
 						LogInfo($"Entering Wyckoff Phase C: Distribution complete after {_sidewaysCount} sideways candles");
 					}
 				}
@@ -239,26 +239,26 @@ public class WyckoffDistributionStrategy : Strategy
 				}
 				break;
 				
-			case WyckoffPhase.PhaseC:
+case WyckoffPhases.PhaseC:
 				// Phase C includes an upthrust (price briefly goes above resistance)
 				if (candle.HighPrice > _lastRangeHigh && candle.ClosePrice < _lastRangeHigh)
 				{
 					_upthrustHigh = candle.HighPrice;
-					_currentPhase = WyckoffPhase.PhaseD;
+_currentPhase = WyckoffPhases.PhaseD;
 					LogInfo($"Entering Wyckoff Phase D: Upthrust detected at {_upthrustHigh}");
 				}
 				break;
 				
-			case WyckoffPhase.PhaseD:
+case WyckoffPhases.PhaseD:
 				// Phase D shows sign of weakness (strong move down with volume)
 				if (isBearish && highVolume && priceBelowMA)
 				{
-					_currentPhase = WyckoffPhase.PhaseE;
+_currentPhase = WyckoffPhases.PhaseE;
 					LogInfo($"Entering Wyckoff Phase E: Sign of weakness detected at {candle.ClosePrice}");
 				}
 				break;
 				
-			case WyckoffPhase.PhaseE:
+case WyckoffPhases.PhaseE:
 				// Phase E is the markdown phase where we enter our position
 				if (isBearish && priceBelowMA && !_positionOpened)
 				{
@@ -280,7 +280,7 @@ public class WyckoffDistributionStrategy : Strategy
 			{
 				BuyMarket(Math.Abs(Position));
 				_positionOpened = false;
-				_currentPhase = WyckoffPhase.None; // Reset the pattern detection
+_currentPhase = WyckoffPhases.None; // Reset the pattern detection
 				
 				LogInfo($"Exit signal: Price broke below range low ({_lastRangeLow}). Closed short position at {candle.ClosePrice}");
 			}
@@ -289,7 +289,7 @@ public class WyckoffDistributionStrategy : Strategy
 			{
 				BuyMarket(Math.Abs(Position));
 				_positionOpened = false;
-				_currentPhase = WyckoffPhase.None; // Reset the pattern detection
+_currentPhase = WyckoffPhases.None; // Reset the pattern detection
 				
 				LogInfo($"Exit signal: Price rose above MA. Pattern may have failed. Closed short position at {candle.ClosePrice}");
 			}

--- a/API/0164_MA_Williams_R/CS/MaWilliamsRStrategy.cs
+++ b/API/0164_MA_Williams_R/CS/MaWilliamsRStrategy.cs
@@ -24,7 +24,7 @@ namespace StockSharp.Samples.Strategies;
 public class MaWilliamsRStrategy : Strategy
 {
 	private readonly StrategyParam<int> _maPeriod;
-	private readonly StrategyParam<MovingAverageTypeEnum> _maType;
+	private readonly StrategyParam<MovingAverageTypes> _maType;
 	private readonly StrategyParam<int> _williamsRPeriod;
 	private readonly StrategyParam<decimal> _williamsROversold;
 	private readonly StrategyParam<decimal> _williamsROverbought;
@@ -43,7 +43,7 @@ public class MaWilliamsRStrategy : Strategy
 	/// <summary>
 	/// Moving Average type.
 	/// </summary>
-	public MovingAverageTypeEnum MaType
+	public MovingAverageTypes MaType
 	{
 		get => _maType.Value;
 		set => _maType.Value = value;
@@ -103,7 +103,7 @@ public class MaWilliamsRStrategy : Strategy
 			.SetGreaterThanZero()
 			.SetDisplay("MA Period", "Period for Moving Average", "MA Parameters");
 
-		_maType = Param(nameof(MaType), MovingAverageTypeEnum.Simple)
+		_maType = Param(nameof(MaType), MovingAverageTypes.Simple)
 			.SetDisplay("MA Type", "Type of Moving Average", "MA Parameters");
 
 		_williamsRPeriod = Param(nameof(WilliamsRPeriod), 14)
@@ -150,19 +150,19 @@ protected override void OnStarted(DateTimeOffset time)
 		// Create MA based on selected type
 		switch (MaType)
 		{
-			case MovingAverageTypeEnum.Exponential:
+			case MovingAverageTypes.Exponential:
 				ma = new ExponentialMovingAverage { Length = MaPeriod };
 				break;
-			case MovingAverageTypeEnum.Weighted:
+			case MovingAverageTypes.Weighted:
 				ma = new WeightedMovingAverage { Length = MaPeriod };
 				break;
-			case MovingAverageTypeEnum.Smoothed:
+			case MovingAverageTypes.Smoothed:
 				ma = new SmoothedMovingAverage { Length = MaPeriod };
 				break;
-			case MovingAverageTypeEnum.HullMA:
+			case MovingAverageTypes.HullMA:
 				ma = new HullMovingAverage { Length = MaPeriod };
 				break;
-			case MovingAverageTypeEnum.Simple:
+			case MovingAverageTypes.Simple:
 			default:
 				ma = new SimpleMovingAverage { Length = MaPeriod };
 				break;
@@ -252,7 +252,7 @@ protected override void OnStarted(DateTimeOffset time)
 	/// <summary>
 	/// Enum for Moving Average types.
 	/// </summary>
-	public enum MovingAverageTypeEnum
+	public enum MovingAverageTypes
 	{
 		/// <summary>
 		/// Simple Moving Average

--- a/API/0319_Bollinger_K-Means_Cluster/CS/BollingerKMeansStrategy.cs
+++ b/API/0319_Bollinger_K-Means_Cluster/CS/BollingerKMeansStrategy.cs
@@ -29,14 +29,14 @@ public class BollingerKMeansStrategy : Strategy
 	private decimal _atrValue;
 
 	// Cluster state tracking
-	private enum ClusterState
+	private enum ClusterStates
 	{
 		Oversold,
 		Neutral,
 		Overbought
 	}
 
-	private ClusterState _currentClusterState = ClusterState.Neutral;
+	private ClusterStates _currentClusterState = ClusterStates.Neutral;
 	private readonly SynchronizedList<decimal> _rsiValues = [];
 	private readonly SynchronizedList<decimal> _priceValues = [];
 	private readonly SynchronizedList<decimal> _volumeValues = [];
@@ -116,7 +116,7 @@ public class BollingerKMeansStrategy : Strategy
 		base.OnReseted();
 
 		_atrValue = default;
-		_currentClusterState = ClusterState.Neutral;
+_currentClusterState = ClusterStates.Neutral;
 		_rsiValues.Clear();
 		_priceValues.Clear();
 		_volumeValues.Clear();
@@ -202,13 +202,13 @@ public class BollingerKMeansStrategy : Strategy
 		CalculateClusters();
 
 		// Trading logic
-		if (candle.ClosePrice < bollingerLower && _currentClusterState == ClusterState.Oversold && Position <= 0)
+if (candle.ClosePrice < bollingerLower && _currentClusterState == ClusterStates.Oversold && Position <= 0)
 		{
 			// Buy signal - price below lower band and in oversold cluster
 			BuyMarket(Volume);
 			LogInfo($"Buy Signal: Price below lower band ({bollingerLower:F2}) in oversold cluster");
 		}
-		else if (candle.ClosePrice > bollingerUpper && _currentClusterState == ClusterState.Overbought && Position >= 0)
+else if (candle.ClosePrice > bollingerUpper && _currentClusterState == ClusterStates.Overbought && Position >= 0)
 		{
 			// Sell signal - price above upper band and in overbought cluster
 			SellMarket(Volume + Math.Abs(Position));
@@ -280,15 +280,15 @@ public class BollingerKMeansStrategy : Strategy
 
 		if (normalizedRsi < 0.3m && normalizedPrice < 0.3m)
 		{
-			_currentClusterState = ClusterState.Oversold;
+_currentClusterState = ClusterStates.Oversold;
 		}
 		else if (normalizedRsi > 0.7m && normalizedPrice > 0.7m)
 		{
-			_currentClusterState = ClusterState.Overbought;
+_currentClusterState = ClusterStates.Overbought;
 		}
 		else
 		{
-			_currentClusterState = ClusterState.Neutral;
+_currentClusterState = ClusterStates.Neutral;
 		}
 
 		LogInfo($"Cluster State: {_currentClusterState}, Normalized RSI: {normalizedRsi:F2}, Normalized Price: {normalizedPrice:F2}");

--- a/API/0320_MACD_Hidden_Markov_Model/CS/MacdHmmStrategy.cs
+++ b/API/0320_MACD_Hidden_Markov_Model/CS/MacdHmmStrategy.cs
@@ -27,14 +27,14 @@ public class MacdHmmStrategy : Strategy
 	private MovingAverageConvergenceDivergenceSignal _macd;
 
 	// Hidden Markov Model states
-	private enum MarketState
+	private enum MarketStates
 	{
 		Bullish,
 		Neutral,
 		Bearish
 	}
 
-	private MarketState _currentState = MarketState.Neutral;
+	private MarketStates _currentState = MarketStates.Neutral;
 
 	// Data for HMM calculations
 	private readonly SynchronizedList<decimal> _priceChanges = [];
@@ -126,7 +126,7 @@ public class MacdHmmStrategy : Strategy
 	{
 		base.OnReseted();
 
-		_currentState = MarketState.Neutral;
+_currentState = MarketStates.Neutral;
 		_prevPrice = 0;
 		_priceChanges.Clear();
 		_volumes.Clear();
@@ -194,20 +194,20 @@ public class MacdHmmStrategy : Strategy
 		var signal = macdTyped.Signal;
 
 		// Generate trade signals based on MACD and HMM state
-		if (macd > signal && _currentState == MarketState.Bullish && Position <= 0)
+			if (macd > signal && _currentState == MarketStates.Bullish && Position <= 0)
 		{
 			// Buy signal - MACD above signal line and bullish state
 			BuyMarket(Volume);
 			LogInfo($"Buy Signal: MACD ({macd:F6}) > Signal ({signal:F6}) in Bullish state");
 		}
-		else if (macd < signal && _currentState == MarketState.Bearish && Position >= 0)
+			else if (macd < signal && _currentState == MarketStates.Bearish && Position >= 0)
 		{
 			// Sell signal - MACD below signal line and bearish state
 			SellMarket(Volume + Math.Abs(Position));
 			LogInfo($"Sell Signal: MACD ({macd:F6}) < Signal ({signal:F6}) in Bearish state");
 		}
-		else if ((Position > 0 && (_currentState == MarketState.Neutral || _currentState == MarketState.Bearish)) ||
-		(Position < 0 && (_currentState == MarketState.Neutral || _currentState == MarketState.Bullish)))
+			else if ((Position > 0 && (_currentState == MarketStates.Neutral || _currentState == MarketStates.Bearish)) ||
+				(Position < 0 && (_currentState == MarketStates.Neutral || _currentState == MarketStates.Bullish)))
 		{
 			// Exit position if market state changes
 			ClosePosition();
@@ -275,15 +275,15 @@ public class MacdHmmStrategy : Strategy
 		// Determine market state based on price change direction and volume
 		if (positiveChanges >= 7 || (positiveChanges >= 6 && upVolume > downVolume * 1.5m))
 		{
-			_currentState = MarketState.Bullish;
+_currentState = MarketStates.Bullish;
 		}
 		else if (negativeChanges >= 7 || (negativeChanges >= 6 && downVolume > upVolume * 1.5m))
 		{
-			_currentState = MarketState.Bearish;
+_currentState = MarketStates.Bearish;
 		}
 		else
 		{
-			_currentState = MarketState.Neutral;
+_currentState = MarketStates.Neutral;
 		}
 
 		LogInfo($"Market State: {_currentState}, Positive Changes: {positiveChanges}, Negative Changes: {negativeChanges}");

--- a/API/0322_Supertrend_RSI_Divergence/CS/SupertrendRsiDivergenceStrategy.cs
+++ b/API/0322_Supertrend_RSI_Divergence/CS/SupertrendRsiDivergenceStrategy.cs
@@ -34,7 +34,7 @@ public class SupertrendRsiDivergenceStrategy : Strategy
 
 	// Supertrend state tracking
 	private decimal _supertrendValue;
-	private TrendDirection _trendDirection = TrendDirection.None;
+	private TrendDirections _trendDirection = TrendDirections.None;
 
 	/// <summary>
 	/// Supertrend period.
@@ -111,7 +111,7 @@ public class SupertrendRsiDivergenceStrategy : Strategy
 		_rsiValues.Clear();
 		_isLongPosition = false;
 		_isShortPosition = false;
-		_trendDirection = TrendDirection.None;
+_trendDirection = TrendDirections.None;
 		_supertrendValue = 0;
 	}
 
@@ -178,15 +178,15 @@ public class SupertrendRsiDivergenceStrategy : Strategy
 		}
 
 		// Determine Supertrend trend direction
-		TrendDirection previousDirection = _trendDirection;
+TrendDirections previousDirection = _trendDirection;
 
 		if (candle.ClosePrice > _supertrendValue)
-		_trendDirection = TrendDirection.Up;
+_trendDirection = TrendDirections.Up;
 		else if (candle.ClosePrice < _supertrendValue)
-		_trendDirection = TrendDirection.Down;
+_trendDirection = TrendDirections.Down;
 
 		// Check for trend direction change
-		bool trendDirectionChanged = previousDirection != TrendDirection.None && previousDirection != _trendDirection;
+bool trendDirectionChanged = previousDirection != TrendDirections.None && previousDirection != _trendDirection;
 
 		// Check for divergence
 		bool bullishDivergence = CheckBullishDivergence();
@@ -276,7 +276,7 @@ public class SupertrendRsiDivergenceStrategy : Strategy
 	}
 
 	// Trend direction enum for tracking Supertrend state
-	private enum TrendDirection
+	private enum TrendDirections
 	{
 		None,
 		Up,

--- a/API/0323_Donchian_Seasonal_Filter/CS/DonchianSeasonalStrategy.cs
+++ b/API/0323_Donchian_Seasonal_Filter/CS/DonchianSeasonalStrategy.cs
@@ -28,7 +28,7 @@ public class DonchianSeasonalStrategy : Strategy
 	private bool _isShortPosition;
 	
 	// Seasonal data storage
-	private readonly SynchronizedDictionary<Month, decimal> _monthlyReturns = [];
+	private readonly SynchronizedDictionary<Months, decimal> _monthlyReturns = [];
 	
 	// Simulated seasonal data count
 
@@ -99,25 +99,25 @@ public class DonchianSeasonalStrategy : Strategy
 			.SetDisplay("Candle Type", "Type of candles to use", "General");
 			
 		// Initialize monthly returns with neutral values
-		foreach (Month month in Enum.GetValues(typeof(Month)))
+foreach (Months month in Enum.GetValues(typeof(Months)))
 		{
 			_monthlyReturns[month] = 0m;
 		}
 		
 		// Simulated historical seasonal data (in a real strategy, this would come from analysis of historical data)
 		// These are example values that suggest certain months tend to be bullish or bearish
-		_monthlyReturns[Month.January] = 0.8m;
-		_monthlyReturns[Month.February] = 0.3m;
-		_monthlyReturns[Month.March] = 0.6m;
-		_monthlyReturns[Month.April] = 0.9m;
-		_monthlyReturns[Month.May] = 0.2m;
-		_monthlyReturns[Month.June] = -0.4m;
-		_monthlyReturns[Month.July] = -0.2m;
-		_monthlyReturns[Month.August] = -0.7m;
-		_monthlyReturns[Month.September] = -0.9m;
-		_monthlyReturns[Month.October] = -0.1m;
-		_monthlyReturns[Month.November] = 0.5m;
-		_monthlyReturns[Month.December] = 0.7m;
+_monthlyReturns[Months.January] = 0.8m;
+_monthlyReturns[Months.February] = 0.3m;
+_monthlyReturns[Months.March] = 0.6m;
+_monthlyReturns[Months.April] = 0.9m;
+_monthlyReturns[Months.May] = 0.2m;
+_monthlyReturns[Months.June] = -0.4m;
+_monthlyReturns[Months.July] = -0.2m;
+_monthlyReturns[Months.August] = -0.7m;
+_monthlyReturns[Months.September] = -0.9m;
+_monthlyReturns[Months.October] = -0.1m;
+_monthlyReturns[Months.November] = 0.5m;
+_monthlyReturns[Months.December] = 0.7m;
 	}
 
 	/// <inheritdoc />
@@ -235,7 +235,7 @@ public class DonchianSeasonalStrategy : Strategy
 	private void UpdateSeasonalStrength(DateTimeOffset time)
 	{
 		// Get current month
-		Month currentMonth = (Month)time.Month;
+		Months currentMonth = (Months)time.Month;
 		
 		// Get historical return for this month
 		_seasonalStrength = _monthlyReturns[currentMonth];
@@ -250,7 +250,7 @@ public class DonchianSeasonalStrategy : Strategy
 	/// <summary>
 	/// Enumeration for months of the year.
 	/// </summary>
-	private enum Month
+	private enum Months
 	{
 		January = 1,
 		February,

--- a/API/0334_Hull_MA_K-Means_Cluster/CS/HullKMeansClusterStrategy.cs
+++ b/API/0334_Hull_MA_K-Means_Cluster/CS/HullKMeansClusterStrategy.cs
@@ -23,7 +23,7 @@ public class HullKMeansClusterStrategy : Strategy
 	private readonly StrategyParam<int> _rsiPeriod;
 	private readonly StrategyParam<DataType> _candleType;
 
-	private enum MarketState
+	private enum MarketStates
 	{
 		Neutral,
 		Bullish,
@@ -31,7 +31,7 @@ public class HullKMeansClusterStrategy : Strategy
 	}
 
 	private decimal _prevHullValue;
-	private MarketState _currentMarketState = MarketState.Neutral;
+	private MarketStates _currentMarketState = MarketStates.Neutral;
 
 	// Feature data for clustering
 	private readonly Queue<decimal> _priceChangeData = [];
@@ -110,7 +110,7 @@ public class HullKMeansClusterStrategy : Strategy
 		base.OnReseted();
 
 		_prevHullValue = default;
-		_currentMarketState = MarketState.Neutral;
+_currentMarketState = MarketStates.Neutral;
 		_lastPrice = default;
 		_avgVolume = default;
 
@@ -181,7 +181,7 @@ public class HullKMeansClusterStrategy : Strategy
 		_volumeRatioData.Count >= ClusterDataLength)
 		{
 			// Perform K-Means clustering for market state detection
-			_currentMarketState = DetectMarketState();
+_currentMarketState = DetectMarketState();
 			LogInfo($"Current market state: {_currentMarketState}");
 		}
 
@@ -189,13 +189,13 @@ public class HullKMeansClusterStrategy : Strategy
 		bool isHullRising = hullValue > _prevHullValue;
 
 		// Trading logic based on Hull MA direction and market state
-		if (isHullRising && _currentMarketState == MarketState.Bullish && Position <= 0)
+if (isHullRising && _currentMarketState == MarketStates.Bullish && Position <= 0)
 		{
 			// Hull MA rising in bullish market state - Buy signal
 			LogInfo($"Buy signal: Hull MA rising ({hullValue} > {_prevHullValue}) in bullish market state");
 			BuyMarket(Volume + Math.Abs(Position));
 		}
-		else if (!isHullRising && _currentMarketState == MarketState.Bearish && Position >= 0)
+else if (!isHullRising && _currentMarketState == MarketStates.Bearish && Position >= 0)
 		{
 			// Hull MA falling in bearish market state - Sell signal
 			LogInfo($"Sell signal: Hull MA falling ({hullValue} < {_prevHullValue}) in bearish market state");
@@ -244,7 +244,7 @@ public class HullKMeansClusterStrategy : Strategy
 		_volumeRatioData.Dequeue();
 	}
 
-	private MarketState DetectMarketState()
+private MarketStates DetectMarketState()
 	{
 		// Simplified implementation of K-Means clustering for market state detection
 		// This is a basic approach - a full implementation would use proper K-Means algorithm
@@ -261,15 +261,15 @@ public class HullKMeansClusterStrategy : Strategy
 
 		if (avgRsi > 60 && avgPriceChange > 0.1m && avgVolumeRatio > 1.1m)
 		{
-			return MarketState.Bullish;
+return MarketStates.Bullish;
 		}
 		else if (avgRsi < 40 && avgPriceChange < -0.1m && avgVolumeRatio > 1.1m)
 		{
-			return MarketState.Bearish;
+return MarketStates.Bearish;
 		}
 		else
 		{
-			return MarketState.Neutral;
+return MarketStates.Neutral;
 		}
 	}
 }

--- a/API/0335_VWAP_Hidden_Markov_Model/CS/VwapHiddenMarkovModelStrategy.cs
+++ b/API/0335_VWAP_Hidden_Markov_Model/CS/VwapHiddenMarkovModelStrategy.cs
@@ -22,14 +22,14 @@ public class VwapHiddenMarkovModelStrategy : Strategy
 	private readonly StrategyParam<decimal> _stopLossPercent;
 	private readonly StrategyParam<DataType> _candleType;
 
-	private enum MarketState
+	private enum MarketStates
 	{
 		Neutral,
 		Bullish,
 		Bearish
 	}
 
-	private MarketState _currentMarketState = MarketState.Neutral;
+	private MarketStates _currentMarketState = MarketStates.Neutral;
 
 	// Feature data for HMM
 	private readonly Queue<decimal> _priceData = [];
@@ -98,7 +98,7 @@ public class VwapHiddenMarkovModelStrategy : Strategy
 	{
 		base.OnReseted();
 
-		_currentMarketState = MarketState.Neutral;
+_currentMarketState = MarketStates.Neutral;
 		_priceData.Clear();
 		_volumeData.Clear();
 	}
@@ -161,13 +161,13 @@ public class VwapHiddenMarkovModelStrategy : Strategy
 		}
 
 		// Trading logic based on VWAP and HMM state
-		if (_currentMarketState == MarketState.Bullish && candle.ClosePrice > vwapValue && Position <= 0)
+		if (_currentMarketState == MarketStates.Bullish && candle.ClosePrice > vwapValue && Position <= 0)
 		{
 			// Price above VWAP in bullish state - Buy signal
 			LogInfo($"Buy signal: Price ({candle.ClosePrice}) above VWAP ({vwapValue}) in bullish state");
 			BuyMarket(Volume + Math.Abs(Position));
 		}
-		else if (_currentMarketState == MarketState.Bearish && candle.ClosePrice < vwapValue && Position >= 0)
+		else if (_currentMarketState == MarketStates.Bearish && candle.ClosePrice < vwapValue && Position >= 0)
 		{
 			// Price below VWAP in bearish state - Sell signal
 			LogInfo($"Sell signal: Price ({candle.ClosePrice}) below VWAP ({vwapValue}) in bearish state");
@@ -180,15 +180,15 @@ public class VwapHiddenMarkovModelStrategy : Strategy
 		// Add price data to queue
 		_priceData.Enqueue(candle.ClosePrice);
 		if (_priceData.Count > HmmDataLength)
-		_priceData.Dequeue();
+			_priceData.Dequeue();
 
 		// Add volume data to queue
 		_volumeData.Enqueue(candle.TotalVolume);
 		if (_volumeData.Count > HmmDataLength)
-		_volumeData.Dequeue();
+			_volumeData.Dequeue();
 	}
 
-	private MarketState RunHmm()
+	private MarketStates RunHmm()
 	{
 		// This is a simplified implementation of Hidden Markov Model
 		// A full implementation would use Baum-Welch algorithm for training and Viterbi algorithm for decoding
@@ -236,7 +236,7 @@ public class VwapHiddenMarkovModelStrategy : Strategy
 		return result;
 	}
 
-	private List<MarketState> SimplifiedViterbi(List<int> observations)
+	private List<MarketStates> SimplifiedViterbi(List<int> observations)
 	{
 		// This is a very simplified version of the Viterbi algorithm
 		// For a real implementation, proper HMM libraries should be used
@@ -251,7 +251,7 @@ public class VwapHiddenMarkovModelStrategy : Strategy
 
 		// Initialize with equal probabilities for each state
 		var currentStateProbabilities = new decimal[3] { 1m / 3, 1m / 3, 1m / 3 };
-		var stateSequence = new List<MarketState>();
+		var stateSequence = new List<MarketStates>();
 
 		// Process each observation
 		foreach (var obs in observations)
@@ -290,7 +290,7 @@ public class VwapHiddenMarkovModelStrategy : Strategy
 			}
 
 			// Add state to sequence
-			stateSequence.Add((MarketState)maxIndex);
+			stateSequence.Add((MarketStates)maxIndex);
 
 			// Update current probabilities
 			currentStateProbabilities = newProbabilities;

--- a/API/0343_Keltner_Reinforcement_Learning_Signal/CS/KeltnerWithRLSignalStrategy.cs
+++ b/API/0343_Keltner_Reinforcement_Learning_Signal/CS/KeltnerWithRLSignalStrategy.cs
@@ -30,14 +30,14 @@ public class KeltnerWithRLSignalStrategy : Strategy
 	private readonly StrategyParam<decimal> _stopLossAtr;
 	private readonly StrategyParam<DataType> _candleType;
 
-	private enum RLSignal
+	private enum RLSignals
 	{
 		None,
 		Buy,
 		Sell
 	}
 
-	private RLSignal _currentSignal = RLSignal.None;
+	private RLSignals _currentSignal = RLSignals.None;
 
 	// State variables for RL
 	private decimal _lastPrice;
@@ -212,14 +212,14 @@ public class KeltnerWithRLSignalStrategy : Strategy
 		// Entry conditions
 
 		// Long entry: Price above upper band and RL signal is Buy
-		if (priceAboveUpperBand && _currentSignal == RLSignal.Buy && Position <= 0)
+if (priceAboveUpperBand && _currentSignal == RLSignals.Buy && Position <= 0)
 		{
 			LogInfo($"Long signal: Price {price} > Upper Band {upperBand}, RL Signal = Buy");
 			BuyMarket(Volume);
 			_previousSignalPrice = price;
 		}
 		// Short entry: Price below lower band and RL signal is Sell
-		else if (priceBelowLowerBand && _currentSignal == RLSignal.Sell && Position >= 0)
+else if (priceBelowLowerBand && _currentSignal == RLSignals.Sell && Position >= 0)
 		{
 			LogInfo($"Short signal: Price {price} < Lower Band {lowerBand}, RL Signal = Sell");
 			SellMarket(Volume);
@@ -277,12 +277,12 @@ public class KeltnerWithRLSignalStrategy : Strategy
 		// Simplified Q-learning decision matrix
 		if (bullishCandle && priceAboveEma && (priceIncreasing || aggressiveMode))
 		{
-			_currentSignal = RLSignal.Buy;
+_currentSignal = RLSignals.Buy;
 			LogInfo("RL Signal: Buy");
 		}
 		else if (!bullishCandle && !priceAboveEma && (!priceIncreasing || aggressiveMode))
 		{
-			_currentSignal = RLSignal.Sell;
+_currentSignal = RLSignals.Sell;
 			LogInfo("RL Signal: Sell");
 		}
 		else
@@ -291,7 +291,7 @@ public class KeltnerWithRLSignalStrategy : Strategy
 			if (volatilityIncreasing)
 			{
 				// High volatility might warrant reducing exposure
-				_currentSignal = RLSignal.None;
+_currentSignal = RLSignals.None;
 				LogInfo("RL Signal: None (high volatility)");
 			}
 			// Otherwise keep current signal

--- a/API/0464_MA_PSAR_ATR_Trend/CS/MaPsarAtrTrendStrategy.cs
+++ b/API/0464_MA_PSAR_ATR_Trend/CS/MaPsarAtrTrendStrategy.cs
@@ -20,8 +20,8 @@ public class MaPsarAtrTrendStrategy : Strategy
 {
 	private readonly StrategyParam<int> _fastMaPeriod;
 	private readonly StrategyParam<int> _slowMaPeriod;
-	private readonly StrategyParam<MovingAverageTypeEnum> _fastMaType;
-	private readonly StrategyParam<MovingAverageTypeEnum> _slowMaType;
+	private readonly StrategyParam<MovingAverageTypes> _fastMaType;
+	private readonly StrategyParam<MovingAverageTypes> _slowMaType;
 	private readonly StrategyParam<decimal> _sarStep;
 	private readonly StrategyParam<decimal> _sarMaxStep;
 	private readonly StrategyParam<int> _atrPeriod;
@@ -54,7 +54,7 @@ public class MaPsarAtrTrendStrategy : Strategy
 	/// <summary>
 	/// Fast MA type.
 	/// </summary>
-	public MovingAverageTypeEnum FastMaType
+	public MovingAverageTypes FastMaType
 	{
 		get => _fastMaType.Value;
 		set => _fastMaType.Value = value;
@@ -63,7 +63,7 @@ public class MaPsarAtrTrendStrategy : Strategy
 	/// <summary>
 	/// Slow MA type.
 	/// </summary>
-	public MovingAverageTypeEnum SlowMaType
+	public MovingAverageTypes SlowMaType
 	{
 		get => _slowMaType.Value;
 		set => _slowMaType.Value = value;
@@ -145,10 +145,10 @@ public class MaPsarAtrTrendStrategy : Strategy
 			.SetDisplay("Slow MA Period", "Period for slow moving average", "MA")
 			.SetGreaterThanZero();
 
-		_fastMaType = Param(nameof(FastMaType), MovingAverageTypeEnum.Simple)
+		_fastMaType = Param(nameof(FastMaType), MovingAverageTypes.Simple)
 			.SetDisplay("Fast MA Type", "Type of fast moving average", "MA");
 
-		_slowMaType = Param(nameof(SlowMaType), MovingAverageTypeEnum.Simple)
+		_slowMaType = Param(nameof(SlowMaType), MovingAverageTypes.Simple)
 			.SetDisplay("Slow MA Type", "Type of slow moving average", "MA");
 
 		_sarStep = Param(nameof(SarStep), 0.02m)
@@ -229,14 +229,14 @@ public class MaPsarAtrTrendStrategy : Strategy
 		}
 	}
 
-	private IIndicator CreateMa(MovingAverageTypeEnum type, int length)
+	private IIndicator CreateMa(MovingAverageTypes type, int length)
 	{
 		return type switch
 		{
-			MovingAverageTypeEnum.Exponential => new ExponentialMovingAverage { Length = length },
-			MovingAverageTypeEnum.Weighted => new WeightedMovingAverage { Length = length },
-			MovingAverageTypeEnum.Smoothed => new SmoothedMovingAverage { Length = length },
-			MovingAverageTypeEnum.Hull => new HullMovingAverage { Length = length },
+			MovingAverageTypes.Exponential => new ExponentialMovingAverage { Length = length },
+			MovingAverageTypes.Weighted => new WeightedMovingAverage { Length = length },
+			MovingAverageTypes.Smoothed => new SmoothedMovingAverage { Length = length },
+			MovingAverageTypes.Hull => new HullMovingAverage { Length = length },
 			_ => new SimpleMovingAverage { Length = length },
 		};
 	}
@@ -296,7 +296,7 @@ public class MaPsarAtrTrendStrategy : Strategy
 	/// <summary>
 	/// Moving average type enumeration.
 	/// </summary>
-	public enum MovingAverageTypeEnum
+	public enum MovingAverageTypes
 	{
 		/// <summary>
 		/// Simple Moving Average.


### PR DESCRIPTION
## Summary
- rename the moving average type enums to `MovingAverageTypes` in the MA PSAR ATR Trend and MA Williams %R strategies
- pluralize the remaining strategy enums (market states, cluster states, RL signals, Wyckoff phases, trend directions, and months) across the early API strategies so they follow the new naming convention

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d833ed2d508323b111a88324143405