### PR TITLE
Rename API enums to plural forms for strategies 3001-4000

### DIFF
--- a/API/3001_Previous_Candle_Breakdown_2/CS/PreviousCandleBreakdown2Strategy.cs
+++ b/API/3001_Previous_Candle_Breakdown_2/CS/PreviousCandleBreakdown2Strategy.cs
@@ -25,7 +25,7 @@ public class PreviousCandleBreakdown2Strategy : Strategy
 	private readonly StrategyParam<int> _fastShift;
 	private readonly StrategyParam<int> _slowPeriod;
 	private readonly StrategyParam<int> _slowShift;
-	private readonly StrategyParam<MaMethod> _maMethod;
+	private readonly StrategyParam<MaMethods> _maMethod;
 	private readonly StrategyParam<decimal> _stopLossPips;
 	private readonly StrategyParam<decimal> _takeProfitPips;
 	private readonly StrategyParam<decimal> _trailingStopPips;
@@ -99,7 +99,7 @@ public class PreviousCandleBreakdown2Strategy : Strategy
 	/// <summary>
 	/// Moving average calculation method.
 	/// </summary>
-	public MaMethod MaMethod
+	public MaMethods MaMethods
 	{
 		get => _maMethod.Value;
 		set => _maMethod.Value = value;
@@ -231,7 +231,7 @@ public class PreviousCandleBreakdown2Strategy : Strategy
 		.SetNotNegative()
 		.SetDisplay("Slow Shift", "Shift for slow MA", "Filters");
 
-		_maMethod = Param(nameof(MaMethod), MaMethod.Simple)
+		_maMethod = Param(nameof(MaMethods), MaMethods.Simple)
 		.SetDisplay("MA Method", "Moving average calculation method", "Filters");
 
 		_stopLossPips = Param(nameof(StopLossPips), 50m)
@@ -602,12 +602,12 @@ public class PreviousCandleBreakdown2Strategy : Strategy
 
 	private IIndicator CreateMovingAverage(int period)
 	{
-		return MaMethod switch
+		return MaMethods switch
 		{
-			MaMethod.Simple => new SimpleMovingAverage { Length = period },
-			MaMethod.Exponential => new ExponentialMovingAverage { Length = period },
-			MaMethod.Smoothed => new SmoothedMovingAverage { Length = period },
-			MaMethod.Weighted => new WeightedMovingAverage { Length = period },
+			MaMethods.Simple => new SimpleMovingAverage { Length = period },
+			MaMethods.Exponential => new ExponentialMovingAverage { Length = period },
+			MaMethods.Smoothed => new SmoothedMovingAverage { Length = period },
+			MaMethods.Weighted => new WeightedMovingAverage { Length = period },
 			_ => new SimpleMovingAverage { Length = period }
 		};
 	}
@@ -663,7 +663,7 @@ public class PreviousCandleBreakdown2Strategy : Strategy
 	/// <summary>
 	/// Moving average method enumeration matching the original MQL parameters.
 	/// </summary>
-	public enum MaMethod
+	public enum MaMethods
 	{
 		Simple,
 		Exponential,

--- a/API/3002_TrendManager_TM_Plus/CS/TrendManagerTmPlusStrategy.cs
+++ b/API/3002_TrendManager_TM_Plus/CS/TrendManagerTmPlusStrategy.cs
@@ -20,8 +20,8 @@ using StockSharp.Messages;
 public class TrendManagerTmPlusStrategy : Strategy
 {
 	private readonly StrategyParam<DataType> _candleType;
-	private readonly StrategyParam<SmoothingMethod> _fastMethod;
-	private readonly StrategyParam<SmoothingMethod> _slowMethod;
+	private readonly StrategyParam<SmoothingMethods> _fastMethod;
+	private readonly StrategyParam<SmoothingMethods> _slowMethod;
 	private readonly StrategyParam<int> _fastLength;
 	private readonly StrategyParam<int> _slowLength;
 	private readonly StrategyParam<decimal> _dvLimit;
@@ -46,7 +46,7 @@ public class TrendManagerTmPlusStrategy : Strategy
 	/// <summary>
 	/// Supported smoothing methods.
 	/// </summary>
-	public enum SmoothingMethod
+	public enum SmoothingMethods
 	{
 		Simple,
 		Exponential,
@@ -64,10 +64,10 @@ public class TrendManagerTmPlusStrategy : Strategy
 		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(4).TimeFrame())
 			.SetDisplay("Candle Type", "Timeframe used for signals", "General");
 
-		_fastMethod = Param(nameof(FastMethod), SmoothingMethod.Simple)
+		_fastMethod = Param(nameof(FastMethod), SmoothingMethods.Simple)
 			.SetDisplay("Fast MA Method", "Smoothing for fast line", "Indicator");
 
-		_slowMethod = Param(nameof(SlowMethod), SmoothingMethod.Simple)
+		_slowMethod = Param(nameof(SlowMethod), SmoothingMethods.Simple)
 			.SetDisplay("Slow MA Method", "Smoothing for slow line", "Indicator");
 
 		_fastLength = Param(nameof(FastLength), 23)
@@ -127,13 +127,13 @@ public class TrendManagerTmPlusStrategy : Strategy
 		set => _candleType.Value = value;
 	}
 
-	public SmoothingMethod FastMethod
+	public SmoothingMethods FastMethod
 	{
 		get => _fastMethod.Value;
 		set => _fastMethod.Value = value;
 	}
 
-	public SmoothingMethod SlowMethod
+	public SmoothingMethods SlowMethod
 	{
 		get => _slowMethod.Value;
 		set => _slowMethod.Value = value;
@@ -233,17 +233,17 @@ public class TrendManagerTmPlusStrategy : Strategy
 		StartProtection();
 	}
 
-	private IIndicator CreateMovingAverage(SmoothingMethod method, int length)
+	private IIndicator CreateMovingAverage(SmoothingMethods method, int length)
 	{
 		// Map the selected smoothing method to a StockSharp indicator implementation.
 		return method switch
 		{
-			SmoothingMethod.Simple => new SimpleMovingAverage { Length = length },
-			SmoothingMethod.Exponential => new ExponentialMovingAverage { Length = length },
-			SmoothingMethod.Smoothed => new SmoothedMovingAverage { Length = length },
-			SmoothingMethod.Weighted => new WeightedMovingAverage { Length = length },
-			SmoothingMethod.Jurik => new JurikMovingAverage { Length = length },
-			SmoothingMethod.Adaptive => new KaufmanAdaptiveMovingAverage { Length = length },
+			SmoothingMethods.Simple => new SimpleMovingAverage { Length = length },
+			SmoothingMethods.Exponential => new ExponentialMovingAverage { Length = length },
+			SmoothingMethods.Smoothed => new SmoothedMovingAverage { Length = length },
+			SmoothingMethods.Weighted => new WeightedMovingAverage { Length = length },
+			SmoothingMethods.Jurik => new JurikMovingAverage { Length = length },
+			SmoothingMethods.Adaptive => new KaufmanAdaptiveMovingAverage { Length = length },
 			_ => new SimpleMovingAverage { Length = length },
 		};
 	}

--- a/API/3011_JS_MA_SAR_Trades/CS/JsMaSarTradesStrategy.cs
+++ b/API/3011_JS_MA_SAR_Trades/CS/JsMaSarTradesStrategy.cs
@@ -30,8 +30,8 @@ public class JsMaSarTradesStrategy : Strategy
 	private readonly StrategyParam<int> _fastMaShift;
 	private readonly StrategyParam<int> _slowMaPeriod;
 	private readonly StrategyParam<int> _slowMaShift;
-	private readonly StrategyParam<MovingAverageTypeEnum> _maType;
-	private readonly StrategyParam<AppliedPriceType> _appliedPrice;
+	private readonly StrategyParam<MovingAverageTypes> _maType;
+	private readonly StrategyParam<AppliedPriceTypes> _appliedPrice;
 	private readonly StrategyParam<decimal> _sarStep;
 	private readonly StrategyParam<decimal> _sarMaxStep;
 	private readonly StrategyParam<int> _zigZagDepth;
@@ -170,7 +170,7 @@ public class JsMaSarTradesStrategy : Strategy
 	/// <summary>
 	/// Moving average type used by both averages.
 	/// </summary>
-	public MovingAverageTypeEnum MaType
+	public MovingAverageTypes MaType
 	{
 		get => _maType.Value;
 		set => _maType.Value = value;
@@ -179,7 +179,7 @@ public class JsMaSarTradesStrategy : Strategy
 	/// <summary>
 	/// Candle price source for moving averages.
 	/// </summary>
-	public AppliedPriceType AppliedPrice
+	public AppliedPriceTypes AppliedPrice
 	{
 		get => _appliedPrice.Value;
 		set => _appliedPrice.Value = value;
@@ -285,10 +285,10 @@ public class JsMaSarTradesStrategy : Strategy
 		_slowMaShift = Param(nameof(SlowMaShift), 0)
 		.SetDisplay("Slow MA Shift", "Shift for slow average", "Moving Averages");
 
-		_maType = Param(nameof(MaType), MovingAverageTypeEnum.Smoothed)
+		_maType = Param(nameof(MaType), MovingAverageTypes.Smoothed)
 		.SetDisplay("MA Type", "Moving average smoothing method", "Moving Averages");
 
-		_appliedPrice = Param(nameof(AppliedPrice), AppliedPriceType.Median)
+		_appliedPrice = Param(nameof(AppliedPrice), AppliedPriceTypes.Median)
 		.SetDisplay("Applied Price", "Price source for MAs", "Moving Averages");
 
 		_sarStep = Param(nameof(SarStep), 0.02m)
@@ -626,12 +626,12 @@ public class JsMaSarTradesStrategy : Strategy
 	{
 		return AppliedPrice switch
 		{
-			AppliedPriceType.Open => candle.OpenPrice,
-			AppliedPriceType.High => candle.HighPrice,
-			AppliedPriceType.Low => candle.LowPrice,
-			AppliedPriceType.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-			AppliedPriceType.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-			AppliedPriceType.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice * 2m) / 4m,
+			AppliedPriceTypes.Open => candle.OpenPrice,
+			AppliedPriceTypes.High => candle.HighPrice,
+			AppliedPriceTypes.Low => candle.LowPrice,
+			AppliedPriceTypes.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+			AppliedPriceTypes.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+			AppliedPriceTypes.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice * 2m) / 4m,
 			_ => candle.ClosePrice,
 		};
 	}
@@ -660,13 +660,13 @@ public class JsMaSarTradesStrategy : Strategy
 		_entryPrice = null;
 	}
 
-	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageTypeEnum type, int length)
+	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageTypes type, int length)
 	{
 		return type switch
 		{
-			MovingAverageTypeEnum.Simple => new SimpleMovingAverage { Length = length },
-			MovingAverageTypeEnum.Exponential => new ExponentialMovingAverage { Length = length },
-			MovingAverageTypeEnum.Weighted => new WeightedMovingAverage { Length = length },
+			MovingAverageTypes.Simple => new SimpleMovingAverage { Length = length },
+			MovingAverageTypes.Exponential => new ExponentialMovingAverage { Length = length },
+			MovingAverageTypes.Weighted => new WeightedMovingAverage { Length = length },
 			_ => new SmoothedMovingAverage { Length = length },
 		};
 	}
@@ -674,7 +674,7 @@ public class JsMaSarTradesStrategy : Strategy
 	/// <summary>
 	/// Moving average smoothing options.
 	/// </summary>
-	public enum MovingAverageTypeEnum
+	public enum MovingAverageTypes
 	{
 		Simple,
 		Exponential,
@@ -685,7 +685,7 @@ public class JsMaSarTradesStrategy : Strategy
 	/// <summary>
 	/// Price source for moving averages.
 	/// </summary>
-	public enum AppliedPriceType
+	public enum AppliedPriceTypes
 	{
 		Close,
 		Open,

--- a/API/3015_XDeMarker_Histogram_Vol/CS/XDeMarkerHistogramVolStrategy.cs
+++ b/API/3015_XDeMarker_Histogram_Vol/CS/XDeMarkerHistogramVolStrategy.cs
@@ -24,10 +24,10 @@ public class XDeMarkerHistogramVolStrategy : Strategy
 	private readonly StrategyParam<decimal> _highLevel2;
 	private readonly StrategyParam<decimal> _lowLevel1;
 	private readonly StrategyParam<decimal> _lowLevel2;
-	private readonly StrategyParam<SmoothingMethod> _smoothingMethod;
+	private readonly StrategyParam<SmoothingMethods> _smoothingMethod;
 	private readonly StrategyParam<int> _smoothingLength;
 	private readonly StrategyParam<int> _signalBar;
-	private readonly StrategyParam<VolumeSource> _volumeSource;
+	private readonly StrategyParam<VolumeSources> _volumeSource;
 	private readonly StrategyParam<bool> _enableLongEntries;
 	private readonly StrategyParam<bool> _enableShortEntries;
 	private readonly StrategyParam<bool> _enableLongExits;
@@ -73,7 +73,7 @@ public class XDeMarkerHistogramVolStrategy : Strategy
 			.SetDisplay("Low Level 2", "Extreme lower level multiplied by smoothed volume", "Indicator")
 			.SetCanOptimize(true);
 
-		_smoothingMethod = Param(nameof(Smoothing), SmoothingMethod.Simple)
+		_smoothingMethod = Param(nameof(Smoothing), SmoothingMethods.Simple)
 			.SetDisplay("Smoothing", "Moving average type applied to the histogram and volume", "Indicator");
 
 		_smoothingLength = Param(nameof(SmoothingLength), 12)
@@ -86,7 +86,7 @@ public class XDeMarkerHistogramVolStrategy : Strategy
 			.SetDisplay("Signal Bar", "Number of closed bars used for signal detection", "Trading")
 			.SetCanOptimize(true);
 
-		_volumeSource = Param(nameof(VolumeType), VolumeSource.Tick)
+		_volumeSource = Param(nameof(VolumeType), VolumeSources.Tick)
 			.SetDisplay("Volume Type", "Source of volume data used in weighting", "Indicator");
 
 		_enableLongEntries = Param(nameof(EnableLongEntries), true)
@@ -135,7 +135,7 @@ public class XDeMarkerHistogramVolStrategy : Strategy
 	/// <summary>
 	/// Smoothing method applied to the histogram.
 	/// </summary>
-	public SmoothingMethod Smoothing { get => _smoothingMethod.Value; set => _smoothingMethod.Value = value; }
+	public SmoothingMethods Smoothing { get => _smoothingMethod.Value; set => _smoothingMethod.Value = value; }
 
 	/// <summary>
 	/// Length of the smoothing moving averages.
@@ -150,7 +150,7 @@ public class XDeMarkerHistogramVolStrategy : Strategy
 	/// <summary>
 	/// Type of volume used in weighting the oscillator.
 	/// </summary>
-	public VolumeSource VolumeType { get => _volumeSource.Value; set => _volumeSource.Value = value; }
+	public VolumeSources VolumeType { get => _volumeSource.Value; set => _volumeSource.Value = value; }
 
 	/// <summary>
 	/// Enable opening long positions.
@@ -330,8 +330,8 @@ public class XDeMarkerHistogramVolStrategy : Strategy
 
 		return VolumeType switch
 		{
-			VolumeSource.Tick => volume,
-			VolumeSource.Real => volume,
+			VolumeSources.Tick => volume,
+			VolumeSources.Real => volume,
 			_ => volume,
 		};
 	}
@@ -358,14 +358,14 @@ public class XDeMarkerHistogramVolStrategy : Strategy
 		return 2;
 	}
 
-	private static LengthIndicator<decimal> CreateMovingAverage(SmoothingMethod method, int length)
+	private static LengthIndicator<decimal> CreateMovingAverage(SmoothingMethods method, int length)
 	{
 		return method switch
 		{
-			SmoothingMethod.Simple => new SimpleMovingAverage { Length = length },
-			SmoothingMethod.Exponential => new ExponentialMovingAverage { Length = length },
-			SmoothingMethod.Smoothed => new SmoothedMovingAverage { Length = length },
-			SmoothingMethod.Weighted => new WeightedMovingAverage { Length = length },
+			SmoothingMethods.Simple => new SimpleMovingAverage { Length = length },
+			SmoothingMethods.Exponential => new ExponentialMovingAverage { Length = length },
+			SmoothingMethods.Smoothed => new SmoothedMovingAverage { Length = length },
+			SmoothingMethods.Weighted => new WeightedMovingAverage { Length = length },
 			_ => new SimpleMovingAverage { Length = length },
 		};
 	}
@@ -373,7 +373,7 @@ public class XDeMarkerHistogramVolStrategy : Strategy
 	/// <summary>
 	/// Supported moving average types.
 	/// </summary>
-	public enum SmoothingMethod
+	public enum SmoothingMethods
 	{
 		/// <summary>Simple moving average.</summary>
 		Simple,
@@ -388,7 +388,7 @@ public class XDeMarkerHistogramVolStrategy : Strategy
 	/// <summary>
 	/// Volume source used for weighting.
 	/// </summary>
-	public enum VolumeSource
+	public enum VolumeSources
 	{
 		/// <summary>Use tick volume. In StockSharp it falls back to candle volume.</summary>
 		Tick,

--- a/API/3019_TradeXpert_Manual_Trading_Panel/CS/TradeXpertManualTradingPanelStrategy.cs
+++ b/API/3019_TradeXpert_Manual_Trading_Panel/CS/TradeXpertManualTradingPanelStrategy.cs
@@ -19,8 +19,8 @@ namespace StockSharp.Samples.Strategies;
 public class TradeXpertManualTradingPanelStrategy : Strategy
 {
 	private readonly StrategyParam<DataType> _candleType;
-	private readonly StrategyParam<TradeXpertEntryAction> _entryAction;
-	private readonly StrategyParam<TradeXpertPendingAction> _pendingAction;
+	private readonly StrategyParam<TradeXpertEntryActions> _entryAction;
+	private readonly StrategyParam<TradeXpertPendingActions> _pendingAction;
 	private readonly StrategyParam<decimal> _pendingPrice;
 	private readonly StrategyParam<decimal> _pendingOffset;
 	private readonly StrategyParam<decimal> _tradeVolume;
@@ -35,9 +35,9 @@ public class TradeXpertManualTradingPanelStrategy : Strategy
 	private readonly StrategyParam<decimal> _reverseVolume;
 
 	private bool _marketActionHandled;
-	private TradeXpertEntryAction _lastEntryAction;
+	private TradeXpertEntryActions _lastEntryAction;
 	private bool _pendingActionHandled;
-	private TradeXpertPendingAction _lastPendingAction;
+	private TradeXpertPendingActions _lastPendingAction;
 	private decimal _entryPrice;
 	private bool _stopTriggered;
 	private bool _takeProfitTriggered;
@@ -46,7 +46,7 @@ public class TradeXpertManualTradingPanelStrategy : Strategy
 	/// <summary>
 	/// Available market actions initiated by the user.
 	/// </summary>
-	public enum TradeXpertEntryAction
+	public enum TradeXpertEntryActions
 	{
 		None,
 		BuyMarket,
@@ -56,7 +56,7 @@ public class TradeXpertManualTradingPanelStrategy : Strategy
 	/// <summary>
 	/// Available pending order actions initiated by the user.
 	/// </summary>
-	public enum TradeXpertPendingAction
+	public enum TradeXpertPendingActions
 	{
 		None,
 		BuyLimit,
@@ -73,10 +73,10 @@ public class TradeXpertManualTradingPanelStrategy : Strategy
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(1).TimeFrame())
 		.SetDisplay("Candle Type", "Type of candles used to monitor price for requests", "Market Data");
 
-		_entryAction = Param(nameof(EntryAction), TradeXpertEntryAction.None)
+		_entryAction = Param(nameof(EntryAction), TradeXpertEntryActions.None)
 		.SetDisplay("Entry Action", "Requested market order action. The value resets after execution.", "Manual Actions");
 
-		_pendingAction = Param(nameof(PendingAction), TradeXpertPendingAction.None)
+		_pendingAction = Param(nameof(PendingAction), TradeXpertPendingActions.None)
 		.SetDisplay("Pending Action", "Requested pending order action. The value resets after the order is sent.", "Manual Actions");
 
 		_pendingPrice = Param(nameof(PendingPrice), 0m)
@@ -144,7 +144,7 @@ public class TradeXpertManualTradingPanelStrategy : Strategy
 	/// <summary>
 	/// Market action requested by the user.
 	/// </summary>
-	public TradeXpertEntryAction EntryAction
+	public TradeXpertEntryActions EntryAction
 	{
 		get => _entryAction.Value;
 		set => _entryAction.Value = value;
@@ -153,7 +153,7 @@ public class TradeXpertManualTradingPanelStrategy : Strategy
 	/// <summary>
 	/// Pending order action requested by the user.
 	/// </summary>
-	public TradeXpertPendingAction PendingAction
+	public TradeXpertPendingActions PendingAction
 	{
 		get => _pendingAction.Value;
 		set => _pendingAction.Value = value;
@@ -272,9 +272,9 @@ public class TradeXpertManualTradingPanelStrategy : Strategy
 	{
 		base.OnReseted();
 
-		_marketActionHandled = EntryAction == TradeXpertEntryAction.None;
+		_marketActionHandled = EntryAction == TradeXpertEntryActions.None;
 		_lastEntryAction = EntryAction;
-		_pendingActionHandled = PendingAction == TradeXpertPendingAction.None;
+		_pendingActionHandled = PendingAction == TradeXpertPendingActions.None;
 		_lastPendingAction = PendingAction;
 		_entryPrice = 0m;
 		_stopTriggered = false;
@@ -345,37 +345,37 @@ public class TradeXpertManualTradingPanelStrategy : Strategy
 		if (volume <= 0)
 		{
 			_marketActionHandled = true;
-			EntryAction = TradeXpertEntryAction.None;
+			EntryAction = TradeXpertEntryActions.None;
 			_lastEntryAction = EntryAction;
 			return;
 		}
 
 		switch (EntryAction)
 		{
-			case TradeXpertEntryAction.None:
+			case TradeXpertEntryActions.None:
 				_marketActionHandled = true;
 				break;
 
-			case TradeXpertEntryAction.BuyMarket:
+			case TradeXpertEntryActions.BuyMarket:
 				// Execute a market buy and reset the request.
 				BuyMarket(volume);
 				_entryPrice = candle.ClosePrice;
 				_stopTriggered = false;
 				_takeProfitTriggered = false;
 				_marketActionHandled = true;
-				EntryAction = TradeXpertEntryAction.None;
+				EntryAction = TradeXpertEntryActions.None;
 				_lastEntryAction = EntryAction;
 				_lastPosition = Position;
 				break;
 
-			case TradeXpertEntryAction.SellMarket:
+			case TradeXpertEntryActions.SellMarket:
 				// Execute a market sell and reset the request.
 				SellMarket(volume);
 				_entryPrice = candle.ClosePrice;
 				_stopTriggered = false;
 				_takeProfitTriggered = false;
 				_marketActionHandled = true;
-				EntryAction = TradeXpertEntryAction.None;
+				EntryAction = TradeXpertEntryActions.None;
 				_lastEntryAction = EntryAction;
 				_lastPosition = Position;
 				break;
@@ -395,7 +395,7 @@ public class TradeXpertManualTradingPanelStrategy : Strategy
 
 		switch (PendingAction)
 		{
-			case TradeXpertPendingAction.None:
+			case TradeXpertPendingActions.None:
 				_pendingActionHandled = true;
 				break;
 
@@ -404,7 +404,7 @@ public class TradeXpertManualTradingPanelStrategy : Strategy
 				if (volume <= 0)
 				{
 					_pendingActionHandled = true;
-					PendingAction = TradeXpertPendingAction.None;
+					PendingAction = TradeXpertPendingActions.None;
 					_lastPendingAction = PendingAction;
 					return;
 				}
@@ -416,25 +416,25 @@ public class TradeXpertManualTradingPanelStrategy : Strategy
 				// Register the requested pending order and reset the action.
 				switch (PendingAction)
 				{
-					case TradeXpertPendingAction.BuyLimit:
+					case TradeXpertPendingActions.BuyLimit:
 						BuyLimit(volume, price);
 						break;
 
-					case TradeXpertPendingAction.BuyStop:
+					case TradeXpertPendingActions.BuyStop:
 						BuyStop(volume, price);
 						break;
 
-					case TradeXpertPendingAction.SellLimit:
+					case TradeXpertPendingActions.SellLimit:
 						SellLimit(volume, price);
 						break;
 
-					case TradeXpertPendingAction.SellStop:
+					case TradeXpertPendingActions.SellStop:
 						SellStop(volume, price);
 						break;
 				}
 
 				_pendingActionHandled = true;
-				PendingAction = TradeXpertPendingAction.None;
+				PendingAction = TradeXpertPendingActions.None;
 				_lastPendingAction = PendingAction;
 				break;
 		}
@@ -453,10 +453,10 @@ public class TradeXpertManualTradingPanelStrategy : Strategy
 		var reference = candle.ClosePrice;
 		return PendingAction switch
 		{
-			TradeXpertPendingAction.BuyLimit => Math.Max(reference - offset, 0m),
-			TradeXpertPendingAction.BuyStop => reference + offset,
-			TradeXpertPendingAction.SellLimit => reference + offset,
-			TradeXpertPendingAction.SellStop => Math.Max(reference - offset, 0m),
+			TradeXpertPendingActions.BuyLimit => Math.Max(reference - offset, 0m),
+			TradeXpertPendingActions.BuyStop => reference + offset,
+			TradeXpertPendingActions.SellLimit => reference + offset,
+			TradeXpertPendingActions.SellStop => Math.Max(reference - offset, 0m),
 			_ => 0m
 		};
 	}

--- a/API/3021_Exp_MA_Rounding_Candle_MMRec/CS/ExpMaRoundingCandleMmrecStrategy.cs
+++ b/API/3021_Exp_MA_Rounding_Candle_MMRec/CS/ExpMaRoundingCandleMmrecStrategy.cs
@@ -22,7 +22,7 @@ public class ExpMaRoundingCandleMmrecStrategy : Strategy
 {
 
 	private readonly StrategyParam<DataType> _candleTypeParam;
-	private readonly StrategyParam<MaSmoothingMethod> _maMethodParam;
+	private readonly StrategyParam<MaSmoothingMethods> _maMethodParam;
 	private readonly StrategyParam<int> _maLengthParam;
 	private readonly StrategyParam<decimal> _roundingFactorParam;
 	private readonly StrategyParam<decimal> _gapParam;
@@ -49,7 +49,7 @@ public class ExpMaRoundingCandleMmrecStrategy : Strategy
 		_candleTypeParam = Param(nameof(CandleType), TimeSpan.FromHours(1).TimeFrame())
 		.SetDisplay("Candle type", "Timeframe used to build MA Rounding candles.", "General");
 
-		_maMethodParam = Param(nameof(SmoothingMethod), MaSmoothingMethod.Simple)
+		_maMethodParam = Param(nameof(SmoothingMethod), MaSmoothingMethods.Simple)
 		.SetDisplay("Smoothing", "Moving average smoothing method.", "Indicator");
 
 		_maLengthParam = Param(nameof(MaLength), 12)
@@ -97,7 +97,7 @@ public class ExpMaRoundingCandleMmrecStrategy : Strategy
 		set => _candleTypeParam.Value = value;
 	}
 
-	public MaSmoothingMethod SmoothingMethod
+	public MaSmoothingMethods SmoothingMethod
 	{
 		get => _maMethodParam.Value;
 		set => _maMethodParam.Value = value;
@@ -344,10 +344,10 @@ public class ExpMaRoundingCandleMmrecStrategy : Strategy
 	{
 		return SmoothingMethod switch
 		{
-			MaSmoothingMethod.Simple => new SimpleMovingAverage { Length = MaLength },
-			MaSmoothingMethod.Exponential => new ExponentialMovingAverage { Length = MaLength },
-			MaSmoothingMethod.Smoothed => new SmoothedMovingAverage { Length = MaLength },
-			MaSmoothingMethod.Weighted => new WeightedMovingAverage { Length = MaLength },
+			MaSmoothingMethods.Simple => new SimpleMovingAverage { Length = MaLength },
+			MaSmoothingMethods.Exponential => new ExponentialMovingAverage { Length = MaLength },
+			MaSmoothingMethods.Smoothed => new SmoothedMovingAverage { Length = MaLength },
+			MaSmoothingMethods.Weighted => new WeightedMovingAverage { Length = MaLength },
 			_ => new SimpleMovingAverage { Length = MaLength },
 		};
 	}
@@ -355,7 +355,7 @@ public class ExpMaRoundingCandleMmrecStrategy : Strategy
 	/// <summary>
 	/// Available moving average smoothing methods.
 	/// </summary>
-	public enum MaSmoothingMethod
+	public enum MaSmoothingMethods
 	{
 		/// <summary>Simple moving average.</summary>
 		Simple,

--- a/API/3022_Exp_XHullTrend_Digit/CS/ExpXHullTrendDigitStrategy.cs
+++ b/API/3022_Exp_XHullTrend_Digit/CS/ExpXHullTrendDigitStrategy.cs
@@ -31,7 +31,7 @@ public class ExpXHullTrendDigitStrategy : Strategy
 	private readonly StrategyParam<int> _baseLength;
 	private readonly StrategyParam<int> _signalLength;
 	private readonly StrategyParam<CandlePrice> _priceSource;
-	private readonly StrategyParam<SmoothMethod> _smoothMethod;
+	private readonly StrategyParam<SmoothMethods> _smoothMethod;
 	private readonly StrategyParam<int> _phase;
 	private readonly StrategyParam<int> _roundDigits;
 	private readonly StrategyParam<int> _signalBar;
@@ -141,7 +141,7 @@ public class ExpXHullTrendDigitStrategy : Strategy
 	/// <summary>
 	/// Smoothing method used by the internal moving averages.
 	/// </summary>
-	public SmoothMethod SmoothMethod
+	public SmoothMethods SmoothMethods
 	{
 		get => _smoothMethod.Value;
 		set => _smoothMethod.Value = value;
@@ -217,7 +217,7 @@ public class ExpXHullTrendDigitStrategy : Strategy
 		_priceSource = Param(nameof(PriceSource), CandlePrice.Close)
 			.SetDisplay("Price Source", "Candle price used in calculations", "Indicator");
 
-		_smoothMethod = Param(nameof(SmoothMethod), SmoothMethod.Weighted)
+		_smoothMethod = Param(nameof(SmoothMethods), SmoothMethods.Weighted)
 			.SetDisplay("Smoothing Method", "Moving average used inside the indicator", "Indicator");
 
 		_phase = Param(nameof(Phase), 15)
@@ -255,7 +255,7 @@ public class ExpXHullTrendDigitStrategy : Strategy
 			BaseLength = BaseLength,
 			SignalLength = SignalLength,
 			PriceType = PriceSource,
-			Method = SmoothMethod,
+			Method = SmoothMethods,
 			Phase = Phase,
 			RoundingDigits = RoundingDigits,
 			PriceStep = Security?.PriceStep ?? 0.0001m
@@ -349,7 +349,7 @@ public class ExpXHullTrendDigitStrategy : Strategy
 /// <summary>
 /// Available smoothing methods for the indicator internals.
 /// </summary>
-public enum SmoothMethod
+public enum SmoothMethods
 {
 	/// <summary>
 	/// Simple moving average.
@@ -385,7 +385,7 @@ public class XHullTrendDigitIndicator : BaseIndicator<decimal>
 	public int BaseLength { get; set; } = 20;
 	public int SignalLength { get; set; } = 5;
 	public CandlePrice PriceType { get; set; } = CandlePrice.Close;
-	public SmoothMethod Method { get; set; } = SmoothMethod.Weighted;
+	public SmoothMethods Method { get; set; } = SmoothMethods.Weighted;
 	public int Phase { get; set; }
 	public int RoundingDigits { get; set; } = 2;
 	public decimal PriceStep { get; set; } = 0.0001m;
@@ -460,9 +460,9 @@ public class XHullTrendDigitIndicator : BaseIndicator<decimal>
 	{
 		return Method switch
 		{
-			SmoothMethod.Simple => new SimpleMovingAverage { Length = length },
-			SmoothMethod.Exponential => new ExponentialMovingAverage { Length = length },
-			SmoothMethod.Smoothed => new SmoothedMovingAverage { Length = length },
+			SmoothMethods.Simple => new SimpleMovingAverage { Length = length },
+			SmoothMethods.Exponential => new ExponentialMovingAverage { Length = length },
+			SmoothMethods.Smoothed => new SmoothedMovingAverage { Length = length },
 			_ => new WeightedMovingAverage { Length = length },
 		};
 	}

--- a/API/3023_Exp_SSL_NRTR_Tm_Plus/CS/ExpSslNrtrTmPlusStrategy.cs
+++ b/API/3023_Exp_SSL_NRTR_Tm_Plus/CS/ExpSslNrtrTmPlusStrategy.cs
@@ -14,7 +14,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-public enum ExpSslNrtrSmoothingMethod
+public enum ExpSslNrtrSmoothingMethods
 {
 	Sma,
 	Ema,
@@ -28,7 +28,7 @@ public enum ExpSslNrtrSmoothingMethod
 	Ama,
 }
 
-public enum MarginMode
+public enum MarginModes
 {
 	FreeMargin,
 	Balance,
@@ -42,7 +42,7 @@ public class ExpSslNrtrTmPlusStrategy : Strategy
 
 	// Store only a limited number of indicator states for signal comparisons.
 	private readonly StrategyParam<decimal> _moneyManagement;
-	private readonly StrategyParam<MarginMode> _marginMode;
+	private readonly StrategyParam<MarginModes> _marginMode;
 	private readonly StrategyParam<decimal> _stopLossPoints;
 	private readonly StrategyParam<decimal> _takeProfitPoints;
 	private readonly StrategyParam<decimal> _slippagePoints;
@@ -53,7 +53,7 @@ public class ExpSslNrtrTmPlusStrategy : Strategy
 	private readonly StrategyParam<bool> _useTimeExit;
 	private readonly StrategyParam<int> _timeExitMinutes;
 	private readonly StrategyParam<DataType> _candleType;
-	private readonly StrategyParam<ExpSslNrtrSmoothingMethod> _smoothingMethod;
+	private readonly StrategyParam<ExpSslNrtrSmoothingMethods> _smoothingMethod;
 	private readonly StrategyParam<int> _length;
 	private readonly StrategyParam<int> _phase;
 	private readonly StrategyParam<int> _signalBar;
@@ -80,7 +80,7 @@ public class ExpSslNrtrTmPlusStrategy : Strategy
 		set => _moneyManagement.Value = value;
 	}
 
-	public MarginMode MarginMode
+	public MarginModes MarginModes
 	{
 		get => _marginMode.Value;
 		set => _marginMode.Value = value;
@@ -146,7 +146,7 @@ public class ExpSslNrtrTmPlusStrategy : Strategy
 		set => _candleType.Value = value;
 	}
 
-	public ExpSslNrtrSmoothingMethod SmoothingMethod
+	public ExpSslNrtrSmoothingMethods SmoothingMethod
 	{
 		get => _smoothingMethod.Value;
 		set => _smoothingMethod.Value = value;
@@ -185,7 +185,7 @@ public class ExpSslNrtrTmPlusStrategy : Strategy
 		_moneyManagement = Param(nameof(MoneyManagement), 0.1m)
 			.SetDisplay("Money Management", "Fraction of capital or direct lots", "Trading");
 
-		_marginMode = Param(nameof(MarginMode), MarginMode.Lot)
+		_marginMode = Param(nameof(MarginModes), MarginModes.Lot)
 			.SetDisplay("Margin Mode", "Mode used to convert money management into volume", "Trading");
 
 		_stopLossPoints = Param(nameof(StopLossPoints), 1000m)
@@ -222,7 +222,7 @@ public class ExpSslNrtrTmPlusStrategy : Strategy
 		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(8).TimeFrame())
 			.SetDisplay("Candle Type", "Working timeframe", "Data");
 
-		_smoothingMethod = Param(nameof(SmoothingMethod), ExpSslNrtrSmoothingMethod.T3)
+		_smoothingMethod = Param(nameof(SmoothingMethod), ExpSslNrtrSmoothingMethods.T3)
 			.SetDisplay("Smoothing Method", "Type of moving average used inside SSL", "Indicator");
 
 		_length = Param(nameof(Length), 12)
@@ -521,17 +521,17 @@ public class ExpSslNrtrTmPlusStrategy : Strategy
 
 		decimal volume;
 
-		switch (MarginMode)
+		switch (MarginModes)
 		{
-			case MarginMode.FreeMargin:
-			case MarginMode.Balance:
+			case MarginModes.FreeMargin:
+			case MarginModes.Balance:
 			{
 				var amount = capital * mm;
 				volume = amount / price;
 				break;
 			}
-			case MarginMode.LossFreeMargin:
-			case MarginMode.LossBalance:
+			case MarginModes.LossFreeMargin:
+			case MarginModes.LossBalance:
 			{
 				var step = Security?.PriceStep ?? 1m;
 				var risk = StopLossPoints * step;
@@ -542,7 +542,7 @@ public class ExpSslNrtrTmPlusStrategy : Strategy
 				volume = lossAmount / risk;
 				break;
 			}
-			case MarginMode.Lot:
+			case MarginModes.Lot:
 			default:
 				volume = mm;
 				break;
@@ -589,16 +589,16 @@ public class ExpSslNrtrTmPlusStrategy : Strategy
 		// Build the smoothing engine requested by the user.
 		return SmoothingMethod switch
 		{
-			ExpSslNrtrSmoothingMethod.Sma => new IndicatorSmoother(new SimpleMovingAverage { Length = Length }),
-			ExpSslNrtrSmoothingMethod.Ema => new IndicatorSmoother(new ExponentialMovingAverage { Length = Length }),
-			ExpSslNrtrSmoothingMethod.Smma => new IndicatorSmoother(new SmoothedMovingAverage { Length = Length }),
-			ExpSslNrtrSmoothingMethod.Lwma => new IndicatorSmoother(new WeightedMovingAverage { Length = Length }),
-			ExpSslNrtrSmoothingMethod.Jjma => new IndicatorSmoother(new JurikMovingAverage { Length = Length }),
-			ExpSslNrtrSmoothingMethod.Jurx => new IndicatorSmoother(new JurikMovingAverage { Length = Length }), // Fallback to Jurik MA.
-			ExpSslNrtrSmoothingMethod.Parma => new IndicatorSmoother(new ExponentialMovingAverage { Length = Length }), // Approximated with EMA.
-			ExpSslNrtrSmoothingMethod.T3 => new TillsonT3Smoother(Length, Phase / 100m),
-			ExpSslNrtrSmoothingMethod.Vidya => new VidyaSmoother(Length, Math.Max(1, Phase)),
-			ExpSslNrtrSmoothingMethod.Ama => new AmaSmoother(Length, Math.Max(1, Phase)),
+			ExpSslNrtrSmoothingMethods.Sma => new IndicatorSmoother(new SimpleMovingAverage { Length = Length }),
+			ExpSslNrtrSmoothingMethods.Ema => new IndicatorSmoother(new ExponentialMovingAverage { Length = Length }),
+			ExpSslNrtrSmoothingMethods.Smma => new IndicatorSmoother(new SmoothedMovingAverage { Length = Length }),
+			ExpSslNrtrSmoothingMethods.Lwma => new IndicatorSmoother(new WeightedMovingAverage { Length = Length }),
+			ExpSslNrtrSmoothingMethods.Jjma => new IndicatorSmoother(new JurikMovingAverage { Length = Length }),
+			ExpSslNrtrSmoothingMethods.Jurx => new IndicatorSmoother(new JurikMovingAverage { Length = Length }), // Fallback to Jurik MA.
+			ExpSslNrtrSmoothingMethods.Parma => new IndicatorSmoother(new ExponentialMovingAverage { Length = Length }), // Approximated with EMA.
+			ExpSslNrtrSmoothingMethods.T3 => new TillsonT3Smoother(Length, Phase / 100m),
+			ExpSslNrtrSmoothingMethods.Vidya => new VidyaSmoother(Length, Math.Max(1, Phase)),
+			ExpSslNrtrSmoothingMethods.Ama => new AmaSmoother(Length, Math.Max(1, Phase)),
 			_ => new IndicatorSmoother(new ExponentialMovingAverage { Length = Length }),
 		};
 	}

--- a/API/3031_ColorSchaffJCCXTrendCycle_MMRec_Duplex/CS/ColorSchaffJccxTrendCycleMmrecDuplexStrategy.cs
+++ b/API/3031_ColorSchaffJCCXTrendCycle_MMRec_Duplex/CS/ColorSchaffJccxTrendCycleMmrecDuplexStrategy.cs
@@ -28,7 +28,7 @@ public class ColorSchaffJccxTrendCycleMmrecDuplexStrategy : Strategy
 	private readonly StrategyParam<int> _longPhase;
 	private readonly StrategyParam<int> _longCycle;
 	private readonly StrategyParam<int> _longSignalBar;
-	private readonly StrategyParam<AppliedPrice> _longAppliedPrice;
+	private readonly StrategyParam<AppliedPrices> _longAppliedPrice;
 	private readonly StrategyParam<bool> _longAllowOpen;
 	private readonly StrategyParam<bool> _longAllowClose;
 	private readonly StrategyParam<int> _longTotalTrigger;
@@ -45,7 +45,7 @@ public class ColorSchaffJccxTrendCycleMmrecDuplexStrategy : Strategy
 	private readonly StrategyParam<int> _shortPhase;
 	private readonly StrategyParam<int> _shortCycle;
 	private readonly StrategyParam<int> _shortSignalBar;
-	private readonly StrategyParam<AppliedPrice> _shortAppliedPrice;
+	private readonly StrategyParam<AppliedPrices> _shortAppliedPrice;
 	private readonly StrategyParam<bool> _shortAllowOpen;
 	private readonly StrategyParam<bool> _shortAllowClose;
 	private readonly StrategyParam<int> _shortTotalTrigger;
@@ -134,7 +134,7 @@ public class ColorSchaffJccxTrendCycleMmrecDuplexStrategy : Strategy
 	/// <summary>
 	/// Price source used for the long calculations.
 	/// </summary>
-	public AppliedPrice LongAppliedPrice
+	public AppliedPrices LongAppliedPrice
 	{
 		get => _longAppliedPrice.Value;
 		set => _longAppliedPrice.Value = value;
@@ -278,7 +278,7 @@ public class ColorSchaffJccxTrendCycleMmrecDuplexStrategy : Strategy
 	/// <summary>
 	/// Price source used for the short calculations.
 	/// </summary>
-	public AppliedPrice ShortAppliedPrice
+	public AppliedPrices ShortAppliedPrice
 	{
 		get => _shortAppliedPrice.Value;
 		set => _shortAppliedPrice.Value = value;
@@ -398,7 +398,7 @@ public class ColorSchaffJccxTrendCycleMmrecDuplexStrategy : Strategy
 		.SetCanOptimize(true)
 		.SetOptimize(0, 3, 1);
 
-		_longAppliedPrice = Param(nameof(LongAppliedPrice), AppliedPrice.Close)
+		_longAppliedPrice = Param(nameof(LongAppliedPrice), AppliedPrices.Close)
 		.SetDisplay("Long Applied Price", "Price source for long logic", "Long");
 
 		_longAllowOpen = Param(nameof(LongAllowOpen), true)
@@ -472,7 +472,7 @@ public class ColorSchaffJccxTrendCycleMmrecDuplexStrategy : Strategy
 		.SetCanOptimize(true)
 		.SetOptimize(0, 3, 1);
 
-		_shortAppliedPrice = Param(nameof(ShortAppliedPrice), AppliedPrice.Close)
+		_shortAppliedPrice = Param(nameof(ShortAppliedPrice), AppliedPrices.Close)
 		.SetDisplay("Short Applied Price", "Price source for short logic", "Short");
 
 		_shortAllowOpen = Param(nameof(ShortAllowOpen), true)
@@ -870,21 +870,21 @@ public class ColorSchaffJccxTrendCycleMmrecDuplexStrategy : Strategy
 		return step is { } value && value > 0m ? value : 1m;
 	}
 
-	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPrice price)
+	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPrices price)
 	{
 		return price switch
 		{
-			AppliedPrice.Open => candle.OpenPrice,
-			AppliedPrice.High => candle.HighPrice,
-			AppliedPrice.Low => candle.LowPrice,
-			AppliedPrice.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-			AppliedPrice.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-			AppliedPrice.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
-			AppliedPrice.Simple => (candle.OpenPrice + candle.ClosePrice) / 2m,
-			AppliedPrice.Quarter => (candle.OpenPrice + candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 4m,
-			AppliedPrice.TrendFollow0 => (candle.HighPrice + candle.LowPrice + candle.ClosePrice + candle.ClosePrice) / 4m,
-			AppliedPrice.TrendFollow1 => (candle.HighPrice + candle.LowPrice + candle.OpenPrice + candle.OpenPrice) / 4m,
-			AppliedPrice.DeMark => candle.ClosePrice < candle.OpenPrice
+			AppliedPrices.Open => candle.OpenPrice,
+			AppliedPrices.High => candle.HighPrice,
+			AppliedPrices.Low => candle.LowPrice,
+			AppliedPrices.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+			AppliedPrices.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+			AppliedPrices.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
+			AppliedPrices.Simple => (candle.OpenPrice + candle.ClosePrice) / 2m,
+			AppliedPrices.Quarter => (candle.OpenPrice + candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 4m,
+			AppliedPrices.TrendFollow0 => (candle.HighPrice + candle.LowPrice + candle.ClosePrice + candle.ClosePrice) / 4m,
+			AppliedPrices.TrendFollow1 => (candle.HighPrice + candle.LowPrice + candle.OpenPrice + candle.OpenPrice) / 4m,
+			AppliedPrices.DeMark => candle.ClosePrice < candle.OpenPrice
 			? (candle.HighPrice + 2m * candle.LowPrice + candle.ClosePrice) / 4m
 			: candle.ClosePrice > candle.OpenPrice
 			? (2m * candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 4m
@@ -903,7 +903,7 @@ public class ColorSchaffJccxTrendCycleMmrecDuplexStrategy : Strategy
 		return factor;
 	}
 
-	private enum AppliedPrice
+	private enum AppliedPrices
 	{
 		Close,
 		Open,

--- a/API/3033_XDeMarker_Histogram_Vol_Direct/CS/XDeMarkerHistogramVolDirectStrategy.cs
+++ b/API/3033_XDeMarker_Histogram_Vol_Direct/CS/XDeMarkerHistogramVolDirectStrategy.cs
@@ -22,12 +22,12 @@ public class XDeMarkerHistogramVolDirectStrategy : Strategy
 {
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<int> _deMarkerPeriod;
-	private readonly StrategyParam<VolumeSource> _volumeSource;
+	private readonly StrategyParam<VolumeSources> _volumeSource;
 	private readonly StrategyParam<int> _highLevel2;
 	private readonly StrategyParam<int> _highLevel1;
 	private readonly StrategyParam<int> _lowLevel1;
 	private readonly StrategyParam<int> _lowLevel2;
-	private readonly StrategyParam<SmoothingMethod> _smoothingMethod;
+	private readonly StrategyParam<SmoothingMethods> _smoothingMethod;
 	private readonly StrategyParam<int> _smoothingLength;
 	private readonly StrategyParam<int> _smoothingPhase;
 	private readonly StrategyParam<int> _signalBar;
@@ -52,7 +52,7 @@ public class XDeMarkerHistogramVolDirectStrategy : Strategy
 		.SetDisplay("DeMarker Period", "Length of the base DeMarker oscillator", "Indicator")
 		.SetCanOptimize(true);
 
-		_volumeSource = Param(nameof(VolumeSource), VolumeSource.Tick)
+		_volumeSource = Param(nameof(VolumeSources), VolumeSources.Tick)
 		.SetDisplay("Volume Source", "Volume stream used in calculations", "Indicator");
 
 		_highLevel2 = Param(nameof(HighLevel2), 0)
@@ -67,7 +67,7 @@ public class XDeMarkerHistogramVolDirectStrategy : Strategy
 		_lowLevel2 = Param(nameof(LowLevel2), 0)
 		.SetDisplay("Low Level 2", "Lower extreme multiplier", "Levels");
 
-		_smoothingMethod = Param(nameof(SmoothingMethod), SmoothingMethod.Sma)
+		_smoothingMethod = Param(nameof(SmoothingMethods), SmoothingMethods.Sma)
 		.SetDisplay("Smoothing Method", "Moving average used for smoothing", "Indicator");
 
 		_smoothingLength = Param(nameof(SmoothingLength), 12)
@@ -115,7 +115,7 @@ public class XDeMarkerHistogramVolDirectStrategy : Strategy
 	/// <summary>
 	/// Source of volume used in indicator calculations.
 	/// </summary>
-	public VolumeSource VolumeSource
+	public VolumeSources VolumeSources
 	{
 		get => _volumeSource.Value;
 		set => _volumeSource.Value = value;
@@ -160,7 +160,7 @@ public class XDeMarkerHistogramVolDirectStrategy : Strategy
 	/// <summary>
 	/// Moving average type applied to the histogram and volume.
 	/// </summary>
-	public SmoothingMethod SmoothingMethod
+	public SmoothingMethods SmoothingMethods
 	{
 		get => _smoothingMethod.Value;
 		set => _smoothingMethod.Value = value;
@@ -255,12 +255,12 @@ public class XDeMarkerHistogramVolDirectStrategy : Strategy
 		_indicator = new XDeMarkerHistogramVolDirectIndicator
 		{
 			Period = DeMarkerPeriod,
-			VolumeSource = VolumeSource,
+			VolumeSources = VolumeSources,
 			HighLevel2 = HighLevel2,
 			HighLevel1 = HighLevel1,
 			LowLevel1 = LowLevel1,
 			LowLevel2 = LowLevel2,
-			Method = SmoothingMethod,
+			Method = SmoothingMethods,
 			Length = SmoothingLength,
 			Phase = SmoothingPhase
 		};
@@ -301,10 +301,10 @@ public class XDeMarkerHistogramVolDirectStrategy : Strategy
 
 		var previousDirection = _directionHistory[^2];
 
-		var closeShort = SellCloseEnabled && previousDirection == (int)DirectionColor.Up && Position < 0;
-		var closeLong = BuyCloseEnabled && previousDirection == (int)DirectionColor.Down && Position > 0;
-		var openLong = BuyOpenEnabled && previousDirection == (int)DirectionColor.Up && currentDirection == (int)DirectionColor.Down && Position <= 0;
-		var openShort = SellOpenEnabled && previousDirection == (int)DirectionColor.Down && currentDirection == (int)DirectionColor.Up && Position >= 0;
+		var closeShort = SellCloseEnabled && previousDirection == (int)DirectionColors.Up && Position < 0;
+		var closeLong = BuyCloseEnabled && previousDirection == (int)DirectionColors.Down && Position > 0;
+		var openLong = BuyOpenEnabled && previousDirection == (int)DirectionColors.Up && currentDirection == (int)DirectionColors.Down && Position <= 0;
+		var openShort = SellOpenEnabled && previousDirection == (int)DirectionColors.Down && currentDirection == (int)DirectionColors.Up && Position >= 0;
 
 		decimal? targetPosition = null;
 
@@ -344,7 +344,7 @@ public class XDeMarkerHistogramVolDirectStrategy : Strategy
 /// <summary>
 /// Source of volume for the indicator calculations.
 /// </summary>
-public enum VolumeSource
+public enum VolumeSources
 {
 	/// <summary>
 	/// Use tick count (number of trades).
@@ -360,7 +360,7 @@ public enum VolumeSource
 /// <summary>
 /// Moving average types supported by the custom indicator.
 /// </summary>
-public enum SmoothingMethod
+public enum SmoothingMethods
 {
 	/// <summary>
 	/// Simple moving average.
@@ -386,7 +386,7 @@ public enum SmoothingMethod
 /// <summary>
 /// Direction labels produced by the indicator.
 /// </summary>
-public enum DirectionColor
+public enum DirectionColors
 {
 	/// <summary>
 	/// Histogram is rising compared to the previous bar.
@@ -411,7 +411,7 @@ public class XDeMarkerHistogramVolDirectIndicator : BaseIndicator<decimal>
 	private decimal? _prevHigh;
 	private decimal? _prevLow;
 	private decimal? _prevSmoothedValue;
-	private int _prevDirection = (int)DirectionColor.Up;
+	private int _prevDirection = (int)DirectionColors.Up;
 	private IIndicator _histogramMa = null!;
 	private IIndicator _volumeMa = null!;
 
@@ -423,7 +423,7 @@ public class XDeMarkerHistogramVolDirectIndicator : BaseIndicator<decimal>
 	/// <summary>
 	/// Source of volume used for scaling the histogram.
 	/// </summary>
-	public VolumeSource VolumeSource { get; set; } = VolumeSource.Tick;
+	public VolumeSources VolumeSources { get; set; } = VolumeSources.Tick;
 
 	/// <summary>
 	/// Upper extreme multiplier.
@@ -448,7 +448,7 @@ public class XDeMarkerHistogramVolDirectIndicator : BaseIndicator<decimal>
 	/// <summary>
 	/// Moving average type for smoothing.
 	/// </summary>
-	public SmoothingMethod Method { get; set; } = SmoothingMethod.Sma;
+	public SmoothingMethods Method { get; set; } = SmoothingMethods.Sma;
 
 	/// <summary>
 	/// Length of the smoothing windows for histogram and volume.
@@ -471,7 +471,7 @@ public class XDeMarkerHistogramVolDirectIndicator : BaseIndicator<decimal>
 		_prevHigh = null;
 		_prevLow = null;
 		_prevSmoothedValue = null;
-		_prevDirection = (int)DirectionColor.Up;
+		_prevDirection = (int)DirectionColors.Up;
 		_histogramMa?.Reset();
 		_volumeMa?.Reset();
 	}
@@ -532,9 +532,9 @@ public class XDeMarkerHistogramVolDirectIndicator : BaseIndicator<decimal>
 		var demarker = denom == 0m ? 0m : _sumDeMax / denom;
 		var histogram = (demarker * 100m) - 50m;
 
-		var volume = VolumeSource switch
+		var volume = VolumeSources switch
 		{
-			VolumeSource.Tick => candle.TotalTicks.HasValue ? (decimal)candle.TotalTicks.Value : candle.TotalVolume ?? 0m,
+			VolumeSources.Tick => candle.TotalTicks.HasValue ? (decimal)candle.TotalTicks.Value : candle.TotalVolume ?? 0m,
 			_ => candle.TotalVolume ?? 0m
 		};
 
@@ -572,9 +572,9 @@ public class XDeMarkerHistogramVolDirectIndicator : BaseIndicator<decimal>
 		var direction = _prevSmoothedValue is null
 		? _prevDirection
 		: histogramValue > _prevSmoothedValue.Value
-		? (int)DirectionColor.Up
+		? (int)DirectionColors.Up
 		: histogramValue < _prevSmoothedValue.Value
-		? (int)DirectionColor.Down
+		? (int)DirectionColors.Down
 		: _prevDirection;
 
 		_prevSmoothedValue = histogramValue;
@@ -595,14 +595,14 @@ public class XDeMarkerHistogramVolDirectIndicator : BaseIndicator<decimal>
 		histogramColor);
 	}
 
-	private static IIndicator CreateMovingAverage(SmoothingMethod method, int length)
+	private static IIndicator CreateMovingAverage(SmoothingMethods method, int length)
 	{
 		return method switch
 		{
-			SmoothingMethod.Sma => new SimpleMovingAverage { Length = length },
-			SmoothingMethod.Ema => new ExponentialMovingAverage { Length = length },
-			SmoothingMethod.Smma => new SmoothedMovingAverage { Length = length },
-			SmoothingMethod.Wma => new WeightedMovingAverage { Length = length },
+			SmoothingMethods.Sma => new SimpleMovingAverage { Length = length },
+			SmoothingMethods.Ema => new ExponentialMovingAverage { Length = length },
+			SmoothingMethods.Smma => new SmoothedMovingAverage { Length = length },
+			SmoothingMethods.Wma => new WeightedMovingAverage { Length = length },
 			_ => throw new ArgumentOutOfRangeException(nameof(method), method, null)
 		};
 	}

--- a/API/3034_Freeman_ATR_MA_RSI_Grid/CS/FreemanAtrMaRsiGridStrategy.cs
+++ b/API/3034_Freeman_ATR_MA_RSI_Grid/CS/FreemanAtrMaRsiGridStrategy.cs
@@ -28,13 +28,13 @@ public class FreemanAtrMaRsiGridStrategy : Strategy
 	private readonly StrategyParam<decimal> _distanceFromMaPips;
 	private readonly StrategyParam<int> _maPeriod;
 	private readonly StrategyParam<int> _maShift;
-	private readonly StrategyParam<MovingAverageMethod> _maMethod;
-	private readonly StrategyParam<AppliedPrice> _maPriceType;
+	private readonly StrategyParam<MovingAverageMethods> _maMethod;
+	private readonly StrategyParam<AppliedPrices> _maPriceType;
 	private readonly StrategyParam<bool> _useRsiFilter;
 	private readonly StrategyParam<decimal> _rsiLevelUp;
 	private readonly StrategyParam<decimal> _rsiLevelDown;
 	private readonly StrategyParam<int> _rsiPeriod;
-	private readonly StrategyParam<AppliedPrice> _rsiPriceType;
+	private readonly StrategyParam<AppliedPrices> _rsiPriceType;
 	private readonly StrategyParam<decimal> _trailingStopPips;
 	private readonly StrategyParam<decimal> _trailingStepPips;
 	private readonly StrategyParam<int> _currentBarOffset;
@@ -103,10 +103,10 @@ public class FreemanAtrMaRsiGridStrategy : Strategy
 		.SetDisplay("MA Shift", "Horizontal shift applied when reading MA values", "Indicators")
 		.SetCanOptimize(true);
 
-		_maMethod = Param(nameof(MaMethod), MovingAverageMethod.Simple)
+		_maMethod = Param(nameof(MaMethod), MovingAverageMethods.Simple)
 		.SetDisplay("MA Method", "Moving average calculation method", "Indicators");
 
-		_maPriceType = Param(nameof(MaPriceType), AppliedPrice.Median)
+		_maPriceType = Param(nameof(MaPriceType), AppliedPrices.Median)
 		.SetDisplay("MA Price", "Price source used by the moving average", "Indicators");
 
 		_useRsiFilter = Param(nameof(UseRsiFilter), true)
@@ -125,7 +125,7 @@ public class FreemanAtrMaRsiGridStrategy : Strategy
 		.SetDisplay("RSI Period", "Number of bars for RSI calculation", "Indicators")
 		.SetCanOptimize(true);
 
-		_rsiPriceType = Param(nameof(RsiPriceType), AppliedPrice.Median)
+		_rsiPriceType = Param(nameof(RsiPriceType), AppliedPrices.Median)
 		.SetDisplay("RSI Price", "Price source used by RSI", "Indicators");
 
 		_trailingStopPips = Param(nameof(TrailingStopPips), 5m)
@@ -237,7 +237,7 @@ public class FreemanAtrMaRsiGridStrategy : Strategy
 	/// <summary>
 	/// Moving average calculation method.
 	/// </summary>
-	public MovingAverageMethod MaMethod
+	public MovingAverageMethods MaMethod
 	{
 		get => _maMethod.Value;
 		set => _maMethod.Value = value;
@@ -246,7 +246,7 @@ public class FreemanAtrMaRsiGridStrategy : Strategy
 	/// <summary>
 	/// Price source used by the moving average.
 	/// </summary>
-	public AppliedPrice MaPriceType
+	public AppliedPrices MaPriceType
 	{
 		get => _maPriceType.Value;
 		set => _maPriceType.Value = value;
@@ -291,7 +291,7 @@ public class FreemanAtrMaRsiGridStrategy : Strategy
 	/// <summary>
 	/// Price source used by RSI.
 	/// </summary>
-	public AppliedPrice RsiPriceType
+	public AppliedPrices RsiPriceType
 	{
 		get => _rsiPriceType.Value;
 		set => _rsiPriceType.Value = value;
@@ -632,17 +632,17 @@ public class FreemanAtrMaRsiGridStrategy : Strategy
 		_pipSize = priceStep;
 	}
 
-	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPrice priceType)
+	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPrices priceType)
 	{
 		return priceType switch
 		{
-			AppliedPrice.Close => candle.ClosePrice,
-			AppliedPrice.Open => candle.OpenPrice,
-			AppliedPrice.High => candle.HighPrice,
-			AppliedPrice.Low => candle.LowPrice,
-			AppliedPrice.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-			AppliedPrice.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-			AppliedPrice.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice + candle.ClosePrice) / 4m,
+			AppliedPrices.Close => candle.ClosePrice,
+			AppliedPrices.Open => candle.OpenPrice,
+			AppliedPrices.High => candle.HighPrice,
+			AppliedPrices.Low => candle.LowPrice,
+			AppliedPrices.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+			AppliedPrices.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+			AppliedPrices.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice + candle.ClosePrice) / 4m,
 			_ => candle.ClosePrice
 		};
 	}
@@ -668,14 +668,14 @@ public class FreemanAtrMaRsiGridStrategy : Strategy
 			values.RemoveAt(0);
 	}
 
-	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageMethod method, int length)
+	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageMethods method, int length)
 	{
 		return method switch
 		{
-			MovingAverageMethod.Simple => new SimpleMovingAverage { Length = length },
-			MovingAverageMethod.Exponential => new ExponentialMovingAverage { Length = length },
-			MovingAverageMethod.Smoothed => new SmoothedMovingAverage { Length = length },
-			MovingAverageMethod.Weighted => new WeightedMovingAverage { Length = length },
+			MovingAverageMethods.Simple => new SimpleMovingAverage { Length = length },
+			MovingAverageMethods.Exponential => new ExponentialMovingAverage { Length = length },
+			MovingAverageMethods.Smoothed => new SmoothedMovingAverage { Length = length },
+			MovingAverageMethods.Weighted => new WeightedMovingAverage { Length = length },
 			_ => new SimpleMovingAverage { Length = length }
 		};
 	}
@@ -692,7 +692,7 @@ public class FreemanAtrMaRsiGridStrategy : Strategy
 	/// <summary>
 	/// Moving average calculation methods supported by the strategy.
 	/// </summary>
-	public enum MovingAverageMethod
+	public enum MovingAverageMethods
 	{
 		Simple,
 		Exponential,
@@ -703,7 +703,7 @@ public class FreemanAtrMaRsiGridStrategy : Strategy
 	/// <summary>
 	/// Price sources that mimic MetaTrader applied price constants.
 	/// </summary>
-	public enum AppliedPrice
+	public enum AppliedPrices
 	{
 		Close,
 		Open,

--- a/API/3040_Exp_Skyscraper_Fix_Duplex/CS/ExpSkyscraperFixDuplexStrategy.cs
+++ b/API/3040_Exp_Skyscraper_Fix_Duplex/CS/ExpSkyscraperFixDuplexStrategy.cs
@@ -26,7 +26,7 @@ public class ExpSkyscraperFixDuplexStrategy : Strategy
 	private readonly StrategyParam<int> _longLength;
 	private readonly StrategyParam<decimal> _longKv;
 	private readonly StrategyParam<decimal> _longPercentage;
-	private readonly StrategyParam<SkyscraperCalculationMode> _longMode;
+	private readonly StrategyParam<SkyscraperCalculationModes> _longMode;
 	private readonly StrategyParam<int> _longSignalBar;
 	private readonly StrategyParam<bool> _enableShortEntries;
 	private readonly StrategyParam<bool> _enableShortExits;
@@ -34,7 +34,7 @@ public class ExpSkyscraperFixDuplexStrategy : Strategy
 	private readonly StrategyParam<int> _shortLength;
 	private readonly StrategyParam<decimal> _shortKv;
 	private readonly StrategyParam<decimal> _shortPercentage;
-	private readonly StrategyParam<SkyscraperCalculationMode> _shortMode;
+	private readonly StrategyParam<SkyscraperCalculationModes> _shortMode;
 	private readonly StrategyParam<int> _shortSignalBar;
 
 	private SkyscraperFixIndicator _longIndicator;
@@ -83,7 +83,7 @@ public class ExpSkyscraperFixDuplexStrategy : Strategy
 	/// <summary>
 	/// Calculation mode for the long indicator.
 	/// </summary>
-	public SkyscraperCalculationMode LongMode { get => _longMode.Value; set => _longMode.Value = value; }
+	public SkyscraperCalculationModes LongMode { get => _longMode.Value; set => _longMode.Value = value; }
 
 	/// <summary>
 	/// Number of closed candles to delay long signals.
@@ -123,7 +123,7 @@ public class ExpSkyscraperFixDuplexStrategy : Strategy
 	/// <summary>
 	/// Calculation mode for the short indicator.
 	/// </summary>
-	public SkyscraperCalculationMode ShortMode { get => _shortMode.Value; set => _shortMode.Value = value; }
+	public SkyscraperCalculationModes ShortMode { get => _shortMode.Value; set => _shortMode.Value = value; }
 
 	/// <summary>
 	/// Number of closed candles to delay short signals.
@@ -159,7 +159,7 @@ public class ExpSkyscraperFixDuplexStrategy : Strategy
 		_longPercentage = Param(nameof(LongPercentage), 0m)
 			.SetDisplay("Long Percentage", "Offset percentage for long trailing line", "Long");
 
-		_longMode = Param(nameof(LongMode), SkyscraperCalculationMode.HighLow)
+		_longMode = Param(nameof(LongMode), SkyscraperCalculationModes.HighLow)
 			.SetDisplay("Long Mode", "Price source for the long indicator", "Long");
 
 		_longSignalBar = Param(nameof(LongSignalBar), 1)
@@ -186,7 +186,7 @@ public class ExpSkyscraperFixDuplexStrategy : Strategy
 		_shortPercentage = Param(nameof(ShortPercentage), 0m)
 			.SetDisplay("Short Percentage", "Offset percentage for short trailing line", "Short");
 
-		_shortMode = Param(nameof(ShortMode), SkyscraperCalculationMode.HighLow)
+		_shortMode = Param(nameof(ShortMode), SkyscraperCalculationModes.HighLow)
 			.SetDisplay("Short Mode", "Price source for the short indicator", "Short");
 
 		_shortSignalBar = Param(nameof(ShortSignalBar), 1)
@@ -325,7 +325,7 @@ public class ExpSkyscraperFixDuplexStrategy : Strategy
 /// <summary>
 /// Calculation mode for the Skyscraper Fix indicator.
 /// </summary>
-public enum SkyscraperCalculationMode
+public enum SkyscraperCalculationModes
 {
 	/// <summary>Use the bar high and low.</summary>
 	HighLow,
@@ -374,7 +374,7 @@ public class SkyscraperFixIndicator : BaseIndicator<decimal>
 	/// <summary>
 	/// Price mode used for envelope construction.
 	/// </summary>
-	public SkyscraperCalculationMode Mode { get; set; } = SkyscraperCalculationMode.HighLow;
+	public SkyscraperCalculationModes Mode { get; set; } = SkyscraperCalculationModes.HighLow;
 
 	/// <summary>
 	/// Instrument price step.
@@ -426,11 +426,11 @@ public class SkyscraperFixIndicator : BaseIndicator<decimal>
 		decimal smin0;
 		switch (Mode)
 		{
-			case SkyscraperCalculationMode.HighLow:
+			case SkyscraperCalculationModes.HighLow:
 				smax0 = candle.LowPrice + doubleStep;
 				smin0 = candle.HighPrice - doubleStep;
 				break;
-			case SkyscraperCalculationMode.Close:
+			case SkyscraperCalculationModes.Close:
 				smax0 = candle.ClosePrice + doubleStep;
 				smin0 = candle.ClosePrice - doubleStep;
 				break;

--- a/API/3046_Exp_X2MACandle_MMRec/CS/ExpX2MaCandleMmRecStrategy.cs
+++ b/API/3046_Exp_X2MACandle_MMRec/CS/ExpX2MaCandleMmRecStrategy.cs
@@ -23,10 +23,10 @@ namespace StockSharp.Samples.Strategies;
 public class ExpX2MaCandleMmRecStrategy : Strategy
 {
 	private readonly StrategyParam<DataType> _candleType;
-	private readonly StrategyParam<SmoothMethod> _firstMethod;
+	private readonly StrategyParam<SmoothMethods> _firstMethod;
 	private readonly StrategyParam<int> _firstLength;
 	private readonly StrategyParam<int> _firstPhase;
-	private readonly StrategyParam<SmoothMethod> _secondMethod;
+	private readonly StrategyParam<SmoothMethods> _secondMethod;
 	private readonly StrategyParam<int> _secondLength;
 	private readonly StrategyParam<int> _secondPhase;
 	private readonly StrategyParam<int> _gapPoints;
@@ -60,7 +60,7 @@ public class ExpX2MaCandleMmRecStrategy : Strategy
 	/// <summary>
 	/// Method for the first smoothing stage.
 	/// </summary>
-	public SmoothMethod FirstMethod
+	public SmoothMethods FirstMethod
 	{
 		get => _firstMethod.Value;
 		set => _firstMethod.Value = value;
@@ -87,7 +87,7 @@ public class ExpX2MaCandleMmRecStrategy : Strategy
 	/// <summary>
 	/// Method for the second smoothing stage.
 	/// </summary>
-	public SmoothMethod SecondMethod
+	public SmoothMethods SecondMethod
 	{
 		get => _secondMethod.Value;
 		set => _secondMethod.Value = value;
@@ -209,7 +209,7 @@ public class ExpX2MaCandleMmRecStrategy : Strategy
 		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(6).TimeFrame())
 		.SetDisplay("Candle Type", "Timeframe for the smoothed candle indicator", "General");
 
-		_firstMethod = Param(nameof(FirstMethod), SmoothMethod.Simple)
+		_firstMethod = Param(nameof(FirstMethod), SmoothMethods.Simple)
 		.SetDisplay("Primary Method", "Method for the first smoothing stage", "Indicator");
 
 		_firstLength = Param(nameof(FirstLength), 12)
@@ -219,7 +219,7 @@ public class ExpX2MaCandleMmRecStrategy : Strategy
 		_firstPhase = Param(nameof(FirstPhase), 15)
 		.SetDisplay("Primary Phase", "Phase for Jurik based smoothing", "Indicator");
 
-		_secondMethod = Param(nameof(SecondMethod), SmoothMethod.Jurik)
+		_secondMethod = Param(nameof(SecondMethod), SmoothMethods.Jurik)
 		.SetDisplay("Secondary Method", "Method for the second smoothing stage", "Indicator");
 
 		_secondLength = Param(nameof(SecondLength), 5)
@@ -424,7 +424,7 @@ public class ExpX2MaCandleMmRecStrategy : Strategy
 	/// <summary>
 	/// Supported smoothing methods.
 	/// </summary>
-	public enum SmoothMethod
+	public enum SmoothMethods
 	{
 	/// <summary>
 	/// Simple moving average.
@@ -498,10 +498,10 @@ public class ExpX2MaCandleMmRecStrategy : Strategy
 	private decimal? _previousClose;
 
 	public X2MaCandleColorIndicator(
-	SmoothMethod firstMethod,
+	SmoothMethods firstMethod,
 	int firstLength,
 	int firstPhase,
-	SmoothMethod secondMethod,
+	SmoothMethods secondMethod,
 	int secondLength,
 	int secondPhase,
 	decimal gap)
@@ -552,10 +552,10 @@ public class ExpX2MaCandleMmRecStrategy : Strategy
 	private readonly IIndicator _second;
 
 	public MovingAveragePipeline(
-	SmoothMethod firstMethod,
+	SmoothMethods firstMethod,
 	int firstLength,
 	int firstPhase,
-	SmoothMethod secondMethod,
+	SmoothMethods secondMethod,
 	int secondLength,
 	int secondPhase)
 	{
@@ -575,15 +575,15 @@ public class ExpX2MaCandleMmRecStrategy : Strategy
 	return secondValue.IsFinal ? secondValue.ToDecimal() : null;
 	}
 
-	private static IIndicator CreateMovingAverage(SmoothMethod method, int length, int phase)
+	private static IIndicator CreateMovingAverage(SmoothMethods method, int length, int phase)
 	{
 	return method switch
 	{
-	SmoothMethod.Simple => new SimpleMovingAverage { Length = Math.Max(1, length) },
-	SmoothMethod.Exponential => new ExponentialMovingAverage { Length = Math.Max(1, length) },
-	SmoothMethod.Smoothed => new SmoothedMovingAverage { Length = Math.Max(1, length) },
-	SmoothMethod.Weighted => new WeightedMovingAverage { Length = Math.Max(1, length) },
-	SmoothMethod.Jurik => CreateJurik(length, phase),
+	SmoothMethods.Simple => new SimpleMovingAverage { Length = Math.Max(1, length) },
+	SmoothMethods.Exponential => new ExponentialMovingAverage { Length = Math.Max(1, length) },
+	SmoothMethods.Smoothed => new SmoothedMovingAverage { Length = Math.Max(1, length) },
+	SmoothMethods.Weighted => new WeightedMovingAverage { Length = Math.Max(1, length) },
+	SmoothMethods.Jurik => CreateJurik(length, phase),
 	_ => new SimpleMovingAverage { Length = Math.Max(1, length) }
 	};
 	}

--- a/API/3051_Exp_Skyscraper_Fix_ColorAML/CS/ExpSkyscraperFixColorAmlStrategy.cs
+++ b/API/3051_Exp_Skyscraper_Fix_ColorAML/CS/ExpSkyscraperFixColorAmlStrategy.cs
@@ -32,7 +32,7 @@ public class ExpSkyscraperFixColorAmlStrategy : Strategy
 	private readonly StrategyParam<int> _skyscraperLength;
 	private readonly StrategyParam<decimal> _skyscraperMultiplier;
 	private readonly StrategyParam<decimal> _skyscraperPercentage;
-	private readonly StrategyParam<SkyscraperMethod> _skyscraperMode;
+	private readonly StrategyParam<SkyscraperMethods> _skyscraperMode;
 	private readonly StrategyParam<int> _skyscraperSignalBar;
 	private readonly StrategyParam<decimal> _skyscraperVolume;
 	private readonly StrategyParam<decimal> _skyscraperStopLoss;
@@ -53,7 +53,7 @@ public class ExpSkyscraperFixColorAmlStrategy : Strategy
 	private readonly List<CandleSnapshot> _skyscraperCandles = new();
 	private readonly List<CandleSnapshot> _colorAmlCandles = new();
 
-	private ModuleSource? _activeModule;
+	private ModuleSources? _activeModule;
 	private decimal? _entryPrice;
 	private decimal? _stopLossPrice;
 	private decimal? _takeProfitPrice;
@@ -104,7 +104,7 @@ public class ExpSkyscraperFixColorAmlStrategy : Strategy
 	.SetNotNegative()
 	.SetDisplay("Percentage Offset", "Optional percentage displacement of the middle line", "Skyscraper");
 
-	_skyscraperMode = Param(nameof(SkyscraperMode), SkyscraperMethod.HighLow)
+	_skyscraperMode = Param(nameof(SkyscraperMode), SkyscraperMethods.HighLow)
 	.SetDisplay("Boundary Source", "Defines whether the module uses High/Low or Close prices", "Skyscraper");
 
 	_skyscraperSignalBar = Param(nameof(SkyscraperSignalBar), 1)
@@ -251,7 +251,7 @@ public class ExpSkyscraperFixColorAmlStrategy : Strategy
 	/// <summary>
 	/// Source mode for Skyscraper boundaries.
 	/// </summary>
-	public SkyscraperMethod SkyscraperMode
+	public SkyscraperMethods SkyscraperMode
 	{
 	get => _skyscraperMode.Value;
 	set => _skyscraperMode.Value = value;
@@ -464,7 +464,7 @@ public class ExpSkyscraperFixColorAmlStrategy : Strategy
 	var closeLong = currentColor == 1 && SkyscraperEnableLongExit;
 	var closeShort = currentColor == 0 && SkyscraperEnableShortExit;
 
-	ExecuteSignals(ModuleSource.Skyscraper, candle, openLong, closeLong, openShort, closeShort, SkyscraperVolume, SkyscraperStopLoss, SkyscraperTakeProfit);
+	ExecuteSignals(ModuleSources.Skyscraper, candle, openLong, closeLong, openShort, closeShort, SkyscraperVolume, SkyscraperStopLoss, SkyscraperTakeProfit);
 	CheckRisk(candle);
 	}
 
@@ -496,11 +496,11 @@ public class ExpSkyscraperFixColorAmlStrategy : Strategy
 	var closeLong = currentColor == 0 && ColorAmlEnableLongExit;
 	var closeShort = currentColor == 2 && ColorAmlEnableShortExit;
 
-	ExecuteSignals(ModuleSource.ColorAml, candle, openLong, closeLong, openShort, closeShort, ColorAmlVolume, ColorAmlStopLoss, ColorAmlTakeProfit);
+	ExecuteSignals(ModuleSources.ColorAml, candle, openLong, closeLong, openShort, closeShort, ColorAmlVolume, ColorAmlStopLoss, ColorAmlTakeProfit);
 	CheckRisk(candle);
 	}
 
-	private void ExecuteSignals(ModuleSource module, ICandleMessage candle, bool openLong, bool closeLong, bool openShort, bool closeShort, decimal volume, decimal stopLossPoints, decimal takeProfitPoints)
+	private void ExecuteSignals(ModuleSources module, ICandleMessage candle, bool openLong, bool closeLong, bool openShort, bool closeShort, decimal volume, decimal stopLossPoints, decimal takeProfitPoints)
 	{
 	if (volume <= 0m)
 	return;
@@ -529,7 +529,7 @@ public class ExpSkyscraperFixColorAmlStrategy : Strategy
 	if (requiredVolume > 0m)
 	{
 	BuyMarket(requiredVolume);
-	SetEntryState(module, candle.ClosePrice, stopLossPoints, takeProfitPoints, TradeDirection.Long);
+	SetEntryState(module, candle.ClosePrice, stopLossPoints, takeProfitPoints, TradeDirections.Long);
 	}
 	}
 
@@ -542,7 +542,7 @@ public class ExpSkyscraperFixColorAmlStrategy : Strategy
 	if (requiredVolume > 0m)
 	{
 	SellMarket(requiredVolume);
-	SetEntryState(module, candle.ClosePrice, stopLossPoints, takeProfitPoints, TradeDirection.Short);
+	SetEntryState(module, candle.ClosePrice, stopLossPoints, takeProfitPoints, TradeDirections.Short);
 	}
 	}
 	}
@@ -584,7 +584,7 @@ public class ExpSkyscraperFixColorAmlStrategy : Strategy
 	}
 	}
 
-	private void SetEntryState(ModuleSource module, decimal entryPrice, decimal stopLossPoints, decimal takeProfitPoints, TradeDirection direction)
+	private void SetEntryState(ModuleSources module, decimal entryPrice, decimal stopLossPoints, decimal takeProfitPoints, TradeDirections direction)
 	{
 	_activeModule = module;
 	_entryPrice = entryPrice;
@@ -593,11 +593,11 @@ public class ExpSkyscraperFixColorAmlStrategy : Strategy
 
 	switch (direction)
 	{
-	case TradeDirection.Long:
+	case TradeDirections.Long:
 	_stopLossPrice = stopLossPoints > 0m ? entryPrice - stopLossPoints * step : null;
 	_takeProfitPrice = takeProfitPoints > 0m ? entryPrice + takeProfitPoints * step : null;
 	break;
-	case TradeDirection.Short:
+	case TradeDirections.Short:
 	_stopLossPrice = stopLossPoints > 0m ? entryPrice + stopLossPoints * step : null;
 	_takeProfitPrice = takeProfitPoints > 0m ? entryPrice - takeProfitPoints * step : null;
 	break;
@@ -628,13 +628,13 @@ public class ExpSkyscraperFixColorAmlStrategy : Strategy
 	return step is > 0m ? step.Value : 0.0001m;
 	}
 
-	private enum ModuleSource
+	private enum ModuleSources
 	{
 	Skyscraper,
 	ColorAml
 	}
 
-	private enum TradeDirection
+	private enum TradeDirections
 	{
 	Long,
 	Short
@@ -643,7 +643,7 @@ public class ExpSkyscraperFixColorAmlStrategy : Strategy
 	/// <summary>
 	/// Price source selection for Skyscraper Fix.
 	/// </summary>
-	public enum SkyscraperMethod
+	public enum SkyscraperMethods
 	{
 	HighLow,
 	Close
@@ -653,7 +653,7 @@ public class ExpSkyscraperFixColorAmlStrategy : Strategy
 
 	private static class SkyscraperCalculator
 	{
-	public static int?[] CalculateColors(IReadOnlyList<CandleSnapshot> candles, decimal point, int length, decimal multiplier, decimal percentage, SkyscraperMethod method)
+	public static int?[] CalculateColors(IReadOnlyList<CandleSnapshot> candles, decimal point, int length, decimal multiplier, decimal percentage, SkyscraperMethods method)
 	{
 	if (candles.Count == 0)
 	return Array.Empty<int?>();
@@ -713,7 +713,7 @@ public class ExpSkyscraperFixColorAmlStrategy : Strategy
 
 	decimal smax0;
 	decimal smin0;
-	if (method == SkyscraperMethod.HighLow)
+	if (method == SkyscraperMethods.HighLow)
 	{
 	smax0 = lowSeries[bar] + x2Step;
 	smin0 = highSeries[bar] - x2Step;

--- a/API/3054_Exp_FisherCG_Oscillator/CS/ExpFisherCgOscillatorStrategy.cs
+++ b/API/3054_Exp_FisherCG_Oscillator/CS/ExpFisherCgOscillatorStrategy.cs
@@ -32,7 +32,7 @@ public class ExpFisherCgOscillatorStrategy : Strategy
 	private readonly StrategyParam<int> _takeProfitPoints;
 	private readonly StrategyParam<decimal> _fixedVolume;
 	private readonly StrategyParam<decimal> _depositShare;
-	private readonly StrategyParam<PositionSizingMode> _sizingMode;
+	private readonly StrategyParam<PositionSizingModes> _sizingMode;
 
 	private FisherCgOscillatorIndicator _oscillator = null!;
 	private readonly List<(decimal Main, decimal Trigger)> _oscillatorHistory = new();
@@ -84,7 +84,7 @@ public class ExpFisherCgOscillatorStrategy : Strategy
 			.SetNotNegative()
 			.SetDisplay("Deposit Share", "Fraction of portfolio value allocated per trade", "Risk");
 
-		_sizingMode = Param(nameof(SizingMode), PositionSizingMode.FixedVolume)
+		_sizingMode = Param(nameof(SizingMode), PositionSizingModes.FixedVolume)
 			.SetDisplay("Position Sizing", "Method used to convert the deposit share into volume", "Risk");
 	}
 
@@ -170,7 +170,7 @@ public class ExpFisherCgOscillatorStrategy : Strategy
 	}
 
 	/// <summary>
-	/// Fixed trade volume when sizing mode is set to <see cref="PositionSizingMode.FixedVolume"/>.
+	/// Fixed trade volume when sizing mode is set to <see cref="PositionSizingModes.FixedVolume"/>.
 	/// </summary>
 	public decimal FixedVolume
 	{
@@ -190,7 +190,7 @@ public class ExpFisherCgOscillatorStrategy : Strategy
 	/// <summary>
 	/// Position sizing behaviour.
 	/// </summary>
-	public PositionSizingMode SizingMode
+	public PositionSizingModes SizingMode
 	{
 		get => _sizingMode.Value;
 		set => _sizingMode.Value = value;
@@ -335,7 +335,7 @@ public class ExpFisherCgOscillatorStrategy : Strategy
 
 	private decimal CalculateOrderVolume(decimal referencePrice)
 	{
-		if (SizingMode == PositionSizingMode.FixedVolume)
+		if (SizingMode == PositionSizingModes.FixedVolume)
 			return FixedVolume;
 
 		if (Portfolio is null || referencePrice <= 0m)
@@ -415,7 +415,7 @@ public class ExpFisherCgOscillatorStrategy : Strategy
 /// <summary>
 /// Position sizing modes supported by the strategy.
 /// </summary>
-public enum PositionSizingMode
+public enum PositionSizingModes
 {
 	/// <summary>Always trade the configured fixed volume.</summary>
 	FixedVolume,

--- a/API/3055_Exp_Skyscraper_Fix_ColorAML_MMRec/CS/ExpSkyscraperFixColorAmlMmrecStrategy.cs
+++ b/API/3055_Exp_Skyscraper_Fix_ColorAML_MMRec/CS/ExpSkyscraperFixColorAmlMmrecStrategy.cs
@@ -35,7 +35,7 @@ public class ExpSkyscraperFixColorAmlMmrecStrategy : Strategy
 	private readonly StrategyParam<int> _skyscraperSellLossTrigger;
 	private readonly StrategyParam<decimal> _skyscraperSmallMm;
 	private readonly StrategyParam<decimal> _skyscraperMm;
-	private readonly StrategyParam<MoneyManagementMode> _skyscraperMmMode;
+	private readonly StrategyParam<MoneyManagementModes> _skyscraperMmMode;
 	private readonly StrategyParam<int> _skyscraperStopLossTicks;
 	private readonly StrategyParam<int> _skyscraperTakeProfitTicks;
 
@@ -51,7 +51,7 @@ public class ExpSkyscraperFixColorAmlMmrecStrategy : Strategy
 	private readonly StrategyParam<int> _colorAmlSellLossTrigger;
 	private readonly StrategyParam<decimal> _colorAmlSmallMm;
 	private readonly StrategyParam<decimal> _colorAmlMm;
-	private readonly StrategyParam<MoneyManagementMode> _colorAmlMmMode;
+	private readonly StrategyParam<MoneyManagementModes> _colorAmlMmMode;
 	private readonly StrategyParam<int> _colorAmlStopLossTicks;
 	private readonly StrategyParam<int> _colorAmlTakeProfitTicks;
 
@@ -77,8 +77,8 @@ public class ExpSkyscraperFixColorAmlMmrecStrategy : Strategy
 	private decimal _signedPosition;
 	private Sides? _lastEntrySide;
 	private decimal _lastEntryPrice;
-	private TradeModule _lastEntryModule = TradeModule.None;
-	private TradeModule? _pendingEntryModule;
+	private TradeModules _lastEntryModule = TradeModules.None;
+	private TradeModules? _pendingEntryModule;
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="ExpSkyscraperFixColorAmlMmrecStrategy"/> class.
@@ -135,7 +135,7 @@ public class ExpSkyscraperFixColorAmlMmrecStrategy : Strategy
 			.SetDisplay("Base Volume", "Standard order volume for Skyscraper signals", "Skyscraper Fix")
 			.SetGreaterThanZero();
 
-		_skyscraperMmMode = Param(nameof(SkyscraperMmMode), MoneyManagementMode.Lot)
+		_skyscraperMmMode = Param(nameof(SkyscraperMmMode), MoneyManagementModes.Lot)
 			.SetDisplay("Volume Mode", "Money management mode used by the original expert", "Skyscraper Fix");
 
 		_skyscraperStopLossTicks = Param(nameof(SkyscraperStopLossTicks), 1000)
@@ -189,7 +189,7 @@ public class ExpSkyscraperFixColorAmlMmrecStrategy : Strategy
 			.SetDisplay("Base Volume", "Standard order volume for Color AML signals", "Color AML")
 			.SetGreaterThanZero();
 
-		_colorAmlMmMode = Param(nameof(ColorAmlMmMode), MoneyManagementMode.Lot)
+		_colorAmlMmMode = Param(nameof(ColorAmlMmMode), MoneyManagementModes.Lot)
 			.SetDisplay("Volume Mode", "Money management mode used by the original expert", "Color AML");
 
 		_colorAmlStopLossTicks = Param(nameof(ColorAmlStopLossTicks), 1000)
@@ -274,7 +274,7 @@ public class ExpSkyscraperFixColorAmlMmrecStrategy : Strategy
 	/// <summary>
 	/// Money management mode for Skyscraper trades.
 	/// </summary>
-	public MoneyManagementMode SkyscraperMmMode { get => _skyscraperMmMode.Value; set => _skyscraperMmMode.Value = value; }
+	public MoneyManagementModes SkyscraperMmMode { get => _skyscraperMmMode.Value; set => _skyscraperMmMode.Value = value; }
 
 	/// <summary>
 	/// Stop-loss distance for Skyscraper trades expressed in price steps.
@@ -349,7 +349,7 @@ public class ExpSkyscraperFixColorAmlMmrecStrategy : Strategy
 	/// <summary>
 	/// Money management mode for Color AML trades.
 	/// </summary>
-	public MoneyManagementMode ColorAmlMmMode { get => _colorAmlMmMode.Value; set => _colorAmlMmMode.Value = value; }
+	public MoneyManagementModes ColorAmlMmMode { get => _colorAmlMmMode.Value; set => _colorAmlMmMode.Value = value; }
 
 	/// <summary>
 	/// Stop-loss distance for Color AML trades expressed in price steps.
@@ -396,7 +396,7 @@ public class ExpSkyscraperFixColorAmlMmrecStrategy : Strategy
 		_signedPosition = 0m;
 		_lastEntrySide = null;
 		_lastEntryPrice = 0m;
-		_lastEntryModule = TradeModule.None;
+		_lastEntryModule = TradeModules.None;
 		_pendingEntryModule = null;
 	}
 
@@ -470,7 +470,7 @@ public class ExpSkyscraperFixColorAmlMmrecStrategy : Strategy
 				CloseShortPosition();
 
 			if (SkyscraperEnableLongEntry && (previous is null || previous <= 0))
-				OpenLong(TradeModule.SkyscraperLong, candle, SkyscraperStopLossTicks, SkyscraperTakeProfitTicks);
+				OpenLong(TradeModules.SkyscraperLong, candle, SkyscraperStopLossTicks, SkyscraperTakeProfitTicks);
 		}
 		else if (trend < 0)
 		{
@@ -478,7 +478,7 @@ public class ExpSkyscraperFixColorAmlMmrecStrategy : Strategy
 				CloseLongPosition();
 
 			if (SkyscraperEnableShortEntry && (previous is null || previous >= 0))
-				OpenShort(TradeModule.SkyscraperShort, candle, SkyscraperStopLossTicks, SkyscraperTakeProfitTicks);
+				OpenShort(TradeModules.SkyscraperShort, candle, SkyscraperStopLossTicks, SkyscraperTakeProfitTicks);
 		}
 	}
 
@@ -514,7 +514,7 @@ public class ExpSkyscraperFixColorAmlMmrecStrategy : Strategy
 				CloseShortPosition();
 
 			if (ColorAmlEnableLongEntry && previous != 2)
-				OpenLong(TradeModule.ColorAmlLong, candle, ColorAmlStopLossTicks, ColorAmlTakeProfitTicks);
+				OpenLong(TradeModules.ColorAmlLong, candle, ColorAmlStopLossTicks, ColorAmlTakeProfitTicks);
 		}
 		else if (color == 0)
 		{
@@ -522,11 +522,11 @@ public class ExpSkyscraperFixColorAmlMmrecStrategy : Strategy
 				CloseLongPosition();
 
 			if (ColorAmlEnableShortEntry && previous != 0)
-				OpenShort(TradeModule.ColorAmlShort, candle, ColorAmlStopLossTicks, ColorAmlTakeProfitTicks);
+				OpenShort(TradeModules.ColorAmlShort, candle, ColorAmlStopLossTicks, ColorAmlTakeProfitTicks);
 		}
 	}
 
-	private void OpenLong(TradeModule module, ICandleMessage candle, int stopTicks, int takeTicks)
+	private void OpenLong(TradeModules module, ICandleMessage candle, int stopTicks, int takeTicks)
 	{
 		if (Position > 0)
 			return;
@@ -543,7 +543,7 @@ public class ExpSkyscraperFixColorAmlMmrecStrategy : Strategy
 		SetProtectiveLevels(module, candle.ClosePrice, true, stopTicks, takeTicks);
 	}
 
-	private void OpenShort(TradeModule module, ICandleMessage candle, int stopTicks, int takeTicks)
+	private void OpenShort(TradeModules module, ICandleMessage candle, int stopTicks, int takeTicks)
 	{
 		if (Position < 0)
 			return;
@@ -590,16 +590,16 @@ public class ExpSkyscraperFixColorAmlMmrecStrategy : Strategy
 		ResetRiskLevels();
 	}
 
-	private decimal SelectVolume(TradeModule module)
+	private decimal SelectVolume(TradeModules module)
 	{
 		UpdateMoneyManagers();
 
 		return module switch
 		{
-			TradeModule.SkyscraperLong => _skyscraperBuyManager.SelectVolume(NormalizeVolume, SkyscraperMmMode),
-			TradeModule.SkyscraperShort => _skyscraperSellManager.SelectVolume(NormalizeVolume, SkyscraperMmMode),
-			TradeModule.ColorAmlLong => _colorAmlBuyManager.SelectVolume(NormalizeVolume, ColorAmlMmMode),
-			TradeModule.ColorAmlShort => _colorAmlSellManager.SelectVolume(NormalizeVolume, ColorAmlMmMode),
+			TradeModules.SkyscraperLong => _skyscraperBuyManager.SelectVolume(NormalizeVolume, SkyscraperMmMode),
+			TradeModules.SkyscraperShort => _skyscraperSellManager.SelectVolume(NormalizeVolume, SkyscraperMmMode),
+			TradeModules.ColorAmlLong => _colorAmlBuyManager.SelectVolume(NormalizeVolume, ColorAmlMmMode),
+			TradeModules.ColorAmlShort => _colorAmlSellManager.SelectVolume(NormalizeVolume, ColorAmlMmMode),
 			_ => 0m
 		};
 	}
@@ -643,7 +643,7 @@ public class ExpSkyscraperFixColorAmlMmrecStrategy : Strategy
 		return steps * step;
 	}
 
-	private void SetProtectiveLevels(TradeModule module, decimal entryPrice, bool isLong, int stopTicks, int takeTicks)
+	private void SetProtectiveLevels(TradeModules module, decimal entryPrice, bool isLong, int stopTicks, int takeTicks)
 	{
 		var step = Security?.PriceStep ?? 1m;
 		if (step <= 0m)
@@ -739,13 +739,13 @@ public class ExpSkyscraperFixColorAmlMmrecStrategy : Strategy
 		{
 			_lastEntrySide = delta > 0m ? Sides.Buy : Sides.Sell;
 			_lastEntryPrice = trade.Trade.Price;
-			_lastEntryModule = _pendingEntryModule ?? TradeModule.None;
+			_lastEntryModule = _pendingEntryModule ?? TradeModules.None;
 			_pendingEntryModule = null;
 		}
 		else if (previous != 0m && _signedPosition == 0m)
 		{
 			var exitPrice = trade.Trade.Price;
-			if (_lastEntrySide != null && _lastEntryModule != TradeModule.None && _lastEntryPrice != 0m)
+			if (_lastEntrySide != null && _lastEntryModule != TradeModules.None && _lastEntryPrice != 0m)
 			{
 				var profit = _lastEntrySide == Sides.Buy
 					? exitPrice - _lastEntryPrice
@@ -754,25 +754,25 @@ public class ExpSkyscraperFixColorAmlMmrecStrategy : Strategy
 			}
 
 			_lastEntrySide = null;
-			_lastEntryModule = TradeModule.None;
+			_lastEntryModule = TradeModules.None;
 			_lastEntryPrice = 0m;
 		}
 	}
 
-	private void RegisterTradeResult(TradeModule module, bool loss)
+	private void RegisterTradeResult(TradeModules module, bool loss)
 	{
 		switch (module)
 		{
-			case TradeModule.SkyscraperLong:
+			case TradeModules.SkyscraperLong:
 				_skyscraperBuyManager.RegisterResult(loss);
 				break;
-			case TradeModule.SkyscraperShort:
+			case TradeModules.SkyscraperShort:
 				_skyscraperSellManager.RegisterResult(loss);
 				break;
-			case TradeModule.ColorAmlLong:
+			case TradeModules.ColorAmlLong:
 				_colorAmlBuyManager.RegisterResult(loss);
 				break;
-			case TradeModule.ColorAmlShort:
+			case TradeModules.ColorAmlShort:
 				_colorAmlSellManager.RegisterResult(loss);
 				break;
 		}
@@ -782,7 +782,7 @@ public class ExpSkyscraperFixColorAmlMmrecStrategy : Strategy
 /// <summary>
 /// Money management mode supported by the MMRec logic.
 /// </summary>
-public enum MoneyManagementMode
+public enum MoneyManagementModes
 {
 	/// <summary>Use a percentage of free margin.</summary>
 	FreeMargin,
@@ -803,7 +803,7 @@ public enum MoneyManagementMode
 /// <summary>
 /// Internal identifier for the module that opened the latest position.
 /// </summary>
-internal enum TradeModule
+internal enum TradeModules
 {
 	None,
 	SkyscraperLong,
@@ -825,10 +825,10 @@ internal sealed class MoneyManager
 
 	private int _lossStreak;
 
-	public decimal SelectVolume(Func<decimal, decimal> normalize, MoneyManagementMode mode)
+	public decimal SelectVolume(Func<decimal, decimal> normalize, MoneyManagementModes mode)
 	{
-		var baseVolume = mode == MoneyManagementMode.Lot ? NormalVolume : NormalVolume;
-		var reducedVolume = mode == MoneyManagementMode.Lot ? SmallVolume : SmallVolume;
+		var baseVolume = mode == MoneyManagementModes.Lot ? NormalVolume : NormalVolume;
+		var reducedVolume = mode == MoneyManagementModes.Lot ? SmallVolume : SmallVolume;
 
 		if (LossTrigger > 0 && _lossStreak >= LossTrigger)
 			baseVolume = reducedVolume;

--- a/API/3056_BARS_Alligator/CS/BarsAlligatorStrategy.cs
+++ b/API/3056_BARS_Alligator/CS/BarsAlligatorStrategy.cs
@@ -25,7 +25,7 @@ public class BarsAlligatorStrategy : Strategy
 	private readonly StrategyParam<int> _takeProfitPips;
 	private readonly StrategyParam<int> _trailingStopPips;
 	private readonly StrategyParam<int> _trailingStepPips;
-	private readonly StrategyParam<MoneyManagementMode> _moneyMode;
+	private readonly StrategyParam<MoneyManagementModes> _moneyMode;
 	private readonly StrategyParam<decimal> _moneyValue;
 	private readonly StrategyParam<int> _maxPositions;
 	private readonly StrategyParam<int> _jawPeriod;
@@ -34,8 +34,8 @@ public class BarsAlligatorStrategy : Strategy
 	private readonly StrategyParam<int> _teethShift;
 	private readonly StrategyParam<int> _lipsPeriod;
 	private readonly StrategyParam<int> _lipsShift;
-	private readonly StrategyParam<MovingAverageType> _maType;
-	private readonly StrategyParam<AppliedPriceType> _appliedPrice;
+	private readonly StrategyParam<MovingAverageTypes> _maType;
+	private readonly StrategyParam<AppliedPriceTypes> _appliedPrice;
 	private readonly StrategyParam<DataType> _candleType;
 
 	private LengthIndicator<decimal> _jaw = null!;
@@ -104,14 +104,14 @@ public class BarsAlligatorStrategy : Strategy
 	/// <summary>
 	/// Money management selection between fixed volume and risk-based sizing.
 	/// </summary>
-	public MoneyManagementMode MoneyMode
+	public MoneyManagementModes MoneyMode
 	{
 		get => _moneyMode.Value;
 		set => _moneyMode.Value = value;
 	}
 
 	/// <summary>
-	/// Risk percentage applied when <see cref="MoneyMode"/> is <see cref="MoneyManagementMode.RiskPercent"/>.
+	/// Risk percentage applied when <see cref="MoneyMode"/> is <see cref="MoneyManagementModes.RiskPercent"/>.
 	/// Ignored when fixed volume sizing is active.
 	/// </summary>
 	public decimal MoneyValue
@@ -186,7 +186,7 @@ public class BarsAlligatorStrategy : Strategy
 	/// <summary>
 	/// Moving average type shared by all Alligator lines.
 	/// </summary>
-	public MovingAverageType MaType
+	public MovingAverageTypes MaType
 	{
 		get => _maType.Value;
 		set => _maType.Value = value;
@@ -195,7 +195,7 @@ public class BarsAlligatorStrategy : Strategy
 	/// <summary>
 	/// Candle price used as input for the moving averages.
 	/// </summary>
-	public AppliedPriceType AppliedPrice
+	public AppliedPriceTypes AppliedPrice
 	{
 		get => _appliedPrice.Value;
 		set => _appliedPrice.Value = value;
@@ -235,7 +235,7 @@ public class BarsAlligatorStrategy : Strategy
 		.SetNotNegative()
 		.SetDisplay("Trailing Step", "Extra distance before the trailing stop moves", "Risk");
 
-		_moneyMode = Param(nameof(MoneyMode), MoneyManagementMode.FixedVolume)
+		_moneyMode = Param(nameof(MoneyMode), MoneyManagementModes.FixedVolume)
 		.SetDisplay("Money Mode", "Choose between fixed volume or risk percentage sizing", "Risk");
 
 		_moneyValue = Param(nameof(MoneyValue), 1m)
@@ -270,10 +270,10 @@ public class BarsAlligatorStrategy : Strategy
 		.SetNotNegative()
 		.SetDisplay("Lips Shift", "Forward shift of the lips line", "Alligator");
 
-		_maType = Param(nameof(MaType), MovingAverageType.Smoothed)
+		_maType = Param(nameof(MaType), MovingAverageTypes.Smoothed)
 		.SetDisplay("MA Type", "Moving average calculation for the Alligator lines", "Alligator");
 
-		_appliedPrice = Param(nameof(AppliedPrice), AppliedPriceType.Median)
+		_appliedPrice = Param(nameof(AppliedPrice), AppliedPriceTypes.Median)
 		.SetDisplay("Applied Price", "Price component supplied to the averages", "Alligator");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(1).TimeFrame())
@@ -571,7 +571,7 @@ public class BarsAlligatorStrategy : Strategy
 
 	private decimal CalculateEntryVolume()
 	{
-		if (MoneyMode == MoneyManagementMode.RiskPercent)
+		if (MoneyMode == MoneyManagementModes.RiskPercent)
 		{
 			if (_stopLossDistance <= 0m)
 			return OrderVolume;
@@ -639,28 +639,28 @@ public class BarsAlligatorStrategy : Strategy
 		return true;
 	}
 
-	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageType type, int length)
+	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageTypes type, int length)
 	{
 		return type switch
 		{
-			MovingAverageType.Simple => new SimpleMovingAverage { Length = length },
-			MovingAverageType.Exponential => new ExponentialMovingAverage { Length = length },
-			MovingAverageType.Smoothed => new SmoothedMovingAverage { Length = length },
-			MovingAverageType.Weighted => new WeightedMovingAverage { Length = length },
+			MovingAverageTypes.Simple => new SimpleMovingAverage { Length = length },
+			MovingAverageTypes.Exponential => new ExponentialMovingAverage { Length = length },
+			MovingAverageTypes.Smoothed => new SmoothedMovingAverage { Length = length },
+			MovingAverageTypes.Weighted => new WeightedMovingAverage { Length = length },
 			_ => new SmoothedMovingAverage { Length = length }
 		};
 	}
 
-	private static decimal GetPrice(ICandleMessage candle, AppliedPriceType priceType)
+	private static decimal GetPrice(ICandleMessage candle, AppliedPriceTypes priceType)
 	{
 		return priceType switch
 		{
-			AppliedPriceType.Open => candle.OpenPrice,
-			AppliedPriceType.High => candle.HighPrice,
-			AppliedPriceType.Low => candle.LowPrice,
-			AppliedPriceType.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-			AppliedPriceType.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-			AppliedPriceType.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
+			AppliedPriceTypes.Open => candle.OpenPrice,
+			AppliedPriceTypes.High => candle.HighPrice,
+			AppliedPriceTypes.Low => candle.LowPrice,
+			AppliedPriceTypes.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+			AppliedPriceTypes.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+			AppliedPriceTypes.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
 			_ => candle.ClosePrice
 		};
 	}
@@ -669,7 +669,7 @@ public class BarsAlligatorStrategy : Strategy
 /// <summary>
 /// Available money management modes.
 /// </summary>
-public enum MoneyManagementMode
+public enum MoneyManagementModes
 {
 	/// <summary>
 	/// Use a fixed volume defined by <see cref="BarsAlligatorStrategy.OrderVolume"/>.
@@ -685,7 +685,7 @@ public enum MoneyManagementMode
 /// <summary>
 /// Moving average types supported by the Alligator implementation.
 /// </summary>
-public enum MovingAverageType
+public enum MovingAverageTypes
 {
 	/// <summary>
 	/// Simple moving average.
@@ -711,7 +711,7 @@ public enum MovingAverageType
 /// <summary>
 /// Price sources that can feed the Alligator averages.
 /// </summary>
-public enum AppliedPriceType
+public enum AppliedPriceTypes
 {
 	/// <summary>
 	/// Candle close price.

--- a/API/3057_Exp_Skyscraper_Fix_ColorAML_X2MACandle_MMRec/CS/ExpSkyscraperFixColorAmlX2MaCandleMmRecStrategy.cs
+++ b/API/3057_Exp_Skyscraper_Fix_ColorAML_X2MACandle_MMRec/CS/ExpSkyscraperFixColorAmlX2MaCandleMmRecStrategy.cs
@@ -49,10 +49,10 @@ public class ExpSkyscraperFixColorAmlX2MaCandleMmRecStrategy : Strategy
 	private readonly StrategyParam<int> _colorAmlSellLossTrigger;
 
 	private readonly StrategyParam<DataType> _x2MaCandleType;
-	private readonly StrategyParam<X2MaSmoothMethod> _x2MaFirstMethod;
+	private readonly StrategyParam<X2MaSmoothMethods> _x2MaFirstMethod;
 	private readonly StrategyParam<int> _x2MaFirstLength;
 	private readonly StrategyParam<int> _x2MaFirstPhase;
-	private readonly StrategyParam<X2MaSmoothMethod> _x2MaSecondMethod;
+	private readonly StrategyParam<X2MaSmoothMethods> _x2MaSecondMethod;
 	private readonly StrategyParam<int> _x2MaSecondLength;
 	private readonly StrategyParam<int> _x2MaSecondPhase;
 	private readonly StrategyParam<int> _x2MaGapPoints;
@@ -160,14 +160,14 @@ public class ExpSkyscraperFixColorAmlX2MaCandleMmRecStrategy : Strategy
 
 		_x2MaCandleType = Param(nameof(X2MaCandleType), TimeSpan.FromHours(4).TimeFrame())
 		.SetDisplay("X2MA Candle", "Timeframe for X2MA candles", "X2MA");
-		_x2MaFirstMethod = Param(nameof(X2MaFirstMethod), X2MaSmoothMethod.Simple)
+		_x2MaFirstMethod = Param(nameof(X2MaFirstMethod), X2MaSmoothMethods.Simple)
 		.SetDisplay("First Method", "First smoothing method", "X2MA");
 		_x2MaFirstLength = Param(nameof(X2MaFirstLength), 12)
 		.SetGreaterThanZero()
 		.SetDisplay("First Length", "Length of the first smoothing stage", "X2MA");
 		_x2MaFirstPhase = Param(nameof(X2MaFirstPhase), 15)
 		.SetDisplay("First Phase", "Compatibility phase for Jurik", "X2MA");
-		_x2MaSecondMethod = Param(nameof(X2MaSecondMethod), X2MaSmoothMethod.Jurik)
+		_x2MaSecondMethod = Param(nameof(X2MaSecondMethod), X2MaSmoothMethods.Jurik)
 		.SetDisplay("Second Method", "Second smoothing method", "X2MA");
 		_x2MaSecondLength = Param(nameof(X2MaSecondLength), 5)
 		.SetGreaterThanZero()
@@ -392,7 +392,7 @@ public class ExpSkyscraperFixColorAmlX2MaCandleMmRecStrategy : Strategy
 	}
 
 	/// <summary>First smoothing method used by X2MA.</summary>
-	public X2MaSmoothMethod X2MaFirstMethod
+	public X2MaSmoothMethods X2MaFirstMethod
 	{
 		get => _x2MaFirstMethod.Value;
 		set => _x2MaFirstMethod.Value = value;
@@ -413,7 +413,7 @@ public class ExpSkyscraperFixColorAmlX2MaCandleMmRecStrategy : Strategy
 	}
 
 	/// <summary>Second smoothing method used by X2MA.</summary>
-	public X2MaSmoothMethod X2MaSecondMethod
+	public X2MaSmoothMethods X2MaSecondMethod
 	{
 		get => _x2MaSecondMethod.Value;
 		set => _x2MaSecondMethod.Value = value;
@@ -1008,10 +1008,10 @@ public class ExpSkyscraperFixColorAmlX2MaCandleMmRecStrategy : Strategy
 							private decimal? _previousClose;
 
 							public X2MaCandleColorIndicator(
-							X2MaSmoothMethod firstMethod,
+							X2MaSmoothMethods firstMethod,
 							int firstLength,
 							int firstPhase,
-							X2MaSmoothMethod secondMethod,
+							X2MaSmoothMethods secondMethod,
 							int secondLength,
 							int secondPhase,
 							decimal gap)
@@ -1060,10 +1060,10 @@ public class ExpSkyscraperFixColorAmlX2MaCandleMmRecStrategy : Strategy
 								private readonly IIndicator _second;
 
 								public MovingAveragePipeline(
-								X2MaSmoothMethod firstMethod,
+								X2MaSmoothMethods firstMethod,
 								int firstLength,
 								int firstPhase,
-								X2MaSmoothMethod secondMethod,
+								X2MaSmoothMethods secondMethod,
 								int secondLength,
 								int secondPhase)
 								{
@@ -1082,15 +1082,15 @@ public class ExpSkyscraperFixColorAmlX2MaCandleMmRecStrategy : Strategy
 									return secondValue.IsFinal ? secondValue.ToDecimal() : null;
 								}
 
-								private static IIndicator CreateMovingAverage(X2MaSmoothMethod method, int length, int phase)
+								private static IIndicator CreateMovingAverage(X2MaSmoothMethods method, int length, int phase)
 								{
 									return method switch
 									{
-										X2MaSmoothMethod.Simple => new SimpleMovingAverage { Length = Math.Max(1, length) },
-										X2MaSmoothMethod.Exponential => new ExponentialMovingAverage { Length = Math.Max(1, length) },
-										X2MaSmoothMethod.Smoothed => new SmoothedMovingAverage { Length = Math.Max(1, length) },
-										X2MaSmoothMethod.Weighted => new WeightedMovingAverage { Length = Math.Max(1, length) },
-										X2MaSmoothMethod.Jurik => CreateJurik(length, phase),
+										X2MaSmoothMethods.Simple => new SimpleMovingAverage { Length = Math.Max(1, length) },
+										X2MaSmoothMethods.Exponential => new ExponentialMovingAverage { Length = Math.Max(1, length) },
+										X2MaSmoothMethods.Smoothed => new SmoothedMovingAverage { Length = Math.Max(1, length) },
+										X2MaSmoothMethods.Weighted => new WeightedMovingAverage { Length = Math.Max(1, length) },
+										X2MaSmoothMethods.Jurik => CreateJurik(length, phase),
 										_ => new SimpleMovingAverage { Length = Math.Max(1, length) }
 									};
 								}
@@ -1112,7 +1112,7 @@ public class ExpSkyscraperFixColorAmlX2MaCandleMmRecStrategy : Strategy
 					}
 
 					/// <summary>Supported smoothing methods for the X2MA candle indicator.</summary>
-					public enum X2MaSmoothMethod
+					public enum X2MaSmoothMethods
 					{
 						/// <summary>Simple moving average.</summary>
 						Simple,

--- a/API/3063_RSI_Expert_TrendFilter/CS/RsiExpertTrendFilterStrategy.cs
+++ b/API/3063_RSI_Expert_TrendFilter/CS/RsiExpertTrendFilterStrategy.cs
@@ -24,7 +24,7 @@ public class RsiExpertTrendFilterStrategy : Strategy
 	private readonly StrategyParam<int> _takeProfitPips;
 	private readonly StrategyParam<int> _trailingStopPips;
 	private readonly StrategyParam<int> _trailingStepPips;
-	private readonly StrategyParam<MoneyManagementMode> _moneyMode;
+	private readonly StrategyParam<MoneyManagementModes> _moneyMode;
 	private readonly StrategyParam<decimal> _volumeOrRiskValue;
 	private readonly StrategyParam<bool> _useMartingale;
 	private readonly StrategyParam<int> _fastMaPeriod;
@@ -32,7 +32,7 @@ public class RsiExpertTrendFilterStrategy : Strategy
 	private readonly StrategyParam<int> _rsiPeriod;
 	private readonly StrategyParam<decimal> _rsiLevelUp;
 	private readonly StrategyParam<decimal> _rsiLevelDown;
-	private readonly StrategyParam<MaTradeMode> _maMode;
+	private readonly StrategyParam<MaTradeModes> _maMode;
 
 	private RelativeStrengthIndex _rsi = null!;
 	private SimpleMovingAverage _fastMa = null!;
@@ -51,7 +51,7 @@ public class RsiExpertTrendFilterStrategy : Strategy
 	/// <summary>
 	/// Money management modes supported by the strategy.
 	/// </summary>
-	public enum MoneyManagementMode
+	public enum MoneyManagementModes
 	{
 		/// <summary>
 		/// Use a fixed volume for every trade.
@@ -67,7 +67,7 @@ public class RsiExpertTrendFilterStrategy : Strategy
 	/// <summary>
 	/// Moving average filter configuration copied from the original EA.
 	/// </summary>
-	public enum MaTradeMode
+	public enum MaTradeModes
 	{
 		/// <summary>
 		/// Ignore the moving average filter.
@@ -113,7 +113,7 @@ public RsiExpertTrendFilterStrategy()
 			.SetDisplay("Trailing Step (pips)", "Additional pips required before trailing moves again", "Risk Management")
 			.SetCanOptimize(true);
 
-		_moneyMode = Param(nameof(MoneyMode), MoneyManagementMode.FixedVolume)
+		_moneyMode = Param(nameof(MoneyMode), MoneyManagementModes.FixedVolume)
 			.SetDisplay("Money Mode", "Choose fixed volume or percent risk sizing", "Money Management");
 
 		_volumeOrRiskValue = Param(nameof(VolumeOrRiskValue), 1m)
@@ -149,7 +149,7 @@ public RsiExpertTrendFilterStrategy()
 			.SetDisplay("RSI Level Down", "Lower RSI threshold for longs", "Indicators")
 			.SetCanOptimize(true);
 
-		_maMode = Param(nameof(MaMode), MaTradeMode.Forward)
+		_maMode = Param(nameof(MaMode), MaTradeModes.Forward)
 			.SetDisplay("MA Trade Mode", "Direction of the moving average confirmation", "Indicators");
 	}
 
@@ -201,14 +201,14 @@ public RsiExpertTrendFilterStrategy()
 	/// <summary>
 	/// Selected money management approach.
 	/// </summary>
-	public MoneyManagementMode MoneyMode
+	public MoneyManagementModes MoneyMode
 	{
 		get => _moneyMode.Value;
 		set => _moneyMode.Value = value;
 	}
 
 	/// <summary>
-	/// Lot size in fixed mode or risk percent when money mode equals <see cref="MoneyManagementMode.RiskPercent"/>.
+	/// Lot size in fixed mode or risk percent when money mode equals <see cref="MoneyManagementModes.RiskPercent"/>.
 	/// </summary>
 	public decimal VolumeOrRiskValue
 	{
@@ -273,7 +273,7 @@ public RsiExpertTrendFilterStrategy()
 	/// <summary>
 	/// Moving average confirmation mode.
 	/// </summary>
-	public MaTradeMode MaMode
+	public MaTradeModes MaMode
 	{
 		get => _maMode.Value;
 		set => _maMode.Value = value;
@@ -357,7 +357,7 @@ public RsiExpertTrendFilterStrategy()
 		var previousRsi = _previousRsi;
 
 		// Wait until indicators have accumulated enough history.
-		if (!_rsi.IsFormed || (MaMode != MaTradeMode.Off && (!_fastMa.IsFormed || !_slowMa.IsFormed)))
+		if (!_rsi.IsFormed || (MaMode != MaTradeModes.Off && (!_fastMa.IsFormed || !_slowMa.IsFormed)))
 		{
 			_previousRsi = currentRsi;
 			return;
@@ -381,13 +381,13 @@ public RsiExpertTrendFilterStrategy()
 		var maSignal = 0;
 		switch (MaMode)
 		{
-			case MaTradeMode.Forward:
+			case MaTradeModes.Forward:
 				if (fastValue > slowValue)
 					maSignal = 1;
 				else if (fastValue < slowValue)
 					maSignal = -1;
 				break;
-			case MaTradeMode.Reverse:
+			case MaTradeModes.Reverse:
 				if (fastValue < slowValue)
 					maSignal = 1;
 				else if (fastValue > slowValue)
@@ -396,9 +396,9 @@ public RsiExpertTrendFilterStrategy()
 		}
 
 		var finalSignal = 0;
-		if (rsiSignal == 1 && (MaMode == MaTradeMode.Off || maSignal == 1))
+		if (rsiSignal == 1 && (MaMode == MaTradeModes.Off || maSignal == 1))
 			finalSignal = 1;
-		else if (rsiSignal == -1 && (MaMode == MaTradeMode.Off || maSignal == -1))
+		else if (rsiSignal == -1 && (MaMode == MaTradeModes.Off || maSignal == -1))
 			finalSignal = -1;
 
 		if (finalSignal > 0 && AllowLong())
@@ -539,7 +539,7 @@ public RsiExpertTrendFilterStrategy()
 
 	private decimal GetOrderVolume()
 	{
-		var volume = MoneyMode == MoneyManagementMode.FixedVolume
+		var volume = MoneyMode == MoneyManagementModes.FixedVolume
 			? VolumeOrRiskValue
 			: CalculateRiskVolume();
 

--- a/API/3067_Exp_Hans_Indicator_Cloud_System_Tm_Plus/CS/ExpHansIndicatorCloudSystemTmPlusStrategy.cs
+++ b/API/3067_Exp_Hans_Indicator_Cloud_System_Tm_Plus/CS/ExpHansIndicatorCloudSystemTmPlusStrategy.cs
@@ -26,7 +26,7 @@ public class ExpHansIndicatorCloudSystemTmPlusStrategy : Strategy
 	private static readonly TimeSpan Session2End = TimeSpan.FromHours(12);
 
 	private readonly StrategyParam<decimal> _moneyManagement;
-	private readonly StrategyParam<MoneyManagementMode> _moneyMode;
+	private readonly StrategyParam<MoneyManagementModes> _moneyMode;
 	private readonly StrategyParam<int> _stopLossPoints;
 	private readonly StrategyParam<int> _takeProfitPoints;
 	private readonly StrategyParam<int> _deviationPoints;
@@ -52,7 +52,7 @@ public class ExpHansIndicatorCloudSystemTmPlusStrategy : Strategy
 	/// Enumeration matching the money management modes of the original expert.
 	/// Currently only the Lot mode is applied; other options are reserved for future extensions.
 	/// </summary>
-	public enum MoneyManagementMode
+	public enum MoneyManagementModes
 	{
 		FreeMargin,
 		Balance,
@@ -73,7 +73,7 @@ public class ExpHansIndicatorCloudSystemTmPlusStrategy : Strategy
 	/// <summary>
 	/// Selected money management interpretation.
 	/// </summary>
-	public MoneyManagementMode MoneyMode
+	public MoneyManagementModes MoneyMode
 	{
 		get => _moneyMode.Value;
 		set => _moneyMode.Value = value;
@@ -226,7 +226,7 @@ public class ExpHansIndicatorCloudSystemTmPlusStrategy : Strategy
 		_moneyManagement = Param(nameof(MoneyManagement), 0.1m)
 		.SetDisplay("Money Management", "Portion of the base volume traded per entry", "Risk");
 
-		_moneyMode = Param(nameof(MoneyMode), MoneyManagementMode.Lot)
+		_moneyMode = Param(nameof(MoneyMode), MoneyManagementModes.Lot)
 		.SetDisplay("Money Mode", "Interpretation of the money management value", "Risk");
 
 		_stopLossPoints = Param(nameof(StopLossPoints), 1000)

--- a/API/3069_Exp_XWPR_Histogram_Vol/CS/ExpXwprHistogramVolStrategy.cs
+++ b/API/3069_Exp_XWPR_Histogram_Vol/CS/ExpXwprHistogramVolStrategy.cs
@@ -31,12 +31,12 @@ public class ExpXwprHistogramVolStrategy : Strategy
 	private readonly StrategyParam<decimal> _deviationSteps;
 	private readonly StrategyParam<int> _signalBar;
 	private readonly StrategyParam<int> _wprPeriod;
-	private readonly StrategyParam<VolumeAggregation> _volumeAggregation;
+	private readonly StrategyParam<VolumeAggregations> _volumeAggregation;
 	private readonly StrategyParam<decimal> _highLevel2;
 	private readonly StrategyParam<decimal> _highLevel1;
 	private readonly StrategyParam<decimal> _lowLevel1;
 	private readonly StrategyParam<decimal> _lowLevel2;
-	private readonly StrategyParam<SmoothMethod> _smoothingMethod;
+	private readonly StrategyParam<SmoothMethods> _smoothingMethod;
 	private readonly StrategyParam<int> _smoothingLength;
 	private readonly StrategyParam<int> _smoothingPhase;
 	private readonly StrategyParam<DataType> _candleType;
@@ -152,7 +152,7 @@ public class ExpXwprHistogramVolStrategy : Strategy
 	/// <summary>
 	/// Volume aggregation used by the histogram (tick count or real volume).
 	/// </summary>
-	public VolumeAggregation VolumeMode
+	public VolumeAggregations VolumeMode
 	{
 		get => _volumeAggregation.Value;
 		set => _volumeAggregation.Value = value;
@@ -197,7 +197,7 @@ public class ExpXwprHistogramVolStrategy : Strategy
 	/// <summary>
 	/// Smoothing method applied to the histogram and the volume baseline.
 	/// </summary>
-	public SmoothMethod SmoothingMethod
+	public SmoothMethods SmoothingMethod
 	{
 		get => _smoothingMethod.Value;
 		set => _smoothingMethod.Value = value;
@@ -280,7 +280,7 @@ public class ExpXwprHistogramVolStrategy : Strategy
 		.SetRange(5, 200)
 		.SetCanOptimize(true);
 
-		_volumeAggregation = Param(nameof(VolumeMode), VolumeAggregation.Tick)
+		_volumeAggregation = Param(nameof(VolumeMode), VolumeAggregations.Tick)
 		.SetDisplay("Volume Mode", "Volume source used in the histogram", "Indicator");
 
 		_highLevel2 = Param(nameof(HighLevel2), 17m)
@@ -303,7 +303,7 @@ public class ExpXwprHistogramVolStrategy : Strategy
 		.SetRange(-100m, 100m)
 		.SetCanOptimize(true);
 
-		_smoothingMethod = Param(nameof(SmoothingMethod), SmoothMethod.Sma)
+		_smoothingMethod = Param(nameof(SmoothingMethod), SmoothMethods.Sma)
 		.SetDisplay("Smoothing Method", "Type of moving average applied", "Indicator");
 
 		_smoothingLength = Param(nameof(SmoothingLength), 12)
@@ -539,7 +539,7 @@ public class ExpXwprHistogramVolStrategy : Strategy
 /// <summary>
 /// Volume aggregation used by <see cref="XwprHistogramVolIndicator"/>.
 /// </summary>
-public enum VolumeAggregation
+public enum VolumeAggregations
 {
 	/// <summary>
 	/// Use the number of ticks traded inside the candle.
@@ -555,7 +555,7 @@ public enum VolumeAggregation
 /// <summary>
 /// Available smoothing methods.
 /// </summary>
-public enum SmoothMethod
+public enum SmoothMethods
 {
 	/// <summary>
 	/// Simple moving average.
@@ -618,7 +618,7 @@ public class XwprHistogramVolIndicator : BaseIndicator<decimal>
 	private IIndicator _volumeSmoother;
 
 	private int _lastPeriod;
-	private SmoothMethod _lastMethod;
+	private SmoothMethods _lastMethod;
 	private int _lastLength;
 	private int _lastPhase;
 
@@ -630,7 +630,7 @@ public class XwprHistogramVolIndicator : BaseIndicator<decimal>
 	/// <summary>
 	/// Volume aggregation used in the histogram.
 	/// </summary>
-	public VolumeAggregation VolumeMode { get; set; } = VolumeAggregation.Tick;
+	public VolumeAggregations VolumeMode { get; set; } = VolumeAggregations.Tick;
 
 	/// <summary>
 	/// Upper histogram multiplier for strong bullish states.
@@ -655,7 +655,7 @@ public class XwprHistogramVolIndicator : BaseIndicator<decimal>
 	/// <summary>
 	/// Smoothing method applied to both the histogram and the baseline volume.
 	/// </summary>
-	public SmoothMethod Method { get; set; } = SmoothMethod.Sma;
+	public SmoothMethods Method { get; set; } = SmoothMethods.Sma;
 
 	/// <summary>
 	/// Length used by the smoothing filters.
@@ -726,8 +726,8 @@ public class XwprHistogramVolIndicator : BaseIndicator<decimal>
 	{
 		return VolumeMode switch
 		{
-			VolumeAggregation.Tick => candle.TotalTicks.HasValue ? candle.TotalTicks.Value : candle.TotalVolume ?? 0m,
-			VolumeAggregation.Real => candle.TotalVolume ?? (candle.TotalTicks.HasValue ? candle.TotalTicks.Value : 0m),
+			VolumeAggregations.Tick => candle.TotalTicks.HasValue ? candle.TotalTicks.Value : candle.TotalVolume ?? 0m,
+			VolumeAggregations.Real => candle.TotalVolume ?? (candle.TotalTicks.HasValue ? candle.TotalTicks.Value : 0m),
 			_ => candle.TotalVolume ?? 0m,
 		};
 	}
@@ -756,16 +756,16 @@ public class XwprHistogramVolIndicator : BaseIndicator<decimal>
 		var length = Math.Max(1, Length);
 		return Method switch
 		{
-			SmoothMethod.Sma => new SimpleMovingAverage { Length = length },
-			SmoothMethod.Ema => new ExponentialMovingAverage { Length = length },
-			SmoothMethod.Smma => new SmoothedMovingAverage { Length = length },
-			SmoothMethod.Lwma => new WeightedMovingAverage { Length = length },
-			SmoothMethod.Jjma => CreateJurik(length),
-			SmoothMethod.JurX => CreateJurik(length),
-			SmoothMethod.ParMa => new ExponentialMovingAverage { Length = length },
-			SmoothMethod.T3 => new TripleExponentialMovingAverage { Length = length },
-			SmoothMethod.Vidya => new ExponentialMovingAverage { Length = length },
-			SmoothMethod.Ama => new KaufmanAdaptiveMovingAverage { Length = length },
+			SmoothMethods.Sma => new SimpleMovingAverage { Length = length },
+			SmoothMethods.Ema => new ExponentialMovingAverage { Length = length },
+			SmoothMethods.Smma => new SmoothedMovingAverage { Length = length },
+			SmoothMethods.Lwma => new WeightedMovingAverage { Length = length },
+			SmoothMethods.Jjma => CreateJurik(length),
+			SmoothMethods.JurX => CreateJurik(length),
+			SmoothMethods.ParMa => new ExponentialMovingAverage { Length = length },
+			SmoothMethods.T3 => new TripleExponentialMovingAverage { Length = length },
+			SmoothMethods.Vidya => new ExponentialMovingAverage { Length = length },
+			SmoothMethods.Ama => new KaufmanAdaptiveMovingAverage { Length = length },
 			_ => new SimpleMovingAverage { Length = length },
 		};
 	}

--- a/API/3070_XWPR_Histogram_Vol_Direct/CS/ExpXwprHistogramVolDirectStrategy.cs
+++ b/API/3070_XWPR_Histogram_Vol_Direct/CS/ExpXwprHistogramVolDirectStrategy.cs
@@ -26,14 +26,14 @@ public class ExpXwprHistogramVolDirectStrategy : Strategy
 	private readonly StrategyParam<int> _highLevel1;
 	private readonly StrategyParam<int> _lowLevel1;
 	private readonly StrategyParam<int> _lowLevel2;
-	private readonly StrategyParam<MovingAverageKind> _smoothingType;
+	private readonly StrategyParam<MovingAverageKinds> _smoothingType;
 	private readonly StrategyParam<int> _smoothingLength;
 	private readonly StrategyParam<int> _signalShift;
 	private readonly StrategyParam<bool> _enableLongEntries;
 	private readonly StrategyParam<bool> _enableShortEntries;
 	private readonly StrategyParam<bool> _enableLongExits;
 	private readonly StrategyParam<bool> _enableShortExits;
-	private readonly StrategyParam<VolumeSource> _volumeSource;
+	private readonly StrategyParam<VolumeSources> _volumeSource;
 	private readonly StrategyParam<int> _stopLossPoints;
 	private readonly StrategyParam<int> _takeProfitPoints;
 	private readonly StrategyParam<DataType> _candleType;
@@ -94,7 +94,7 @@ public class ExpXwprHistogramVolDirectStrategy : Strategy
 	/// <summary>
 	/// Moving average smoothing type.
 	/// </summary>
-	public MovingAverageKind SmoothingType
+	public MovingAverageKinds SmoothingType
 	{
 		get => _smoothingType.Value;
 		set => _smoothingType.Value = value;
@@ -157,7 +157,7 @@ public class ExpXwprHistogramVolDirectStrategy : Strategy
 	/// <summary>
 	/// Volume source used to weight Williams %R values.
 	/// </summary>
-	public VolumeSource VolumeSource
+	public VolumeSources VolumeSources
 	{
 		get => _volumeSource.Value;
 		set => _volumeSource.Value = value;
@@ -216,7 +216,7 @@ public class ExpXwprHistogramVolDirectStrategy : Strategy
 		.SetRange(-200, 200)
 		.SetDisplay("Low Level 2", "Extreme bearish multiplier", "Indicator");
 
-		_smoothingType = Param(nameof(SmoothingType), MovingAverageKind.Simple)
+		_smoothingType = Param(nameof(SmoothingType), MovingAverageKinds.Simple)
 		.SetDisplay("Smoothing Type", "Moving average type used for smoothing", "Indicator");
 
 		_smoothingLength = Param(nameof(SmoothingLength), 12)
@@ -240,7 +240,7 @@ public class ExpXwprHistogramVolDirectStrategy : Strategy
 		_enableShortExits = Param(nameof(EnableShortExits), true)
 		.SetDisplay("Enable Short Exits", "Allow the strategy to close short positions", "Trading Rules");
 
-		_volumeSource = Param(nameof(VolumeSource), VolumeSource.Tick)
+		_volumeSource = Param(nameof(VolumeSources), VolumeSources.Tick)
 		.SetDisplay("Volume Source", "Type of volume used for weighting", "Indicator");
 
 		_stopLossPoints = Param(nameof(StopLossPoints), 1000)
@@ -312,7 +312,7 @@ public class ExpXwprHistogramVolDirectStrategy : Strategy
 		return;
 
 		var time = candle.OpenTime;
-		decimal volume = VolumeSource == VolumeSource.Tick ? candle.TotalTicks : candle.TotalVolume;
+		decimal volume = VolumeSources == VolumeSources.Tick ? candle.TotalTicks : candle.TotalVolume;
 		var weightedValue = (williamsValue + 50m) * volume;
 
 		var valueResult = _valueSmoother.Process(weightedValue, time, true);
@@ -479,18 +479,18 @@ public class ExpXwprHistogramVolDirectStrategy : Strategy
 		return "Neutral";
 	}
 
-	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageKind type, int length)
+	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageKinds type, int length)
 	{
 		return type switch
 		{
-			MovingAverageKind.Simple => new SimpleMovingAverage { Length = length },
-			MovingAverageKind.Exponential => new ExponentialMovingAverage { Length = length },
-			MovingAverageKind.Smoothed => new SmoothedMovingAverage { Length = length },
-			MovingAverageKind.Weighted => new WeightedMovingAverage { Length = length },
-			MovingAverageKind.Hull => new HullMovingAverage { Length = length },
-			MovingAverageKind.VolumeWeighted => new VolumeWeightedMovingAverage { Length = length },
-			MovingAverageKind.DoubleExponential => new DoubleExponentialMovingAverage { Length = length },
-			MovingAverageKind.TripleExponential => new TripleExponentialMovingAverage { Length = length },
+			MovingAverageKinds.Simple => new SimpleMovingAverage { Length = length },
+			MovingAverageKinds.Exponential => new ExponentialMovingAverage { Length = length },
+			MovingAverageKinds.Smoothed => new SmoothedMovingAverage { Length = length },
+			MovingAverageKinds.Weighted => new WeightedMovingAverage { Length = length },
+			MovingAverageKinds.Hull => new HullMovingAverage { Length = length },
+			MovingAverageKinds.VolumeWeighted => new VolumeWeightedMovingAverage { Length = length },
+			MovingAverageKinds.DoubleExponential => new DoubleExponentialMovingAverage { Length = length },
+			MovingAverageKinds.TripleExponential => new TripleExponentialMovingAverage { Length = length },
 			_ => new SimpleMovingAverage { Length = length },
 		};
 	}
@@ -498,7 +498,7 @@ public class ExpXwprHistogramVolDirectStrategy : Strategy
 	/// <summary>
 	/// Supported moving average types.
 	/// </summary>
-	public enum MovingAverageKind
+	public enum MovingAverageKinds
 	{
 		Simple,
 		Exponential,
@@ -513,7 +513,7 @@ public class ExpXwprHistogramVolDirectStrategy : Strategy
 	/// <summary>
 	/// Volume source used to weight Williams %R values.
 	/// </summary>
-	public enum VolumeSource
+	public enum VolumeSources
 	{
 		Tick,
 		Real,

--- a/API/3072_ColorMetroDuplex/CS/ColorMetroDuplexStrategy.cs
+++ b/API/3072_ColorMetroDuplex/CS/ColorMetroDuplexStrategy.cs
@@ -180,8 +180,8 @@ public class ColorMetroDuplexStrategy : Strategy
 		private readonly StrategyParam<decimal> _deviationTicks;
 		private readonly StrategyParam<bool> _openAllowed;
 		private readonly StrategyParam<bool> _closeAllowed;
-		private readonly StrategyParam<MarginMode> _marginMode;
-		private readonly StrategyParam<MetroAppliedPrice> _priceMode;
+		private readonly StrategyParam<MarginModes> _marginMode;
+		private readonly StrategyParam<MetroAppliedPrices> _priceMode;
 
 		private readonly List<decimal> _upHistory = new();
 		private readonly List<decimal> _downHistory = new();
@@ -250,10 +250,10 @@ public class ColorMetroDuplexStrategy : Strategy
 			_closeAllowed = strategy.Param(key + "_CloseAllowed", closeAllowed)
 				.SetDisplay(key + " Close Allowed", "Allow this module to close positions", key);
 
-			_marginMode = strategy.Param(key + "_MarginMode", MarginMode.Lot)
+			_marginMode = strategy.Param(key + "_MarginMode", MarginModes.Lot)
 				.SetDisplay(key + " Margin Mode", "Money management mode (not used in this port)", key);
 
-			_priceMode = strategy.Param(key + "_AppliedPrice", MetroAppliedPrice.Close)
+			_priceMode = strategy.Param(key + "_AppliedPrice", MetroAppliedPrices.Close)
 				.SetDisplay(key + " Price", "Price source for the ColorMETRO calculation", key);
 		}
 
@@ -277,9 +277,9 @@ public class ColorMetroDuplexStrategy : Strategy
 
 		public bool CloseAllowed => _closeAllowed.Value;
 
-		public MarginMode MarginMode => _marginMode.Value;
+		public MarginModes MarginModes => _marginMode.Value;
 
-		public MetroAppliedPrice PriceMode => _priceMode.Value;
+		public MetroAppliedPrices PriceMode => _priceMode.Value;
 
 		public decimal StopLossTicks => _stopLossTicks.Value;
 
@@ -391,7 +391,7 @@ public class ColorMetroDuplexStrategy : Strategy
 	/// <summary>
 	/// Money management modes replicated from the MT5 expert for compatibility.
 	/// </summary>
-	public enum MarginMode
+	public enum MarginModes
 	{
 		FreeMargin = 0,
 		Balance = 1,
@@ -403,7 +403,7 @@ public class ColorMetroDuplexStrategy : Strategy
 	/// <summary>
 	/// Price options supported by the ColorMETRO indicator.
 	/// </summary>
-	public enum MetroAppliedPrice
+	public enum MetroAppliedPrices
 	{
 		Close,
 		Open,
@@ -483,7 +483,7 @@ public sealed class ColorMetroDuplexIndicator : BaseIndicator<ColorMetroDuplexVa
 	/// <summary>
 	/// Price selection mode for RSI input.
 	/// </summary>
-	public ColorMetroDuplexStrategy.MetroAppliedPrice PriceMode { get; set; } = ColorMetroDuplexStrategy.MetroAppliedPrice.Close;
+	public ColorMetroDuplexStrategy.MetroAppliedPrices PriceMode { get; set; } = ColorMetroDuplexStrategy.MetroAppliedPrices.Close;
 
 	/// <inheritdoc />
 	protected override IIndicatorValue OnProcess(IIndicatorValue input)
@@ -582,16 +582,16 @@ public sealed class ColorMetroDuplexIndicator : BaseIndicator<ColorMetroDuplexVa
 		_slowTrend = 0;
 	}
 
-	private static decimal SelectPrice(ICandleMessage candle, ColorMetroDuplexStrategy.MetroAppliedPrice priceMode)
+	private static decimal SelectPrice(ICandleMessage candle, ColorMetroDuplexStrategy.MetroAppliedPrices priceMode)
 	{
 		return priceMode switch
 		{
-			ColorMetroDuplexStrategy.MetroAppliedPrice.Open => candle.OpenPrice,
-			ColorMetroDuplexStrategy.MetroAppliedPrice.High => candle.HighPrice,
-			ColorMetroDuplexStrategy.MetroAppliedPrice.Low => candle.LowPrice,
-			ColorMetroDuplexStrategy.MetroAppliedPrice.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-			ColorMetroDuplexStrategy.MetroAppliedPrice.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-			ColorMetroDuplexStrategy.MetroAppliedPrice.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
+			ColorMetroDuplexStrategy.MetroAppliedPrices.Open => candle.OpenPrice,
+			ColorMetroDuplexStrategy.MetroAppliedPrices.High => candle.HighPrice,
+			ColorMetroDuplexStrategy.MetroAppliedPrices.Low => candle.LowPrice,
+			ColorMetroDuplexStrategy.MetroAppliedPrices.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+			ColorMetroDuplexStrategy.MetroAppliedPrices.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+			ColorMetroDuplexStrategy.MetroAppliedPrices.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
 			_ => candle.ClosePrice,
 		};
 	}

--- a/API/3073_Color_Ma_Rsi_Trigger_Duplex/CS/ColorMaRsiTriggerDuplexStrategy.cs
+++ b/API/3073_Color_Ma_Rsi_Trigger_Duplex/CS/ColorMaRsiTriggerDuplexStrategy.cs
@@ -31,12 +31,12 @@ public class ColorMaRsiTriggerDuplexStrategy : Strategy
 	private readonly StrategyParam<int> _longRsiLongPeriod;
 	private readonly StrategyParam<int> _longMaPeriod;
 	private readonly StrategyParam<int> _longMaLongPeriod;
-	private readonly StrategyParam<AppliedPriceType> _longRsiPrice;
-	private readonly StrategyParam<AppliedPriceType> _longRsiLongPrice;
-	private readonly StrategyParam<AppliedPriceType> _longMaPrice;
-	private readonly StrategyParam<AppliedPriceType> _longMaLongPrice;
-	private readonly StrategyParam<MovingAverageMethod> _longMaType;
-	private readonly StrategyParam<MovingAverageMethod> _longMaLongType;
+	private readonly StrategyParam<AppliedPriceTypes> _longRsiPrice;
+	private readonly StrategyParam<AppliedPriceTypes> _longRsiLongPrice;
+	private readonly StrategyParam<AppliedPriceTypes> _longMaPrice;
+	private readonly StrategyParam<AppliedPriceTypes> _longMaLongPrice;
+	private readonly StrategyParam<MovingAverageMethods> _longMaType;
+	private readonly StrategyParam<MovingAverageMethods> _longMaLongType;
 
 	private readonly StrategyParam<DataType> _shortCandleType;
 	private readonly StrategyParam<decimal> _shortVolume;
@@ -49,12 +49,12 @@ public class ColorMaRsiTriggerDuplexStrategy : Strategy
 	private readonly StrategyParam<int> _shortRsiLongPeriod;
 	private readonly StrategyParam<int> _shortMaPeriod;
 	private readonly StrategyParam<int> _shortMaLongPeriod;
-	private readonly StrategyParam<AppliedPriceType> _shortRsiPrice;
-	private readonly StrategyParam<AppliedPriceType> _shortRsiLongPrice;
-	private readonly StrategyParam<AppliedPriceType> _shortMaPrice;
-	private readonly StrategyParam<AppliedPriceType> _shortMaLongPrice;
-	private readonly StrategyParam<MovingAverageMethod> _shortMaType;
-	private readonly StrategyParam<MovingAverageMethod> _shortMaLongType;
+	private readonly StrategyParam<AppliedPriceTypes> _shortRsiPrice;
+	private readonly StrategyParam<AppliedPriceTypes> _shortRsiLongPrice;
+	private readonly StrategyParam<AppliedPriceTypes> _shortMaPrice;
+	private readonly StrategyParam<AppliedPriceTypes> _shortMaLongPrice;
+	private readonly StrategyParam<MovingAverageMethods> _shortMaType;
+	private readonly StrategyParam<MovingAverageMethods> _shortMaLongType;
 
 	private ColorMaRsiTriggerCalculator _longCalculator = null!;
 	private ColorMaRsiTriggerCalculator _shortCalculator = null!;
@@ -107,22 +107,22 @@ public class ColorMaRsiTriggerDuplexStrategy : Strategy
 			.SetGreaterThanZero()
 			.SetDisplay("Long MA Slow Period", "Slow moving average length for the long block", "Long Block");
 
-		_longRsiPrice = Param(nameof(LongRsiPrice), AppliedPriceType.Weighted)
+		_longRsiPrice = Param(nameof(LongRsiPrice), AppliedPriceTypes.Weighted)
 			.SetDisplay("Long RSI Price", "Price mode fed into the fast RSI", "Long Block");
 
-		_longRsiLongPrice = Param(nameof(LongRsiLongPrice), AppliedPriceType.Median)
+		_longRsiLongPrice = Param(nameof(LongRsiLongPrice), AppliedPriceTypes.Median)
 			.SetDisplay("Long RSI Slow Price", "Price mode fed into the slow RSI", "Long Block");
 
-		_longMaPrice = Param(nameof(LongMaPrice), AppliedPriceType.Close)
+		_longMaPrice = Param(nameof(LongMaPrice), AppliedPriceTypes.Close)
 			.SetDisplay("Long MA Price", "Price mode fed into the fast moving average", "Long Block");
 
-		_longMaLongPrice = Param(nameof(LongMaLongPrice), AppliedPriceType.Close)
+		_longMaLongPrice = Param(nameof(LongMaLongPrice), AppliedPriceTypes.Close)
 			.SetDisplay("Long MA Slow Price", "Price mode fed into the slow moving average", "Long Block");
 
-		_longMaType = Param(nameof(LongMaType), MovingAverageMethod.Exponential)
+		_longMaType = Param(nameof(LongMaType), MovingAverageMethods.Exponential)
 			.SetDisplay("Long MA Type", "Smoothing algorithm for the fast moving average", "Long Block");
 
-		_longMaLongType = Param(nameof(LongMaLongType), MovingAverageMethod.Exponential)
+		_longMaLongType = Param(nameof(LongMaLongType), MovingAverageMethods.Exponential)
 			.SetDisplay("Long MA Slow Type", "Smoothing algorithm for the slow moving average", "Long Block");
 
 		_shortCandleType = Param(nameof(ShortCandleType), TimeSpan.FromHours(4).TimeFrame())
@@ -162,22 +162,22 @@ public class ColorMaRsiTriggerDuplexStrategy : Strategy
 			.SetGreaterThanZero()
 			.SetDisplay("Short MA Slow Period", "Slow moving average length for the short block", "Short Block");
 
-		_shortRsiPrice = Param(nameof(ShortRsiPrice), AppliedPriceType.Weighted)
+		_shortRsiPrice = Param(nameof(ShortRsiPrice), AppliedPriceTypes.Weighted)
 			.SetDisplay("Short RSI Price", "Price mode fed into the fast RSI", "Short Block");
 
-		_shortRsiLongPrice = Param(nameof(ShortRsiLongPrice), AppliedPriceType.Median)
+		_shortRsiLongPrice = Param(nameof(ShortRsiLongPrice), AppliedPriceTypes.Median)
 			.SetDisplay("Short RSI Slow Price", "Price mode fed into the slow RSI", "Short Block");
 
-		_shortMaPrice = Param(nameof(ShortMaPrice), AppliedPriceType.Close)
+		_shortMaPrice = Param(nameof(ShortMaPrice), AppliedPriceTypes.Close)
 			.SetDisplay("Short MA Price", "Price mode fed into the fast moving average", "Short Block");
 
-		_shortMaLongPrice = Param(nameof(ShortMaLongPrice), AppliedPriceType.Close)
+		_shortMaLongPrice = Param(nameof(ShortMaLongPrice), AppliedPriceTypes.Close)
 			.SetDisplay("Short MA Slow Price", "Price mode fed into the slow moving average", "Short Block");
 
-		_shortMaType = Param(nameof(ShortMaType), MovingAverageMethod.Exponential)
+		_shortMaType = Param(nameof(ShortMaType), MovingAverageMethods.Exponential)
 			.SetDisplay("Short MA Type", "Smoothing algorithm for the fast moving average", "Short Block");
 
-		_shortMaLongType = Param(nameof(ShortMaLongType), MovingAverageMethod.Exponential)
+		_shortMaLongType = Param(nameof(ShortMaLongType), MovingAverageMethods.Exponential)
 			.SetDisplay("Short MA Slow Type", "Smoothing algorithm for the slow moving average", "Short Block");
 	}
 	/// <summary>
@@ -282,7 +282,7 @@ public class ColorMaRsiTriggerDuplexStrategy : Strategy
 	/// <summary>
 	/// Price source used by the fast RSI in the long block.
 	/// </summary>
-	public AppliedPriceType LongRsiPrice
+	public AppliedPriceTypes LongRsiPrice
 	{
 		get => _longRsiPrice.Value;
 		set => _longRsiPrice.Value = value;
@@ -291,7 +291,7 @@ public class ColorMaRsiTriggerDuplexStrategy : Strategy
 	/// <summary>
 	/// Price source used by the slow RSI in the long block.
 	/// </summary>
-	public AppliedPriceType LongRsiLongPrice
+	public AppliedPriceTypes LongRsiLongPrice
 	{
 		get => _longRsiLongPrice.Value;
 		set => _longRsiLongPrice.Value = value;
@@ -300,7 +300,7 @@ public class ColorMaRsiTriggerDuplexStrategy : Strategy
 	/// <summary>
 	/// Price source used by the fast moving average in the long block.
 	/// </summary>
-	public AppliedPriceType LongMaPrice
+	public AppliedPriceTypes LongMaPrice
 	{
 		get => _longMaPrice.Value;
 		set => _longMaPrice.Value = value;
@@ -309,7 +309,7 @@ public class ColorMaRsiTriggerDuplexStrategy : Strategy
 	/// <summary>
 	/// Price source used by the slow moving average in the long block.
 	/// </summary>
-	public AppliedPriceType LongMaLongPrice
+	public AppliedPriceTypes LongMaLongPrice
 	{
 		get => _longMaLongPrice.Value;
 		set => _longMaLongPrice.Value = value;
@@ -318,7 +318,7 @@ public class ColorMaRsiTriggerDuplexStrategy : Strategy
 	/// <summary>
 	/// Moving average method applied to the fast moving average in the long block.
 	/// </summary>
-	public MovingAverageMethod LongMaType
+	public MovingAverageMethods LongMaType
 	{
 		get => _longMaType.Value;
 		set => _longMaType.Value = value;
@@ -327,7 +327,7 @@ public class ColorMaRsiTriggerDuplexStrategy : Strategy
 	/// <summary>
 	/// Moving average method applied to the slow moving average in the long block.
 	/// </summary>
-	public MovingAverageMethod LongMaLongType
+	public MovingAverageMethods LongMaLongType
 	{
 		get => _longMaLongType.Value;
 		set => _longMaLongType.Value = value;
@@ -435,7 +435,7 @@ public class ColorMaRsiTriggerDuplexStrategy : Strategy
 	/// <summary>
 	/// Price source used by the fast RSI in the short block.
 	/// </summary>
-	public AppliedPriceType ShortRsiPrice
+	public AppliedPriceTypes ShortRsiPrice
 	{
 		get => _shortRsiPrice.Value;
 		set => _shortRsiPrice.Value = value;
@@ -444,7 +444,7 @@ public class ColorMaRsiTriggerDuplexStrategy : Strategy
 	/// <summary>
 	/// Price source used by the slow RSI in the short block.
 	/// </summary>
-	public AppliedPriceType ShortRsiLongPrice
+	public AppliedPriceTypes ShortRsiLongPrice
 	{
 		get => _shortRsiLongPrice.Value;
 		set => _shortRsiLongPrice.Value = value;
@@ -453,7 +453,7 @@ public class ColorMaRsiTriggerDuplexStrategy : Strategy
 	/// <summary>
 	/// Price source used by the fast moving average in the short block.
 	/// </summary>
-	public AppliedPriceType ShortMaPrice
+	public AppliedPriceTypes ShortMaPrice
 	{
 		get => _shortMaPrice.Value;
 		set => _shortMaPrice.Value = value;
@@ -462,7 +462,7 @@ public class ColorMaRsiTriggerDuplexStrategy : Strategy
 	/// <summary>
 	/// Price source used by the slow moving average in the short block.
 	/// </summary>
-	public AppliedPriceType ShortMaLongPrice
+	public AppliedPriceTypes ShortMaLongPrice
 	{
 		get => _shortMaLongPrice.Value;
 		set => _shortMaLongPrice.Value = value;
@@ -471,7 +471,7 @@ public class ColorMaRsiTriggerDuplexStrategy : Strategy
 	/// <summary>
 	/// Moving average method applied to the fast moving average in the short block.
 	/// </summary>
-	public MovingAverageMethod ShortMaType
+	public MovingAverageMethods ShortMaType
 	{
 		get => _shortMaType.Value;
 		set => _shortMaType.Value = value;
@@ -480,7 +480,7 @@ public class ColorMaRsiTriggerDuplexStrategy : Strategy
 	/// <summary>
 	/// Moving average method applied to the slow moving average in the short block.
 	/// </summary>
-	public MovingAverageMethod ShortMaLongType
+	public MovingAverageMethods ShortMaLongType
 	{
 		get => _shortMaLongType.Value;
 		set => _shortMaLongType.Value = value;
@@ -712,29 +712,29 @@ public class ColorMaRsiTriggerDuplexStrategy : Strategy
 			history.RemoveAt(history.Count - 1);
 	}
 
-	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageMethod method, int length)
+	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageMethods method, int length)
 	{
 		return method switch
 		{
-			MovingAverageMethod.Simple => new SimpleMovingAverage { Length = length },
-			MovingAverageMethod.Exponential => new ExponentialMovingAverage { Length = length },
-			MovingAverageMethod.Smoothed => new SmoothedMovingAverage { Length = length },
-			MovingAverageMethod.Weighted => new WeightedMovingAverage { Length = length },
+			MovingAverageMethods.Simple => new SimpleMovingAverage { Length = length },
+			MovingAverageMethods.Exponential => new ExponentialMovingAverage { Length = length },
+			MovingAverageMethods.Smoothed => new SmoothedMovingAverage { Length = length },
+			MovingAverageMethods.Weighted => new WeightedMovingAverage { Length = length },
 			_ => new SimpleMovingAverage { Length = length },
 		};
 	}
 
-	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPriceType priceType)
+	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPriceTypes priceType)
 	{
 		return priceType switch
 		{
-			AppliedPriceType.Close => candle.ClosePrice,
-			AppliedPriceType.Open => candle.OpenPrice,
-			AppliedPriceType.High => candle.HighPrice,
-			AppliedPriceType.Low => candle.LowPrice,
-			AppliedPriceType.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-			AppliedPriceType.Typical => (candle.ClosePrice + candle.HighPrice + candle.LowPrice) / 3m,
-			AppliedPriceType.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice * 2m) / 4m,
+			AppliedPriceTypes.Close => candle.ClosePrice,
+			AppliedPriceTypes.Open => candle.OpenPrice,
+			AppliedPriceTypes.High => candle.HighPrice,
+			AppliedPriceTypes.Low => candle.LowPrice,
+			AppliedPriceTypes.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+			AppliedPriceTypes.Typical => (candle.ClosePrice + candle.HighPrice + candle.LowPrice) / 3m,
+			AppliedPriceTypes.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice * 2m) / 4m,
 			_ => candle.ClosePrice,
 		};
 	}
@@ -742,7 +742,7 @@ public class ColorMaRsiTriggerDuplexStrategy : Strategy
 	/// <summary>
 	/// Supported moving average smoothing algorithms.
 	/// </summary>
-	public enum MovingAverageMethod
+	public enum MovingAverageMethods
 	{
 		/// <summary>Simple moving average.</summary>
 		Simple,
@@ -757,7 +757,7 @@ public class ColorMaRsiTriggerDuplexStrategy : Strategy
 	/// <summary>
 	/// Price selection modes compatible with MetaTrader's ENUM_APPLIED_PRICE.
 	/// </summary>
-	public enum AppliedPriceType
+	public enum AppliedPriceTypes
 	{
 		/// <summary>Use the candle close price.</summary>
 		Close,
@@ -781,20 +781,20 @@ public class ColorMaRsiTriggerDuplexStrategy : Strategy
 		private readonly LengthIndicator<decimal> _slowMa;
 		private readonly RelativeStrengthIndex _fastRsi;
 		private readonly RelativeStrengthIndex _slowRsi;
-		private readonly AppliedPriceType _fastMaPrice;
-		private readonly AppliedPriceType _slowMaPrice;
-		private readonly AppliedPriceType _fastRsiPrice;
-		private readonly AppliedPriceType _slowRsiPrice;
+		private readonly AppliedPriceTypes _fastMaPrice;
+		private readonly AppliedPriceTypes _slowMaPrice;
+		private readonly AppliedPriceTypes _fastRsiPrice;
+		private readonly AppliedPriceTypes _slowRsiPrice;
 
 		public ColorMaRsiTriggerCalculator(
 			LengthIndicator<decimal> fastMa,
 			LengthIndicator<decimal> slowMa,
 			RelativeStrengthIndex fastRsi,
 			RelativeStrengthIndex slowRsi,
-			AppliedPriceType fastMaPrice,
-			AppliedPriceType slowMaPrice,
-			AppliedPriceType fastRsiPrice,
-			AppliedPriceType slowRsiPrice)
+			AppliedPriceTypes fastMaPrice,
+			AppliedPriceTypes slowMaPrice,
+			AppliedPriceTypes fastRsiPrice,
+			AppliedPriceTypes slowRsiPrice)
 		{
 			_fastMa = fastMa ?? throw new ArgumentNullException(nameof(fastMa));
 			_slowMa = slowMa ?? throw new ArgumentNullException(nameof(slowMa));

--- a/API/3074_Adaptive_Renko_Duplex/CS/AdaptiveRenkoDuplexStrategy.cs
+++ b/API/3074_Adaptive_Renko_Duplex/CS/AdaptiveRenkoDuplexStrategy.cs
@@ -23,14 +23,14 @@ public class AdaptiveRenkoDuplexStrategy : Strategy
 {
 	private readonly StrategyParam<DataType> _longCandleType;
 	private readonly StrategyParam<DataType> _shortCandleType;
-	private readonly StrategyParam<AdaptiveRenkoVolatilityMode> _longVolatilityMode;
-	private readonly StrategyParam<AdaptiveRenkoVolatilityMode> _shortVolatilityMode;
+	private readonly StrategyParam<AdaptiveRenkoVolatilityModes> _longVolatilityMode;
+	private readonly StrategyParam<AdaptiveRenkoVolatilityModes> _shortVolatilityMode;
 	private readonly StrategyParam<int> _longVolatilityPeriod;
 	private readonly StrategyParam<int> _shortVolatilityPeriod;
 	private readonly StrategyParam<decimal> _longSensitivity;
 	private readonly StrategyParam<decimal> _shortSensitivity;
-	private readonly StrategyParam<AdaptiveRenkoPriceMode> _longPriceMode;
-	private readonly StrategyParam<AdaptiveRenkoPriceMode> _shortPriceMode;
+	private readonly StrategyParam<AdaptiveRenkoPriceModes> _longPriceMode;
+	private readonly StrategyParam<AdaptiveRenkoPriceModes> _shortPriceMode;
 	private readonly StrategyParam<decimal> _longMinimumBrickPoints;
 	private readonly StrategyParam<decimal> _shortMinimumBrickPoints;
 	private readonly StrategyParam<int> _longSignalBarOffset;
@@ -58,10 +58,10 @@ public class AdaptiveRenkoDuplexStrategy : Strategy
 		_shortCandleType = Param(nameof(ShortCandleType), TimeSpan.FromHours(4).TimeFrame())
 			.SetDisplay("Short Candle Type", "Timeframe used to derive short-side signals", "Short Side");
 
-		_longVolatilityMode = Param(nameof(LongVolatilityMode), AdaptiveRenkoVolatilityMode.AverageTrueRange)
+		_longVolatilityMode = Param(nameof(LongVolatilityMode), AdaptiveRenkoVolatilityModes.AverageTrueRange)
 			.SetDisplay("Long Volatility Source", "Volatility measure controlling long Renko brick size", "Long Side");
 
-		_shortVolatilityMode = Param(nameof(ShortVolatilityMode), AdaptiveRenkoVolatilityMode.AverageTrueRange)
+		_shortVolatilityMode = Param(nameof(ShortVolatilityMode), AdaptiveRenkoVolatilityModes.AverageTrueRange)
 			.SetDisplay("Short Volatility Source", "Volatility measure controlling short Renko brick size", "Short Side");
 
 		_longVolatilityPeriod = Param(nameof(LongVolatilityPeriod), 10)
@@ -84,10 +84,10 @@ public class AdaptiveRenkoDuplexStrategy : Strategy
 			.SetDisplay("Short Sensitivity", "Multiplier applied to volatility for short bricks", "Short Side")
 			.SetCanOptimize(true);
 
-		_longPriceMode = Param(nameof(LongPriceMode), AdaptiveRenkoPriceMode.Close)
+		_longPriceMode = Param(nameof(LongPriceMode), AdaptiveRenkoPriceModes.Close)
 			.SetDisplay("Long Price Mode", "Price source used when building long bricks", "Long Side");
 
-		_shortPriceMode = Param(nameof(ShortPriceMode), AdaptiveRenkoPriceMode.Close)
+		_shortPriceMode = Param(nameof(ShortPriceMode), AdaptiveRenkoPriceModes.Close)
 			.SetDisplay("Short Price Mode", "Price source used when building short bricks", "Short Side");
 
 		_longMinimumBrickPoints = Param(nameof(LongMinimumBrickPoints), 2m)
@@ -156,7 +156,7 @@ public class AdaptiveRenkoDuplexStrategy : Strategy
 	/// <summary>
 	/// Volatility mode for the long Renko stream.
 	/// </summary>
-	public AdaptiveRenkoVolatilityMode LongVolatilityMode
+	public AdaptiveRenkoVolatilityModes LongVolatilityMode
 	{
 		get => _longVolatilityMode.Value;
 		set => _longVolatilityMode.Value = value;
@@ -165,7 +165,7 @@ public class AdaptiveRenkoDuplexStrategy : Strategy
 	/// <summary>
 	/// Volatility mode for the short Renko stream.
 	/// </summary>
-	public AdaptiveRenkoVolatilityMode ShortVolatilityMode
+	public AdaptiveRenkoVolatilityModes ShortVolatilityMode
 	{
 		get => _shortVolatilityMode.Value;
 		set => _shortVolatilityMode.Value = value;
@@ -210,7 +210,7 @@ public class AdaptiveRenkoDuplexStrategy : Strategy
 	/// <summary>
 	/// Price source used while building long bricks.
 	/// </summary>
-	public AdaptiveRenkoPriceMode LongPriceMode
+	public AdaptiveRenkoPriceModes LongPriceMode
 	{
 		get => _longPriceMode.Value;
 		set => _longPriceMode.Value = value;
@@ -219,7 +219,7 @@ public class AdaptiveRenkoDuplexStrategy : Strategy
 	/// <summary>
 	/// Price source used while building short bricks.
 	/// </summary>
-	public AdaptiveRenkoPriceMode ShortPriceMode
+	public AdaptiveRenkoPriceModes ShortPriceMode
 	{
 		get => _shortPriceMode.Value;
 		set => _shortPriceMode.Value = value;
@@ -406,7 +406,7 @@ public class AdaptiveRenkoDuplexStrategy : Strategy
 		if (signal == null)
 			return;
 
-		if (LongExitsEnabled && Position > 0 && signal.Value.Trend == RenkoTrend.Down)
+		if (LongExitsEnabled && Position > 0 && signal.Value.Trend == RenkoTrends.Down)
 		{
 			TryCloseLong("Adaptive Renko bearish reversal", candle);
 		}
@@ -414,7 +414,7 @@ public class AdaptiveRenkoDuplexStrategy : Strategy
 		if (!IsFormedAndOnlineAndAllowTrading())
 			return;
 
-		if (LongEntriesEnabled && signal.Value.Trend == RenkoTrend.Up)
+		if (LongEntriesEnabled && signal.Value.Trend == RenkoTrends.Up)
 		{
 			TryOpenLong(candle, signal.Value);
 		}
@@ -441,7 +441,7 @@ public class AdaptiveRenkoDuplexStrategy : Strategy
 		if (signal == null)
 			return;
 
-		if (ShortExitsEnabled && Position < 0 && signal.Value.Trend == RenkoTrend.Up)
+		if (ShortExitsEnabled && Position < 0 && signal.Value.Trend == RenkoTrends.Up)
 		{
 			TryCloseShort("Adaptive Renko bullish reversal", candle);
 		}
@@ -449,7 +449,7 @@ public class AdaptiveRenkoDuplexStrategy : Strategy
 		if (!IsFormedAndOnlineAndAllowTrading())
 			return;
 
-		if (ShortEntriesEnabled && signal.Value.Trend == RenkoTrend.Down)
+		if (ShortEntriesEnabled && signal.Value.Trend == RenkoTrends.Down)
 		{
 			TryOpenShort(candle, signal.Value);
 		}
@@ -583,12 +583,12 @@ public class AdaptiveRenkoDuplexStrategy : Strategy
 		LogInfo($"Short exit: {reason} at {candle.ClosePrice:F5}.");
 	}
 
-	private static IIndicator CreateVolatilityIndicator(AdaptiveRenkoVolatilityMode mode, int period)
+	private static IIndicator CreateVolatilityIndicator(AdaptiveRenkoVolatilityModes mode, int period)
 	{
 		return mode switch
 		{
-			AdaptiveRenkoVolatilityMode.AverageTrueRange => new AverageTrueRange { Length = period },
-			AdaptiveRenkoVolatilityMode.StandardDeviation => new StandardDeviation { Length = period },
+			AdaptiveRenkoVolatilityModes.AverageTrueRange => new AverageTrueRange { Length = period },
+			AdaptiveRenkoVolatilityModes.StandardDeviation => new StandardDeviation { Length = period },
 			_ => throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unsupported volatility mode"),
 		};
 	}
@@ -608,7 +608,7 @@ public class AdaptiveRenkoDuplexStrategy : Strategy
 		return 1m;
 	}
 
-	private enum RenkoTrend
+	private enum RenkoTrends
 	{
 		None = 0,
 		Up = 1,
@@ -617,7 +617,7 @@ public class AdaptiveRenkoDuplexStrategy : Strategy
 
 	private readonly struct RenkoSnapshot
 	{
-		public RenkoSnapshot(DateTimeOffset time, RenkoTrend trend, decimal? support, decimal? resistance)
+		public RenkoSnapshot(DateTimeOffset time, RenkoTrends trend, decimal? support, decimal? resistance)
 		{
 			Time = time;
 			Trend = trend;
@@ -627,7 +627,7 @@ public class AdaptiveRenkoDuplexStrategy : Strategy
 
 		public DateTimeOffset Time { get; }
 
-		public RenkoTrend Trend { get; }
+		public RenkoTrends Trend { get; }
 
 		public decimal? Support { get; }
 
@@ -641,11 +641,11 @@ public class AdaptiveRenkoDuplexStrategy : Strategy
 		private decimal _up;
 		private decimal _down;
 		private decimal _brick;
-		private RenkoTrend _trend;
+		private RenkoTrends _trend;
 
-		public RenkoSnapshot? Process(ICandleMessage candle, decimal volatility, decimal sensitivity, decimal minimumBrickPoints, AdaptiveRenkoPriceMode priceMode, int signalOffset, decimal step)
+		public RenkoSnapshot? Process(ICandleMessage candle, decimal volatility, decimal sensitivity, decimal minimumBrickPoints, AdaptiveRenkoPriceModes priceMode, int signalOffset, decimal step)
 		{
-			var (high, low) = priceMode == AdaptiveRenkoPriceMode.Close
+			var (high, low) = priceMode == AdaptiveRenkoPriceModes.Close
 				? (candle.ClosePrice, candle.ClosePrice)
 				: (candle.HighPrice, candle.LowPrice);
 
@@ -659,10 +659,10 @@ public class AdaptiveRenkoDuplexStrategy : Strategy
 				_up = high;
 				_down = low;
 				_brick = initialBrick > 0m ? initialBrick : minBrick;
-				_trend = RenkoTrend.None;
+				_trend = RenkoTrends.None;
 				_initialized = true;
 
-				var initialSnapshot = new RenkoSnapshot(GetCandleTime(candle), RenkoTrend.None, null, null);
+				var initialSnapshot = new RenkoSnapshot(GetCandleTime(candle), RenkoTrends.None, null, null);
 				AppendSnapshot(initialSnapshot, signalOffset);
 				return initialSnapshot;
 			}
@@ -718,18 +718,18 @@ public class AdaptiveRenkoDuplexStrategy : Strategy
 			}
 
 			if (_up < up)
-				trend = RenkoTrend.Up;
+				trend = RenkoTrends.Up;
 
 			if (_down > down)
-				trend = RenkoTrend.Down;
+				trend = RenkoTrends.Down;
 
 			_up = up;
 			_down = down;
 			_brick = brick;
 			_trend = trend;
 
-			var support = trend == RenkoTrend.Up ? down - brick : (decimal?)null;
-			var resistance = trend == RenkoTrend.Down ? up + brick : (decimal?)null;
+			var support = trend == RenkoTrends.Up ? down - brick : (decimal?)null;
+			var resistance = trend == RenkoTrends.Down ? up + brick : (decimal?)null;
 
 			var snapshot = new RenkoSnapshot(GetCandleTime(candle), trend, support, resistance);
 			AppendSnapshot(snapshot, signalOffset);
@@ -755,7 +755,7 @@ public class AdaptiveRenkoDuplexStrategy : Strategy
 			_up = 0m;
 			_down = 0m;
 			_brick = 0m;
-			_trend = RenkoTrend.None;
+			_trend = RenkoTrends.None;
 		}
 
 		private void AppendSnapshot(RenkoSnapshot snapshot, int signalOffset)
@@ -776,13 +776,13 @@ public class AdaptiveRenkoDuplexStrategy : Strategy
 		}
 	}
 
-	public enum AdaptiveRenkoVolatilityMode
+	public enum AdaptiveRenkoVolatilityModes
 	{
 		AverageTrueRange,
 		StandardDeviation
 	}
 
-	public enum AdaptiveRenkoPriceMode
+	public enum AdaptiveRenkoPriceModes
 	{
 		HighLow,
 		Close

--- a/API/3076_Three_Indicators/CS/ThreeIndicatorsStrategy.cs
+++ b/API/3076_Three_Indicators/CS/ThreeIndicatorsStrategy.cs
@@ -27,12 +27,12 @@ public class ThreeIndicatorsStrategy : Strategy
 	private readonly StrategyParam<int> _macdFastPeriod;
 	private readonly StrategyParam<int> _macdSlowPeriod;
 	private readonly StrategyParam<int> _macdSignalPeriod;
-	private readonly StrategyParam<IndicatorAppliedPrice> _macdPriceType;
+	private readonly StrategyParam<IndicatorAppliedPrices> _macdPriceType;
 	private readonly StrategyParam<int> _stochasticKPeriod;
 	private readonly StrategyParam<int> _stochasticDPeriod;
 	private readonly StrategyParam<int> _stochasticSlowing;
 	private readonly StrategyParam<int> _rsiPeriod;
-	private readonly StrategyParam<IndicatorAppliedPrice> _rsiPriceType;
+	private readonly StrategyParam<IndicatorAppliedPrices> _rsiPriceType;
 
 	private MovingAverageConvergenceDivergenceSignal _macd = null!;
 	private StochasticOscillator _stochastic = null!;
@@ -62,7 +62,7 @@ public class ThreeIndicatorsStrategy : Strategy
 			.SetGreaterThanZero()
 			.SetDisplay("MACD signal EMA", "Signal smoothing length for the MACD line.", "MACD");
 
-		_macdPriceType = Param(nameof(MacdPriceType), IndicatorAppliedPrice.Close)
+		_macdPriceType = Param(nameof(MacdPriceType), IndicatorAppliedPrices.Close)
 			.SetDisplay("MACD price", "Applied price used when feeding data into MACD.", "MACD");
 
 		_stochasticKPeriod = Param(nameof(StochasticKPeriod), 40)
@@ -81,7 +81,7 @@ public class ThreeIndicatorsStrategy : Strategy
 			.SetGreaterThanZero()
 			.SetDisplay("RSI period", "Averaging length for the RSI filter.", "RSI");
 
-		_rsiPriceType = Param(nameof(RsiPriceType), IndicatorAppliedPrice.Close)
+		_rsiPriceType = Param(nameof(RsiPriceType), IndicatorAppliedPrices.Close)
 			.SetDisplay("RSI price", "Applied price used by the RSI filter.", "RSI");
 	}
 
@@ -133,7 +133,7 @@ public class ThreeIndicatorsStrategy : Strategy
 	/// <summary>
 	/// Applied price used for feeding MACD.
 	/// </summary>
-	public IndicatorAppliedPrice MacdPriceType
+	public IndicatorAppliedPrices MacdPriceType
 	{
 		get => _macdPriceType.Value;
 		set => _macdPriceType.Value = value;
@@ -178,7 +178,7 @@ public class ThreeIndicatorsStrategy : Strategy
 	/// <summary>
 	/// Applied price used for the RSI calculation.
 	/// </summary>
-	public IndicatorAppliedPrice RsiPriceType
+	public IndicatorAppliedPrices RsiPriceType
 	{
 		get => _rsiPriceType.Value;
 		set => _rsiPriceType.Value = value;
@@ -374,22 +374,22 @@ public class ThreeIndicatorsStrategy : Strategy
 		return 0;
 	}
 
-	private static decimal GetAppliedPrice(ICandleMessage candle, IndicatorAppliedPrice priceType)
+	private static decimal GetAppliedPrice(ICandleMessage candle, IndicatorAppliedPrices priceType)
 	{
 		return priceType switch
 		{
-			IndicatorAppliedPrice.Open => candle.OpenPrice,
-			IndicatorAppliedPrice.High => candle.HighPrice,
-			IndicatorAppliedPrice.Low => candle.LowPrice,
-			IndicatorAppliedPrice.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-			IndicatorAppliedPrice.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-			IndicatorAppliedPrice.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice + candle.ClosePrice) / 4m,
+			IndicatorAppliedPrices.Open => candle.OpenPrice,
+			IndicatorAppliedPrices.High => candle.HighPrice,
+			IndicatorAppliedPrices.Low => candle.LowPrice,
+			IndicatorAppliedPrices.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+			IndicatorAppliedPrices.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+			IndicatorAppliedPrices.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice + candle.ClosePrice) / 4m,
 			_ => candle.ClosePrice
 		};
 	}
 }
 
-public enum IndicatorAppliedPrice
+public enum IndicatorAppliedPrices
 {
 	Close,
 	Open,

--- a/API/3078_MAMy_Expert/CS/MamyExpertStrategy.cs
+++ b/API/3078_MAMy_Expert/CS/MamyExpertStrategy.cs
@@ -20,7 +20,7 @@ public class MamyExpertStrategy : Strategy
 {
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<int> _maPeriod;
-	private readonly StrategyParam<MaCalculationType> _maType;
+	private readonly StrategyParam<MaCalculationTypes> _maType;
 	private readonly StrategyParam<decimal> _tradeVolume;
 
 	private LengthIndicator<decimal> _closeMa;
@@ -42,7 +42,7 @@ public class MamyExpertStrategy : Strategy
 			.SetGreaterThanZero()
 			.SetDisplay("MA period", "Length applied to all moving averages.", "Indicator");
 
-		_maType = Param(nameof(MaType), MaCalculationType.Weighted)
+		_maType = Param(nameof(MaType), MaCalculationTypes.Weighted)
 			.SetDisplay("MA method", "Averaging algorithm applied to open/close/weighted prices.", "Indicator");
 
 		_tradeVolume = Param(nameof(TradeVolume), 1m)
@@ -62,7 +62,7 @@ public class MamyExpertStrategy : Strategy
 		set => _maPeriod.Value = value;
 	}
 
-	public MaCalculationType MaType
+	public MaCalculationTypes MaType
 	{
 		get => _maType.Value;
 		set => _maType.Value = value;
@@ -226,19 +226,19 @@ public class MamyExpertStrategy : Strategy
 		return (candle.HighPrice + candle.LowPrice + candle.ClosePrice * 2m) / 4m;
 	}
 
-	private static LengthIndicator<decimal> CreateMovingAverage(MaCalculationType type, int length)
+	private static LengthIndicator<decimal> CreateMovingAverage(MaCalculationTypes type, int length)
 	{
 		return type switch
 		{
-			MaCalculationType.Simple => new SimpleMovingAverage { Length = length },
-			MaCalculationType.Exponential => new ExponentialMovingAverage { Length = length },
-			MaCalculationType.Smoothed => new SmoothedMovingAverage { Length = length },
+			MaCalculationTypes.Simple => new SimpleMovingAverage { Length = length },
+			MaCalculationTypes.Exponential => new ExponentialMovingAverage { Length = length },
+			MaCalculationTypes.Smoothed => new SmoothedMovingAverage { Length = length },
 			_ => new WeightedMovingAverage { Length = length },
 		};
 	}
 }
 
-public enum MaCalculationType
+public enum MaCalculationTypes
 {
 	Simple,
 	Exponential,

--- a/API/3079_Constituents_EA/CS/ConstituentsEAStrategy.cs
+++ b/API/3079_Constituents_EA/CS/ConstituentsEAStrategy.cs
@@ -21,7 +21,7 @@ public class ConstituentsEaStrategy : Strategy
 {
 	private readonly StrategyParam<int> _startHour;
 	private readonly StrategyParam<int> _searchDepth;
-	private readonly StrategyParam<OrderMode> _orderMode;
+	private readonly StrategyParam<OrderModes> _orderMode;
 	private readonly StrategyParam<decimal> _stopLossPips;
 	private readonly StrategyParam<decimal> _takeProfitPips;
 	private readonly StrategyParam<decimal> _pointValue;
@@ -40,7 +40,7 @@ public class ConstituentsEaStrategy : Strategy
 	/// <summary>
 	/// Type of pending order to place when the entry conditions are met.
 	/// </summary>
-	public enum OrderMode
+	public enum OrderModes
 	{
 		/// <summary>
 		/// Place limit orders at the identified support and resistance levels.
@@ -67,7 +67,7 @@ public class ConstituentsEaStrategy : Strategy
 			.SetDisplay("Search Depth", "Number of completed candles used to find extremes", "Setup")
 			.SetCanOptimize(true);
 
-		_orderMode = Param(nameof(PendingOrderMode), OrderMode.Limit)
+		_orderMode = Param(nameof(PendingOrderMode), OrderModes.Limit)
 			.SetDisplay("Order Type", "Pending order style (limit or stop)", "Setup");
 
 		_stopLossPips = Param(nameof(StopLossPips), 0m)
@@ -115,7 +115,7 @@ public class ConstituentsEaStrategy : Strategy
 	/// <summary>
 	/// Pending order style (limit or stop).
 	/// </summary>
-	public OrderMode PendingOrderMode
+	public OrderModes PendingOrderMode
 	{
 		get => _orderMode.Value;
 		set => _orderMode.Value = value;
@@ -274,7 +274,7 @@ public class ConstituentsEaStrategy : Strategy
 		var referenceBid = _bestBid > 0m ? _bestBid : candle.ClosePrice;
 		var referenceAsk = _bestAsk > 0m ? _bestAsk : candle.ClosePrice;
 
-		if (PendingOrderMode == OrderMode.Limit)
+		if (PendingOrderMode == OrderModes.Limit)
 		{
 			TryPlaceBuyLimit(lowValue, referenceBid, minOrderDistance);
 			TryPlaceSellLimit(highValue, referenceAsk, minOrderDistance);

--- a/API/3080_Exp_XBullsBearsEyes_Vol/CS/ExpXBullsBearsEyesVolStrategy.cs
+++ b/API/3080_Exp_XBullsBearsEyes_Vol/CS/ExpXBullsBearsEyesVolStrategy.cs
@@ -37,12 +37,12 @@ public class ExpXBullsBearsEyesVolStrategy : Strategy
 
 	private readonly StrategyParam<int> _indicatorPeriod;
 	private readonly StrategyParam<decimal> _gamma;
-	private readonly StrategyParam<AppliedVolume> _volumeType;
+	private readonly StrategyParam<AppliedVolumes> _volumeType;
 	private readonly StrategyParam<int> _highLevel2;
 	private readonly StrategyParam<int> _highLevel1;
 	private readonly StrategyParam<int> _lowLevel1;
 	private readonly StrategyParam<int> _lowLevel2;
-	private readonly StrategyParam<SmoothMethod> _smoothMethod;
+	private readonly StrategyParam<SmoothMethods> _smoothMethod;
 	private readonly StrategyParam<int> _smoothLength;
 	private readonly StrategyParam<int> _smoothPhase;
 	private readonly StrategyParam<int> _signalBar;
@@ -104,7 +104,7 @@ public class ExpXBullsBearsEyesVolStrategy : Strategy
 		_gamma = Param(nameof(Gamma), 0.6m)
 		.SetDisplay("Gamma", "Adaptive smoothing factor used by the four-stage filter", "Indicator");
 
-		_volumeType = Param(nameof(VolumeType), AppliedVolume.Tick)
+		_volumeType = Param(nameof(VolumeType), AppliedVolumes.Tick)
 		.SetDisplay("Volume Type", "Volume source multiplied by the indicator", "Indicator");
 
 		_highLevel2 = Param(nameof(HighLevel2), 25)
@@ -119,7 +119,7 @@ public class ExpXBullsBearsEyesVolStrategy : Strategy
 		_lowLevel2 = Param(nameof(LowLevel2), -25)
 		.SetDisplay("Low Level 2", "Lower level that marks strong bearish pressure", "Indicator");
 
-		_smoothMethod = Param(nameof(SmoothingMethod), SmoothMethod.Sma)
+		_smoothMethod = Param(nameof(SmoothingMethod), SmoothMethods.Sma)
 		.SetDisplay("Smoothing Method", "Moving average used for indicator smoothing", "Indicator");
 
 		_smoothLength = Param(nameof(SmoothingLength), 12)
@@ -236,7 +236,7 @@ public class ExpXBullsBearsEyesVolStrategy : Strategy
 	/// <summary>
 	/// Volume source multiplied by the indicator output.
 	/// </summary>
-	public AppliedVolume VolumeType
+	public AppliedVolumes VolumeType
 	{
 		get => _volumeType.Value;
 		set => _volumeType.Value = value;
@@ -281,7 +281,7 @@ public class ExpXBullsBearsEyesVolStrategy : Strategy
 	/// <summary>
 	/// Moving average used for indicator smoothing.
 	/// </summary>
-	public SmoothMethod SmoothingMethod
+	public SmoothMethods SmoothingMethod
 	{
 		get => _smoothMethod.Value;
 		set => _smoothMethod.Value = value;
@@ -553,7 +553,7 @@ public class ExpXBullsBearsEyesVolStrategy : Strategy
 	/// <summary>
 	/// Volume source applied to the indicator output.
 	/// </summary>
-	public enum AppliedVolume
+	public enum AppliedVolumes
 {
 	/// <summary>
 	/// Multiply the indicator by tick volume.
@@ -569,7 +569,7 @@ public class ExpXBullsBearsEyesVolStrategy : Strategy
 	/// <summary>
 	/// Moving average methods supported by the indicator.
 	/// </summary>
-	public enum SmoothMethod
+	public enum SmoothMethods
 {
 	/// <summary>
 	/// Simple moving average.
@@ -627,7 +627,7 @@ public class ExpXBullsBearsEyesVolStrategy : Strategy
 	private readonly ExponentialMovingAverage _ema;
 	private readonly LengthIndicator<decimal> _valueSmoother;
 	private readonly LengthIndicator<decimal> _volumeSmoother;
-	private readonly AppliedVolume _volumeType;
+	private readonly AppliedVolumes _volumeType;
 	private readonly decimal _gamma;
 	private readonly decimal _highLevel2;
 	private readonly decimal _highLevel1;
@@ -642,12 +642,12 @@ public class ExpXBullsBearsEyesVolStrategy : Strategy
 	public XBullsBearsEyesVolCalculator(
 		int emaPeriod,
 		decimal gamma,
-		AppliedVolume volumeType,
+		AppliedVolumes volumeType,
 		int highLevel2,
 		int highLevel1,
 		int lowLevel1,
 		int lowLevel2,
-		SmoothMethod method,
+		SmoothMethods method,
 		int smoothLength,
 		int smoothPhase)
 		{
@@ -756,28 +756,28 @@ public class ExpXBullsBearsEyesVolStrategy : Strategy
 		{
 			return _volumeType switch
 			{
-				AppliedVolume.Tick => candle.TotalTicks.HasValue ? (decimal)candle.TotalTicks.Value : candle.TotalVolume ?? 0m,
-				AppliedVolume.Real => candle.TotalVolume ?? (candle.TotalTicks.HasValue ? (decimal)candle.TotalTicks.Value : 0m),
+				AppliedVolumes.Tick => candle.TotalTicks.HasValue ? (decimal)candle.TotalTicks.Value : candle.TotalVolume ?? 0m,
+				AppliedVolumes.Real => candle.TotalVolume ?? (candle.TotalTicks.HasValue ? (decimal)candle.TotalTicks.Value : 0m),
 				_ => candle.TotalVolume ?? 0m,
 			};
 		}
 
-		private static LengthIndicator<decimal> CreateSmoother(SmoothMethod method, int length, int phase)
+		private static LengthIndicator<decimal> CreateSmoother(SmoothMethods method, int length, int phase)
 		{
 			var normalizedLength = Math.Max(1, length);
 
 			return method switch
 			{
-				SmoothMethod.Sma => new SimpleMovingAverage { Length = normalizedLength },
-				SmoothMethod.Ema => new ExponentialMovingAverage { Length = normalizedLength },
-				SmoothMethod.Smma => new SmoothedMovingAverage { Length = normalizedLength },
-				SmoothMethod.Lwma => new WeightedMovingAverage { Length = normalizedLength },
-				SmoothMethod.Jjma => CreateJurik(normalizedLength, phase),
-				SmoothMethod.JurX => CreateJurik(normalizedLength, phase),
-				SmoothMethod.ParMa => new ExponentialMovingAverage { Length = normalizedLength },
-				SmoothMethod.T3 => new TripleExponentialMovingAverage { Length = normalizedLength },
-				SmoothMethod.Vidya => new ExponentialMovingAverage { Length = normalizedLength },
-				SmoothMethod.Ama => new KaufmanAdaptiveMovingAverage { Length = normalizedLength },
+				SmoothMethods.Sma => new SimpleMovingAverage { Length = normalizedLength },
+				SmoothMethods.Ema => new ExponentialMovingAverage { Length = normalizedLength },
+				SmoothMethods.Smma => new SmoothedMovingAverage { Length = normalizedLength },
+				SmoothMethods.Lwma => new WeightedMovingAverage { Length = normalizedLength },
+				SmoothMethods.Jjma => CreateJurik(normalizedLength, phase),
+				SmoothMethods.JurX => CreateJurik(normalizedLength, phase),
+				SmoothMethods.ParMa => new ExponentialMovingAverage { Length = normalizedLength },
+				SmoothMethods.T3 => new TripleExponentialMovingAverage { Length = normalizedLength },
+				SmoothMethods.Vidya => new ExponentialMovingAverage { Length = normalizedLength },
+				SmoothMethods.Ama => new KaufmanAdaptiveMovingAverage { Length = normalizedLength },
 				_ => new SimpleMovingAverage { Length = normalizedLength },
 			};
 		}

--- a/API/3081_Exp_XBullsBearsEyes_Vol_Direct/CS/ExpXBullsBearsEyesVolDirectStrategy.cs
+++ b/API/3081_Exp_XBullsBearsEyes_Vol_Direct/CS/ExpXBullsBearsEyesVolDirectStrategy.cs
@@ -25,8 +25,8 @@ public class ExpXBullsBearsEyesVolDirectStrategy : Strategy
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<int> _period;
 	private readonly StrategyParam<decimal> _gamma;
-	private readonly StrategyParam<VolumeSource> _volumeSource;
-	private readonly StrategyParam<SmoothingMethod> _smoothingMethod;
+	private readonly StrategyParam<VolumeSources> _volumeSource;
+	private readonly StrategyParam<SmoothingMethods> _smoothingMethod;
 	private readonly StrategyParam<int> _smoothingLength;
 	private readonly StrategyParam<int> _smoothingPhase;
 	private readonly StrategyParam<int> _signalBar;
@@ -80,7 +80,7 @@ public class ExpXBullsBearsEyesVolDirectStrategy : Strategy
 	/// <summary>
 	/// Volume source used to weight the oscillator.
 	/// </summary>
-	public VolumeSource VolumeMode
+	public VolumeSources VolumeMode
 	{
 		get => _volumeSource.Value;
 		set => _volumeSource.Value = value;
@@ -89,7 +89,7 @@ public class ExpXBullsBearsEyesVolDirectStrategy : Strategy
 	/// <summary>
 	/// Moving average type for smoothing histogram and volume.
 	/// </summary>
-	public SmoothingMethod Method
+	public SmoothingMethods Method
 	{
 		get => _smoothingMethod.Value;
 		set => _smoothingMethod.Value = value;
@@ -200,10 +200,10 @@ public class ExpXBullsBearsEyesVolDirectStrategy : Strategy
 		_gamma = Param(nameof(Gamma), 0.6m)
 		.SetDisplay("Gamma", "Adaptive filter smoothing factor", "Indicator");
 
-		_volumeSource = Param(nameof(VolumeMode), VolumeSource.Tick)
+		_volumeSource = Param(nameof(VolumeMode), VolumeSources.Tick)
 		.SetDisplay("Volume Source", "Volume applied to the histogram", "Indicator");
 
-		_smoothingMethod = Param(nameof(Method), SmoothingMethod.Sma)
+		_smoothingMethod = Param(nameof(Method), SmoothingMethods.Sma)
 		.SetDisplay("Smoothing Method", "Moving average type for histogram and volume", "Indicator");
 
 		_smoothingLength = Param(nameof(SmoothingLength), 12)
@@ -497,22 +497,22 @@ public class ExpXBullsBearsEyesVolDirectStrategy : Strategy
 	{
 		return VolumeMode switch
 		{
-			VolumeSource.Tick => candle.TotalTicks.HasValue ? (decimal)candle.TotalTicks.Value : candle.TotalVolume ?? candle.Volume ?? 0m,
-			VolumeSource.Real => candle.TotalVolume ?? candle.Volume ?? 0m,
+			VolumeSources.Tick => candle.TotalTicks.HasValue ? (decimal)candle.TotalTicks.Value : candle.TotalVolume ?? candle.Volume ?? 0m,
+			VolumeSources.Real => candle.TotalVolume ?? candle.Volume ?? 0m,
 			_ => candle.TotalVolume ?? candle.Volume ?? 0m,
 		};
 	}
 
-	private static IIndicator CreateMovingAverage(SmoothingMethod method, int length, int phase)
+	private static IIndicator CreateMovingAverage(SmoothingMethods method, int length, int phase)
 	{
 		var effectiveLength = Math.Max(1, length);
 		return method switch
 		{
-			SmoothingMethod.Sma => new SimpleMovingAverage { Length = effectiveLength },
-			SmoothingMethod.Ema => new ExponentialMovingAverage { Length = effectiveLength },
-			SmoothingMethod.Smma => new SmoothedMovingAverage { Length = effectiveLength },
-			SmoothingMethod.Lwma => new LinearWeightedMovingAverage { Length = effectiveLength },
-			SmoothingMethod.Jurik => CreateJurik(effectiveLength, phase),
+			SmoothingMethods.Sma => new SimpleMovingAverage { Length = effectiveLength },
+			SmoothingMethods.Ema => new ExponentialMovingAverage { Length = effectiveLength },
+			SmoothingMethods.Smma => new SmoothedMovingAverage { Length = effectiveLength },
+			SmoothingMethods.Lwma => new LinearWeightedMovingAverage { Length = effectiveLength },
+			SmoothingMethods.Jurik => CreateJurik(effectiveLength, phase),
 			_ => new SimpleMovingAverage { Length = effectiveLength },
 		};
 	}
@@ -537,7 +537,7 @@ public class ExpXBullsBearsEyesVolDirectStrategy : Strategy
 	/// <summary>
 	/// Supported volume sources.
 	/// </summary>
-	public enum VolumeSource
+	public enum VolumeSources
 	{
 		/// <summary>
 		/// Use tick count when available.
@@ -553,7 +553,7 @@ public class ExpXBullsBearsEyesVolDirectStrategy : Strategy
 	/// <summary>
 	/// Supported smoothing methods.
 	/// </summary>
-	public enum SmoothingMethod
+	public enum SmoothingMethods
 	{
 		/// <summary>
 		/// Simple moving average.

--- a/API/3084_Starter/CS/StarterStrategy.cs
+++ b/API/3084_Starter/CS/StarterStrategy.cs
@@ -26,7 +26,7 @@ public class StarterStrategy : Strategy
 	private readonly StrategyParam<int> _cciCurrentBar;
 	private readonly StrategyParam<int> _cciPreviousBar;
 	private readonly StrategyParam<int> _maPeriod;
-	private readonly StrategyParam<MovingAverageMethod> _maMethod;
+	private readonly StrategyParam<MovingAverageMethods> _maMethod;
 	private readonly StrategyParam<int> _maCurrentBar;
 	private readonly StrategyParam<decimal> _maDelta;
 	private readonly StrategyParam<decimal> _stopLossPips;
@@ -92,7 +92,7 @@ public class StarterStrategy : Strategy
 			.SetCanOptimize(true)
 			.SetOptimize(20, 200, 5);
 
-		_maMethod = Param(nameof(MaMethod), MovingAverageMethod.Simple)
+		_maMethod = Param(nameof(MaMethod), MovingAverageMethods.Simple)
 			.SetDisplay("MA Method", "Smoothing method applied to the moving average", "Indicators");
 
 		_maCurrentBar = Param(nameof(MaCurrentBar), 0)
@@ -193,7 +193,7 @@ public class StarterStrategy : Strategy
 	/// <summary>
 	/// Moving average smoothing method.
 	/// </summary>
-	public MovingAverageMethod MaMethod
+	public MovingAverageMethods MaMethod
 	{
 		get => _maMethod.Value;
 		set => _maMethod.Value = value;
@@ -517,14 +517,14 @@ public class StarterStrategy : Strategy
 		return Math.Max(cciRequirement, maRequirement);
 	}
 
-	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageMethod method, int period)
+	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageMethods method, int period)
 	{
 		return method switch
 		{
-			MovingAverageMethod.Simple => new SimpleMovingAverage { Length = period },
-			MovingAverageMethod.Exponential => new ExponentialMovingAverage { Length = period },
-			MovingAverageMethod.Smoothed => new SmoothedMovingAverage { Length = period },
-			MovingAverageMethod.LinearWeighted => new WeightedMovingAverage { Length = period },
+			MovingAverageMethods.Simple => new SimpleMovingAverage { Length = period },
+			MovingAverageMethods.Exponential => new ExponentialMovingAverage { Length = period },
+			MovingAverageMethods.Smoothed => new SmoothedMovingAverage { Length = period },
+			MovingAverageMethods.LinearWeighted => new WeightedMovingAverage { Length = period },
 			_ => new SimpleMovingAverage { Length = period }
 		};
 	}
@@ -592,7 +592,7 @@ public class StarterStrategy : Strategy
 /// <summary>
 /// Moving average methods supported by <see cref="StarterStrategy"/>.
 /// </summary>
-public enum MovingAverageMethod
+public enum MovingAverageMethods
 {
 	/// <summary>
 	/// Simple moving average (equivalent to MODE_SMA in MetaTrader).

--- a/API/3085_Smoothing_Average_Crossover/CS/SmoothingAverageCrossoverStrategy.cs
+++ b/API/3085_Smoothing_Average_Crossover/CS/SmoothingAverageCrossoverStrategy.cs
@@ -23,7 +23,7 @@ public class SmoothingAverageCrossoverStrategy : Strategy
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<int> _maLength;
 	private readonly StrategyParam<int> _maShift;
-	private readonly StrategyParam<MovingAverageKind> _maType;
+	private readonly StrategyParam<MovingAverageKinds> _maType;
 	private readonly StrategyParam<CandlePrice> _priceSource;
 	private readonly StrategyParam<decimal> _entryDeltaPips;
 	private readonly StrategyParam<decimal> _closeDeltaCoefficient;
@@ -51,7 +51,7 @@ public class SmoothingAverageCrossoverStrategy : Strategy
 			.SetGreaterThanOrEqualToZero()
 			.SetDisplay("MA Shift", "Horizontal shift applied to the average", "Moving Average");
 
-		_maType = Param(nameof(MaType), MovingAverageKind.Simple)
+		_maType = Param(nameof(MaType), MovingAverageKinds.Simple)
 			.SetDisplay("MA Type", "Type of smoothing applied", "Moving Average");
 
 		_priceSource = Param(nameof(PriceSource), CandlePrice.Typical)
@@ -103,7 +103,7 @@ public class SmoothingAverageCrossoverStrategy : Strategy
 	/// <summary>
 	/// Moving average type.
 	/// </summary>
-	public MovingAverageKind MaType
+	public MovingAverageKinds MaType
 	{
 		get => _maType.Value;
 		set => _maType.Value = value;
@@ -296,14 +296,14 @@ public class SmoothingAverageCrossoverStrategy : Strategy
 		return digits == 3 || digits == 5 ? step * 10m : step;
 	}
 
-	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageKind type, int length)
+	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageKinds type, int length)
 	{
 		return type switch
 		{
-			MovingAverageKind.Simple => new SimpleMovingAverage { Length = length },
-			MovingAverageKind.Exponential => new ExponentialMovingAverage { Length = length },
-			MovingAverageKind.Smoothed => new SmoothedMovingAverage { Length = length },
-			MovingAverageKind.LinearWeighted => new WeightedMovingAverage { Length = length },
+			MovingAverageKinds.Simple => new SimpleMovingAverage { Length = length },
+			MovingAverageKinds.Exponential => new ExponentialMovingAverage { Length = length },
+			MovingAverageKinds.Smoothed => new SmoothedMovingAverage { Length = length },
+			MovingAverageKinds.LinearWeighted => new WeightedMovingAverage { Length = length },
 			_ => new SimpleMovingAverage { Length = length }
 		};
 	}
@@ -345,7 +345,7 @@ public class SmoothingAverageCrossoverStrategy : Strategy
 	/// <summary>
 	/// Supported moving average types replicating the MQL5 enumeration.
 	/// </summary>
-	public enum MovingAverageKind
+	public enum MovingAverageKinds
 	{
 		Simple,
 		Exponential,

--- a/API/3086_Tunnel_Gen4/CS/TunnelGen4Strategy.cs
+++ b/API/3086_Tunnel_Gen4/CS/TunnelGen4Strategy.cs
@@ -25,7 +25,7 @@ public class TunnelGen4Strategy : Strategy
 	private readonly StrategyParam<decimal> _startVolume;
 	private readonly StrategyParam<decimal> _stepPips;
 
-	private readonly Dictionary<Order, OrderIntent> _orderIntents = new();
+	private readonly Dictionary<Order, OrderIntents> _orderIntents = new();
 	private readonly HashSet<Order> _entryOrders = new();
 
 	private decimal _pipValue;
@@ -42,7 +42,7 @@ public class TunnelGen4Strategy : Strategy
 	private decimal _shortExposure;
 	private bool _isClosing;
 
-	private enum OrderIntent
+	private enum OrderIntents
 	{
 		OpenLong,
 		OpenShort,
@@ -159,25 +159,25 @@ public class TunnelGen4Strategy : Strategy
 
 		switch (intent)
 		{
-			case OrderIntent.OpenLong:
+			case OrderIntents.OpenLong:
 				_longExposure += volume;
 				if (_firstEntryPrice == 0m)
 				_firstEntryPrice = price;
 				break;
-			case OrderIntent.OpenShort:
+			case OrderIntents.OpenShort:
 				_shortExposure += volume;
 				if (_firstEntryPrice == 0m)
 				_firstEntryPrice = price;
 				break;
-			case OrderIntent.CloseLong:
+			case OrderIntents.CloseLong:
 				_longExposure = Math.Max(0m, _longExposure - volume);
 				break;
-			case OrderIntent.CloseShort:
+			case OrderIntents.CloseShort:
 				_shortExposure = Math.Max(0m, _shortExposure - volume);
 				break;
 		}
 
-		if (order == _secondEntryOrder && intent is OrderIntent.OpenLong or OrderIntent.OpenShort && _secondEntryPrice == 0m)
+		if (order == _secondEntryOrder && intent is OrderIntents.OpenLong or OrderIntents.OpenShort && _secondEntryPrice == 0m)
 		{
 			_secondEntryPrice = price;
 			_waitingForSecondEntry = false;
@@ -268,8 +268,8 @@ public class TunnelGen4Strategy : Strategy
 		if (volume <= 0m)
 		return;
 
-		RegisterOrder(BuyMarket(volume), OrderIntent.OpenLong, true);
-		RegisterOrder(SellMarket(volume), OrderIntent.OpenShort, true);
+		RegisterOrder(BuyMarket(volume), OrderIntents.OpenLong, true);
+		RegisterOrder(SellMarket(volume), OrderIntents.OpenShort, true);
 	}
 
 	private void OpenSecondStage(Sides side)
@@ -279,7 +279,7 @@ public class TunnelGen4Strategy : Strategy
 		return;
 
 		Order order = side == Sides.Buy ? BuyMarket(volume) : SellMarket(volume);
-		RegisterOrder(order, side == Sides.Buy ? OrderIntent.OpenLong : OrderIntent.OpenShort, true);
+		RegisterOrder(order, side == Sides.Buy ? OrderIntents.OpenLong : OrderIntents.OpenShort, true);
 
 		if (order != null)
 		{
@@ -297,16 +297,16 @@ public class TunnelGen4Strategy : Strategy
 		_isClosing = true;
 
 		if (_longExposure > VolumeTolerance)
-		RegisterOrder(SellMarket(_longExposure), OrderIntent.CloseLong, false);
+		RegisterOrder(SellMarket(_longExposure), OrderIntents.CloseLong, false);
 
 		if (_shortExposure > VolumeTolerance)
-		RegisterOrder(BuyMarket(_shortExposure), OrderIntent.CloseShort, false);
+		RegisterOrder(BuyMarket(_shortExposure), OrderIntents.CloseShort, false);
 
 		if (!HasActiveExitOrders() && !HasExposure())
 		ResetCycle();
 	}
 
-	private void RegisterOrder(Order order, OrderIntent intent, bool isEntry)
+	private void RegisterOrder(Order order, OrderIntents intent, bool isEntry)
 	{
 		if (order == null)
 		return;
@@ -351,7 +351,7 @@ public class TunnelGen4Strategy : Strategy
 	{
 		foreach (var pair in _orderIntents)
 		{
-			if ((pair.Value == OrderIntent.CloseLong || pair.Value == OrderIntent.CloseShort) && !IsOrderCompleted(pair.Key))
+			if ((pair.Value == OrderIntents.CloseLong || pair.Value == OrderIntents.CloseShort) && !IsOrderCompleted(pair.Key))
 			return true;
 		}
 

--- a/API/3089_ScalpWiz_9001/CS/ScalpWiz9001Strategy.cs
+++ b/API/3089_ScalpWiz_9001/CS/ScalpWiz9001Strategy.cs
@@ -21,7 +21,7 @@ public class ScalpWiz9001Strategy : Strategy
 {
 	private readonly StrategyParam<int> _levelCount;
 
-	private enum VolumeMode
+	private enum VolumeModes
 	{
 		FixedVolume,
 		RiskPercent,
@@ -35,7 +35,7 @@ public class ScalpWiz9001Strategy : Strategy
 	private readonly StrategyParam<decimal> _trailingStopPips;
 	private readonly StrategyParam<decimal> _trailingStepPips;
 	private readonly StrategyParam<int> _expirationMinutes;
-	private readonly StrategyParam<VolumeMode> _volumeMode;
+	private readonly StrategyParam<VolumeModes> _volumeMode;
 	private readonly StrategyParam<decimal>[] _levelValues;
 	private readonly StrategyParam<decimal>[] _levelPips;
 
@@ -94,7 +94,7 @@ public class ScalpWiz9001Strategy : Strategy
 			.SetNotNegative()
 			.SetDisplay("Expiration (minutes)", "Lifetime of pending stop orders", "Orders");
 
-		_volumeMode = Param(nameof(ManagementMode), VolumeMode.RiskPercent)
+		_volumeMode = Param(nameof(ManagementMode), VolumeModes.RiskPercent)
 			.SetDisplay("Management Mode", "Interpretation of level values (fixed lot or risk percent)", "Money Management");
 
 		_levelCount = Param(nameof(LevelCount), levelSlots)
@@ -218,7 +218,7 @@ public class ScalpWiz9001Strategy : Strategy
 	/// <summary>
 	/// Interprets level values either as fixed volumes or risk percentages.
 	/// </summary>
-	public VolumeMode ManagementMode
+	public VolumeModes ManagementMode
 	{
 		get => _volumeMode.Value;
 		set => _volumeMode.Value = value;
@@ -673,7 +673,7 @@ public class ScalpWiz9001Strategy : Strategy
 			return 0m;
 		}
 
-		if (ManagementMode == VolumeMode.FixedVolume)
+		if (ManagementMode == VolumeModes.FixedVolume)
 		{
 			return value;
 		}

--- a/API/3092_FxNode_Safe_Tunnel/CS/FxNodeSafeTunnelStrategy.cs
+++ b/API/3092_FxNode_Safe_Tunnel/CS/FxNodeSafeTunnelStrategy.cs
@@ -22,7 +22,7 @@ public class FxNodeSafeTunnelStrategy : Strategy
 	private readonly StrategyParam<decimal> _atrMultiplier;
 
 	private readonly StrategyParam<DataType> _candleType;
-	private readonly StrategyParam<TrendPreference> _trendPreference;
+	private readonly StrategyParam<TrendPreferences> _trendPreference;
 	private readonly StrategyParam<decimal> _takeProfitPips;
 	private readonly StrategyParam<decimal> _maxStopLossPips;
 	private readonly StrategyParam<decimal> _fixedTakeProfitPips;
@@ -77,7 +77,7 @@ public class FxNodeSafeTunnelStrategy : Strategy
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(30).TimeFrame())
 		.SetDisplay("Candle Type", "Primary timeframe used for trading", "General");
 
-		_trendPreference = Param(nameof(TrendPreference), TrendPreference.Both)
+		_trendPreference = Param(nameof(TrendPreferences), TrendPreferences.Both)
 		.SetDisplay("Trend Preference", "Directional bias for new trades", "General");
 
 		_takeProfitPips = Param(nameof(TakeProfitPips), 800m)
@@ -177,7 +177,7 @@ public class FxNodeSafeTunnelStrategy : Strategy
 	/// <summary>
 	/// Preferred trade direction.
 	/// </summary>
-	public TrendPreference TrendPreference
+	public TrendPreferences TrendPreferences
 	{
 		get => _trendPreference.Value;
 		set => _trendPreference.Value = value;
@@ -507,7 +507,7 @@ public class FxNodeSafeTunnelStrategy : Strategy
 		var ask = _hasBestAsk && _bestAsk is decimal bestAsk ? bestAsk : candle.ClosePrice;
 		var bid = _hasBestBid && _bestBid is decimal bestBid ? bestBid : candle.ClosePrice;
 
-		if (TrendPreference != TrendPreference.SellOnly && Position <= 0)
+		if (TrendPreferences != TrendPreferences.SellOnly && Position <= 0)
 		{
 			var takeLong = support is decimal sup && ask > sup && ask <= sup + touchBuyDistance;
 			if (takeLong)
@@ -525,7 +525,7 @@ public class FxNodeSafeTunnelStrategy : Strategy
 			}
 		}
 
-		if (TrendPreference != TrendPreference.BuyOnly && Position >= 0)
+		if (TrendPreferences != TrendPreferences.BuyOnly && Position >= 0)
 		{
 			var takeShort = resistance is decimal res && bid < res && bid >= res - touchSellDistance;
 			if (takeShort)
@@ -925,7 +925,7 @@ public class FxNodeSafeTunnelStrategy : Strategy
 	/// <summary>
 	/// Trade direction preference parameter.
 	/// </summary>
-	public enum TrendPreference
+	public enum TrendPreferences
 	{
 		BuyOnly,
 		SellOnly,

--- a/API/3093_NRTR_Revers/CS/NrtrReversStrategy.cs
+++ b/API/3093_NRTR_Revers/CS/NrtrReversStrategy.cs
@@ -43,8 +43,8 @@ public class NrtrReversStrategy : Strategy
 	private decimal _reverseDistance;
 	private int _historyCapacity;
 
-	private TradeDirection _currentTrend = TradeDirection.Long;
-	private TradeDirection _desiredTrend = TradeDirection.Long;
+	private TradeDirections _currentTrend = TradeDirections.Long;
+	private TradeDirections _desiredTrend = TradeDirections.Long;
 	private bool _waitForFlat;
 
 	private decimal? _longStopPrice;
@@ -52,7 +52,7 @@ public class NrtrReversStrategy : Strategy
 	private decimal? _shortStopPrice;
 	private decimal? _shortTakeProfit;
 
-	private enum TradeDirection
+	private enum TradeDirections
 	{
 		Long,
 		Short
@@ -201,8 +201,8 @@ public class NrtrReversStrategy : Strategy
 		_reverseDistance = 0m;
 		_historyCapacity = 0;
 
-		_currentTrend = TradeDirection.Long;
-		_desiredTrend = TradeDirection.Long;
+		_currentTrend = TradeDirections.Long;
+		_desiredTrend = TradeDirections.Long;
 		_waitForFlat = false;
 
 		_longStopPrice = null;
@@ -248,7 +248,7 @@ public class NrtrReversStrategy : Strategy
 		{
 			_waitForFlat = false;
 
-			if (_desiredTrend == TradeDirection.Long)
+			if (_desiredTrend == TradeDirections.Long)
 			{
 				EnterLong(candle);
 			}
@@ -283,7 +283,7 @@ public class NrtrReversStrategy : Strategy
 		if (halfPeriod <= 0)
 		halfPeriod = 1;
 
-		if (_currentTrend == TradeDirection.Long)
+		if (_currentTrend == TradeDirections.Long)
 		{
 			var primaryLow = GetLowest(2, AtrPeriod - 1);
 			if (!primaryLow.HasValue)
@@ -303,8 +303,8 @@ public class NrtrReversStrategy : Strategy
 			if (shouldReverse)
 			{
 				LogInfo("Change the trend. Now 'SELL'.");
-				_currentTrend = TradeDirection.Short;
-				_desiredTrend = TradeDirection.Short;
+				_currentTrend = TradeDirections.Short;
+				_desiredTrend = TradeDirections.Short;
 
 				if (Position > 0)
 				{
@@ -338,8 +338,8 @@ public class NrtrReversStrategy : Strategy
 			if (shouldReverse)
 			{
 				LogInfo("Change the trend. Now 'BUY'.");
-				_currentTrend = TradeDirection.Long;
-				_desiredTrend = TradeDirection.Long;
+				_currentTrend = TradeDirections.Long;
+				_desiredTrend = TradeDirections.Long;
 
 				if (Position < 0)
 				{

--- a/API/3094_XD_Range_Switch/CS/XdRangeSwitchStrategy.cs
+++ b/API/3094_XD_Range_Switch/CS/XdRangeSwitchStrategy.cs
@@ -16,14 +16,14 @@ namespace StockSharp.Samples.Strategies;
 /// <summary>
 /// XD-RangeSwitch strategy converted from the MetaTrader 5 expert advisor.
 /// The logic monitors channel breakouts identified by the XD-RangeSwitch indicator
-/// and optionally flips the trading direction based on the <see cref="XdRangeSwitchTradeDirection"/> parameter.
+/// and optionally flips the trading direction based on the <see cref="XdRangeSwitchTradeDirections"/> parameter.
 /// </summary>
 public class XdRangeSwitchStrategy : Strategy
 {
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<int> _peaks;
 	private readonly StrategyParam<int> _signalBar;
-	private readonly StrategyParam<XdRangeSwitchTradeDirection> _tradeDirection;
+	private readonly StrategyParam<XdRangeSwitchTradeDirections> _tradeDirection;
 	private readonly StrategyParam<bool> _allowBuyEntry;
 	private readonly StrategyParam<bool> _allowSellEntry;
 	private readonly StrategyParam<bool> _allowBuyExit;
@@ -58,7 +58,7 @@ public class XdRangeSwitchStrategy : Strategy
 		.SetNotNegative()
 		.SetDisplay("Signal Bar", "How many completed bars back to read the indicator buffers", "Indicator");
 
-		_tradeDirection = Param(nameof(TradeDirection), XdRangeSwitchTradeDirection.AgainstSignal)
+		_tradeDirection = Param(nameof(TradeDirection), XdRangeSwitchTradeDirections.AgainstSignal)
 		.SetDisplay("Trade Direction", "Trade with or against the XD-RangeSwitch signals", "Trading");
 
 		_allowBuyEntry = Param(nameof(AllowBuyEntry), true)
@@ -118,7 +118,7 @@ public class XdRangeSwitchStrategy : Strategy
 	/// <summary>
 	/// Determines whether trades follow or fade the indicator signals.
 	/// </summary>
-	public XdRangeSwitchTradeDirection TradeDirection
+	public XdRangeSwitchTradeDirections TradeDirection
 	{
 		get => _tradeDirection.Value;
 		set => _tradeDirection.Value = value;
@@ -260,7 +260,7 @@ public class XdRangeSwitchStrategy : Strategy
 		decimal? downTrend;
 		decimal? downSignal;
 
-		if (TradeDirection == XdRangeSwitchTradeDirection.WithSignal)
+		if (TradeDirection == XdRangeSwitchTradeDirections.WithSignal)
 		{
 		upTrend = reference.LowerBand;
 		upSignal = reference.DownSignal;
@@ -504,7 +504,7 @@ public class XdRangeSwitchStrategy : Strategy
 /// <summary>
 /// Trade direction selection matching the MT5 expert advisor input.
 /// </summary>
-public enum XdRangeSwitchTradeDirection
+public enum XdRangeSwitchTradeDirections
 {
 	/// <summary>
 	/// Counter-trend logic: buy on downward channel breaks and sell on upward breaks.

--- a/API/3095_Volatility_Pivot/CS/VolatilityPivotStrategy.cs
+++ b/API/3095_Volatility_Pivot/CS/VolatilityPivotStrategy.cs
@@ -31,8 +31,8 @@ public class VolatilityPivotStrategy : Strategy
 	private readonly StrategyParam<bool> _enableSellEntries;
 	private readonly StrategyParam<bool> _allowLongExits;
 	private readonly StrategyParam<bool> _allowShortExits;
-	private readonly StrategyParam<VolatilityPivotDirection> _tradeDirection;
-	private readonly StrategyParam<VolatilityPivotMode> _pivotMode;
+	private readonly StrategyParam<VolatilityPivotDirections> _tradeDirection;
+	private readonly StrategyParam<VolatilityPivotModes> _pivotMode;
 	private readonly StrategyParam<decimal> _stopLoss;
 	private readonly StrategyParam<decimal> _takeProfit;
 
@@ -49,7 +49,7 @@ public class VolatilityPivotStrategy : Strategy
 	/// <summary>
 	/// Directional mode for interpreting pivot signals.
 	/// </summary>
-	public enum VolatilityPivotDirection
+	public enum VolatilityPivotDirections
 	{
 		/// <summary>
 		/// Trade in the same direction as the pivot breakout.
@@ -65,7 +65,7 @@ public class VolatilityPivotStrategy : Strategy
 	/// <summary>
 	/// Calculation mode for the pivot distance.
 	/// </summary>
-	public enum VolatilityPivotMode
+	public enum VolatilityPivotModes
 	{
 		/// <summary>
 		/// Use ATR multiplied by a smoothing EMA.
@@ -171,7 +171,7 @@ public class VolatilityPivotStrategy : Strategy
 	/// <summary>
 	/// Directional handling of pivot signals.
 	/// </summary>
-	public VolatilityPivotDirection TradeDirection
+	public VolatilityPivotDirections TradeDirection
 	{
 		get => _tradeDirection.Value;
 		set => _tradeDirection.Value = value;
@@ -180,7 +180,7 @@ public class VolatilityPivotStrategy : Strategy
 	/// <summary>
 	/// Pivot calculation mode.
 	/// </summary>
-	public VolatilityPivotMode PivotMode
+	public VolatilityPivotModes PivotMode
 	{
 		get => _pivotMode.Value;
 		set => _pivotMode.Value = value;
@@ -248,10 +248,10 @@ public class VolatilityPivotStrategy : Strategy
 		_allowShortExits = Param(nameof(AllowShortExits), true)
 			.SetDisplay("Allow Short Exits", "Permit closing existing short positions", "Trading Logic");
 
-		_tradeDirection = Param(nameof(TradeDirection), VolatilityPivotDirection.WithTrend)
+		_tradeDirection = Param(nameof(TradeDirection), VolatilityPivotDirections.WithTrend)
 			.SetDisplay("Trade Direction", "Follow or fade the pivot breakout", "Trading Logic");
 
-		_pivotMode = Param(nameof(PivotMode), VolatilityPivotMode.Atr)
+		_pivotMode = Param(nameof(PivotMode), VolatilityPivotModes.Atr)
 			.SetDisplay("Pivot Mode", "Choose ATR based or fixed deviation mode", "Indicator");
 
 		_stopLoss = Param(nameof(StopLoss), 0m)
@@ -342,7 +342,7 @@ public class VolatilityPivotStrategy : Strategy
 
 	private decimal? CalculateDeltaStop(IIndicatorValue atrValue)
 	{
-		if (PivotMode == VolatilityPivotMode.PriceDeviation)
+		if (PivotMode == VolatilityPivotModes.PriceDeviation)
 			return DeltaPrice;
 
 		if (!atrValue.IsFinal)
@@ -425,7 +425,7 @@ public class VolatilityPivotStrategy : Strategy
 		var upTrendPrice = pivot.UpTrendPrice;
 		var downTrendPrice = pivot.DownTrendPrice;
 
-		if (TradeDirection == VolatilityPivotDirection.CounterTrend)
+		if (TradeDirection == VolatilityPivotDirections.CounterTrend)
 		{
 			upSignal = pivot.DownSignal;
 			downSignal = pivot.UpSignal;

--- a/API/3097_Fluctuate/CS/FluctuateStrategy.cs
+++ b/API/3097_Fluctuate/CS/FluctuateStrategy.cs
@@ -17,7 +17,7 @@ using StockSharp.Algo;
 
 public class FluctuateStrategy : Strategy
 {
-	private enum LotMode
+	private enum LotModes
 	{
 		FixedVolume,
 		RiskPercent
@@ -38,7 +38,7 @@ public class FluctuateStrategy : Strategy
 	private readonly StrategyParam<bool> _closeAllAtStart;
 	private readonly StrategyParam<int> _startHour;
 	private readonly StrategyParam<int> _endHour;
-	private readonly StrategyParam<LotMode> _lotMode;
+	private readonly StrategyParam<LotModes> _lotMode;
 	private readonly StrategyParam<decimal> _volumeOrRisk;
 
 	private readonly Queue<decimal> _closeHistory = new();
@@ -128,7 +128,7 @@ public class FluctuateStrategy : Strategy
 		.SetRange(0, 23)
 		.SetDisplay("End hour", "Hour when trading stops accepting new signals (exclusive).", "Schedule");
 
-		_lotMode = Param(nameof(PositionSizingMode), LotMode.FixedVolume)
+		_lotMode = Param(nameof(PositionSizingMode), LotModes.FixedVolume)
 		.SetDisplay("Sizing mode", "Select between fixed volume and risk-based position sizing.", "Money Management");
 
 		_volumeOrRisk = Param(nameof(VolumeOrRisk), 1m)
@@ -226,7 +226,7 @@ public class FluctuateStrategy : Strategy
 		set => _endHour.Value = value;
 	}
 
-	public LotMode PositionSizingMode
+	public LotModes PositionSizingMode
 	{
 		get => _lotMode.Value;
 		set => _lotMode.Value = value;
@@ -502,7 +502,7 @@ public class FluctuateStrategy : Strategy
 	{
 		decimal volume = 0m;
 
-		if (PositionSizingMode == LotMode.RiskPercent)
+		if (PositionSizingMode == LotModes.RiskPercent)
 			volume = CalculateRiskVolume(entryPrice, stopPrice);
 
 		if (volume <= 0m)

--- a/API/3098_Doubler/CS/DoublerStrategy.cs
+++ b/API/3098_Doubler/CS/DoublerStrategy.cs
@@ -277,7 +277,7 @@ public class DoublerStrategy : Strategy
 			Position = position,
 			IsEntry = true,
 			RemainingVolume = order.Volume,
-			CloseReason = CloseReason.None
+			CloseReasons = CloseReasons.None
 		};
 
 		_pendingEntryOrders++;
@@ -285,14 +285,14 @@ public class DoublerStrategy : Strategy
 		RegisterOrder(order);
 	}
 
-	private void RegisterExitOrder(Order order, PositionState position, CloseReason reason)
+	private void RegisterExitOrder(Order order, PositionState position, CloseReasons reason)
 	{
 		_pendingOrders[order] = new PendingOrderInfo
 		{
 			Position = position,
 			IsEntry = false,
 			RemainingVolume = order.Volume,
-			CloseReason = reason
+			CloseReasons = reason
 		};
 
 		RegisterOrder(order);
@@ -322,13 +322,13 @@ public class DoublerStrategy : Strategy
 
 		if (position.StopPrice is decimal stop && stop > 0m && price <= stop)
 		{
-			ClosePosition(position, CloseReason.StopLoss);
+			ClosePosition(position, CloseReasons.StopLoss);
 			return;
 		}
 
 		if (position.TakePrice is decimal take && take > 0m && price >= take)
 		{
-			ClosePosition(position, CloseReason.TakeProfit);
+			ClosePosition(position, CloseReasons.TakeProfit);
 			return;
 		}
 
@@ -346,13 +346,13 @@ public class DoublerStrategy : Strategy
 
 		if (position.StopPrice is decimal stop && stop > 0m && price >= stop)
 		{
-			ClosePosition(position, CloseReason.StopLoss);
+			ClosePosition(position, CloseReasons.StopLoss);
 			return;
 		}
 
 		if (position.TakePrice is decimal take && take > 0m && price <= take)
 		{
-			ClosePosition(position, CloseReason.TakeProfit);
+			ClosePosition(position, CloseReasons.TakeProfit);
 			return;
 		}
 
@@ -403,7 +403,7 @@ public class DoublerStrategy : Strategy
 		}
 	}
 
-	private void ClosePosition(PositionState position, CloseReason reason)
+	private void ClosePosition(PositionState position, CloseReasons reason)
 	{
 		if (Security == null || Portfolio == null)
 			return;
@@ -419,7 +419,7 @@ public class DoublerStrategy : Strategy
 		}
 
 		var exitSide = position.Side == Sides.Buy ? Sides.Sell : Sides.Buy;
-		var comment = reason == CloseReason.TakeProfit ? "Doubler:TakeProfit" : "Doubler:StopLoss";
+		var comment = reason == CloseReasons.TakeProfit ? "Doubler:TakeProfit" : "Doubler:StopLoss";
 
 		var order = CreateMarketOrder(exitSide, volume, comment);
 		position.IsClosing = true;
@@ -496,7 +496,7 @@ public class DoublerStrategy : Strategy
 			else
 				_shortPosition = null;
 
-			LogTrade($"{position.Side} exit filled at {averagePrice} with volume {info.FilledVolume} ({info.CloseReason})");
+			LogTrade($"{position.Side} exit filled at {averagePrice} with volume {info.FilledVolume} ({info.CloseReasons})");
 		}
 	}
 
@@ -561,7 +561,7 @@ public class DoublerStrategy : Strategy
 			LogInfo(message);
 	}
 
-	private enum CloseReason
+	private enum CloseReasons
 	{
 		None,
 		StopLoss,
@@ -588,7 +588,7 @@ public class DoublerStrategy : Strategy
 		public decimal RemainingVolume { get; set; }
 		public decimal FilledVolume { get; set; }
 		public decimal WeightedPrice { get; set; }
-		public CloseReason CloseReason { get; init; }
+		public CloseReasons CloseReasons { get; init; }
 	}
 }
 

--- a/API/3104_MA_MACD_Position_Averaging/CS/MaMacdPositionAveragingStrategy.cs
+++ b/API/3104_MA_MACD_Position_Averaging/CS/MaMacdPositionAveragingStrategy.cs
@@ -40,13 +40,13 @@ public class MaMacdPositionAveragingStrategy : Strategy
 	private readonly StrategyParam<int> _signalBar;
 	private readonly StrategyParam<int> _maPeriod;
 	private readonly StrategyParam<int> _maShift;
-	private readonly StrategyParam<MovingAverageMethod> _maMethod;
-	private readonly StrategyParam<AppliedPriceType> _maAppliedPrice;
+	private readonly StrategyParam<MovingAverageMethods> _maMethod;
+	private readonly StrategyParam<AppliedPriceTypes> _maAppliedPrice;
 	private readonly StrategyParam<int> _indentPips;
 	private readonly StrategyParam<int> _macdFastPeriod;
 	private readonly StrategyParam<int> _macdSlowPeriod;
 	private readonly StrategyParam<int> _macdSignalPeriod;
-	private readonly StrategyParam<AppliedPriceType> _macdAppliedPrice;
+	private readonly StrategyParam<AppliedPriceTypes> _macdAppliedPrice;
 	private readonly StrategyParam<decimal> _macdRatio;
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<int> _bufferCapacity;
@@ -158,7 +158,7 @@ public class MaMacdPositionAveragingStrategy : Strategy
 	/// <summary>
 	/// Moving average calculation method.
 	/// </summary>
-	public MovingAverageMethod MaMethod
+	public MovingAverageMethods MaMethod
 	{
 		get => _maMethod.Value;
 		set => _maMethod.Value = value;
@@ -167,7 +167,7 @@ public class MaMacdPositionAveragingStrategy : Strategy
 	/// <summary>
 	/// Price source supplied to the moving average.
 	/// </summary>
-	public AppliedPriceType MaAppliedPrice
+	public AppliedPriceTypes MaAppliedPrice
 	{
 		get => _maAppliedPrice.Value;
 		set => _maAppliedPrice.Value = value;
@@ -212,7 +212,7 @@ public class MaMacdPositionAveragingStrategy : Strategy
 	/// <summary>
 	/// Price source used by the MACD filter.
 	/// </summary>
-	public AppliedPriceType MacdAppliedPrice
+	public AppliedPriceTypes MacdAppliedPrice
 	{
 		get => _macdAppliedPrice.Value;
 		set => _macdAppliedPrice.Value = value;
@@ -298,10 +298,10 @@ public class MaMacdPositionAveragingStrategy : Strategy
 			.SetNotNegative()
 			.SetDisplay("MA Shift", "Horizontal shift of the moving average", "Indicators");
 
-		_maMethod = Param(nameof(MaMethod), MovingAverageMethod.Weighted)
+		_maMethod = Param(nameof(MaMethod), MovingAverageMethods.Weighted)
 			.SetDisplay("MA Method", "Moving average smoothing type", "Indicators");
 
-		_maAppliedPrice = Param(nameof(MaAppliedPrice), AppliedPriceType.Weighted)
+		_maAppliedPrice = Param(nameof(MaAppliedPrice), AppliedPriceTypes.Weighted)
 			.SetDisplay("MA Price", "Applied price for the moving average", "Indicators");
 
 		_indentPips = Param(nameof(IndentPips), 4)
@@ -324,7 +324,7 @@ public class MaMacdPositionAveragingStrategy : Strategy
 			.SetCanOptimize(true)
 			.SetDisplay("MACD Signal", "Signal line length", "Indicators");
 
-		_macdAppliedPrice = Param(nameof(MacdAppliedPrice), AppliedPriceType.Weighted)
+		_macdAppliedPrice = Param(nameof(MacdAppliedPrice), AppliedPriceTypes.Weighted)
 			.SetDisplay("MACD Price", "Applied price for MACD", "Indicators");
 
 		_macdRatio = Param(nameof(MacdRatio), 0.9m)
@@ -768,13 +768,13 @@ public class MaMacdPositionAveragingStrategy : Strategy
 		return true;
 	}
 
-	private LengthIndicator<decimal> CreateMovingAverage(MovingAverageMethod method, int period)
+	private LengthIndicator<decimal> CreateMovingAverage(MovingAverageMethods method, int period)
 	{
 		return method switch
 		{
-			MovingAverageMethod.Simple => new SimpleMovingAverage { Length = period },
-			MovingAverageMethod.Exponential => new ExponentialMovingAverage { Length = period },
-			MovingAverageMethod.Smoothed => new SmoothedMovingAverage { Length = period },
+			MovingAverageMethods.Simple => new SimpleMovingAverage { Length = period },
+			MovingAverageMethods.Exponential => new ExponentialMovingAverage { Length = period },
+			MovingAverageMethods.Smoothed => new SmoothedMovingAverage { Length = period },
 			_ => new WeightedMovingAverage { Length = period },
 		};
 	}
@@ -833,17 +833,17 @@ public class MaMacdPositionAveragingStrategy : Strategy
 		return (int)Math.Round(value);
 	}
 
-	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPriceType priceType)
+	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPriceTypes priceType)
 	{
 		return priceType switch
 		{
-			AppliedPriceType.Close => candle.ClosePrice,
-			AppliedPriceType.Open => candle.OpenPrice,
-			AppliedPriceType.High => candle.HighPrice,
-			AppliedPriceType.Low => candle.LowPrice,
-			AppliedPriceType.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-			AppliedPriceType.Typical => (candle.ClosePrice + candle.HighPrice + candle.LowPrice) / 3m,
-			AppliedPriceType.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice * 2m) / 4m,
+			AppliedPriceTypes.Close => candle.ClosePrice,
+			AppliedPriceTypes.Open => candle.OpenPrice,
+			AppliedPriceTypes.High => candle.HighPrice,
+			AppliedPriceTypes.Low => candle.LowPrice,
+			AppliedPriceTypes.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+			AppliedPriceTypes.Typical => (candle.ClosePrice + candle.HighPrice + candle.LowPrice) / 3m,
+			AppliedPriceTypes.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice * 2m) / 4m,
 			_ => candle.ClosePrice,
 		};
 	}
@@ -851,7 +851,7 @@ public class MaMacdPositionAveragingStrategy : Strategy
 	/// <summary>
 	/// Moving average calculation options mirroring MetaTrader modes.
 	/// </summary>
-	public enum MovingAverageMethod
+	public enum MovingAverageMethods
 	{
 		/// <summary>Simple moving average.</summary>
 		Simple,
@@ -866,7 +866,7 @@ public class MaMacdPositionAveragingStrategy : Strategy
 	/// <summary>
 	/// Price selection modes compatible with MetaTrader applied prices.
 	/// </summary>
-	public enum AppliedPriceType
+	public enum AppliedPriceTypes
 	{
 		/// <summary>Use the candle close price.</summary>
 		Close,

--- a/API/3106_MA_MACD_Position_Averaging_v2/CS/MaMacdPositionAveragingV2Strategy.cs
+++ b/API/3106_MA_MACD_Position_Averaging_v2/CS/MaMacdPositionAveragingV2Strategy.cs
@@ -42,7 +42,7 @@ public class MaMacdPositionAveragingV2Strategy : Strategy
 
 	private readonly StrategyParam<int> _maPeriod;
 	private readonly StrategyParam<int> _maShift;
-	private readonly StrategyParam<MovingAverageMethod> _maMethod;
+	private readonly StrategyParam<MovingAverageMethods> _maMethod;
 	private readonly StrategyParam<CandlePrice> _maPrice;
 	private readonly StrategyParam<decimal> _maIndentPips;
 
@@ -130,7 +130,7 @@ public class MaMacdPositionAveragingV2Strategy : Strategy
 			.SetRange(0, 1000)
 			.SetDisplay("MA Shift", "Forward shift applied to the moving average", "Moving Average");
 
-		_maMethod = Param(nameof(MaMethod), MovingAverageMethod.Weighted)
+		_maMethod = Param(nameof(MaMethod), MovingAverageMethods.Weighted)
 			.SetDisplay("MA Method", "Smoothing method for the moving average", "Moving Average");
 
 		_maPrice = Param(nameof(MaPrice), CandlePrice.Weighted)
@@ -269,7 +269,7 @@ public class MaMacdPositionAveragingV2Strategy : Strategy
 	/// <summary>
 	/// Moving average smoothing method.
 	/// </summary>
-	public MovingAverageMethod MaMethod
+	public MovingAverageMethods MaMethod
 	{
 		get => _maMethod.Value;
 		set => _maMethod.Value = value;
@@ -672,16 +672,16 @@ public class MaMacdPositionAveragingV2Strategy : Strategy
 		_shortLegs.Clear();
 	}
 
-	private MovingAverage CreateMovingAverage(MovingAverageMethod method, int period, CandlePrice price)
+	private MovingAverage CreateMovingAverage(MovingAverageMethods method, int period, CandlePrice price)
 	{
 		var length = Math.Max(1, period);
 
 		MovingAverage indicator = method switch
 		{
-			MovingAverageMethod.Simple => new SimpleMovingAverage { Length = length },
-			MovingAverageMethod.Exponential => new ExponentialMovingAverage { Length = length },
-			MovingAverageMethod.Smoothed => new SmoothedMovingAverage { Length = length },
-			MovingAverageMethod.Weighted => new WeightedMovingAverage { Length = length },
+			MovingAverageMethods.Simple => new SimpleMovingAverage { Length = length },
+			MovingAverageMethods.Exponential => new ExponentialMovingAverage { Length = length },
+			MovingAverageMethods.Smoothed => new SmoothedMovingAverage { Length = length },
+			MovingAverageMethods.Weighted => new WeightedMovingAverage { Length = length },
 			_ => new WeightedMovingAverage { Length = length }
 		};
 
@@ -768,7 +768,7 @@ public class MaMacdPositionAveragingV2Strategy : Strategy
 /// <summary>
 /// Moving average smoothing modes mirroring the MetaTrader enumeration.
 /// </summary>
-public enum MovingAverageMethod
+public enum MovingAverageMethods
 {
 	/// <summary>
 	/// Simple moving average.

--- a/API/3107_Exp_i_KlPrice_Vol/CS/ExpIKlPriceVolStrategy.cs
+++ b/API/3107_Exp_i_KlPrice_Vol/CS/ExpIKlPriceVolStrategy.cs
@@ -33,15 +33,15 @@ public class ExpIKlPriceVolStrategy : Strategy
 	private readonly StrategyParam<bool> _allowLongExit;
 	private readonly StrategyParam<bool> _allowShortExit;
 	private readonly StrategyParam<DataType> _candleType;
-	private readonly StrategyParam<SmoothMethod> _priceMaMethod;
+	private readonly StrategyParam<SmoothMethods> _priceMaMethod;
 	private readonly StrategyParam<int> _priceMaLength;
 	private readonly StrategyParam<int> _priceMaPhase;
-	private readonly StrategyParam<SmoothMethod> _rangeMaMethod;
+	private readonly StrategyParam<SmoothMethods> _rangeMaMethod;
 	private readonly StrategyParam<int> _rangeMaLength;
 	private readonly StrategyParam<int> _rangeMaPhase;
 	private readonly StrategyParam<int> _smoothingLength;
-	private readonly StrategyParam<AppliedPrice> _appliedPrice;
-	private readonly StrategyParam<AppliedVolume> _volumeType;
+	private readonly StrategyParam<AppliedPrices> _appliedPrice;
+	private readonly StrategyParam<AppliedVolumes> _volumeType;
 	private readonly StrategyParam<int> _highLevel2;
 	private readonly StrategyParam<int> _highLevel1;
 	private readonly StrategyParam<int> _lowLevel1;
@@ -98,7 +98,7 @@ public class ExpIKlPriceVolStrategy : Strategy
 		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(8).TimeFrame())
 			.SetDisplay("Candle Type", "Time frame used by the indicator", "General");
 
-		_priceMaMethod = Param(nameof(PriceMaMethod), SmoothMethod.Sma)
+		_priceMaMethod = Param(nameof(PriceMaMethod), SmoothMethods.Sma)
 			.SetDisplay("Price MA Method", "Moving average type used to smooth price", "Indicator");
 
 		_priceMaLength = Param(nameof(PriceMaLength), 100)
@@ -110,7 +110,7 @@ public class ExpIKlPriceVolStrategy : Strategy
 		_priceMaPhase = Param(nameof(PriceMaPhase), 15)
 			.SetDisplay("Price MA Phase", "Phase parameter for Jurik style filters", "Indicator");
 
-		_rangeMaMethod = Param(nameof(RangeMaMethod), SmoothMethod.Jjma)
+		_rangeMaMethod = Param(nameof(RangeMaMethod), SmoothMethods.Jjma)
 			.SetDisplay("Range MA Method", "Moving average type used to smooth the candle range", "Indicator");
 
 		_rangeMaLength = Param(nameof(RangeMaLength), 20)
@@ -126,10 +126,10 @@ public class ExpIKlPriceVolStrategy : Strategy
 			.SetGreaterThanZero()
 			.SetDisplay("Smoothing Length", "Length of the Jurik smoother applied to the oscillator", "Indicator");
 
-		_appliedPrice = Param(nameof(AppliedPrice), AppliedPrice.Close)
+		_appliedPrice = Param(nameof(AppliedPrices), AppliedPrices.Close)
 			.SetDisplay("Applied Price", "Price input used in oscillator calculations", "Indicator");
 
-		_volumeType = Param(nameof(VolumeType), AppliedVolume.Tick)
+		_volumeType = Param(nameof(VolumeType), AppliedVolumes.Tick)
 			.SetDisplay("Volume Type", "Volume source multiplied by the oscillator", "Indicator");
 
 		_highLevel2 = Param(nameof(HighLevel2), 150)
@@ -233,7 +233,7 @@ public class ExpIKlPriceVolStrategy : Strategy
 	/// <summary>
 	/// Moving average method used for price smoothing.
 	/// </summary>
-	public SmoothMethod PriceMaMethod
+	public SmoothMethods PriceMaMethod
 	{
 		get => _priceMaMethod.Value;
 		set => _priceMaMethod.Value = value;
@@ -260,7 +260,7 @@ public class ExpIKlPriceVolStrategy : Strategy
 	/// <summary>
 	/// Moving average method applied to the candle range.
 	/// </summary>
-	public SmoothMethod RangeMaMethod
+	public SmoothMethods RangeMaMethod
 	{
 		get => _rangeMaMethod.Value;
 		set => _rangeMaMethod.Value = value;
@@ -296,7 +296,7 @@ public class ExpIKlPriceVolStrategy : Strategy
 	/// <summary>
 	/// Price input used by the oscillator.
 	/// </summary>
-	public AppliedPrice AppliedPrice
+	public AppliedPrices AppliedPrices
 	{
 		get => _appliedPrice.Value;
 		set => _appliedPrice.Value = value;
@@ -305,7 +305,7 @@ public class ExpIKlPriceVolStrategy : Strategy
 	/// <summary>
 	/// Volume source multiplied by the oscillator output.
 	/// </summary>
-	public AppliedVolume VolumeType
+	public AppliedVolumes VolumeType
 	{
 		get => _volumeType.Value;
 		set => _volumeType.Value = value;
@@ -392,7 +392,7 @@ public class ExpIKlPriceVolStrategy : Strategy
 			RangeMaLength,
 			RangeMaPhase,
 			SmoothingLength,
-			AppliedPrice,
+			AppliedPrices,
 			VolumeType,
 			HighLevel2,
 			HighLevel1,
@@ -563,7 +563,7 @@ public class ExpIKlPriceVolStrategy : Strategy
 	/// <summary>
 	/// Volume source applied to the oscillator.
 	/// </summary>
-	public enum AppliedVolume
+	public enum AppliedVolumes
 	{
 		/// <summary>
 		/// Multiply by tick volume.
@@ -579,7 +579,7 @@ public class ExpIKlPriceVolStrategy : Strategy
 	/// <summary>
 	/// Price source used in calculations.
 	/// </summary>
-	public enum AppliedPrice
+	public enum AppliedPrices
 	{
 		/// <summary>
 		/// Close price.
@@ -645,7 +645,7 @@ public class ExpIKlPriceVolStrategy : Strategy
 	/// <summary>
 	/// Moving average methods supported by the calculator.
 	/// </summary>
-	public enum SmoothMethod
+	public enum SmoothMethods
 	{
 		/// <summary>
 		/// Simple moving average.
@@ -704,23 +704,23 @@ public class ExpIKlPriceVolStrategy : Strategy
 		private readonly LengthIndicator<decimal> _rangeMa;
 		private readonly LengthIndicator<decimal> _valueSmoother;
 		private readonly LengthIndicator<decimal> _volumeSmoother;
-		private readonly AppliedPrice _appliedPrice;
-		private readonly AppliedVolume _volumeType;
+		private readonly AppliedPrices _appliedPrice;
+		private readonly AppliedVolumes _volumeType;
 		private readonly decimal _highLevel2;
 		private readonly decimal _highLevel1;
 		private readonly decimal _lowLevel1;
 		private readonly decimal _lowLevel2;
 
 		public KlPriceVolCalculator(
-			SmoothMethod priceMethod,
+			SmoothMethods priceMethod,
 			int priceLength,
 			int pricePhase,
-			SmoothMethod rangeMethod,
+			SmoothMethods rangeMethod,
 			int rangeLength,
 			int rangePhase,
 			int smoothingLength,
-			AppliedPrice appliedPrice,
-			AppliedVolume volumeType,
+			AppliedPrices appliedPrice,
+			AppliedVolumes volumeType,
 			int highLevel2,
 			int highLevel1,
 			int lowLevel1,
@@ -732,8 +732,8 @@ public class ExpIKlPriceVolStrategy : Strategy
 
 			_priceMa = CreateSmoother(priceMethod, priceLen, pricePhase);
 			_rangeMa = CreateSmoother(rangeMethod, rangeLen, rangePhase);
-			_valueSmoother = CreateSmoother(SmoothMethod.Jjma, smoothLen, 100);
-			_volumeSmoother = CreateSmoother(SmoothMethod.Jjma, smoothLen, 100);
+			_valueSmoother = CreateSmoother(SmoothMethods.Jjma, smoothLen, 100);
+			_volumeSmoother = CreateSmoother(SmoothMethods.Jjma, smoothLen, 100);
 			_appliedPrice = appliedPrice;
 			_volumeType = volumeType;
 			_highLevel2 = highLevel2;
@@ -805,35 +805,35 @@ public class ExpIKlPriceVolStrategy : Strategy
 		{
 			return _volumeType switch
 			{
-				AppliedVolume.Tick => candle.TotalTicks.HasValue ? (decimal)candle.TotalTicks.Value : candle.TotalVolume ?? 0m,
-				AppliedVolume.Real => candle.TotalVolume ?? (candle.TotalTicks.HasValue ? (decimal)candle.TotalTicks.Value : 0m),
+				AppliedVolumes.Tick => candle.TotalTicks.HasValue ? (decimal)candle.TotalTicks.Value : candle.TotalVolume ?? 0m,
+				AppliedVolumes.Real => candle.TotalVolume ?? (candle.TotalTicks.HasValue ? (decimal)candle.TotalTicks.Value : 0m),
 				_ => candle.TotalVolume ?? 0m,
 			};
 		}
 
-		private static LengthIndicator<decimal> CreateSmoother(SmoothMethod method, int length, int phase)
+		private static LengthIndicator<decimal> CreateSmoother(SmoothMethods method, int length, int phase)
 		{
 			switch (method)
 			{
-				case SmoothMethod.Sma:
+				case SmoothMethods.Sma:
 					return new SimpleMovingAverage { Length = length };
-				case SmoothMethod.Ema:
+				case SmoothMethods.Ema:
 					return new ExponentialMovingAverage { Length = length };
-				case SmoothMethod.Smma:
+				case SmoothMethods.Smma:
 					return new SmoothedMovingAverage { Length = length };
-				case SmoothMethod.Lwma:
+				case SmoothMethods.Lwma:
 					return new WeightedMovingAverage { Length = length };
-				case SmoothMethod.Jjma:
+				case SmoothMethods.Jjma:
 					return CreateJurik(length, phase);
-				case SmoothMethod.JurX:
+				case SmoothMethods.JurX:
 					return CreateJurik(length, phase);
-				case SmoothMethod.ParMa:
+				case SmoothMethods.ParMa:
 					return new ExponentialMovingAverage { Length = length };
-				case SmoothMethod.T3:
+				case SmoothMethods.T3:
 					return new TripleExponentialMovingAverage { Length = length };
-				case SmoothMethod.Vidya:
+				case SmoothMethods.Vidya:
 					return new ExponentialMovingAverage { Length = length };
-				case SmoothMethod.Ama:
+				case SmoothMethods.Ama:
 					return new KaufmanAdaptiveMovingAverage { Length = length };
 				default:
 					return new SimpleMovingAverage { Length = length };
@@ -853,26 +853,26 @@ public class ExpIKlPriceVolStrategy : Strategy
 			return jurik;
 		}
 
-		private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPrice price)
+		private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPrices price)
 		{
 			return price switch
 			{
-				AppliedPrice.Close => candle.ClosePrice,
-				AppliedPrice.Open => candle.OpenPrice,
-				AppliedPrice.High => candle.HighPrice,
-				AppliedPrice.Low => candle.LowPrice,
-				AppliedPrice.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-				AppliedPrice.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-				AppliedPrice.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
-				AppliedPrice.Simple => (candle.OpenPrice + candle.ClosePrice) / 2m,
-				AppliedPrice.Quarter => (candle.OpenPrice + candle.ClosePrice + candle.HighPrice + candle.LowPrice) / 4m,
-				AppliedPrice.TrendFollow0 => candle.ClosePrice > candle.OpenPrice
+				AppliedPrices.Close => candle.ClosePrice,
+				AppliedPrices.Open => candle.OpenPrice,
+				AppliedPrices.High => candle.HighPrice,
+				AppliedPrices.Low => candle.LowPrice,
+				AppliedPrices.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+				AppliedPrices.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+				AppliedPrices.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
+				AppliedPrices.Simple => (candle.OpenPrice + candle.ClosePrice) / 2m,
+				AppliedPrices.Quarter => (candle.OpenPrice + candle.ClosePrice + candle.HighPrice + candle.LowPrice) / 4m,
+				AppliedPrices.TrendFollow0 => candle.ClosePrice > candle.OpenPrice
 					? candle.HighPrice
 					: candle.ClosePrice < candle.OpenPrice ? candle.LowPrice : candle.ClosePrice,
-				AppliedPrice.TrendFollow1 => candle.ClosePrice > candle.OpenPrice
+				AppliedPrices.TrendFollow1 => candle.ClosePrice > candle.OpenPrice
 					? (candle.HighPrice + candle.ClosePrice) / 2m
 					: candle.ClosePrice < candle.OpenPrice ? (candle.LowPrice + candle.ClosePrice) / 2m : candle.ClosePrice,
-				AppliedPrice.Demark => GetDemarkPrice(candle),
+				AppliedPrices.Demark => GetDemarkPrice(candle),
 				_ => candle.ClosePrice,
 			};
 		}

--- a/API/3110_BitexOneMarketMaker/CS/BitexOneMarketMakerStrategy.cs
+++ b/API/3110_BitexOneMarketMaker/CS/BitexOneMarketMakerStrategy.cs
@@ -21,7 +21,7 @@ public class BitexOneMarketMakerStrategy : Strategy
 	private readonly StrategyParam<decimal> _maxVolumePerLevel;
 	private readonly StrategyParam<decimal> _shiftCoefficient;
 	private readonly StrategyParam<int> _levelCount;
-	private readonly StrategyParam<LeadPriceSource> _priceSource;
+	private readonly StrategyParam<LeadPriceSources> _priceSource;
 	private readonly StrategyParam<Security> _leadSecurityParam;
 	private readonly StrategyParam<decimal> _priceToleranceRatio;
 	private readonly StrategyParam<decimal> _volumeTolerance;
@@ -71,7 +71,7 @@ public class BitexOneMarketMakerStrategy : Strategy
 	/// <summary>
 	/// Source that supplies the reference price for the quoting ladder.
 	/// </summary>
-	public LeadPriceSource PriceSource
+	public LeadPriceSources PriceSource
 	{
 		get => _priceSource.Value;
 		set => _priceSource.Value = value;
@@ -125,7 +125,7 @@ public class BitexOneMarketMakerStrategy : Strategy
 		.SetGreaterThanZero()
 		.SetDisplay("Level Count", "Number of price levels quoted above and below the reference.", "Orders");
 
-		_priceSource = Param(nameof(PriceSource), LeadPriceSource.MarkPrice)
+		_priceSource = Param(nameof(PriceSource), LeadPriceSources.MarkPrice)
 		.SetDisplay("Price Source", "Defines where the reference quote is taken from.", "General");
 
 		_leadSecurityParam = Param<Security>(nameof(LeadSecurity))
@@ -191,7 +191,7 @@ public class BitexOneMarketMakerStrategy : Strategy
 		_volumeStep = Security.VolumeStep ?? 0m;
 		_minVolume = Security.MinVolume ?? 0m;
 
-		_leadSecurity = PriceSource == LeadPriceSource.OrderBook ? Security : LeadSecurity ?? Security;
+		_leadSecurity = PriceSource == LeadPriceSources.OrderBook ? Security : LeadSecurity ?? Security;
 
 		var initialLeadBid = _leadSecurity?.BestBid?.Price ?? Security.BestBid?.Price;
 		if (initialLeadBid is decimal bid && bid > 0m)
@@ -530,7 +530,7 @@ public class BitexOneMarketMakerStrategy : Strategy
 /// <summary>
 /// Defines available sources of reference prices for the market-making grid.
 /// </summary>
-public enum LeadPriceSource
+public enum LeadPriceSources
 {
 	/// <summary>
 	/// Use the strategy security order book as the reference.

--- a/API/3111_Exp_AFIRMA/CS/ExpAfirmaStrategy.cs
+++ b/API/3111_Exp_AFIRMA/CS/ExpAfirmaStrategy.cs
@@ -25,7 +25,7 @@ public class ExpAfirmaStrategy : Strategy
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<int> _periods;
 	private readonly StrategyParam<int> _taps;
-	private readonly StrategyParam<AfirmaIndicator.WindowType> _window;
+	private readonly StrategyParam<AfirmaIndicator.WindowTypes> _window;
 	private readonly StrategyParam<int> _signalBar;
 	private readonly StrategyParam<bool> _buyEntries;
 	private readonly StrategyParam<bool> _sellEntries;
@@ -57,7 +57,7 @@ public class ExpAfirmaStrategy : Strategy
 			.SetGreaterThanZero()
 			.SetDisplay("Taps", "Number of FIR coefficients (odd value)", "Indicator");
 
-		_window = Param(nameof(Window), AfirmaIndicator.WindowType.Blackman)
+		_window = Param(nameof(Window), AfirmaIndicator.WindowTypes.Blackman)
 			.SetDisplay("Window", "Window function applied to FIR coefficients", "Indicator");
 
 		_signalBar = Param(nameof(SignalBar), 1)
@@ -121,7 +121,7 @@ public class ExpAfirmaStrategy : Strategy
 	/// <summary>
 	/// Window function applied to FIR coefficients.
 	/// </summary>
-	public AfirmaIndicator.WindowType Window
+	public AfirmaIndicator.WindowTypes Window
 	{
 		get => _window.Value;
 		set => _window.Value = value;
@@ -334,7 +334,7 @@ public sealed class AfirmaIndicator : BaseIndicator<decimal>
 	/// <summary>
 	/// Available window functions for the FIR design.
 	/// </summary>
-	public enum WindowType
+	public enum WindowTypes
 	{
 		Rectangular = 1,
 		Hanning1,
@@ -356,7 +356,7 @@ public sealed class AfirmaIndicator : BaseIndicator<decimal>
 	/// <summary>
 	/// Window function applied to the FIR coefficients.
 	/// </summary>
-	public WindowType Window { get; set; } = WindowType.Blackman;
+	public WindowTypes Window { get; set; } = WindowTypes.Blackman;
 
 	/// <inheritdoc />
 	protected override IIndicatorValue OnProcess(IIndicatorValue input)
@@ -426,11 +426,11 @@ public sealed class AfirmaIndicator : BaseIndicator<decimal>
 		{
 			double weight = Window switch
 			{
-				WindowType.Rectangular => 1.0,
-				WindowType.Hanning1 => 0.50 - 0.50 * Math.Cos(2.0 * Math.PI * k / _effectiveTaps),
-				WindowType.Hanning2 => 0.54 - 0.46 * Math.Cos(2.0 * Math.PI * k / _effectiveTaps),
-				WindowType.Blackman => 0.42 - 0.50 * Math.Cos(2.0 * Math.PI * k / _effectiveTaps) + 0.08 * Math.Cos(4.0 * Math.PI * k / _effectiveTaps),
-				WindowType.BlackmanHarris => 0.35875 - 0.48829 * Math.Cos(2.0 * Math.PI * k / _effectiveTaps) + 0.14128 * Math.Cos(4.0 * Math.PI * k / _effectiveTaps) - 0.01168 * Math.Cos(6.0 * Math.PI * k / _effectiveTaps),
+				WindowTypes.Rectangular => 1.0,
+				WindowTypes.Hanning1 => 0.50 - 0.50 * Math.Cos(2.0 * Math.PI * k / _effectiveTaps),
+				WindowTypes.Hanning2 => 0.54 - 0.46 * Math.Cos(2.0 * Math.PI * k / _effectiveTaps),
+				WindowTypes.Blackman => 0.42 - 0.50 * Math.Cos(2.0 * Math.PI * k / _effectiveTaps) + 0.08 * Math.Cos(4.0 * Math.PI * k / _effectiveTaps),
+				WindowTypes.BlackmanHarris => 0.35875 - 0.48829 * Math.Cos(2.0 * Math.PI * k / _effectiveTaps) + 0.14128 * Math.Cos(4.0 * Math.PI * k / _effectiveTaps) - 0.01168 * Math.Cos(6.0 * Math.PI * k / _effectiveTaps),
 				_ => 1.0
 			};
 

--- a/API/3113_Exp_RJTX_Matches_Smoothed_Duplex/CS/ExpRjtxMatchesSmoothedDuplexStrategy.cs
+++ b/API/3113_Exp_RJTX_Matches_Smoothed_Duplex/CS/ExpRjtxMatchesSmoothedDuplexStrategy.cs
@@ -29,7 +29,7 @@ public class ExpRjtxMatchesSmoothedDuplexStrategy : Strategy
 	private readonly StrategyParam<int> _longTakeProfitPoints;
 	private readonly StrategyParam<int> _longSignalBar;
 	private readonly StrategyParam<int> _longPeriod;
-	private readonly StrategyParam<SmoothingMethod> _longMethod;
+	private readonly StrategyParam<SmoothingMethods> _longMethod;
 	private readonly StrategyParam<int> _longLength;
 	private readonly StrategyParam<int> _longPhase;
 
@@ -41,7 +41,7 @@ public class ExpRjtxMatchesSmoothedDuplexStrategy : Strategy
 	private readonly StrategyParam<int> _shortTakeProfitPoints;
 	private readonly StrategyParam<int> _shortSignalBar;
 	private readonly StrategyParam<int> _shortPeriod;
-	private readonly StrategyParam<SmoothingMethod> _shortMethod;
+	private readonly StrategyParam<SmoothingMethods> _shortMethod;
 	private readonly StrategyParam<int> _shortLength;
 	private readonly StrategyParam<int> _shortPhase;
 
@@ -51,9 +51,9 @@ public class ExpRjtxMatchesSmoothedDuplexStrategy : Strategy
 	private IIndicator _shortCloseSmoother = null!;
 
 	private readonly List<decimal> _longOpenHistory = new();
-	private readonly List<RjtxSignal> _longSignalHistory = new();
+	private readonly List<RjtxSignals> _longSignalHistory = new();
 	private readonly List<decimal> _shortOpenHistory = new();
-	private readonly List<RjtxSignal> _shortSignalHistory = new();
+	private readonly List<RjtxSignals> _shortSignalHistory = new();
 
 	private decimal? _longEntryPrice;
 	private decimal? _shortEntryPrice;
@@ -91,7 +91,7 @@ public class ExpRjtxMatchesSmoothedDuplexStrategy : Strategy
 		.SetGreaterThanZero()
 		.SetDisplay("Long Period", "Lookback used when comparing smoothed open prices", "Long Block");
 
-		_longMethod = Param(nameof(LongMethod), SmoothingMethod.Sma)
+		_longMethod = Param(nameof(LongMethod), SmoothingMethods.Sma)
 		.SetDisplay("Long Smooth Method", "Smoothing algorithm applied to open/close prices", "Long Block");
 
 		_longLength = Param(nameof(LongLength), 12)
@@ -130,7 +130,7 @@ public class ExpRjtxMatchesSmoothedDuplexStrategy : Strategy
 		.SetGreaterThanZero()
 		.SetDisplay("Short Period", "Lookback used when comparing smoothed open prices", "Short Block");
 
-		_shortMethod = Param(nameof(ShortMethod), SmoothingMethod.Sma)
+		_shortMethod = Param(nameof(ShortMethod), SmoothingMethods.Sma)
 		.SetDisplay("Short Smooth Method", "Smoothing algorithm applied to open/close prices", "Short Block");
 
 		_shortLength = Param(nameof(ShortLength), 12)
@@ -217,7 +217,7 @@ public class ExpRjtxMatchesSmoothedDuplexStrategy : Strategy
 	/// <summary>
 	/// Smoothing algorithm used by the long block.
 	/// </summary>
-	public SmoothingMethod LongMethod
+	public SmoothingMethods LongMethod
 	{
 		get => _longMethod.Value;
 		set => _longMethod.Value = value;
@@ -316,7 +316,7 @@ public class ExpRjtxMatchesSmoothedDuplexStrategy : Strategy
 	/// <summary>
 	/// Smoothing algorithm used by the short block.
 	/// </summary>
-	public SmoothingMethod ShortMethod
+	public SmoothingMethods ShortMethod
 	{
 		get => _shortMethod.Value;
 		set => _shortMethod.Value = value;
@@ -421,12 +421,12 @@ public class ExpRjtxMatchesSmoothedDuplexStrategy : Strategy
 
 		if (_longOpenHistory.Count <= LongPeriod)
 		{
-			UpdateHistory(_longSignalHistory, RjtxSignal.None, Math.Max(2, LongSignalBar + 2));
+			UpdateHistory(_longSignalHistory, RjtxSignals.None, Math.Max(2, LongSignalBar + 2));
 			return;
 		}
 
 		var referenceOpen = _longOpenHistory[LongPeriod];
-		var signal = smoothedClose > referenceOpen ? RjtxSignal.Bullish : RjtxSignal.Bearish;
+		var signal = smoothedClose > referenceOpen ? RjtxSignals.Bullish : RjtxSignals.Bearish;
 
 		UpdateHistory(_longSignalHistory, signal, Math.Max(2, LongSignalBar + 2));
 
@@ -438,9 +438,9 @@ public class ExpRjtxMatchesSmoothedDuplexStrategy : Strategy
 
 		var executedSignal = _longSignalHistory[LongSignalBar];
 
-		if (executedSignal == RjtxSignal.Bullish)
+		if (executedSignal == RjtxSignals.Bullish)
 		TryOpenLong(candle.ClosePrice);
-		else if (executedSignal == RjtxSignal.Bearish && LongAllowClose)
+		else if (executedSignal == RjtxSignals.Bearish && LongAllowClose)
 		CloseLong();
 
 		UpdateRiskManagement(candle);
@@ -466,12 +466,12 @@ public class ExpRjtxMatchesSmoothedDuplexStrategy : Strategy
 
 		if (_shortOpenHistory.Count <= ShortPeriod)
 		{
-			UpdateHistory(_shortSignalHistory, RjtxSignal.None, Math.Max(2, ShortSignalBar + 2));
+			UpdateHistory(_shortSignalHistory, RjtxSignals.None, Math.Max(2, ShortSignalBar + 2));
 			return;
 		}
 
 		var referenceOpen = _shortOpenHistory[ShortPeriod];
-		var signal = smoothedClose > referenceOpen ? RjtxSignal.Bullish : RjtxSignal.Bearish;
+		var signal = smoothedClose > referenceOpen ? RjtxSignals.Bullish : RjtxSignals.Bearish;
 
 		UpdateHistory(_shortSignalHistory, signal, Math.Max(2, ShortSignalBar + 2));
 
@@ -483,9 +483,9 @@ public class ExpRjtxMatchesSmoothedDuplexStrategy : Strategy
 
 		var executedSignal = _shortSignalHistory[ShortSignalBar];
 
-		if (executedSignal == RjtxSignal.Bearish)
+		if (executedSignal == RjtxSignals.Bearish)
 		TryOpenShort(candle.ClosePrice);
-		else if (executedSignal == RjtxSignal.Bullish && ShortAllowClose)
+		else if (executedSignal == RjtxSignals.Bullish && ShortAllowClose)
 		CloseShort();
 
 		UpdateRiskManagement(candle);
@@ -603,7 +603,7 @@ public class ExpRjtxMatchesSmoothedDuplexStrategy : Strategy
 		history.RemoveAt(history.Count - 1);
 	}
 
-	private static IIndicator CreateSmoother(SmoothingMethod method, int length, int phase)
+	private static IIndicator CreateSmoother(SmoothingMethods method, int length, int phase)
 	{
 		var normalizedLength = Math.Max(1, length);
 		var offset = 0.5m + phase / 200m;
@@ -611,16 +611,16 @@ public class ExpRjtxMatchesSmoothedDuplexStrategy : Strategy
 
 		return method switch
 		{
-			SmoothingMethod.Sma => new SimpleMovingAverage { Length = normalizedLength },
-			SmoothingMethod.Ema => new ExponentialMovingAverage { Length = normalizedLength },
-			SmoothingMethod.Smma => new SmoothedMovingAverage { Length = normalizedLength },
-			SmoothingMethod.Lwma => new WeightedMovingAverage { Length = normalizedLength },
-			SmoothingMethod.Jjma => CreateJurik(normalizedLength, phase),
-			SmoothingMethod.Jurx => new ZeroLagExponentialMovingAverage { Length = normalizedLength },
-			SmoothingMethod.Parma => new ArnaudLegouxMovingAverage { Length = normalizedLength, Offset = offset, Sigma = 6m },
-			SmoothingMethod.T3 => new TripleExponentialMovingAverage { Length = normalizedLength },
-			SmoothingMethod.Vidya => new ExponentialMovingAverage { Length = normalizedLength },
-			SmoothingMethod.Ama => new KaufmanAdaptiveMovingAverage { Length = normalizedLength },
+			SmoothingMethods.Sma => new SimpleMovingAverage { Length = normalizedLength },
+			SmoothingMethods.Ema => new ExponentialMovingAverage { Length = normalizedLength },
+			SmoothingMethods.Smma => new SmoothedMovingAverage { Length = normalizedLength },
+			SmoothingMethods.Lwma => new WeightedMovingAverage { Length = normalizedLength },
+			SmoothingMethods.Jjma => CreateJurik(normalizedLength, phase),
+			SmoothingMethods.Jurx => new ZeroLagExponentialMovingAverage { Length = normalizedLength },
+			SmoothingMethods.Parma => new ArnaudLegouxMovingAverage { Length = normalizedLength, Offset = offset, Sigma = 6m },
+			SmoothingMethods.T3 => new TripleExponentialMovingAverage { Length = normalizedLength },
+			SmoothingMethods.Vidya => new ExponentialMovingAverage { Length = normalizedLength },
+			SmoothingMethods.Ama => new KaufmanAdaptiveMovingAverage { Length = normalizedLength },
 			_ => new SimpleMovingAverage { Length = normalizedLength },
 		};
 	}
@@ -639,7 +639,7 @@ public class ExpRjtxMatchesSmoothedDuplexStrategy : Strategy
 		return jurik;
 	}
 
-	private enum RjtxSignal
+	private enum RjtxSignals
 	{
 		None,
 		Bullish,
@@ -649,7 +649,7 @@ public class ExpRjtxMatchesSmoothedDuplexStrategy : Strategy
 	/// <summary>
 	/// Supported smoothing algorithms mirroring the SmoothAlgorithms library.
 	/// </summary>
-	public enum SmoothingMethod
+	public enum SmoothingMethods
 	{
 		/// <summary>Simple moving average.</summary>
 		Sma,

--- a/API/3114_LBS/CS/LbsStrategy.cs
+++ b/API/3114_LBS/CS/LbsStrategy.cs
@@ -23,7 +23,7 @@ public class LbsStrategy : Strategy
 	private readonly StrategyParam<int> _stopLossPips;
 	private readonly StrategyParam<int> _trailingStopPips;
 	private readonly StrategyParam<int> _trailingStepPips;
-	private readonly StrategyParam<MoneyManagementMode> _moneyMode;
+	private readonly StrategyParam<MoneyManagementModes> _moneyMode;
 	private readonly StrategyParam<decimal> _volumeOrRisk;
 	private readonly StrategyParam<int> _hour1;
 	private readonly StrategyParam<int> _hour2;
@@ -71,7 +71,7 @@ public class LbsStrategy : Strategy
 	/// <summary>
 	/// Money management mode controlling how the volume parameter is interpreted.
 	/// </summary>
-	public MoneyManagementMode MoneyMode
+	public MoneyManagementModes MoneyMode
 	{
 		get => _moneyMode.Value;
 		set => _moneyMode.Value = value;
@@ -139,7 +139,7 @@ public class LbsStrategy : Strategy
 		.SetDisplay("Trailing Step (pips)", "Additional pips required before the trailing stop moves.", "Risk Management")
 		.SetCanOptimize(true);
 
-		_moneyMode = Param(nameof(MoneyMode), MoneyManagementMode.FixedLot)
+		_moneyMode = Param(nameof(MoneyMode), MoneyManagementModes.FixedLot)
 		.SetDisplay("Money Mode", "Use fixed lots or risk percentage for sizing.", "Money Management");
 
 		_volumeOrRisk = Param(nameof(VolumeOrRisk), 1m)
@@ -441,8 +441,8 @@ public class LbsStrategy : Strategy
 
 		return MoneyMode switch
 		{
-			MoneyManagementMode.FixedLot => NormalizeVolume(VolumeOrRisk),
-			MoneyManagementMode.RiskPercent => CalculateRiskVolume(entryPrice, stopPrice),
+			MoneyManagementModes.FixedLot => NormalizeVolume(VolumeOrRisk),
+			MoneyManagementModes.RiskPercent => CalculateRiskVolume(entryPrice, stopPrice),
 			_ => 0m
 		};
 	}
@@ -615,7 +615,7 @@ public class LbsStrategy : Strategy
 /// <summary>
 /// Money management options reproduced from the original MQL strategy.
 /// </summary>
-public enum MoneyManagementMode
+public enum MoneyManagementModes
 {
 	/// <summary>
 	/// Use a fixed trading volume.

--- a/API/3117_Lego_EA/CS/LegoEaStrategy.cs
+++ b/API/3117_Lego_EA/CS/LegoEaStrategy.cs
@@ -39,7 +39,7 @@ public class LegoEaStrategy : Strategy
 	private readonly StrategyParam<int> _maFastPeriod;
 	private readonly StrategyParam<int> _maSlowPeriod;
 	private readonly StrategyParam<int> _maShift;
-	private readonly StrategyParam<MaMethodOption> _maMethod;
+	private readonly StrategyParam<MaMethodOptions> _maMethod;
 	private readonly StrategyParam<CandlePrice> _maPrice;
 	private readonly StrategyParam<int> _stochasticKPeriod;
 	private readonly StrategyParam<int> _stochasticDPeriod;
@@ -139,7 +139,7 @@ public class LegoEaStrategy : Strategy
 			.SetDisplay("MA Shift", "Number of completed bars used to offset moving averages", "Indicators")
 			.SetNotNegative();
 
-		_maMethod = Param(nameof(MaMethod), MaMethodOption.Simple)
+		_maMethod = Param(nameof(MaMethod), MaMethodOptions.Simple)
 			.SetDisplay("MA Method", "Smoothing method for moving averages", "Indicators");
 
 		_maPrice = Param(nameof(MaPrice), CandlePrice.Close)
@@ -352,7 +352,7 @@ public class LegoEaStrategy : Strategy
 	/// <summary>
 	/// Moving average smoothing method.
 	/// </summary>
-	public MaMethodOption MaMethod
+	public MaMethodOptions MaMethod
 	{
 		get => _maMethod.Value;
 		set => _maMethod.Value = value;
@@ -771,14 +771,14 @@ public class LegoEaStrategy : Strategy
 		return priceStep * pipFactor;
 	}
 
-	private static LengthIndicator<decimal> CreateMovingAverage(MaMethodOption method, int length, CandlePrice price)
+	private static LengthIndicator<decimal> CreateMovingAverage(MaMethodOptions method, int length, CandlePrice price)
 	{
 		LengthIndicator<decimal> indicator = method switch
 		{
-			MaMethodOption.Simple => new SimpleMovingAverage(),
-			MaMethodOption.Exponential => new ExponentialMovingAverage(),
-			MaMethodOption.Smoothed => new SmoothedMovingAverage(),
-			MaMethodOption.Weighted => new WeightedMovingAverage(),
+			MaMethodOptions.Simple => new SimpleMovingAverage(),
+			MaMethodOptions.Exponential => new ExponentialMovingAverage(),
+			MaMethodOptions.Smoothed => new SmoothedMovingAverage(),
+			MaMethodOptions.Weighted => new WeightedMovingAverage(),
 			_ => new SimpleMovingAverage()
 		};
 
@@ -790,7 +790,7 @@ public class LegoEaStrategy : Strategy
 	/// <summary>
 	/// Available moving average smoothing methods.
 	/// </summary>
-	public enum MaMethodOption
+	public enum MaMethodOptions
 	{
 		/// <summary>
 		/// Simple moving average.

--- a/API/3118_GlamTrader/CS/GlamTraderStrategy.cs
+++ b/API/3118_GlamTrader/CS/GlamTraderStrategy.cs
@@ -29,8 +29,8 @@ public class GlamTraderStrategy : Strategy
 	private readonly StrategyParam<decimal> _trailingStepPips;
 	private readonly StrategyParam<int> _maPeriod;
 	private readonly StrategyParam<int> _maShift;
-	private readonly StrategyParam<MaMethod> _maMethod;
-	private readonly StrategyParam<AppliedPrice> _appliedPrice;
+	private readonly StrategyParam<MaMethods> _maMethod;
+	private readonly StrategyParam<AppliedPrices> _appliedPrice;
 	private readonly StrategyParam<decimal> _laguerreGamma;
 
 	private LengthIndicator<decimal> _maIndicator = null!;
@@ -115,10 +115,10 @@ public class GlamTraderStrategy : Strategy
 		.SetCanOptimize(true)
 		.SetOptimize(0, 5, 1);
 
-		_maMethod = Param(nameof(MaMethod), MaMethod.LinearWeighted)
+		_maMethod = Param(nameof(MaMethods), MaMethods.LinearWeighted)
 		.SetDisplay("MA Method", "Averaging method applied to the moving average", "Indicators");
 
-		_appliedPrice = Param(nameof(AppliedPrice), AppliedPrice.Weighted)
+		_appliedPrice = Param(nameof(AppliedPrices), AppliedPrices.Weighted)
 		.SetDisplay("Applied Price", "Price source used for both MA and Laguerre filters", "Indicators");
 
 		_laguerreGamma = Param(nameof(LaguerreGamma), 0.7m)
@@ -221,7 +221,7 @@ public class GlamTraderStrategy : Strategy
 	/// <summary>
 	/// Moving average method replicated from MetaTrader constants.
 	/// </summary>
-	public MaMethod MaMethod
+	public MaMethods MaMethods
 	{
 		get => _maMethod.Value;
 		set => _maMethod.Value = value;
@@ -230,7 +230,7 @@ public class GlamTraderStrategy : Strategy
 	/// <summary>
 	/// Price source used by the moving average and Laguerre filter.
 	/// </summary>
-	public AppliedPrice AppliedPrice
+	public AppliedPrices AppliedPrices
 	{
 		get => _appliedPrice.Value;
 		set => _appliedPrice.Value = value;
@@ -290,7 +290,7 @@ public class GlamTraderStrategy : Strategy
 			_pipSize = _priceStep * 10m;
 		}
 
-		_maIndicator = CreateMovingAverage(MaMethod, MaPeriod);
+		_maIndicator = CreateMovingAverage(MaMethods, MaPeriod);
 		_awesomeOscillator = new AwesomeOscillator();
 
 		var subscription = SubscribeCandles(CandleType);
@@ -609,27 +609,27 @@ public class GlamTraderStrategy : Strategy
 
 	private decimal GetAppliedPrice(ICandleMessage candle)
 	{
-		return AppliedPrice switch
+		return AppliedPrices switch
 		{
-			AppliedPrice.Close => candle.ClosePrice,
-			AppliedPrice.Open => candle.OpenPrice,
-			AppliedPrice.High => candle.HighPrice,
-			AppliedPrice.Low => candle.LowPrice,
-			AppliedPrice.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-			AppliedPrice.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-			AppliedPrice.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
+			AppliedPrices.Close => candle.ClosePrice,
+			AppliedPrices.Open => candle.OpenPrice,
+			AppliedPrices.High => candle.HighPrice,
+			AppliedPrices.Low => candle.LowPrice,
+			AppliedPrices.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+			AppliedPrices.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+			AppliedPrices.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
 			_ => candle.ClosePrice,
 		};
 	}
 
-	private LengthIndicator<decimal> CreateMovingAverage(MaMethod method, int length)
+	private LengthIndicator<decimal> CreateMovingAverage(MaMethods method, int length)
 	{
 		return method switch
 		{
-			MaMethod.Simple => new SimpleMovingAverage { Length = length },
-			MaMethod.Exponential => new ExponentialMovingAverage { Length = length },
-			MaMethod.Smoothed => new SmoothedMovingAverage { Length = length },
-			MaMethod.LinearWeighted => new WeightedMovingAverage { Length = length },
+			MaMethods.Simple => new SimpleMovingAverage { Length = length },
+			MaMethods.Exponential => new ExponentialMovingAverage { Length = length },
+			MaMethods.Smoothed => new SmoothedMovingAverage { Length = length },
+			MaMethods.LinearWeighted => new WeightedMovingAverage { Length = length },
 			_ => new SimpleMovingAverage { Length = length },
 		};
 	}
@@ -659,7 +659,7 @@ public class GlamTraderStrategy : Strategy
 	/// <summary>
 	/// Moving average methods corresponding to MetaTrader modes.
 	/// </summary>
-	public enum MaMethod
+	public enum MaMethods
 	{
 		Simple,
 		Exponential,
@@ -670,7 +670,7 @@ public class GlamTraderStrategy : Strategy
 	/// <summary>
 	/// Price source equivalents of MetaTrader's applied price constants.
 	/// </summary>
-	public enum AppliedPrice
+	public enum AppliedPrices
 	{
 		Close,
 		Open,

--- a/API/3120_Contrarian_trade_MA_Monday/CS/ContrarianTradeMaMondayStrategy.cs
+++ b/API/3120_Contrarian_trade_MA_Monday/CS/ContrarianTradeMaMondayStrategy.cs
@@ -22,8 +22,8 @@ public class ContrarianTradeMaMondayStrategy : Strategy
 	private readonly StrategyParam<int> _stopLossPips;
 	private readonly StrategyParam<int> _maPeriod;
 	private readonly StrategyParam<int> _maShift;
-	private readonly StrategyParam<MovingAverageMethod> _maMethod;
-	private readonly StrategyParam<AppliedPriceType> _appliedPrice;
+	private readonly StrategyParam<MovingAverageMethods> _maMethod;
+	private readonly StrategyParam<AppliedPriceTypes> _appliedPrice;
 	private readonly StrategyParam<DataType> _tradeCandleType;
 	private readonly StrategyParam<DataType> _maCandleType;
 
@@ -82,7 +82,7 @@ public class ContrarianTradeMaMondayStrategy : Strategy
 	/// <summary>
 	/// Moving average smoothing method.
 	/// </summary>
-	public MovingAverageMethod MaMethod
+	public MovingAverageMethods MaMethod
 	{
 		get => _maMethod.Value;
 		set => _maMethod.Value = value;
@@ -91,7 +91,7 @@ public class ContrarianTradeMaMondayStrategy : Strategy
 	/// <summary>
 	/// Price source used in the moving average calculation.
 	/// </summary>
-	public AppliedPriceType AppliedPrice
+	public AppliedPriceTypes AppliedPrice
 	{
 		get => _appliedPrice.Value;
 		set => _appliedPrice.Value = value;
@@ -142,10 +142,10 @@ public class ContrarianTradeMaMondayStrategy : Strategy
 			.SetNotNegative()
 			.SetDisplay("MA Shift", "Horizontal shift applied to the moving average", "Moving Average");
 
-		_maMethod = Param(nameof(MaMethod), MovingAverageMethod.LinearWeighted)
+		_maMethod = Param(nameof(MaMethod), MovingAverageMethods.LinearWeighted)
 			.SetDisplay("MA Method", "Moving average smoothing method", "Moving Average");
 
-		_appliedPrice = Param(nameof(AppliedPrice), AppliedPriceType.Weighted)
+		_appliedPrice = Param(nameof(AppliedPrice), AppliedPriceTypes.Weighted)
 			.SetDisplay("Applied Price", "Price source fed into the moving average", "Moving Average");
 
 		_tradeCandleType = Param(nameof(TradeCandleType), TimeSpan.FromDays(1).TimeFrame())
@@ -389,28 +389,28 @@ public class ContrarianTradeMaMondayStrategy : Strategy
 		return step.Value * StopLossPips;
 	}
 
-	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPriceType type)
+	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPriceTypes type)
 	{
 		return type switch
 		{
-			AppliedPriceType.Open => candle.OpenPrice,
-			AppliedPriceType.High => candle.HighPrice,
-			AppliedPriceType.Low => candle.LowPrice,
-			AppliedPriceType.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-			AppliedPriceType.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-			AppliedPriceType.Weighted => (candle.HighPrice + candle.LowPrice + (2m * candle.ClosePrice)) / 4m,
+			AppliedPriceTypes.Open => candle.OpenPrice,
+			AppliedPriceTypes.High => candle.HighPrice,
+			AppliedPriceTypes.Low => candle.LowPrice,
+			AppliedPriceTypes.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+			AppliedPriceTypes.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+			AppliedPriceTypes.Weighted => (candle.HighPrice + candle.LowPrice + (2m * candle.ClosePrice)) / 4m,
 			_ => candle.ClosePrice,
 		};
 	}
 
-	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageMethod method, int length)
+	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageMethods method, int length)
 	{
 		return method switch
 		{
-			MovingAverageMethod.Simple => new SimpleMovingAverage { Length = length },
-			MovingAverageMethod.Exponential => new ExponentialMovingAverage { Length = length },
-			MovingAverageMethod.Smoothed => new SmoothedMovingAverage { Length = length },
-			MovingAverageMethod.LinearWeighted => new WeightedMovingAverage { Length = length },
+			MovingAverageMethods.Simple => new SimpleMovingAverage { Length = length },
+			MovingAverageMethods.Exponential => new ExponentialMovingAverage { Length = length },
+			MovingAverageMethods.Smoothed => new SmoothedMovingAverage { Length = length },
+			MovingAverageMethods.LinearWeighted => new WeightedMovingAverage { Length = length },
 			_ => new ExponentialMovingAverage { Length = length },
 		};
 	}
@@ -418,7 +418,7 @@ public class ContrarianTradeMaMondayStrategy : Strategy
 	/// <summary>
 	/// Moving average methods supported by the strategy.
 	/// </summary>
-	public enum MovingAverageMethod
+	public enum MovingAverageMethods
 	{
 		Simple,
 		Exponential,
@@ -429,7 +429,7 @@ public class ContrarianTradeMaMondayStrategy : Strategy
 	/// <summary>
 	/// Price sources that can be fed into the moving average.
 	/// </summary>
-	public enum AppliedPriceType
+	public enum AppliedPriceTypes
 	{
 		Close,
 		Open,

--- a/API/3123_Secwenta_MultiBar_Signals/CS/SecwentaMultiBarSignalsStrategy.cs
+++ b/API/3123_Secwenta_MultiBar_Signals/CS/SecwentaMultiBarSignalsStrategy.cs
@@ -24,13 +24,13 @@ public class SecwentaMultiBarSignalsStrategy : Strategy
 	private readonly StrategyParam<int> _bearishBarCount;
 	private readonly StrategyParam<DataType> _candleType;
 
-	private readonly Queue<CandleDirection> _directions = new();
+	private readonly Queue<CandleDirections> _directions = new();
 
 	private int _bullCounter;
 	private int _bearCounter;
 	private int _maxBufferSize;
 
-	private enum CandleDirection
+	private enum CandleDirections
 	{
 		Neutral,
 		Bullish,
@@ -305,16 +305,16 @@ public class SecwentaMultiBarSignalsStrategy : Strategy
 			RemoveOldest();
 	}
 
-	private void AddDirection(CandleDirection direction)
+	private void AddDirection(CandleDirections direction)
 	{
 		_directions.Enqueue(direction);
 
 		switch (direction)
 		{
-			case CandleDirection.Bullish:
+			case CandleDirections.Bullish:
 				_bullCounter++;
 				break;
-			case CandleDirection.Bearish:
+			case CandleDirections.Bearish:
 				_bearCounter++;
 				break;
 		}
@@ -332,24 +332,24 @@ public class SecwentaMultiBarSignalsStrategy : Strategy
 
 		switch (removed)
 		{
-			case CandleDirection.Bullish:
+			case CandleDirections.Bullish:
 				_bullCounter = Math.Max(0, _bullCounter - 1);
 				break;
-			case CandleDirection.Bearish:
+			case CandleDirections.Bearish:
 				_bearCounter = Math.Max(0, _bearCounter - 1);
 				break;
 		}
 	}
 
-	private static CandleDirection GetDirection(ICandleMessage candle)
+	private static CandleDirections GetDirection(ICandleMessage candle)
 	{
 		if (candle.ClosePrice > candle.OpenPrice)
-			return CandleDirection.Bullish;
+			return CandleDirections.Bullish;
 
 		if (candle.ClosePrice < candle.OpenPrice)
-			return CandleDirection.Bearish;
+			return CandleDirections.Bearish;
 
-		return CandleDirection.Neutral;
+		return CandleDirections.Neutral;
 	}
 }
 

--- a/API/3130_Exp_ColorTSI_Oscillator/CS/ExpColorTsiOscillatorStrategy.cs
+++ b/API/3130_Exp_ColorTSI_Oscillator/CS/ExpColorTsiOscillatorStrategy.cs
@@ -24,13 +24,13 @@ using StockSharp.Algo;
 public class ExpColorTsiOscillatorStrategy : Strategy
 {
 	private readonly StrategyParam<DataType> _candleType;
-	private readonly StrategyParam<ColorTsiSmoothingMethod> _firstMethod;
+	private readonly StrategyParam<ColorTsiSmoothingMethods> _firstMethod;
 	private readonly StrategyParam<int> _firstLength;
 	private readonly StrategyParam<int> _firstPhase;
-	private readonly StrategyParam<ColorTsiSmoothingMethod> _secondMethod;
+	private readonly StrategyParam<ColorTsiSmoothingMethods> _secondMethod;
 	private readonly StrategyParam<int> _secondLength;
 	private readonly StrategyParam<int> _secondPhase;
-	private readonly StrategyParam<ColorTsiAppliedPrice> _priceMode;
+	private readonly StrategyParam<ColorTsiAppliedPrices> _priceMode;
 	private readonly StrategyParam<int> _signalBar;
 	private readonly StrategyParam<int> _triggerShift;
 	private readonly StrategyParam<bool> _enableLongEntries;
@@ -62,7 +62,7 @@ public class ExpColorTsiOscillatorStrategy : Strategy
 		.SetDisplay("Candle Type", "Timeframe used for signal calculations", "General");
 
 
-		_firstMethod = Param(nameof(FirstMethod), ColorTsiSmoothingMethod.Sma)
+		_firstMethod = Param(nameof(FirstMethod), ColorTsiSmoothingMethods.Sma)
 		.SetDisplay("Momentum Smoother", "Smoothing method applied to price momentum", "Indicator");
 
 		_firstLength = Param(nameof(FirstLength), 12)
@@ -75,7 +75,7 @@ public class ExpColorTsiOscillatorStrategy : Strategy
 		.SetDisplay("Momentum Phase", "Phase parameter for Jurik-style averages", "Indicator")
 		.SetRange(-100, 100);
 
-		_secondMethod = Param(nameof(SecondMethod), ColorTsiSmoothingMethod.Sma)
+		_secondMethod = Param(nameof(SecondMethod), ColorTsiSmoothingMethods.Sma)
 		.SetDisplay("Signal Smoother", "Smoothing method applied to the second stage", "Indicator");
 
 		_secondLength = Param(nameof(SecondLength), 12)
@@ -88,7 +88,7 @@ public class ExpColorTsiOscillatorStrategy : Strategy
 		.SetDisplay("Signal Phase", "Phase parameter for the second stage", "Indicator")
 		.SetRange(-100, 100);
 
-		_priceMode = Param(nameof(PriceMode), ColorTsiAppliedPrice.Close)
+		_priceMode = Param(nameof(PriceMode), ColorTsiAppliedPrices.Close)
 		.SetDisplay("Applied Price", "Price source fed to the oscillator", "Indicator");
 
 		_signalBar = Param(nameof(SignalBar), 1)
@@ -133,7 +133,7 @@ public DataType CandleType
 /// <summary>
 /// Smoothing algorithm applied to raw momentum values.
 /// </summary>
-public ColorTsiSmoothingMethod FirstMethod
+public ColorTsiSmoothingMethods FirstMethod
 {
 get => _firstMethod.Value;
 set => _firstMethod.Value = value;
@@ -160,7 +160,7 @@ set => _firstPhase.Value = value;
 /// <summary>
 /// Smoothing algorithm applied to the second stage.
 /// </summary>
-public ColorTsiSmoothingMethod SecondMethod
+public ColorTsiSmoothingMethods SecondMethod
 {
 get => _secondMethod.Value;
 set => _secondMethod.Value = value;
@@ -187,7 +187,7 @@ set => _secondPhase.Value = value;
 /// <summary>
 /// Applied price used as oscillator input.
 /// </summary>
-public ColorTsiAppliedPrice PriceMode
+public ColorTsiAppliedPrices PriceMode
 {
 get => _priceMode.Value;
 set => _priceMode.Value = value;
@@ -450,22 +450,22 @@ _lastLongEntryTime = null;
 _lastShortEntryTime = null;
 }
 
-private static decimal GetAppliedPrice(ICandleMessage candle, ColorTsiAppliedPrice priceMode)
+private static decimal GetAppliedPrice(ICandleMessage candle, ColorTsiAppliedPrices priceMode)
 {
 return priceMode switch
 {
-ColorTsiAppliedPrice.Close => candle.ClosePrice,
-ColorTsiAppliedPrice.Open => candle.OpenPrice,
-ColorTsiAppliedPrice.High => candle.HighPrice,
-ColorTsiAppliedPrice.Low => candle.LowPrice,
-ColorTsiAppliedPrice.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-ColorTsiAppliedPrice.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-ColorTsiAppliedPrice.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice * 2m) / 4m,
-ColorTsiAppliedPrice.Simple => (candle.OpenPrice + candle.ClosePrice) / 2m,
-ColorTsiAppliedPrice.Quarter => (candle.OpenPrice + candle.ClosePrice + candle.HighPrice + candle.LowPrice) / 4m,
-ColorTsiAppliedPrice.TrendFollow0 => candle.ClosePrice > candle.OpenPrice ? candle.HighPrice : candle.ClosePrice < candle.OpenPrice ? candle.LowPrice : candle.ClosePrice,
-ColorTsiAppliedPrice.TrendFollow1 => candle.ClosePrice > candle.OpenPrice ? (candle.HighPrice + candle.ClosePrice) / 2m : candle.ClosePrice < candle.OpenPrice ? (candle.LowPrice + candle.ClosePrice) / 2m : candle.ClosePrice,
-ColorTsiAppliedPrice.Demark => CalculateDemarkPrice(candle),
+ColorTsiAppliedPrices.Close => candle.ClosePrice,
+ColorTsiAppliedPrices.Open => candle.OpenPrice,
+ColorTsiAppliedPrices.High => candle.HighPrice,
+ColorTsiAppliedPrices.Low => candle.LowPrice,
+ColorTsiAppliedPrices.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+ColorTsiAppliedPrices.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+ColorTsiAppliedPrices.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice * 2m) / 4m,
+ColorTsiAppliedPrices.Simple => (candle.OpenPrice + candle.ClosePrice) / 2m,
+ColorTsiAppliedPrices.Quarter => (candle.OpenPrice + candle.ClosePrice + candle.HighPrice + candle.LowPrice) / 4m,
+ColorTsiAppliedPrices.TrendFollow0 => candle.ClosePrice > candle.OpenPrice ? candle.HighPrice : candle.ClosePrice < candle.OpenPrice ? candle.LowPrice : candle.ClosePrice,
+ColorTsiAppliedPrices.TrendFollow1 => candle.ClosePrice > candle.OpenPrice ? (candle.HighPrice + candle.ClosePrice) / 2m : candle.ClosePrice < candle.OpenPrice ? (candle.LowPrice + candle.ClosePrice) / 2m : candle.ClosePrice,
+ColorTsiAppliedPrices.Demark => CalculateDemarkPrice(candle),
 _ => candle.ClosePrice,
 };
 }
@@ -484,7 +484,7 @@ sum = (sum + candle.ClosePrice) / 2m;
 return ((sum - candle.LowPrice) + (sum - candle.HighPrice)) / 2m;
 }
 
-private static IIndicator CreateSmoother(ColorTsiSmoothingMethod method, int length, int phase)
+private static IIndicator CreateSmoother(ColorTsiSmoothingMethods method, int length, int phase)
 {
 var normalizedLength = Math.Max(1, length);
 var offset = 0.5m + phase / 200m;
@@ -492,16 +492,16 @@ offset = Math.Max(0m, Math.Min(1m, offset));
 
 return method switch
 {
-ColorTsiSmoothingMethod.Sma => new SimpleMovingAverage { Length = normalizedLength },
-ColorTsiSmoothingMethod.Ema => new ExponentialMovingAverage { Length = normalizedLength },
-ColorTsiSmoothingMethod.Smma => new SmoothedMovingAverage { Length = normalizedLength },
-ColorTsiSmoothingMethod.Lwma => new WeightedMovingAverage { Length = normalizedLength },
-ColorTsiSmoothingMethod.Jjma => CreateJurik(normalizedLength, phase),
-ColorTsiSmoothingMethod.Jurx => new ZeroLagExponentialMovingAverage { Length = normalizedLength },
-ColorTsiSmoothingMethod.Parma => new ArnaudLegouxMovingAverage { Length = normalizedLength, Offset = offset, Sigma = 6m },
-ColorTsiSmoothingMethod.T3 => new TripleExponentialMovingAverage { Length = normalizedLength },
-ColorTsiSmoothingMethod.Vidya => new ExponentialMovingAverage { Length = normalizedLength },
-ColorTsiSmoothingMethod.Ama => new KaufmanAdaptiveMovingAverage { Length = normalizedLength },
+ColorTsiSmoothingMethods.Sma => new SimpleMovingAverage { Length = normalizedLength },
+ColorTsiSmoothingMethods.Ema => new ExponentialMovingAverage { Length = normalizedLength },
+ColorTsiSmoothingMethods.Smma => new SmoothedMovingAverage { Length = normalizedLength },
+ColorTsiSmoothingMethods.Lwma => new WeightedMovingAverage { Length = normalizedLength },
+ColorTsiSmoothingMethods.Jjma => CreateJurik(normalizedLength, phase),
+ColorTsiSmoothingMethods.Jurx => new ZeroLagExponentialMovingAverage { Length = normalizedLength },
+ColorTsiSmoothingMethods.Parma => new ArnaudLegouxMovingAverage { Length = normalizedLength, Offset = offset, Sigma = 6m },
+ColorTsiSmoothingMethods.T3 => new TripleExponentialMovingAverage { Length = normalizedLength },
+ColorTsiSmoothingMethods.Vidya => new ExponentialMovingAverage { Length = normalizedLength },
+ColorTsiSmoothingMethods.Ama => new KaufmanAdaptiveMovingAverage { Length = normalizedLength },
 _ => new SimpleMovingAverage { Length = normalizedLength },
 };
 }
@@ -523,7 +523,7 @@ return jurik;
 /// <summary>
 /// Supported smoothing methods for the ColorTSI oscillator.
 /// </summary>
-public enum ColorTsiSmoothingMethod
+public enum ColorTsiSmoothingMethods
 {
 /// <summary>Simple moving average.</summary>
 Sma,
@@ -550,7 +550,7 @@ Ama
 /// <summary>
 /// Applied price options mirroring the original indicator.
 /// </summary>
-public enum ColorTsiAppliedPrice
+public enum ColorTsiAppliedPrices
 {
 /// <summary>Close price.</summary>
 Close,

--- a/API/3137_Stochastic_CG_Oscillator/CS/StochasticCgOscillatorStrategy.cs
+++ b/API/3137_Stochastic_CG_Oscillator/CS/StochasticCgOscillatorStrategy.cs
@@ -32,7 +32,7 @@ public class StochasticCgOscillatorStrategy : Strategy
 	private readonly StrategyParam<int> _takeProfitPoints;
 	private readonly StrategyParam<decimal> _fixedVolume;
 	private readonly StrategyParam<decimal> _depositShare;
-	private readonly StrategyParam<PositionSizingMode> _sizingMode;
+	private readonly StrategyParam<PositionSizingModes> _sizingMode;
 
 	private StochasticCgOscillatorIndicator _oscillator = null!;
 	private readonly List<(decimal Main, decimal Trigger)> _oscillatorHistory = new();
@@ -84,7 +84,7 @@ public class StochasticCgOscillatorStrategy : Strategy
 			.SetNotNegative()
 			.SetDisplay("Deposit Share", "Fraction of portfolio value allocated per trade", "Risk");
 
-		_sizingMode = Param(nameof(SizingMode), PositionSizingMode.FixedVolume)
+		_sizingMode = Param(nameof(SizingMode), PositionSizingModes.FixedVolume)
 			.SetDisplay("Position Sizing", "Method used to convert the deposit share into volume", "Risk");
 	}
 
@@ -170,7 +170,7 @@ public class StochasticCgOscillatorStrategy : Strategy
 	}
 
 	/// <summary>
-	/// Fixed trade volume when sizing mode is <see cref="PositionSizingMode.FixedVolume"/>.
+	/// Fixed trade volume when sizing mode is <see cref="PositionSizingModes.FixedVolume"/>.
 	/// </summary>
 	public decimal FixedVolume
 	{
@@ -190,7 +190,7 @@ public class StochasticCgOscillatorStrategy : Strategy
 	/// <summary>
 	/// Position sizing behaviour.
 	/// </summary>
-	public PositionSizingMode SizingMode
+	public PositionSizingModes SizingMode
 	{
 		get => _sizingMode.Value;
 		set => _sizingMode.Value = value;
@@ -334,7 +334,7 @@ public class StochasticCgOscillatorStrategy : Strategy
 
 	private decimal CalculateOrderVolume(decimal referencePrice)
 	{
-		if (SizingMode == PositionSizingMode.FixedVolume)
+		if (SizingMode == PositionSizingModes.FixedVolume)
 			return FixedVolume;
 
 		if (Portfolio is null || referencePrice <= 0m)
@@ -414,7 +414,7 @@ public class StochasticCgOscillatorStrategy : Strategy
 /// <summary>
 /// Position sizing modes supported by the strategy.
 /// </summary>
-public enum PositionSizingMode
+public enum PositionSizingModes
 {
 	/// <summary>Always trade the configured fixed volume.</summary>
 	FixedVolume,

--- a/API/3140_Exp_Slow_Stoch_Duplex/CS/ExpSlowStochDuplexStrategy.cs
+++ b/API/3140_Exp_Slow_Stoch_Duplex/CS/ExpSlowStochDuplexStrategy.cs
@@ -24,7 +24,7 @@ public class ExpSlowStochDuplexStrategy : Strategy
 	private readonly StrategyParam<int> _longDPeriod;
 	private readonly StrategyParam<int> _longSlowing;
 	private readonly StrategyParam<int> _longSignalBar;
-	private readonly StrategyParam<SmoothingMethod> _longSmoothingMethod;
+	private readonly StrategyParam<SmoothingMethods> _longSmoothingMethod;
 	private readonly StrategyParam<int> _longSmoothingLength;
 	private readonly StrategyParam<bool> _longEnableOpen;
 	private readonly StrategyParam<bool> _longEnableClose;
@@ -34,7 +34,7 @@ public class ExpSlowStochDuplexStrategy : Strategy
 	private readonly StrategyParam<int> _shortDPeriod;
 	private readonly StrategyParam<int> _shortSlowing;
 	private readonly StrategyParam<int> _shortSignalBar;
-	private readonly StrategyParam<SmoothingMethod> _shortSmoothingMethod;
+	private readonly StrategyParam<SmoothingMethods> _shortSmoothingMethod;
 	private readonly StrategyParam<int> _shortSmoothingLength;
 	private readonly StrategyParam<bool> _shortEnableOpen;
 	private readonly StrategyParam<bool> _shortEnableClose;
@@ -79,7 +79,7 @@ public class ExpSlowStochDuplexStrategy : Strategy
 			.SetNotNegative()
 			.SetDisplay("Long Signal Bar", "Shift in bars used to detect the crossover for longs", "Logic");
 
-		_longSmoothingMethod = Param(nameof(LongSmoothingMethod), SmoothingMethod.Smoothed)
+		_longSmoothingMethod = Param(nameof(LongSmoothingMethod), SmoothingMethods.Smoothed)
 			.SetDisplay("Long Smoothing", "Post-processing method applied to %K and %D", "Indicators");
 
 		_longSmoothingLength = Param(nameof(LongSmoothingLength), 5)
@@ -111,7 +111,7 @@ public class ExpSlowStochDuplexStrategy : Strategy
 			.SetNotNegative()
 			.SetDisplay("Short Signal Bar", "Shift in bars used to detect the crossover for shorts", "Logic");
 
-		_shortSmoothingMethod = Param(nameof(ShortSmoothingMethod), SmoothingMethod.Smoothed)
+		_shortSmoothingMethod = Param(nameof(ShortSmoothingMethod), SmoothingMethods.Smoothed)
 			.SetDisplay("Short Smoothing", "Post-processing method applied to %K and %D", "Indicators");
 
 		_shortSmoothingLength = Param(nameof(ShortSmoothingLength), 5)
@@ -185,7 +185,7 @@ public class ExpSlowStochDuplexStrategy : Strategy
 	/// <summary>
 	/// Smoothing method applied to the long stochastic output.
 	/// </summary>
-	public SmoothingMethod LongSmoothingMethod
+	public SmoothingMethods LongSmoothingMethod
 	{
 		get => _longSmoothingMethod.Value;
 		set => _longSmoothingMethod.Value = value;
@@ -266,7 +266,7 @@ public class ExpSlowStochDuplexStrategy : Strategy
 	/// <summary>
 	/// Smoothing method applied to the short stochastic output.
 	/// </summary>
-	public SmoothingMethod ShortSmoothingMethod
+	public SmoothingMethods ShortSmoothingMethod
 	{
 		get => _shortSmoothingMethod.Value;
 		set => _shortSmoothingMethod.Value = value;
@@ -511,17 +511,17 @@ public class ExpSlowStochDuplexStrategy : Strategy
 		}
 	}
 
-	private static LengthIndicator<decimal> CreateSmoother(SmoothingMethod method, int length)
+	private static LengthIndicator<decimal> CreateSmoother(SmoothingMethods method, int length)
 	{
-		if (method == SmoothingMethod.None || length <= 1)
+		if (method == SmoothingMethods.None || length <= 1)
 			return null;
 
 		return method switch
 		{
-			SmoothingMethod.Simple => new SimpleMovingAverage { Length = length },
-			SmoothingMethod.Exponential => new ExponentialMovingAverage { Length = length },
-			SmoothingMethod.Weighted => new WeightedMovingAverage { Length = length },
-			SmoothingMethod.Smoothed => new SmoothedMovingAverage { Length = length },
+			SmoothingMethods.Simple => new SimpleMovingAverage { Length = length },
+			SmoothingMethods.Exponential => new ExponentialMovingAverage { Length = length },
+			SmoothingMethods.Weighted => new WeightedMovingAverage { Length = length },
+			SmoothingMethods.Smoothed => new SmoothedMovingAverage { Length = length },
 			_ => null,
 		};
 	}
@@ -571,7 +571,7 @@ public class ExpSlowStochDuplexStrategy : Strategy
 	/// <summary>
 	/// Available smoothing methods for the secondary averaging stage.
 	/// </summary>
-	public enum SmoothingMethod
+	public enum SmoothingMethods
 	{
 		/// <summary>
 		/// No additional smoothing.

--- a/API/3143_Vortex_Indicator_MMRec_Duplex/CS/VortexIndicatorMmrecDuplexStrategy.cs
+++ b/API/3143_Vortex_Indicator_MMRec_Duplex/CS/VortexIndicatorMmrecDuplexStrategy.cs
@@ -37,8 +37,8 @@ public class VortexIndicatorMmrecDuplexStrategy : Strategy
 	private readonly StrategyParam<decimal> _shortSmallMoneyManagement;
 	private readonly StrategyParam<decimal> _longMoneyManagement;
 	private readonly StrategyParam<decimal> _shortMoneyManagement;
-	private readonly StrategyParam<MarginModeOption> _longMarginMode;
-	private readonly StrategyParam<MarginModeOption> _shortMarginMode;
+	private readonly StrategyParam<MarginModeOptions> _longMarginMode;
+	private readonly StrategyParam<MarginModeOptions> _shortMarginMode;
 	private readonly StrategyParam<decimal> _longStopLossSteps;
 	private readonly StrategyParam<decimal> _shortStopLossSteps;
 	private readonly StrategyParam<decimal> _longTakeProfitSteps;
@@ -141,10 +141,10 @@ public class VortexIndicatorMmrecDuplexStrategy : Strategy
 		.SetNotNegative()
 		.SetDisplay("Short Base MM", "Default money-management setting for short trades.", "Risk");
 
-		_longMarginMode = Param(nameof(LongMarginMode), MarginModeOption.Lot)
+		_longMarginMode = Param(nameof(LongMarginMode), MarginModeOptions.Lot)
 		.SetDisplay("Long Margin Mode", "Interpretation of the long money-management value.", "Risk");
 
-		_shortMarginMode = Param(nameof(ShortMarginMode), MarginModeOption.Lot)
+		_shortMarginMode = Param(nameof(ShortMarginMode), MarginModeOptions.Lot)
 		.SetDisplay("Short Margin Mode", "Interpretation of the short money-management value.", "Risk");
 
 		_longStopLossSteps = Param(nameof(LongStopLossSteps), 1000m)
@@ -337,7 +337,7 @@ public class VortexIndicatorMmrecDuplexStrategy : Strategy
 	/// <summary>
 	/// Margin interpretation for long trades.
 	/// </summary>
-	public MarginModeOption LongMarginMode
+	public MarginModeOptions LongMarginMode
 	{
 		get => _longMarginMode.Value;
 		set => _longMarginMode.Value = value;
@@ -346,7 +346,7 @@ public class VortexIndicatorMmrecDuplexStrategy : Strategy
 	/// <summary>
 	/// Margin interpretation for short trades.
 	/// </summary>
-	public MarginModeOption ShortMarginMode
+	public MarginModeOptions ShortMarginMode
 	{
 		get => _shortMarginMode.Value;
 		set => _shortMarginMode.Value = value;
@@ -742,7 +742,7 @@ public class VortexIndicatorMmrecDuplexStrategy : Strategy
 		return true;
 	}
 
-	private decimal CalculateVolume(decimal mmValue, MarginModeOption mode, decimal stopSteps, decimal price)
+	private decimal CalculateVolume(decimal mmValue, MarginModeOptions mode, decimal stopSteps, decimal price)
 	{
 		if (mmValue <= 0m)
 		{
@@ -750,7 +750,7 @@ public class VortexIndicatorMmrecDuplexStrategy : Strategy
 		}
 
 		var capital = Portfolio?.CurrentValue ?? 0m;
-		if (mode == MarginModeOption.Lot)
+		if (mode == MarginModeOptions.Lot)
 		{
 			return NormalizeVolume(mmValue);
 		}
@@ -764,14 +764,14 @@ public class VortexIndicatorMmrecDuplexStrategy : Strategy
 
 		switch (mode)
 		{
-			case MarginModeOption.FreeMargin:
-			case MarginModeOption.Balance:
+			case MarginModeOptions.FreeMargin:
+			case MarginModeOptions.Balance:
 			{
 				volume = price > 0m ? capital * mmValue / price : 0m;
 				break;
 			}
-			case MarginModeOption.LossFreeMargin:
-			case MarginModeOption.LossBalance:
+			case MarginModeOptions.LossFreeMargin:
+			case MarginModeOptions.LossBalance:
 			{
 				var distance = stopSteps > 0m ? GetStepValue(stopSteps) : 0m;
 				if (distance <= 0m && price > 0m)
@@ -900,7 +900,7 @@ public class VortexIndicatorMmrecDuplexStrategy : Strategy
 	/// <summary>
 	/// Margin interpretation modes reproduced from the MetaTrader expert.
 	/// </summary>
-	public enum MarginModeOption
+	public enum MarginModeOptions
 	{
 		/// <summary>
 		/// Treat the money-management value as a share of free margin or balance.

--- a/API/3145_Day_Trading_PAMXA/CS/DayTradingPamxaStrategy.cs
+++ b/API/3145_Day_Trading_PAMXA/CS/DayTradingPamxaStrategy.cs
@@ -23,7 +23,7 @@ public class DayTradingPamxaStrategy : Strategy
 	private readonly StrategyParam<int> _takeProfitPips;
 	private readonly StrategyParam<int> _trailingStopPips;
 	private readonly StrategyParam<int> _trailingStepPips;
-	private readonly StrategyParam<PositionSizingMode> _moneyMode;
+	private readonly StrategyParam<PositionSizingModes> _moneyMode;
 	private readonly StrategyParam<decimal> _moneyValue;
 	private readonly StrategyParam<decimal> _orderVolume;
 	private readonly StrategyParam<int> _stochasticKPeriod;
@@ -93,7 +93,7 @@ public class DayTradingPamxaStrategy : Strategy
 	/// <summary>
 	/// Position sizing approach.
 	/// </summary>
-	public PositionSizingMode MoneyMode
+	public PositionSizingModes MoneyMode
 	{
 		get => _moneyMode.Value;
 		set => _moneyMode.Value = value;
@@ -109,7 +109,7 @@ public class DayTradingPamxaStrategy : Strategy
 	}
 
 	/// <summary>
-	/// Fixed trading volume used when <see cref="MoneyMode"/> is <see cref="PositionSizingMode.FixedVolume"/>.
+	/// Fixed trading volume used when <see cref="MoneyMode"/> is <see cref="PositionSizingModes.FixedVolume"/>.
 	/// </summary>
 	public decimal OrderVolume
 	{
@@ -236,7 +236,7 @@ public class DayTradingPamxaStrategy : Strategy
 			.SetCanOptimize(true)
 			.SetOptimize(1, 50, 1);
 
-		_moneyMode = Param(nameof(MoneyMode), PositionSizingMode.FixedVolume)
+		_moneyMode = Param(nameof(MoneyMode), PositionSizingModes.FixedVolume)
 			.SetDisplay("Money Mode", "Choose between fixed volume or risk percentage", "Risk Management");
 
 		_moneyValue = Param(nameof(MoneyValue), 1m)
@@ -596,7 +596,7 @@ public class DayTradingPamxaStrategy : Strategy
 
 	private decimal CalculateEntryVolume()
 	{
-		if (MoneyMode == PositionSizingMode.RiskPercent)
+		if (MoneyMode == PositionSizingModes.RiskPercent)
 		{
 			// Convert the configured risk percentage into trade size using the stop distance.
 			if (_stopLossDistance <= 0m)
@@ -647,7 +647,7 @@ public class DayTradingPamxaStrategy : Strategy
 /// <summary>
 /// Position sizing modes supported by <see cref="DayTradingPamxaStrategy"/>.
 /// </summary>
-public enum PositionSizingMode
+public enum PositionSizingModes
 {
 	/// <summary>
 	/// Always trade a fixed volume regardless of the stop distance.

--- a/API/3146_Exp_ColorMETRO_MMRec_Duplex/CS/ExpColorMetroMmrecDuplexStrategy.cs
+++ b/API/3146_Exp_ColorMETRO_MMRec_Duplex/CS/ExpColorMetroMmrecDuplexStrategy.cs
@@ -37,7 +37,7 @@ public class ExpColorMetroMmrecDuplexStrategy : Strategy
 		defaultLossTrigger: 3,
 		defaultSmallMm: 0.01m,
 		defaultMm: 0.1m,
-		defaultMarginMode: MarginMode.Lot,
+		defaultMarginMode: MarginModes.Lot,
 		defaultStopLoss: 1000m,
 		defaultTakeProfit: 2000m,
 		defaultDeviation: 10m,
@@ -58,7 +58,7 @@ public class ExpColorMetroMmrecDuplexStrategy : Strategy
 		defaultLossTrigger: 3,
 		defaultSmallMm: 0.01m,
 		defaultMm: 0.1m,
-		defaultMarginMode: MarginMode.Lot,
+		defaultMarginMode: MarginModes.Lot,
 		defaultStopLoss: 1000m,
 		defaultTakeProfit: 2000m,
 		defaultDeviation: 10m,
@@ -343,19 +343,19 @@ public class ExpColorMetroMmrecDuplexStrategy : Strategy
 	/// <summary>
 	/// Money management mode for the long module (kept for reference).
 	/// </summary>
-	public MarginMode LongMarginMode
+	public MarginModes LongMarginMode
 	{
-		get => _longModule.MarginMode;
-		set => _longModule.MarginMode = value;
+		get => _longModule.MarginModes;
+		set => _longModule.MarginModes = value;
 	}
 
 	/// <summary>
 	/// Money management mode for the short module (kept for reference).
 	/// </summary>
-	public MarginMode ShortMarginMode
+	public MarginModes ShortMarginMode
 	{
-		get => _shortModule.MarginMode;
-		set => _shortModule.MarginMode = value;
+		get => _shortModule.MarginModes;
+		set => _shortModule.MarginModes = value;
 	}
 
 	/// <inheritdoc />
@@ -480,7 +480,7 @@ public class ExpColorMetroMmrecDuplexStrategy : Strategy
 	/// <summary>
 	/// Money management modes preserved from the MT5 source for reference.
 	/// </summary>
-	public enum MarginMode
+	public enum MarginModes
 	{
 		/// <summary>
 		/// Position size derived from the available free margin.
@@ -525,7 +525,7 @@ public class ExpColorMetroMmrecDuplexStrategy : Strategy
 		private readonly StrategyParam<decimal> _stopLossTicks;
 		private readonly StrategyParam<decimal> _takeProfitTicks;
 		private readonly StrategyParam<decimal> _deviationTicks;
-		private readonly StrategyParam<MarginMode> _marginMode;
+		private readonly StrategyParam<MarginModes> _marginMode;
 
 		private readonly List<decimal> _upHistory = new();
 		private readonly List<decimal> _downHistory = new();
@@ -545,7 +545,7 @@ public class ExpColorMetroMmrecDuplexStrategy : Strategy
 		int defaultLossTrigger,
 		decimal defaultSmallMm,
 		decimal defaultMm,
-		MarginMode defaultMarginMode,
+		MarginModes defaultMarginMode,
 		decimal defaultStopLoss,
 		decimal defaultTakeProfit,
 		decimal defaultDeviation,
@@ -713,7 +713,7 @@ public class ExpColorMetroMmrecDuplexStrategy : Strategy
 			set => _deviationTicks.Value = value;
 		}
 
-		public MarginMode MarginMode
+		public MarginModes MarginModes
 		{
 			get => _marginMode.Value;
 			set => _marginMode.Value = value;

--- a/API/3147_MACD_No_Sample/CS/MacdNoSampleStrategy.cs
+++ b/API/3147_MACD_No_Sample/CS/MacdNoSampleStrategy.cs
@@ -23,7 +23,7 @@ public class MacdNoSampleStrategy : Strategy
 	/// <summary>
 	/// Moving-average calculation options mirroring the original EA inputs.
 	/// </summary>
-	public enum MaMethodOption
+	public enum MaMethodOptions
 	{
 		Simple,
 		Exponential,
@@ -34,7 +34,7 @@ public class MacdNoSampleStrategy : Strategy
 	/// <summary>
 	/// Candle price used when feeding the indicators.
 	/// </summary>
-	public enum AppliedPriceOption
+	public enum AppliedPriceOptions
 	{
 		Close,
 		Open,
@@ -48,7 +48,7 @@ public class MacdNoSampleStrategy : Strategy
 	/// <summary>
 	/// Position sizing mode: fixed trade volume or percentage risk per trade.
 	/// </summary>
-	public enum PositionSizingMode
+	public enum PositionSizingModes
 	{
 		FixedVolume,
 		RiskPercent,
@@ -59,15 +59,15 @@ public class MacdNoSampleStrategy : Strategy
 	private readonly StrategyParam<decimal> _takeProfitPips;
 	private readonly StrategyParam<decimal> _trailingStopPips;
 	private readonly StrategyParam<decimal> _trailingStepPips;
-	private readonly StrategyParam<PositionSizingMode> _sizingMode;
+	private readonly StrategyParam<PositionSizingModes> _sizingMode;
 	private readonly StrategyParam<decimal> _riskPercent;
 	private readonly StrategyParam<int> _maPeriod;
-	private readonly StrategyParam<MaMethodOption> _maMethod;
-	private readonly StrategyParam<AppliedPriceOption> _maPrice;
+	private readonly StrategyParam<MaMethodOptions> _maMethod;
+	private readonly StrategyParam<AppliedPriceOptions> _maPrice;
 	private readonly StrategyParam<int> _macdFastPeriod;
 	private readonly StrategyParam<int> _macdSlowPeriod;
 	private readonly StrategyParam<int> _macdSignalPeriod;
-	private readonly StrategyParam<AppliedPriceOption> _macdPrice;
+	private readonly StrategyParam<AppliedPriceOptions> _macdPrice;
 	private readonly StrategyParam<decimal> _macdLevelPips;
 	private readonly StrategyParam<DataType> _candleType;
 
@@ -112,7 +112,7 @@ public class MacdNoSampleStrategy : Strategy
 		.SetNotNegative()
 		.SetDisplay("Trailing Step (pips)", "Minimal pip improvement required before moving the trailing stop.", "Risk");
 
-		_sizingMode = Param(nameof(SizingMode), PositionSizingMode.FixedVolume)
+		_sizingMode = Param(nameof(SizingMode), PositionSizingModes.FixedVolume)
 		.SetDisplay("Position Sizing", "Select between fixed volume or risk percentage per trade.", "Trading");
 
 		_riskPercent = Param(nameof(RiskPercent), 1m)
@@ -123,10 +123,10 @@ public class MacdNoSampleStrategy : Strategy
 		.SetGreaterThanZero()
 		.SetDisplay("MA Period", "Averaging period for the trend filter.", "Indicator");
 
-		_maMethod = Param(nameof(MaMethod), MaMethodOption.Weighted)
+		_maMethod = Param(nameof(MaMethod), MaMethodOptions.Weighted)
 		.SetDisplay("MA Method", "Moving-average smoothing algorithm.", "Indicator");
 
-		_maPrice = Param(nameof(MaPrice), AppliedPriceOption.Weighted)
+		_maPrice = Param(nameof(MaPrice), AppliedPriceOptions.Weighted)
 		.SetDisplay("MA Price", "Candle price used for the moving-average filter.", "Indicator");
 
 		_macdFastPeriod = Param(nameof(MacdFastPeriod), 12)
@@ -141,7 +141,7 @@ public class MacdNoSampleStrategy : Strategy
 		.SetGreaterThanZero()
 		.SetDisplay("MACD Signal", "Signal-line EMA length.", "Indicator");
 
-		_macdPrice = Param(nameof(MacdPrice), AppliedPriceOption.Weighted)
+		_macdPrice = Param(nameof(MacdPrice), AppliedPriceOptions.Weighted)
 		.SetDisplay("MACD Price", "Candle price type fed into MACD.", "Indicator");
 
 		_macdLevelPips = Param(nameof(MacdLevelPips), 1m)
@@ -153,7 +153,7 @@ public class MacdNoSampleStrategy : Strategy
 	}
 
 	/// <summary>
-	/// Fixed volume submitted with each market order when sizing mode is set to <see cref="PositionSizingMode.FixedVolume"/>.
+	/// Fixed volume submitted with each market order when sizing mode is set to <see cref="PositionSizingModes.FixedVolume"/>.
 	/// </summary>
 	public decimal TradeVolume
 	{
@@ -200,14 +200,14 @@ public class MacdNoSampleStrategy : Strategy
 	/// <summary>
 	/// Chooses between fixed volume and risk-based sizing.
 	/// </summary>
-	public PositionSizingMode SizingMode
+	public PositionSizingModes SizingMode
 	{
 		get => _sizingMode.Value;
 		set => _sizingMode.Value = value;
 	}
 
 	/// <summary>
-	/// Portfolio percentage used to size trades when <see cref="SizingMode"/> equals <see cref="PositionSizingMode.RiskPercent"/>.
+	/// Portfolio percentage used to size trades when <see cref="SizingMode"/> equals <see cref="PositionSizingModes.RiskPercent"/>.
 	/// </summary>
 	public decimal RiskPercent
 	{
@@ -227,7 +227,7 @@ public class MacdNoSampleStrategy : Strategy
 	/// <summary>
 	/// Moving-average smoothing method.
 	/// </summary>
-	public MaMethodOption MaMethod
+	public MaMethodOptions MaMethod
 	{
 		get => _maMethod.Value;
 		set => _maMethod.Value = value;
@@ -236,7 +236,7 @@ public class MacdNoSampleStrategy : Strategy
 	/// <summary>
 	/// Applied price for the moving-average filter.
 	/// </summary>
-	public AppliedPriceOption MaPrice
+	public AppliedPriceOptions MaPrice
 	{
 		get => _maPrice.Value;
 		set => _maPrice.Value = value;
@@ -272,7 +272,7 @@ public class MacdNoSampleStrategy : Strategy
 	/// <summary>
 	/// Applied price for the MACD calculation.
 	/// </summary>
-	public AppliedPriceOption MacdPrice
+	public AppliedPriceOptions MacdPrice
 	{
 		get => _macdPrice.Value;
 		set => _macdPrice.Value = value;
@@ -618,7 +618,7 @@ public class MacdNoSampleStrategy : Strategy
 
 	private decimal GetOrderVolume(decimal price)
 	{
-		if (SizingMode == PositionSizingMode.FixedVolume)
+		if (SizingMode == PositionSizingModes.FixedVolume)
 		return TradeVolume;
 
 		if (Portfolio is null || price <= 0m)
@@ -681,27 +681,27 @@ public class MacdNoSampleStrategy : Strategy
 		return priceStep.Value;
 	}
 
-	private decimal GetAppliedPrice(ICandleMessage candle, AppliedPriceOption priceOption)
+	private decimal GetAppliedPrice(ICandleMessage candle, AppliedPriceOptions priceOption)
 	{
 		return priceOption switch
 		{
-		AppliedPriceOption.Open => candle.OpenPrice,
-		AppliedPriceOption.High => candle.HighPrice,
-		AppliedPriceOption.Low => candle.LowPrice,
-		AppliedPriceOption.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-		AppliedPriceOption.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-		AppliedPriceOption.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice * 2m) / 4m,
+		AppliedPriceOptions.Open => candle.OpenPrice,
+		AppliedPriceOptions.High => candle.HighPrice,
+		AppliedPriceOptions.Low => candle.LowPrice,
+		AppliedPriceOptions.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+		AppliedPriceOptions.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+		AppliedPriceOptions.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice * 2m) / 4m,
 		_ => candle.ClosePrice,
 		};
 	}
 
-	private MovingAverage CreateMovingAverage(MaMethodOption method)
+	private MovingAverage CreateMovingAverage(MaMethodOptions method)
 	{
 		return method switch
 		{
-		MaMethodOption.Exponential => new ExponentialMovingAverage(),
-		MaMethodOption.Smoothed => new SmoothedMovingAverage(),
-		MaMethodOption.Weighted => new WeightedMovingAverage(),
+		MaMethodOptions.Exponential => new ExponentialMovingAverage(),
+		MaMethodOptions.Smoothed => new SmoothedMovingAverage(),
+		MaMethodOptions.Weighted => new WeightedMovingAverage(),
 		_ => new SimpleMovingAverage(),
 		};
 	}

--- a/API/3151_EMALWMARSI/CS/EmaLwmaRsiStrategy.cs
+++ b/API/3151_EMALWMARSI/CS/EmaLwmaRsiStrategy.cs
@@ -24,8 +24,8 @@ public class EmaLwmaRsiStrategy : Strategy
 	private readonly StrategyParam<int> _lwmaPeriod;
 	private readonly StrategyParam<int> _maShift;
 	private readonly StrategyParam<int> _rsiPeriod;
-	private readonly StrategyParam<AppliedPriceType> _maAppliedPrice;
-	private readonly StrategyParam<AppliedPriceType> _rsiAppliedPrice;
+	private readonly StrategyParam<AppliedPriceTypes> _maAppliedPrice;
+	private readonly StrategyParam<AppliedPriceTypes> _rsiAppliedPrice;
 	private readonly StrategyParam<DataType> _candleType;
 
 	private ExponentialMovingAverage _ema;
@@ -80,10 +80,10 @@ public class EmaLwmaRsiStrategy : Strategy
 			.SetCanOptimize(true)
 			.SetOptimize(5, 50, 1);
 
-		_maAppliedPrice = Param(nameof(MaAppliedPrice), AppliedPriceType.Weighted)
+		_maAppliedPrice = Param(nameof(MaAppliedPrice), AppliedPriceTypes.Weighted)
 			.SetDisplay("MA applied price", "Candle price forwarded to EMA and LWMA.", "Indicators");
 
-		_rsiAppliedPrice = Param(nameof(RsiAppliedPrice), AppliedPriceType.Weighted)
+		_rsiAppliedPrice = Param(nameof(RsiAppliedPrice), AppliedPriceTypes.Weighted)
 			.SetDisplay("RSI applied price", "Price source used by the RSI.", "Indicators");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(1).TimeFrame())
@@ -126,13 +126,13 @@ public class EmaLwmaRsiStrategy : Strategy
 		set => _rsiPeriod.Value = value;
 	}
 
-	public AppliedPriceType MaAppliedPrice
+	public AppliedPriceTypes MaAppliedPrice
 	{
 		get => _maAppliedPrice.Value;
 		set => _maAppliedPrice.Value = value;
 	}
 
-	public AppliedPriceType RsiAppliedPrice
+	public AppliedPriceTypes RsiAppliedPrice
 	{
 		get => _rsiAppliedPrice.Value;
 		set => _rsiAppliedPrice.Value = value;
@@ -366,23 +366,23 @@ public class EmaLwmaRsiStrategy : Strategy
 		return step * multiplier;
 	}
 
-	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPriceType priceType)
+	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPriceTypes priceType)
 	{
 		return priceType switch
 		{
-			AppliedPriceType.Close => candle.ClosePrice,
-			AppliedPriceType.Open => candle.OpenPrice,
-			AppliedPriceType.High => candle.HighPrice,
-			AppliedPriceType.Low => candle.LowPrice,
-			AppliedPriceType.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-			AppliedPriceType.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-			AppliedPriceType.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
-			AppliedPriceType.Average => (candle.OpenPrice + candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 4m,
+			AppliedPriceTypes.Close => candle.ClosePrice,
+			AppliedPriceTypes.Open => candle.OpenPrice,
+			AppliedPriceTypes.High => candle.HighPrice,
+			AppliedPriceTypes.Low => candle.LowPrice,
+			AppliedPriceTypes.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+			AppliedPriceTypes.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+			AppliedPriceTypes.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
+			AppliedPriceTypes.Average => (candle.OpenPrice + candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 4m,
 			_ => candle.ClosePrice,
 		};
 	}
 
-	public enum AppliedPriceType
+	public enum AppliedPriceTypes
 	{
 		Close,
 		Open,

--- a/API/3153_Puria_Method/CS/PuriaMethodStrategy.cs
+++ b/API/3153_Puria_Method/CS/PuriaMethodStrategy.cs
@@ -30,17 +30,17 @@ public class PuriaMethodStrategy : Strategy
 
 	private readonly StrategyParam<int> _ma0Period;
 	private readonly StrategyParam<int> _ma0Shift;
-	private readonly StrategyParam<MaMethod> _ma0Method;
+	private readonly StrategyParam<MaMethods> _ma0Method;
 	private readonly StrategyParam<CandlePrice> _ma0Price;
 
 	private readonly StrategyParam<int> _ma1Period;
 	private readonly StrategyParam<int> _ma1Shift;
-	private readonly StrategyParam<MaMethod> _ma1Method;
+	private readonly StrategyParam<MaMethods> _ma1Method;
 	private readonly StrategyParam<CandlePrice> _ma1Price;
 
 	private readonly StrategyParam<int> _ma2Period;
 	private readonly StrategyParam<int> _ma2Shift;
-	private readonly StrategyParam<MaMethod> _ma2Method;
+	private readonly StrategyParam<MaMethods> _ma2Method;
 	private readonly StrategyParam<CandlePrice> _ma2Price;
 
 	private readonly StrategyParam<int> _macdFastPeriod;
@@ -118,7 +118,7 @@ public class PuriaMethodStrategy : Strategy
 			.SetNotNegative()
 			.SetDisplay("MA 0 Shift", "Bars to shift the first MA", "Indicators");
 
-		_ma0Method = Param(nameof(Ma0Method), MaMethod.Smoothed)
+		_ma0Method = Param(nameof(Ma0Method), MaMethods.Smoothed)
 			.SetDisplay("MA 0 Method", "Smoothing for first MA", "Indicators");
 
 		_ma0Price = Param(nameof(Ma0Price), CandlePrice.High)
@@ -132,7 +132,7 @@ public class PuriaMethodStrategy : Strategy
 			.SetNotNegative()
 			.SetDisplay("MA 1 Shift", "Bars to shift the second MA", "Indicators");
 
-		_ma1Method = Param(nameof(Ma1Method), MaMethod.Smoothed)
+		_ma1Method = Param(nameof(Ma1Method), MaMethods.Smoothed)
 			.SetDisplay("MA 1 Method", "Smoothing for second MA", "Indicators");
 
 		_ma1Price = Param(nameof(Ma1Price), CandlePrice.High)
@@ -146,7 +146,7 @@ public class PuriaMethodStrategy : Strategy
 			.SetNotNegative()
 			.SetDisplay("MA 2 Shift", "Bars to shift the third MA", "Indicators");
 
-		_ma2Method = Param(nameof(Ma2Method), MaMethod.Exponential)
+		_ma2Method = Param(nameof(Ma2Method), MaMethods.Exponential)
 			.SetDisplay("MA 2 Method", "Smoothing for third MA", "Indicators");
 
 		_ma2Price = Param(nameof(Ma2Price), CandlePrice.Open)
@@ -265,7 +265,7 @@ public class PuriaMethodStrategy : Strategy
 	/// <summary>
 	/// Method used to smooth the first moving average.
 	/// </summary>
-	public MaMethod Ma0Method
+	public MaMethods Ma0Method
 	{
 		get => _ma0Method.Value;
 		set => _ma0Method.Value = value;
@@ -301,7 +301,7 @@ public class PuriaMethodStrategy : Strategy
 	/// <summary>
 	/// Method used to smooth the second moving average.
 	/// </summary>
-	public MaMethod Ma1Method
+	public MaMethods Ma1Method
 	{
 		get => _ma1Method.Value;
 		set => _ma1Method.Value = value;
@@ -337,7 +337,7 @@ public class PuriaMethodStrategy : Strategy
 	/// <summary>
 	/// Method used to smooth the third moving average.
 	/// </summary>
-	public MaMethod Ma2Method
+	public MaMethods Ma2Method
 	{
 		get => _ma2Method.Value;
 		set => _ma2Method.Value = value;
@@ -853,16 +853,16 @@ public class PuriaMethodStrategy : Strategy
 		_shortLowestPrice = null;
 	}
 
-	private static LengthIndicator<decimal> CreateMovingAverage(MaMethod method, int length, CandlePrice price)
+	private static LengthIndicator<decimal> CreateMovingAverage(MaMethods method, int length, CandlePrice price)
 	{
 		var maLength = Math.Max(1, length);
 
 		return method switch
 		{
-			MaMethod.Simple => new SimpleMovingAverage { Length = maLength, CandlePrice = price },
-			MaMethod.Exponential => new ExponentialMovingAverage { Length = maLength, CandlePrice = price },
-			MaMethod.Smoothed => new SmoothedMovingAverage { Length = maLength, CandlePrice = price },
-			MaMethod.LinearWeighted => new WeightedMovingAverage { Length = maLength, CandlePrice = price },
+			MaMethods.Simple => new SimpleMovingAverage { Length = maLength, CandlePrice = price },
+			MaMethods.Exponential => new ExponentialMovingAverage { Length = maLength, CandlePrice = price },
+			MaMethods.Smoothed => new SmoothedMovingAverage { Length = maLength, CandlePrice = price },
+			MaMethods.LinearWeighted => new WeightedMovingAverage { Length = maLength, CandlePrice = price },
 			_ => new SimpleMovingAverage { Length = maLength, CandlePrice = price }
 		};
 	}
@@ -870,7 +870,7 @@ public class PuriaMethodStrategy : Strategy
 	/// <summary>
 	/// Moving average smoothing modes that mirror the original MetaTrader inputs.
 	/// </summary>
-	public enum MaMethod
+	public enum MaMethods
 	{
 		/// <summary>
 		/// Simple moving average.

--- a/API/3156_SR_Rate_Indicator/CS/SrRateIndicatorStrategy.cs
+++ b/API/3156_SR_Rate_Indicator/CS/SrRateIndicatorStrategy.cs
@@ -331,7 +331,7 @@ public class SrRateIndicatorStrategy : Strategy
 
 	private sealed class SrRateIndicator : BaseIndicator<SrRateIndicatorValue>
 	{
-		private enum PriceMode
+		private enum PriceModes
 		{
 			High,
 			Low,
@@ -386,11 +386,11 @@ public class SrRateIndicatorStrategy : Strategy
 				if (!HasEnoughData(index))
 				return 0m;
 
-				var low = Smooth(PriceMode.Low, index);
+				var low = Smooth(PriceModes.Low, index);
 				if (low < min)
 				min = low;
 
-				var high = Smooth(PriceMode.High, index);
+				var high = Smooth(PriceModes.High, index);
 				if (high > max)
 				max = high;
 			}
@@ -398,11 +398,11 @@ public class SrRateIndicatorStrategy : Strategy
 			if (max <= min)
 			return 0m;
 
-			var weighted = Smooth(PriceMode.Weighted, shift);
+			var weighted = Smooth(PriceModes.Weighted, shift);
 			return 200m * (weighted - min) / (max - min) - 100m;
 		}
 
-		private decimal Smooth(PriceMode mode, int shift)
+		private decimal Smooth(PriceModes mode, int shift)
 		{
 			if (!HasEnoughData(shift))
 			return 0m;
@@ -440,13 +440,13 @@ public class SrRateIndicatorStrategy : Strategy
 			return 2m;
 		}
 
-		private static decimal GetPrice(ICandleMessage candle, PriceMode mode)
+		private static decimal GetPrice(ICandleMessage candle, PriceModes mode)
 		{
 			return mode switch
 			{
-				PriceMode.High => candle.HighPrice,
-				PriceMode.Low => candle.LowPrice,
-				PriceMode.Weighted => (2m * candle.ClosePrice + candle.HighPrice + candle.LowPrice) / 4m,
+				PriceModes.High => candle.HighPrice,
+				PriceModes.Low => candle.LowPrice,
+				PriceModes.Weighted => (2m * candle.ClosePrice + candle.HighPrice + candle.LowPrice) / 4m,
 				_ => candle.ClosePrice
 			};
 		}

--- a/API/3159_Exp_SpearmanRankCorrelation_Histogram/CS/ExpSpearmanRankCorrelationHistogramStrategy.cs
+++ b/API/3159_Exp_SpearmanRankCorrelation_Histogram/CS/ExpSpearmanRankCorrelationHistogramStrategy.cs
@@ -18,7 +18,7 @@ namespace StockSharp.Samples.Strategies;
 /// <summary>
 /// Trading mode options from the original expert advisor.
 /// </summary>
-public enum ExpSpearmanTradeMode
+public enum ExpSpearmanTradeModes
 {
 	/// <summary>
 	/// Mode 1: close opposite positions and open when the histogram crosses neutral levels.
@@ -52,7 +52,7 @@ public class ExpSpearmanRankCorrelationHistogramStrategy : Strategy
 	private readonly StrategyParam<bool> _allowSellEntries;
 	private readonly StrategyParam<bool> _allowBuyExits;
 	private readonly StrategyParam<bool> _allowSellExits;
-	private readonly StrategyParam<ExpSpearmanTradeMode> _tradeMode;
+	private readonly StrategyParam<ExpSpearmanTradeModes> _tradeMode;
 	private readonly StrategyParam<decimal> _stopLossPoints;
 	private readonly StrategyParam<decimal> _takeProfitPoints;
 	private readonly StrategyParam<bool> _invertCorrelation;
@@ -100,7 +100,7 @@ public class ExpSpearmanRankCorrelationHistogramStrategy : Strategy
 		_allowSellExits = Param(nameof(AllowSellExits), true)
 			.SetDisplay("Allow Sell Exits", "Enable automatic closing of short positions", "Trading");
 
-		_tradeMode = Param(nameof(TradeMode), ExpSpearmanTradeMode.Mode1)
+		_tradeMode = Param(nameof(TradeMode), ExpSpearmanTradeModes.Mode1)
 			.SetDisplay("Trade Mode", "Replica of the original expert trade mode switch", "Trading");
 
 		_stopLossPoints = Param(nameof(StopLossPoints), 0m)
@@ -206,7 +206,7 @@ public class ExpSpearmanRankCorrelationHistogramStrategy : Strategy
 	/// <summary>
 	/// Trade mode copied from the MetaTrader implementation.
 	/// </summary>
-	public ExpSpearmanTradeMode TradeMode
+	public ExpSpearmanTradeModes TradeMode
 	{
 		get => _tradeMode.Value;
 		set => _tradeMode.Value = value;
@@ -328,7 +328,7 @@ public class ExpSpearmanRankCorrelationHistogramStrategy : Strategy
 
 		switch (TradeMode)
 		{
-		case ExpSpearmanTradeMode.Mode1:
+		case ExpSpearmanTradeModes.Mode1:
 		{
 		if (olderColor > 2)
 		{
@@ -351,7 +351,7 @@ public class ExpSpearmanRankCorrelationHistogramStrategy : Strategy
 		break;
 		}
 
-		case ExpSpearmanTradeMode.Mode2:
+		case ExpSpearmanTradeModes.Mode2:
 		{
 		if (olderColor == 4)
 		{
@@ -374,7 +374,7 @@ public class ExpSpearmanRankCorrelationHistogramStrategy : Strategy
 		break;
 		}
 
-		case ExpSpearmanTradeMode.Mode3:
+		case ExpSpearmanTradeModes.Mode3:
 		{
 		if (olderColor == 4)
 		{

--- a/API/3160_Cidomo/CS/CidomoStrategy.cs
+++ b/API/3160_Cidomo/CS/CidomoStrategy.cs
@@ -28,7 +28,7 @@ public class CidomoStrategy : Strategy
 	private readonly StrategyParam<decimal> _trailingStepPips;
 	private readonly StrategyParam<decimal> _indentPips;
 	private readonly StrategyParam<int> _barsCount;
-	private readonly StrategyParam<CidomoMoneyManagementMode> _moneyManagementMode;
+	private readonly StrategyParam<CidomoMoneyManagementModes> _moneyManagementMode;
 	private readonly StrategyParam<decimal> _riskPercent;
 	private readonly StrategyParam<decimal> _tradeVolume;
 	private readonly StrategyParam<bool> _useTimeFilter;
@@ -90,7 +90,7 @@ public class CidomoStrategy : Strategy
 			.SetGreaterThanZero()
 			.SetDisplay("Lookback Bars", "Number of completed candles used for the breakout range", "General");
 
-		_moneyManagementMode = Param(nameof(MoneyManagement), CidomoMoneyManagementMode.RiskPercent)
+		_moneyManagementMode = Param(nameof(MoneyManagement), CidomoMoneyManagementModes.RiskPercent)
 			.SetDisplay("Money Management", "Volume calculation mode", "Trading");
 
 		_riskPercent = Param(nameof(RiskPercent), 1m)
@@ -183,7 +183,7 @@ public class CidomoStrategy : Strategy
 	/// <summary>
 	/// Money management mode.
 	/// </summary>
-	public CidomoMoneyManagementMode MoneyManagement
+	public CidomoMoneyManagementModes MoneyManagement
 	{
 		get => _moneyManagementMode.Value;
 		set => _moneyManagementMode.Value = value;
@@ -487,7 +487,7 @@ public class CidomoStrategy : Strategy
 
 	private decimal CalculateEntryVolume(decimal stopDistance)
 	{
-		if (MoneyManagement == CidomoMoneyManagementMode.RiskPercent)
+		if (MoneyManagement == CidomoMoneyManagementModes.RiskPercent)
 		{
 			if (stopDistance <= 0m)
 				return TradeVolume;
@@ -625,7 +625,7 @@ public class CidomoStrategy : Strategy
 /// <summary>
 /// Money management modes supported by <see cref="CidomoStrategy"/>.
 /// </summary>
-public enum CidomoMoneyManagementMode
+public enum CidomoMoneyManagementModes
 {
 	/// <summary>
 	/// Always trade the fixed volume specified by <see cref="CidomoStrategy.TradeVolume"/>.

--- a/API/3161_ColorMaRsiTrigger_MMRec_Duplex/CS/ColorMaRsiTriggerMmRecDuplexStrategy.cs
+++ b/API/3161_ColorMaRsiTrigger_MMRec_Duplex/CS/ColorMaRsiTriggerMmRecDuplexStrategy.cs
@@ -30,12 +30,12 @@ public class ColorMaRsiTriggerMmRecDuplexStrategy : Strategy
 	private readonly StrategyParam<int> _longRsiLongPeriod;
 	private readonly StrategyParam<int> _longMaPeriod;
 	private readonly StrategyParam<int> _longMaLongPeriod;
-	private readonly StrategyParam<AppliedPriceType> _longRsiPrice;
-	private readonly StrategyParam<AppliedPriceType> _longRsiLongPrice;
-	private readonly StrategyParam<AppliedPriceType> _longMaPrice;
-	private readonly StrategyParam<AppliedPriceType> _longMaLongPrice;
-	private readonly StrategyParam<MovingAverageMethod> _longMaType;
-	private readonly StrategyParam<MovingAverageMethod> _longMaLongType;
+	private readonly StrategyParam<AppliedPriceTypes> _longRsiPrice;
+	private readonly StrategyParam<AppliedPriceTypes> _longRsiLongPrice;
+	private readonly StrategyParam<AppliedPriceTypes> _longMaPrice;
+	private readonly StrategyParam<AppliedPriceTypes> _longMaLongPrice;
+	private readonly StrategyParam<MovingAverageMethods> _longMaType;
+	private readonly StrategyParam<MovingAverageMethods> _longMaLongType;
 	private readonly StrategyParam<decimal> _longNormalVolume;
 	private readonly StrategyParam<decimal> _longReducedVolume;
 	private readonly StrategyParam<int> _longHistoryDepth;
@@ -51,12 +51,12 @@ public class ColorMaRsiTriggerMmRecDuplexStrategy : Strategy
 	private readonly StrategyParam<int> _shortRsiLongPeriod;
 	private readonly StrategyParam<int> _shortMaPeriod;
 	private readonly StrategyParam<int> _shortMaLongPeriod;
-	private readonly StrategyParam<AppliedPriceType> _shortRsiPrice;
-	private readonly StrategyParam<AppliedPriceType> _shortRsiLongPrice;
-	private readonly StrategyParam<AppliedPriceType> _shortMaPrice;
-	private readonly StrategyParam<AppliedPriceType> _shortMaLongPrice;
-	private readonly StrategyParam<MovingAverageMethod> _shortMaType;
-	private readonly StrategyParam<MovingAverageMethod> _shortMaLongType;
+	private readonly StrategyParam<AppliedPriceTypes> _shortRsiPrice;
+	private readonly StrategyParam<AppliedPriceTypes> _shortRsiLongPrice;
+	private readonly StrategyParam<AppliedPriceTypes> _shortMaPrice;
+	private readonly StrategyParam<AppliedPriceTypes> _shortMaLongPrice;
+	private readonly StrategyParam<MovingAverageMethods> _shortMaType;
+	private readonly StrategyParam<MovingAverageMethods> _shortMaLongType;
 	private readonly StrategyParam<decimal> _shortNormalVolume;
 	private readonly StrategyParam<decimal> _shortReducedVolume;
 	private readonly StrategyParam<int> _shortHistoryDepth;
@@ -117,22 +117,22 @@ public class ColorMaRsiTriggerMmRecDuplexStrategy : Strategy
 			.SetGreaterThanZero()
 			.SetDisplay("Long MA Slow", "Slow moving average length for the long block", "Long Block");
 
-		_longRsiPrice = Param(nameof(LongRsiPrice), AppliedPriceType.Weighted)
+		_longRsiPrice = Param(nameof(LongRsiPrice), AppliedPriceTypes.Weighted)
 			.SetDisplay("Long RSI Price", "Price mode for the fast RSI", "Long Block");
 
-		_longRsiLongPrice = Param(nameof(LongRsiLongPrice), AppliedPriceType.Median)
+		_longRsiLongPrice = Param(nameof(LongRsiLongPrice), AppliedPriceTypes.Median)
 			.SetDisplay("Long RSI Slow Price", "Price mode for the slow RSI", "Long Block");
 
-		_longMaPrice = Param(nameof(LongMaPrice), AppliedPriceType.Close)
+		_longMaPrice = Param(nameof(LongMaPrice), AppliedPriceTypes.Close)
 			.SetDisplay("Long MA Price", "Price mode for the fast moving average", "Long Block");
 
-		_longMaLongPrice = Param(nameof(LongMaLongPrice), AppliedPriceType.Close)
+		_longMaLongPrice = Param(nameof(LongMaLongPrice), AppliedPriceTypes.Close)
 			.SetDisplay("Long MA Slow Price", "Price mode for the slow moving average", "Long Block");
 
-		_longMaType = Param(nameof(LongMaType), MovingAverageMethod.Exponential)
+		_longMaType = Param(nameof(LongMaType), MovingAverageMethods.Exponential)
 			.SetDisplay("Long MA Method", "Smoothing algorithm for the fast moving average", "Long Block");
 
-		_longMaLongType = Param(nameof(LongMaLongType), MovingAverageMethod.Exponential)
+		_longMaLongType = Param(nameof(LongMaLongType), MovingAverageMethods.Exponential)
 			.SetDisplay("Long MA Slow Method", "Smoothing algorithm for the slow moving average", "Long Block");
 
 		_longNormalVolume = Param(nameof(LongNormalVolume), 0.1m)
@@ -188,22 +188,22 @@ public class ColorMaRsiTriggerMmRecDuplexStrategy : Strategy
 			.SetGreaterThanZero()
 			.SetDisplay("Short MA Slow", "Slow moving average length for the short block", "Short Block");
 
-		_shortRsiPrice = Param(nameof(ShortRsiPrice), AppliedPriceType.Weighted)
+		_shortRsiPrice = Param(nameof(ShortRsiPrice), AppliedPriceTypes.Weighted)
 			.SetDisplay("Short RSI Price", "Price mode for the fast RSI", "Short Block");
 
-		_shortRsiLongPrice = Param(nameof(ShortRsiLongPrice), AppliedPriceType.Median)
+		_shortRsiLongPrice = Param(nameof(ShortRsiLongPrice), AppliedPriceTypes.Median)
 			.SetDisplay("Short RSI Slow Price", "Price mode for the slow RSI", "Short Block");
 
-		_shortMaPrice = Param(nameof(ShortMaPrice), AppliedPriceType.Close)
+		_shortMaPrice = Param(nameof(ShortMaPrice), AppliedPriceTypes.Close)
 			.SetDisplay("Short MA Price", "Price mode for the fast moving average", "Short Block");
 
-		_shortMaLongPrice = Param(nameof(ShortMaLongPrice), AppliedPriceType.Close)
+		_shortMaLongPrice = Param(nameof(ShortMaLongPrice), AppliedPriceTypes.Close)
 			.SetDisplay("Short MA Slow Price", "Price mode for the slow moving average", "Short Block");
 
-		_shortMaType = Param(nameof(ShortMaType), MovingAverageMethod.Exponential)
+		_shortMaType = Param(nameof(ShortMaType), MovingAverageMethods.Exponential)
 			.SetDisplay("Short MA Method", "Smoothing algorithm for the fast moving average", "Short Block");
 
-		_shortMaLongType = Param(nameof(ShortMaLongType), MovingAverageMethod.Exponential)
+		_shortMaLongType = Param(nameof(ShortMaLongType), MovingAverageMethods.Exponential)
 			.SetDisplay("Short MA Slow Method", "Smoothing algorithm for the slow moving average", "Short Block");
 
 		_shortNormalVolume = Param(nameof(ShortNormalVolume), 0.1m)
@@ -316,7 +316,7 @@ public class ColorMaRsiTriggerMmRecDuplexStrategy : Strategy
 	/// <summary>
 	/// Applied price used by the fast RSI in the long block.
 	/// </summary>
-	public AppliedPriceType LongRsiPrice
+	public AppliedPriceTypes LongRsiPrice
 	{
 		get => _longRsiPrice.Value;
 		set => _longRsiPrice.Value = value;
@@ -325,7 +325,7 @@ public class ColorMaRsiTriggerMmRecDuplexStrategy : Strategy
 	/// <summary>
 	/// Applied price used by the slow RSI in the long block.
 	/// </summary>
-	public AppliedPriceType LongRsiLongPrice
+	public AppliedPriceTypes LongRsiLongPrice
 	{
 		get => _longRsiLongPrice.Value;
 		set => _longRsiLongPrice.Value = value;
@@ -334,7 +334,7 @@ public class ColorMaRsiTriggerMmRecDuplexStrategy : Strategy
 	/// <summary>
 	/// Applied price used by the fast moving average in the long block.
 	/// </summary>
-	public AppliedPriceType LongMaPrice
+	public AppliedPriceTypes LongMaPrice
 	{
 		get => _longMaPrice.Value;
 		set => _longMaPrice.Value = value;
@@ -343,7 +343,7 @@ public class ColorMaRsiTriggerMmRecDuplexStrategy : Strategy
 	/// <summary>
 	/// Applied price used by the slow moving average in the long block.
 	/// </summary>
-	public AppliedPriceType LongMaLongPrice
+	public AppliedPriceTypes LongMaLongPrice
 	{
 		get => _longMaLongPrice.Value;
 		set => _longMaLongPrice.Value = value;
@@ -352,7 +352,7 @@ public class ColorMaRsiTriggerMmRecDuplexStrategy : Strategy
 	/// <summary>
 	/// Moving average method for the fast line in the long block.
 	/// </summary>
-	public MovingAverageMethod LongMaType
+	public MovingAverageMethods LongMaType
 	{
 		get => _longMaType.Value;
 		set => _longMaType.Value = value;
@@ -361,7 +361,7 @@ public class ColorMaRsiTriggerMmRecDuplexStrategy : Strategy
 	/// <summary>
 	/// Moving average method for the slow line in the long block.
 	/// </summary>
-	public MovingAverageMethod LongMaLongType
+	public MovingAverageMethods LongMaLongType
 	{
 		get => _longMaLongType.Value;
 		set => _longMaLongType.Value = value;
@@ -496,7 +496,7 @@ public class ColorMaRsiTriggerMmRecDuplexStrategy : Strategy
 	/// <summary>
 	/// Applied price used by the fast RSI in the short block.
 	/// </summary>
-	public AppliedPriceType ShortRsiPrice
+	public AppliedPriceTypes ShortRsiPrice
 	{
 		get => _shortRsiPrice.Value;
 		set => _shortRsiPrice.Value = value;
@@ -505,7 +505,7 @@ public class ColorMaRsiTriggerMmRecDuplexStrategy : Strategy
 	/// <summary>
 	/// Applied price used by the slow RSI in the short block.
 	/// </summary>
-	public AppliedPriceType ShortRsiLongPrice
+	public AppliedPriceTypes ShortRsiLongPrice
 	{
 		get => _shortRsiLongPrice.Value;
 		set => _shortRsiLongPrice.Value = value;
@@ -514,7 +514,7 @@ public class ColorMaRsiTriggerMmRecDuplexStrategy : Strategy
 	/// <summary>
 	/// Applied price used by the fast moving average in the short block.
 	/// </summary>
-	public AppliedPriceType ShortMaPrice
+	public AppliedPriceTypes ShortMaPrice
 	{
 		get => _shortMaPrice.Value;
 		set => _shortMaPrice.Value = value;
@@ -523,7 +523,7 @@ public class ColorMaRsiTriggerMmRecDuplexStrategy : Strategy
 	/// <summary>
 	/// Applied price used by the slow moving average in the short block.
 	/// </summary>
-	public AppliedPriceType ShortMaLongPrice
+	public AppliedPriceTypes ShortMaLongPrice
 	{
 		get => _shortMaLongPrice.Value;
 		set => _shortMaLongPrice.Value = value;
@@ -532,7 +532,7 @@ public class ColorMaRsiTriggerMmRecDuplexStrategy : Strategy
 	/// <summary>
 	/// Moving average method for the fast line in the short block.
 	/// </summary>
-	public MovingAverageMethod ShortMaType
+	public MovingAverageMethods ShortMaType
 	{
 		get => _shortMaType.Value;
 		set => _shortMaType.Value = value;
@@ -541,7 +541,7 @@ public class ColorMaRsiTriggerMmRecDuplexStrategy : Strategy
 	/// <summary>
 	/// Moving average method for the slow line in the short block.
 	/// </summary>
-	public MovingAverageMethod ShortMaLongType
+	public MovingAverageMethods ShortMaLongType
 	{
 		get => _shortMaLongType.Value;
 		set => _shortMaLongType.Value = value;
@@ -910,30 +910,30 @@ public class ColorMaRsiTriggerMmRecDuplexStrategy : Strategy
 			history.RemoveAt(history.Count - 1);
 	}
 
-	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageMethod method, int length)
+	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageMethods method, int length)
 	{
 		var maLength = Math.Max(1, length);
 		return method switch
 		{
-			MovingAverageMethod.Simple => new SimpleMovingAverage { Length = maLength },
-			MovingAverageMethod.Exponential => new ExponentialMovingAverage { Length = maLength },
-			MovingAverageMethod.Smoothed => new SmoothedMovingAverage { Length = maLength },
-			MovingAverageMethod.Weighted => new WeightedMovingAverage { Length = maLength },
+			MovingAverageMethods.Simple => new SimpleMovingAverage { Length = maLength },
+			MovingAverageMethods.Exponential => new ExponentialMovingAverage { Length = maLength },
+			MovingAverageMethods.Smoothed => new SmoothedMovingAverage { Length = maLength },
+			MovingAverageMethods.Weighted => new WeightedMovingAverage { Length = maLength },
 			_ => new SimpleMovingAverage { Length = maLength },
 		};
 	}
 
-	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPriceType priceType)
+	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPriceTypes priceType)
 	{
 		return priceType switch
 		{
-			AppliedPriceType.Close => candle.ClosePrice,
-			AppliedPriceType.Open => candle.OpenPrice,
-			AppliedPriceType.High => candle.HighPrice,
-			AppliedPriceType.Low => candle.LowPrice,
-			AppliedPriceType.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-			AppliedPriceType.Typical => (candle.ClosePrice + candle.HighPrice + candle.LowPrice) / 3m,
-			AppliedPriceType.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice * 2m) / 4m,
+			AppliedPriceTypes.Close => candle.ClosePrice,
+			AppliedPriceTypes.Open => candle.OpenPrice,
+			AppliedPriceTypes.High => candle.HighPrice,
+			AppliedPriceTypes.Low => candle.LowPrice,
+			AppliedPriceTypes.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+			AppliedPriceTypes.Typical => (candle.ClosePrice + candle.HighPrice + candle.LowPrice) / 3m,
+			AppliedPriceTypes.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice * 2m) / 4m,
 			_ => candle.ClosePrice,
 		};
 	}
@@ -941,7 +941,7 @@ public class ColorMaRsiTriggerMmRecDuplexStrategy : Strategy
 	/// <summary>
 	/// Supported moving average methods.
 	/// </summary>
-	public enum MovingAverageMethod
+	public enum MovingAverageMethods
 	{
 		/// <summary>Simple moving average.</summary>
 		Simple,
@@ -956,7 +956,7 @@ public class ColorMaRsiTriggerMmRecDuplexStrategy : Strategy
 	/// <summary>
 	/// Price selection modes matching MetaTrader's applied price enumeration.
 	/// </summary>
-	public enum AppliedPriceType
+	public enum AppliedPriceTypes
 	{
 		/// <summary>Use the candle close price.</summary>
 		Close,
@@ -980,20 +980,20 @@ public class ColorMaRsiTriggerMmRecDuplexStrategy : Strategy
 		private readonly LengthIndicator<decimal> _slowMa;
 		private readonly RelativeStrengthIndex _fastRsi;
 		private readonly RelativeStrengthIndex _slowRsi;
-		private readonly AppliedPriceType _fastMaPrice;
-		private readonly AppliedPriceType _slowMaPrice;
-		private readonly AppliedPriceType _fastRsiPrice;
-		private readonly AppliedPriceType _slowRsiPrice;
+		private readonly AppliedPriceTypes _fastMaPrice;
+		private readonly AppliedPriceTypes _slowMaPrice;
+		private readonly AppliedPriceTypes _fastRsiPrice;
+		private readonly AppliedPriceTypes _slowRsiPrice;
 
 		public ColorMaRsiTriggerCalculator(
 			LengthIndicator<decimal> fastMa,
 			LengthIndicator<decimal> slowMa,
 			RelativeStrengthIndex fastRsi,
 			RelativeStrengthIndex slowRsi,
-			AppliedPriceType fastMaPrice,
-			AppliedPriceType slowMaPrice,
-			AppliedPriceType fastRsiPrice,
-			AppliedPriceType slowRsiPrice)
+			AppliedPriceTypes fastMaPrice,
+			AppliedPriceTypes slowMaPrice,
+			AppliedPriceTypes fastRsiPrice,
+			AppliedPriceTypes slowRsiPrice)
 		{
 			_fastMa = fastMa ?? throw new ArgumentNullException(nameof(fastMa));
 			_slowMa = slowMa ?? throw new ArgumentNullException(nameof(slowMa));

--- a/API/3167_Daily_Range/CS/DailyRangeStrategy.cs
+++ b/API/3167_Daily_Range/CS/DailyRangeStrategy.cs
@@ -19,7 +19,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class DailyRangeStrategy : Strategy
 {
-	private readonly StrategyParam<DailyRangeCalculation> _rangeMode;
+	private readonly StrategyParam<DailyRangeCalculations> _rangeMode;
 	private readonly StrategyParam<int> _slidingWindowDays;
 	private readonly StrategyParam<decimal> _stopLossCoefficient;
 	private readonly StrategyParam<decimal> _takeProfitCoefficient;
@@ -41,7 +41,7 @@ public class DailyRangeStrategy : Strategy
 	/// <summary>
 	/// Calculation method used for the daily range.
 	/// </summary>
-	public DailyRangeCalculation RangeMode
+	public DailyRangeCalculations RangeMode
 	{
 		get => _rangeMode.Value;
 		set => _rangeMode.Value = value;
@@ -115,7 +115,7 @@ public class DailyRangeStrategy : Strategy
 	/// </summary>
 	public DailyRangeStrategy()
 	{
-		_rangeMode = Param(nameof(RangeMode), DailyRangeCalculation.HighestLowest)
+		_rangeMode = Param(nameof(RangeMode), DailyRangeCalculations.HighestLowest)
 			.SetDisplay("Range Mode", "Daily range calculation method", "General")
 			.SetCanOptimize(true);
 
@@ -276,7 +276,7 @@ public class DailyRangeStrategy : Strategy
 			return false;
 		}
 
-		range = RangeMode == DailyRangeCalculation.HighestLowest || diffCount == 0
+		range = RangeMode == DailyRangeCalculations.HighestLowest || diffCount == 0
 			? highest - lowest
 			: diffSum / diffCount;
 
@@ -357,7 +357,7 @@ public class DailyRangeStrategy : Strategy
 	/// <summary>
 	/// Range calculation modes.
 	/// </summary>
-	public enum DailyRangeCalculation
+	public enum DailyRangeCalculations
 	{
 		/// <summary>
 		/// Use the distance between the highest high and the lowest low within the window.

--- a/API/3168_Three_Neural_Networks/CS/ThreeNeuralNetworksStrategy.cs
+++ b/API/3168_Three_Neural_Networks/CS/ThreeNeuralNetworksStrategy.cs
@@ -23,7 +23,7 @@ public class ThreeNeuralNetworksStrategy : Strategy
 	private readonly StrategyParam<decimal> _takeProfitPips;
 	private readonly StrategyParam<decimal> _trailingStopPips;
 	private readonly StrategyParam<decimal> _trailingStepPips;
-	private readonly StrategyParam<MoneyManagementMode> _moneyManagementMode;
+	private readonly StrategyParam<MoneyManagementModes> _moneyManagementMode;
 	private readonly StrategyParam<decimal> _volumeOrRisk;
 	private readonly StrategyParam<int> _h1Period;
 	private readonly StrategyParam<int> _h1Shift;
@@ -61,7 +61,7 @@ public class ThreeNeuralNetworksStrategy : Strategy
 	/// <summary>
 	/// Specifies how trade volume is calculated.
 	/// </summary>
-	public enum MoneyManagementMode
+	public enum MoneyManagementModes
 	{
 		/// <summary>
 		/// Uses the configured value as a fixed lot size.
@@ -97,7 +97,7 @@ public class ThreeNeuralNetworksStrategy : Strategy
 		.SetRange(0m, 10000m)
 		.SetDisplay("Trailing Step (pips)", "Minimum improvement before the trailing stop is moved", "Risk");
 
-		_moneyManagementMode = Param(nameof(ManagementMode), MoneyManagementMode.RiskPercent)
+		_moneyManagementMode = Param(nameof(ManagementMode), MoneyManagementModes.RiskPercent)
 		.SetDisplay("Money Management", "Select between fixed volume or risk-percentage sizing", "Money Management");
 
 		_volumeOrRisk = Param(nameof(VolumeOrRisk), 1m)
@@ -202,7 +202,7 @@ public class ThreeNeuralNetworksStrategy : Strategy
 	/// <summary>
 	/// Selected money management mode.
 	/// </summary>
-	public MoneyManagementMode ManagementMode
+	public MoneyManagementModes ManagementMode
 	{
 		get => _moneyManagementMode.Value;
 		set => _moneyManagementMode.Value = value;
@@ -706,7 +706,7 @@ public class ThreeNeuralNetworksStrategy : Strategy
 	{
 		var volume = VolumeOrRisk;
 
-		if (ManagementMode == MoneyManagementMode.RiskPercent && Portfolio is { CurrentValue: > 0m } portfolio && price > 0m)
+		if (ManagementMode == MoneyManagementModes.RiskPercent && Portfolio is { CurrentValue: > 0m } portfolio && price > 0m)
 		{
 			var riskAmount = portfolio.CurrentValue * VolumeOrRisk / 100m;
 			if (riskAmount > 0m)

--- a/API/3170_SpearmanRankCorrelationHistogramTimeWeekPeriod/CS/SpearmanRankCorrelationHistogramTimeWeekPeriodStrategy.cs
+++ b/API/3170_SpearmanRankCorrelationHistogramTimeWeekPeriod/CS/SpearmanRankCorrelationHistogramTimeWeekPeriodStrategy.cs
@@ -15,7 +15,7 @@ using StockSharp.Messages;
 
 public class SpearmanRankCorrelationHistogramTimeWeekPeriodStrategy : Strategy
 {
-	public enum SpearmanTradeMode
+	public enum SpearmanTradeModes
 	{
 		Mode1 = 0,
 		Mode2 = 1,
@@ -31,7 +31,7 @@ public class SpearmanRankCorrelationHistogramTimeWeekPeriodStrategy : Strategy
 	private readonly StrategyParam<bool> _sellOpen;
 	private readonly StrategyParam<bool> _buyClose;
 	private readonly StrategyParam<bool> _sellClose;
-	private readonly StrategyParam<SpearmanTradeMode> _tradeMode;
+	private readonly StrategyParam<SpearmanTradeModes> _tradeMode;
 	private readonly StrategyParam<bool> _timeTrade;
 	private readonly StrategyParam<DayOfWeek> _startDay;
 	private readonly StrategyParam<int> _startHour;
@@ -116,7 +116,7 @@ public class SpearmanRankCorrelationHistogramTimeWeekPeriodStrategy : Strategy
 		set => _sellClose.Value = value;
 	}
 
-	public SpearmanTradeMode TradeMode
+	public SpearmanTradeModes TradeMode
 	{
 		get => _tradeMode.Value;
 		set => _tradeMode.Value = value;
@@ -250,7 +250,7 @@ public class SpearmanRankCorrelationHistogramTimeWeekPeriodStrategy : Strategy
 		_sellClose = Param(nameof(SellClose), true)
 		.SetDisplay("Allow Short Exits", "Allow closing short positions on signals.", "Trading");
 
-		_tradeMode = Param(nameof(TradeMode), SpearmanTradeMode.Mode1)
+		_tradeMode = Param(nameof(TradeMode), SpearmanTradeModes.Mode1)
 		.SetDisplay("Trade Mode", "Signal interpretation mode for the histogram colors.", "Trading");
 
 		_timeTrade = Param(nameof(TimeTrade), true)
@@ -422,7 +422,7 @@ public class SpearmanRankCorrelationHistogramTimeWeekPeriodStrategy : Strategy
 
 		switch (TradeMode)
 		{
-			case SpearmanTradeMode.Mode1:
+			case SpearmanTradeModes.Mode1:
 			{
 				if (currentColor > 2)
 				{
@@ -446,7 +446,7 @@ public class SpearmanRankCorrelationHistogramTimeWeekPeriodStrategy : Strategy
 
 				break;
 			}
-			case SpearmanTradeMode.Mode2:
+			case SpearmanTradeModes.Mode2:
 			{
 				if (currentColor == 4)
 				{
@@ -476,7 +476,7 @@ public class SpearmanRankCorrelationHistogramTimeWeekPeriodStrategy : Strategy
 
 				break;
 			}
-			case SpearmanTradeMode.Mode3:
+			case SpearmanTradeModes.Mode3:
 			{
 				if (currentColor == 4)
 				{

--- a/API/3175_Exp_Adaptive_Renko_MMRec_Duplex/CS/ExpAdaptiveRenkoMmrecDuplexStrategy.cs
+++ b/API/3175_Exp_Adaptive_Renko_MMRec_Duplex/CS/ExpAdaptiveRenkoMmrecDuplexStrategy.cs
@@ -23,14 +23,14 @@ public class ExpAdaptiveRenkoMmrecDuplexStrategy : Strategy
 {
 	private readonly StrategyParam<DataType> _longCandleType;
 	private readonly StrategyParam<DataType> _shortCandleType;
-	private readonly StrategyParam<AdaptiveRenkoVolatilityMode> _longVolatilityMode;
-	private readonly StrategyParam<AdaptiveRenkoVolatilityMode> _shortVolatilityMode;
+	private readonly StrategyParam<AdaptiveRenkoVolatilityModes> _longVolatilityMode;
+	private readonly StrategyParam<AdaptiveRenkoVolatilityModes> _shortVolatilityMode;
 	private readonly StrategyParam<int> _longVolatilityPeriod;
 	private readonly StrategyParam<int> _shortVolatilityPeriod;
 	private readonly StrategyParam<decimal> _longSensitivity;
 	private readonly StrategyParam<decimal> _shortSensitivity;
-	private readonly StrategyParam<AdaptiveRenkoPriceMode> _longPriceMode;
-	private readonly StrategyParam<AdaptiveRenkoPriceMode> _shortPriceMode;
+	private readonly StrategyParam<AdaptiveRenkoPriceModes> _longPriceMode;
+	private readonly StrategyParam<AdaptiveRenkoPriceModes> _shortPriceMode;
 	private readonly StrategyParam<decimal> _longMinimumBrickPoints;
 	private readonly StrategyParam<decimal> _shortMinimumBrickPoints;
 	private readonly StrategyParam<int> _longSignalBarOffset;
@@ -47,8 +47,8 @@ public class ExpAdaptiveRenkoMmrecDuplexStrategy : Strategy
 	private readonly StrategyParam<decimal> _shortSmallMoneyManagement;
 	private readonly StrategyParam<decimal> _longMoneyManagement;
 	private readonly StrategyParam<decimal> _shortMoneyManagement;
-	private readonly StrategyParam<MarginModeOption> _longMarginMode;
-	private readonly StrategyParam<MarginModeOption> _shortMarginMode;
+	private readonly StrategyParam<MarginModeOptions> _longMarginMode;
+	private readonly StrategyParam<MarginModeOptions> _shortMarginMode;
 	private readonly StrategyParam<decimal> _longStopLossPoints;
 	private readonly StrategyParam<decimal> _longTakeProfitPoints;
 	private readonly StrategyParam<decimal> _shortStopLossPoints;
@@ -75,10 +75,10 @@ public class ExpAdaptiveRenkoMmrecDuplexStrategy : Strategy
 		_shortCandleType = Param(nameof(ShortCandleType), TimeSpan.FromHours(4).TimeFrame())
 			.SetDisplay("Short Candle Type", "Timeframe used to derive short-side signals", "Short Side");
 
-		_longVolatilityMode = Param(nameof(LongVolatilityMode), AdaptiveRenkoVolatilityMode.AverageTrueRange)
+		_longVolatilityMode = Param(nameof(LongVolatilityMode), AdaptiveRenkoVolatilityModes.AverageTrueRange)
 			.SetDisplay("Long Volatility Source", "Volatility measure controlling long Renko brick size", "Long Side");
 
-		_shortVolatilityMode = Param(nameof(ShortVolatilityMode), AdaptiveRenkoVolatilityMode.AverageTrueRange)
+		_shortVolatilityMode = Param(nameof(ShortVolatilityMode), AdaptiveRenkoVolatilityModes.AverageTrueRange)
 			.SetDisplay("Short Volatility Source", "Volatility measure controlling short Renko brick size", "Short Side");
 
 		_longVolatilityPeriod = Param(nameof(LongVolatilityPeriod), 10)
@@ -101,10 +101,10 @@ public class ExpAdaptiveRenkoMmrecDuplexStrategy : Strategy
 			.SetDisplay("Short Sensitivity", "Multiplier applied to volatility for short bricks", "Short Side")
 			.SetCanOptimize(true);
 
-		_longPriceMode = Param(nameof(LongPriceMode), AdaptiveRenkoPriceMode.Close)
+		_longPriceMode = Param(nameof(LongPriceMode), AdaptiveRenkoPriceModes.Close)
 			.SetDisplay("Long Price Mode", "Price source used when building long bricks", "Long Side");
 
-		_shortPriceMode = Param(nameof(ShortPriceMode), AdaptiveRenkoPriceMode.Close)
+		_shortPriceMode = Param(nameof(ShortPriceMode), AdaptiveRenkoPriceModes.Close)
 			.SetDisplay("Short Price Mode", "Price source used when building short bricks", "Short Side");
 
 		_longMinimumBrickPoints = Param(nameof(LongMinimumBrickPoints), 2m)
@@ -167,10 +167,10 @@ public class ExpAdaptiveRenkoMmrecDuplexStrategy : Strategy
 			.SetNotNegative()
 			.SetDisplay("Short Base MM", "Default money-management value for short entries", "MMRec");
 
-		_longMarginMode = Param(nameof(LongMarginMode), MarginModeOption.Lot)
+		_longMarginMode = Param(nameof(LongMarginMode), MarginModeOptions.Lot)
 			.SetDisplay("Long Margin Mode", "Interpretation of the long money-management value", "MMRec");
 
-		_shortMarginMode = Param(nameof(ShortMarginMode), MarginModeOption.Lot)
+		_shortMarginMode = Param(nameof(ShortMarginMode), MarginModeOptions.Lot)
 			.SetDisplay("Short Margin Mode", "Interpretation of the short money-management value", "MMRec");
 
 		_longStopLossPoints = Param(nameof(LongStopLossPoints), 1000m)
@@ -219,7 +219,7 @@ public class ExpAdaptiveRenkoMmrecDuplexStrategy : Strategy
 	/// <summary>
 	/// Volatility mode for the long Renko stream.
 	/// </summary>
-	public AdaptiveRenkoVolatilityMode LongVolatilityMode
+	public AdaptiveRenkoVolatilityModes LongVolatilityMode
 	{
 		get => _longVolatilityMode.Value;
 		set => _longVolatilityMode.Value = value;
@@ -228,7 +228,7 @@ public class ExpAdaptiveRenkoMmrecDuplexStrategy : Strategy
 	/// <summary>
 	/// Volatility mode for the short Renko stream.
 	/// </summary>
-	public AdaptiveRenkoVolatilityMode ShortVolatilityMode
+	public AdaptiveRenkoVolatilityModes ShortVolatilityMode
 	{
 		get => _shortVolatilityMode.Value;
 		set => _shortVolatilityMode.Value = value;
@@ -273,7 +273,7 @@ public class ExpAdaptiveRenkoMmrecDuplexStrategy : Strategy
 	/// <summary>
 	/// Price source used while building long bricks.
 	/// </summary>
-	public AdaptiveRenkoPriceMode LongPriceMode
+	public AdaptiveRenkoPriceModes LongPriceMode
 	{
 		get => _longPriceMode.Value;
 		set => _longPriceMode.Value = value;
@@ -282,7 +282,7 @@ public class ExpAdaptiveRenkoMmrecDuplexStrategy : Strategy
 	/// <summary>
 	/// Price source used while building short bricks.
 	/// </summary>
-	public AdaptiveRenkoPriceMode ShortPriceMode
+	public AdaptiveRenkoPriceModes ShortPriceMode
 	{
 		get => _shortPriceMode.Value;
 		set => _shortPriceMode.Value = value;
@@ -471,7 +471,7 @@ public class ExpAdaptiveRenkoMmrecDuplexStrategy : Strategy
 	/// <summary>
 	/// Interpretation of the long money-management parameter.
 	/// </summary>
-	public MarginModeOption LongMarginMode
+	public MarginModeOptions LongMarginMode
 	{
 		get => _longMarginMode.Value;
 		set => _longMarginMode.Value = value;
@@ -480,7 +480,7 @@ public class ExpAdaptiveRenkoMmrecDuplexStrategy : Strategy
 	/// <summary>
 	/// Interpretation of the short money-management parameter.
 	/// </summary>
-	public MarginModeOption ShortMarginMode
+	public MarginModeOptions ShortMarginMode
 	{
 		get => _shortMarginMode.Value;
 		set => _shortMarginMode.Value = value;
@@ -586,7 +586,7 @@ _shortPnls.Clear();
 		if (signal == null)
 			return;
 
-		if (LongExitsEnabled && Position > 0 && signal.Value.Trend == RenkoTrend.Down)
+		if (LongExitsEnabled && Position > 0 && signal.Value.Trend == RenkoTrends.Down)
 		{
 			TryCloseLong("Adaptive Renko bearish reversal", candle);
 		}
@@ -594,7 +594,7 @@ _shortPnls.Clear();
 		if (!IsFormedAndOnlineAndAllowTrading())
 			return;
 
-		if (LongEntriesEnabled && signal.Value.Trend == RenkoTrend.Up)
+		if (LongEntriesEnabled && signal.Value.Trend == RenkoTrends.Up)
 		{
 			TryOpenLong(candle);
 		}
@@ -620,7 +620,7 @@ _shortPnls.Clear();
 		if (signal == null)
 			return;
 
-		if (ShortExitsEnabled && Position < 0 && signal.Value.Trend == RenkoTrend.Up)
+		if (ShortExitsEnabled && Position < 0 && signal.Value.Trend == RenkoTrends.Up)
 		{
 			TryCloseShort("Adaptive Renko bullish reversal", candle);
 		}
@@ -628,7 +628,7 @@ _shortPnls.Clear();
 		if (!IsFormedAndOnlineAndAllowTrading())
 			return;
 
-		if (ShortEntriesEnabled && signal.Value.Trend == RenkoTrend.Down)
+		if (ShortEntriesEnabled && signal.Value.Trend == RenkoTrends.Down)
 		{
 			TryOpenShort(candle);
 		}
@@ -818,12 +818,12 @@ _shortPnls.Clear();
 	}
 
 
-	private static IIndicator CreateVolatilityIndicator(AdaptiveRenkoVolatilityMode mode, int period)
+	private static IIndicator CreateVolatilityIndicator(AdaptiveRenkoVolatilityModes mode, int period)
 	{
 		return mode switch
 		{
-			AdaptiveRenkoVolatilityMode.AverageTrueRange => new AverageTrueRange { Length = period },
-			AdaptiveRenkoVolatilityMode.StandardDeviation => new StandardDeviation { Length = period },
+			AdaptiveRenkoVolatilityModes.AverageTrueRange => new AverageTrueRange { Length = period },
+			AdaptiveRenkoVolatilityModes.StandardDeviation => new StandardDeviation { Length = period },
 			_ => throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unsupported volatility mode"),
 		};
 	}
@@ -844,7 +844,7 @@ _shortPnls.Clear();
 	}
 
 
-	private decimal CalculateVolume(decimal mmValue, MarginModeOption mode, decimal stopSteps, decimal price)
+	private decimal CalculateVolume(decimal mmValue, MarginModeOptions mode, decimal stopSteps, decimal price)
 	{
 		if (mmValue == 0m)
 			return 0m;
@@ -858,8 +858,8 @@ _shortPnls.Clear();
 
 		switch (mode)
 		{
-			case MarginModeOption.FreeMargin:
-			case MarginModeOption.Balance:
+			case MarginModeOptions.FreeMargin:
+			case MarginModeOptions.Balance:
 			{
 				if (capital <= 0m || price <= 0m)
 					return NormalizeVolume(mmValue);
@@ -867,8 +867,8 @@ _shortPnls.Clear();
 				volume = capital * mmValue / price;
 				break;
 			}
-			case MarginModeOption.LossFreeMargin:
-			case MarginModeOption.LossBalance:
+			case MarginModeOptions.LossFreeMargin:
+			case MarginModeOptions.LossBalance:
 			{
 				var distance = stopSteps > 0m ? stopSteps * _priceStep : price;
 				if (capital <= 0m || distance <= 0m)
@@ -877,7 +877,7 @@ _shortPnls.Clear();
 				volume = capital * mmValue / distance;
 				break;
 			}
-			case MarginModeOption.Lot:
+			case MarginModeOptions.Lot:
 			default:
 			{
 				volume = mmValue;
@@ -959,7 +959,7 @@ _shortPnls.Clear();
 			queue.Dequeue();
 	}
 
-	private enum RenkoTrend
+	private enum RenkoTrends
 	{
 		None = 0,
 		Up = 1,
@@ -968,7 +968,7 @@ _shortPnls.Clear();
 
 	private readonly struct RenkoSnapshot
 	{
-		public RenkoSnapshot(DateTimeOffset time, RenkoTrend trend, decimal? support, decimal? resistance)
+		public RenkoSnapshot(DateTimeOffset time, RenkoTrends trend, decimal? support, decimal? resistance)
 		{
 			Time = time;
 			Trend = trend;
@@ -978,7 +978,7 @@ _shortPnls.Clear();
 
 		public DateTimeOffset Time { get; }
 
-		public RenkoTrend Trend { get; }
+		public RenkoTrends Trend { get; }
 
 		public decimal? Support { get; }
 
@@ -989,7 +989,7 @@ _shortPnls.Clear();
 	/// <summary>
 	/// Margin interpretation modes reproduced from the MetaTrader expert.
 	/// </summary>
-	public enum MarginModeOption
+	public enum MarginModeOptions
 	{
 		/// <summary>
 		/// Treat the money-management value as a share of free margin.
@@ -1024,11 +1024,11 @@ _shortPnls.Clear();
 		private decimal _up;
 		private decimal _down;
 		private decimal _brick;
-		private RenkoTrend _trend;
+		private RenkoTrends _trend;
 
-		public RenkoSnapshot? Process(ICandleMessage candle, decimal volatility, decimal sensitivity, decimal minimumBrickPoints, AdaptiveRenkoPriceMode priceMode, int signalOffset, decimal step)
+		public RenkoSnapshot? Process(ICandleMessage candle, decimal volatility, decimal sensitivity, decimal minimumBrickPoints, AdaptiveRenkoPriceModes priceMode, int signalOffset, decimal step)
 		{
-			var (high, low) = priceMode == AdaptiveRenkoPriceMode.Close
+			var (high, low) = priceMode == AdaptiveRenkoPriceModes.Close
 				? (candle.ClosePrice, candle.ClosePrice)
 				: (candle.HighPrice, candle.LowPrice);
 
@@ -1042,10 +1042,10 @@ _shortPnls.Clear();
 				_up = high;
 				_down = low;
 				_brick = initialBrick > 0m ? initialBrick : minBrick;
-				_trend = RenkoTrend.None;
+				_trend = RenkoTrends.None;
 				_initialized = true;
 
-				var initialSnapshot = new RenkoSnapshot(GetCandleTime(candle), RenkoTrend.None, null, null);
+				var initialSnapshot = new RenkoSnapshot(GetCandleTime(candle), RenkoTrends.None, null, null);
 				AppendSnapshot(initialSnapshot, signalOffset);
 				return initialSnapshot;
 			}
@@ -1101,18 +1101,18 @@ _shortPnls.Clear();
 			}
 
 			if (_up < up)
-				trend = RenkoTrend.Up;
+				trend = RenkoTrends.Up;
 
 			if (_down > down)
-				trend = RenkoTrend.Down;
+				trend = RenkoTrends.Down;
 
 			_up = up;
 			_down = down;
 			_brick = brick;
 			_trend = trend;
 
-			var support = trend == RenkoTrend.Up ? down - brick : (decimal?)null;
-			var resistance = trend == RenkoTrend.Down ? up + brick : (decimal?)null;
+			var support = trend == RenkoTrends.Up ? down - brick : (decimal?)null;
+			var resistance = trend == RenkoTrends.Down ? up + brick : (decimal?)null;
 
 			var snapshot = new RenkoSnapshot(GetCandleTime(candle), trend, support, resistance);
 			AppendSnapshot(snapshot, signalOffset);
@@ -1138,7 +1138,7 @@ _shortPnls.Clear();
 			_up = 0m;
 			_down = 0m;
 			_brick = 0m;
-			_trend = RenkoTrend.None;
+			_trend = RenkoTrends.None;
 		}
 
 		private void AppendSnapshot(RenkoSnapshot snapshot, int signalOffset)
@@ -1159,13 +1159,13 @@ _shortPnls.Clear();
 		}
 	}
 
-	public enum AdaptiveRenkoVolatilityMode
+	public enum AdaptiveRenkoVolatilityModes
 	{
 		AverageTrueRange,
 		StandardDeviation
 	}
 
-	public enum AdaptiveRenkoPriceMode
+	public enum AdaptiveRenkoPriceModes
 	{
 		HighLow,
 		Close

--- a/API/3177_iMAiStochasticCustom/CS/IMAIStochasticCustomStrategy.cs
+++ b/API/3177_iMAiStochasticCustom/CS/IMAIStochasticCustomStrategy.cs
@@ -22,11 +22,11 @@ public class IMAIStochasticCustomStrategy : Strategy
 	private readonly StrategyParam<int> _takeProfitPips;
 	private readonly StrategyParam<int> _trailingStopPips;
 	private readonly StrategyParam<int> _trailingStepPips;
-	private readonly StrategyParam<VolumeMode> _volumeMode;
+	private readonly StrategyParam<VolumeModes> _volumeMode;
 	private readonly StrategyParam<decimal> _volumeValue;
 	private readonly StrategyParam<int> _maPeriod;
 	private readonly StrategyParam<int> _maShift;
-	private readonly StrategyParam<MaMethod> _maMethod;
+	private readonly StrategyParam<MaMethods> _maMethod;
 	private readonly StrategyParam<int> _levelUpPips;
 	private readonly StrategyParam<int> _levelDownPips;
 	private readonly StrategyParam<int> _stochasticKPeriod;
@@ -76,7 +76,7 @@ public class IMAIStochasticCustomStrategy : Strategy
 		.SetCanOptimize(true)
 		.SetOptimize(0, 50, 5);
 
-		_volumeMode = Param(nameof(ManagementMode), VolumeMode.RiskPercent)
+		_volumeMode = Param(nameof(ManagementMode), VolumeModes.RiskPercent)
 		.SetDisplay("Money Management", "Volume sizing rule applied to new orders.", "Risk");
 
 		_volumeValue = Param(nameof(VolumeValue), 1m)
@@ -93,7 +93,7 @@ public class IMAIStochasticCustomStrategy : Strategy
 		.SetNotNegative()
 		.SetDisplay("MA Shift", "Number of completed bars used to shift the moving average.", "Indicators");
 
-		_maMethod = Param(nameof(MaMethod), MaMethod.Smoothed)
+		_maMethod = Param(nameof(MaMethods), MaMethods.Smoothed)
 		.SetDisplay("MA Method", "Calculation method for the moving average envelope.", "Indicators");
 
 		_levelUpPips = Param(nameof(LevelUpPips), 80)
@@ -164,7 +164,7 @@ public class IMAIStochasticCustomStrategy : Strategy
 		set => _trailingStepPips.Value = value;
 	}
 
-	public VolumeMode ManagementMode
+	public VolumeModes ManagementMode
 	{
 		get => _volumeMode.Value;
 		set => _volumeMode.Value = value;
@@ -188,7 +188,7 @@ public class IMAIStochasticCustomStrategy : Strategy
 		set => _maShift.Value = value;
 	}
 
-	public MaMethod MaMethod
+	public MaMethods MaMethods
 	{
 		get => _maMethod.Value;
 		set => _maMethod.Value = value;
@@ -264,7 +264,7 @@ public class IMAIStochasticCustomStrategy : Strategy
 
 		_pipSize = GetPipSize();
 
-		_movingAverage = CreateMovingAverage(MaMethod, Math.Max(1, MaPeriod));
+		_movingAverage = CreateMovingAverage(MaMethods, Math.Max(1, MaPeriod));
 		_stochastic = new StochasticOscillator
 		{
 			Length = Math.Max(1, StochasticKPeriod),
@@ -474,10 +474,10 @@ public class IMAIStochasticCustomStrategy : Strategy
 
 	private decimal CalculateOrderVolume()
 	{
-		if (ManagementMode == VolumeMode.FixedLot)
+		if (ManagementMode == VolumeModes.FixedLot)
 		return VolumeValue;
 
-		if (ManagementMode != VolumeMode.RiskPercent)
+		if (ManagementMode != VolumeModes.RiskPercent)
 		return 0m;
 
 		if (VolumeValue <= 0m)
@@ -570,24 +570,24 @@ public class IMAIStochasticCustomStrategy : Strategy
 		return decimals >= 3 ? step * 10m : step;
 	}
 
-	private static LengthIndicator<decimal> CreateMovingAverage(MaMethod method, int period)
+	private static LengthIndicator<decimal> CreateMovingAverage(MaMethods method, int period)
 	{
 		return method switch
 		{
-			MaMethod.Simple => new SimpleMovingAverage { Length = period },
-			MaMethod.Exponential => new ExponentialMovingAverage { Length = period },
-			MaMethod.LinearWeighted => new LinearWeightedMovingAverage { Length = period },
+			MaMethods.Simple => new SimpleMovingAverage { Length = period },
+			MaMethods.Exponential => new ExponentialMovingAverage { Length = period },
+			MaMethods.LinearWeighted => new LinearWeightedMovingAverage { Length = period },
 			_ => new SmoothedMovingAverage { Length = period }
 		};
 	}
 
-	public enum VolumeMode
+	public enum VolumeModes
 	{
 		FixedLot,
 		RiskPercent
 	}
 
-	public enum MaMethod
+	public enum MaMethods
 	{
 		Simple,
 		Exponential,

--- a/API/3180_Fraktrak_Xonax/CS/FraktrakXonaxAdvancedStrategy.cs
+++ b/API/3180_Fraktrak_Xonax/CS/FraktrakXonaxAdvancedStrategy.cs
@@ -27,7 +27,7 @@ public class FraktrakXonaxAdvancedStrategy : Strategy
 	private readonly StrategyParam<int> _trailingStepPips;
 	private readonly StrategyParam<bool> _reverseMode;
 	private readonly StrategyParam<bool> _closeOpposite;
-	private readonly StrategyParam<MoneyManagementMode> _moneyManagementMode;
+	private readonly StrategyParam<MoneyManagementModes> _moneyManagementMode;
 	private readonly StrategyParam<decimal> _moneyManagementValue;
 	private readonly StrategyParam<DataType> _candleType;
 
@@ -106,7 +106,7 @@ public class FraktrakXonaxAdvancedStrategy : Strategy
 	/// <summary>
 	/// Selected position sizing approach.
 	/// </summary>
-	public MoneyManagementMode ManagementMode
+	public MoneyManagementModes ManagementMode
 	{
 		get => _moneyManagementMode.Value;
 		set => _moneyManagementMode.Value = value;
@@ -114,8 +114,8 @@ public class FraktrakXonaxAdvancedStrategy : Strategy
 
 	/// <summary>
 	/// Value used by the selected money management mode.
-	/// For <see cref="MoneyManagementMode.FixedLot"/> it is the fixed order volume.
-	/// For <see cref="MoneyManagementMode.RiskPercent"/> it is the risk percentage per trade.
+	/// For <see cref="MoneyManagementModes.FixedLot"/> it is the fixed order volume.
+	/// For <see cref="MoneyManagementModes.RiskPercent"/> it is the risk percentage per trade.
 	/// </summary>
 	public decimal ManagementValue
 	{
@@ -135,7 +135,7 @@ public class FraktrakXonaxAdvancedStrategy : Strategy
 	/// <summary>
 	/// Available money management configurations.
 	/// </summary>
-	public enum MoneyManagementMode
+	public enum MoneyManagementModes
 	{
 		/// <summary>
 		/// Always trade the specified fixed volume.
@@ -171,7 +171,7 @@ public class FraktrakXonaxAdvancedStrategy : Strategy
 		_closeOpposite = Param(nameof(CloseOpposite), false)
 		.SetDisplay("Close Opposite", "Close opposite positions before entering", "Trading");
 
-		_moneyManagementMode = Param(nameof(ManagementMode), MoneyManagementMode.RiskPercent)
+		_moneyManagementMode = Param(nameof(ManagementMode), MoneyManagementModes.RiskPercent)
 		.SetDisplay("Money Management", "Volume calculation mode", "Trading");
 
 		_moneyManagementValue = Param(nameof(ManagementValue), 3m)
@@ -461,7 +461,7 @@ public class FraktrakXonaxAdvancedStrategy : Strategy
 
 	private decimal CalculateOrderVolume(decimal entryPrice, decimal? stopPrice)
 	{
-		if (ManagementMode == MoneyManagementMode.FixedLot || stopPrice is null)
+		if (ManagementMode == MoneyManagementModes.FixedLot || stopPrice is null)
 			return ManagementValue;
 
 		var stopDistance = Math.Abs(entryPrice - stopPrice.Value);

--- a/API/3183_ColorPEMA_Digit_Tm_Plus/CS/ExpColorPemaDigitTmPlusStrategy.cs
+++ b/API/3183_ColorPEMA_Digit_Tm_Plus/CS/ExpColorPemaDigitTmPlusStrategy.cs
@@ -16,7 +16,7 @@ using StockSharp.Messages;
 public class ExpColorPemaDigitTmPlusStrategy : Strategy
 {
 	private readonly StrategyParam<decimal> _moneyManagement;
-	private readonly StrategyParam<MoneyManagementMode> _moneyMode;
+	private readonly StrategyParam<MoneyManagementModes> _moneyMode;
 	private readonly StrategyParam<decimal> _stopLossPoints;
 	private readonly StrategyParam<decimal> _takeProfitPoints;
 	private readonly StrategyParam<int> _deviationPoints;
@@ -28,13 +28,13 @@ public class ExpColorPemaDigitTmPlusStrategy : Strategy
 	private readonly StrategyParam<int> _holdingMinutes;
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<decimal> _emaLength;
-	private readonly StrategyParam<AppliedPrice> _appliedPrice;
+	private readonly StrategyParam<AppliedPrices> _appliedPrice;
 	private readonly StrategyParam<int> _digitPrecision;
 	private readonly StrategyParam<int> _signalBar;
 
 	private ExponentialMovingAverage[] _emaStages;
 	private readonly List<decimal> _pemaValues = new();
-	private readonly List<TrendState> _trendStates = new();
+	private readonly List<TrendStates> _trendStates = new();
 
 	private bool _pendingLongEntry;
 	private bool _pendingShortEntry;
@@ -61,7 +61,7 @@ public class ExpColorPemaDigitTmPlusStrategy : Strategy
 			.SetGreaterThanZero()
 			.SetCanOptimize(true);
 
-		_moneyMode = Param(nameof(MoneyMode), MoneyManagementMode.Lot)
+		_moneyMode = Param(nameof(MoneyMode), MoneyManagementModes.Lot)
 			.SetDisplay("Money Mode", "Position sizing model replicated from the MetaTrader expert.", "Trading")
 			.SetCanOptimize(true);
 
@@ -107,7 +107,7 @@ public class ExpColorPemaDigitTmPlusStrategy : Strategy
 			.SetGreaterThanZero()
 			.SetCanOptimize(true);
 
-		_appliedPrice = Param(nameof(PriceMode), AppliedPrice.Close)
+		_appliedPrice = Param(nameof(PriceMode), AppliedPrices.Close)
 			.SetDisplay("Applied Price", "Price source used to feed the Pentuple EMA calculation.", "Indicator");
 
 		_digitPrecision = Param(nameof(DigitPrecision), 2)
@@ -126,7 +126,7 @@ public class ExpColorPemaDigitTmPlusStrategy : Strategy
 		set => _moneyManagement.Value = value;
 	}
 
-	public MoneyManagementMode MoneyMode
+	public MoneyManagementModes MoneyMode
 	{
 		get => _moneyMode.Value;
 		set => _moneyMode.Value = value;
@@ -198,7 +198,7 @@ public class ExpColorPemaDigitTmPlusStrategy : Strategy
 		set => _emaLength.Value = value;
 	}
 
-	public AppliedPrice PriceMode
+	public AppliedPrices PriceMode
 	{
 		get => _appliedPrice.Value;
 		set => _appliedPrice.Value = value;
@@ -316,14 +316,14 @@ public class ExpColorPemaDigitTmPlusStrategy : Strategy
 		var maxHistory = Math.Max(SignalBar + 5, 20);
 		TrimHistory(_pemaValues, maxHistory);
 
-		var trend = TrendState.Flat;
+		var trend = TrendStates.Flat;
 		if (_pemaValues.Count > 1)
 		{
 			var previous = _pemaValues[^2];
 			if (rounded > previous)
-				trend = TrendState.Up;
+				trend = TrendStates.Up;
 			else if (rounded < previous)
-				trend = TrendState.Down;
+				trend = TrendStates.Down;
 			else if (_trendStates.Count > 0)
 				trend = _trendStates[^1];
 		}
@@ -349,7 +349,7 @@ public class ExpColorPemaDigitTmPlusStrategy : Strategy
 		var currentState = _trendStates[currentIndex];
 		var previousState = _trendStates[previousIndex];
 
-		if (currentState == TrendState.Up && previousState != TrendState.Up)
+		if (currentState == TrendStates.Up && previousState != TrendStates.Up)
 		{
 			if (BuyPosOpen)
 			{
@@ -362,7 +362,7 @@ public class ExpColorPemaDigitTmPlusStrategy : Strategy
 				_pendingShortExit = true;
 			}
 		}
-		else if (currentState == TrendState.Down && previousState != TrendState.Down)
+		else if (currentState == TrendStates.Down && previousState != TrendStates.Down)
 		{
 			if (SellPosOpen)
 			{
@@ -477,18 +477,18 @@ public class ExpColorPemaDigitTmPlusStrategy : Strategy
 	{
 		return PriceMode switch
 		{
-			AppliedPrice.Close => candle.ClosePrice,
-			AppliedPrice.Open => candle.OpenPrice,
-			AppliedPrice.High => candle.HighPrice,
-			AppliedPrice.Low => candle.LowPrice,
-			AppliedPrice.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-			AppliedPrice.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-			AppliedPrice.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice + candle.ClosePrice) / 4m,
-			AppliedPrice.Simplified => (candle.OpenPrice + candle.ClosePrice) / 2m,
-			AppliedPrice.Quarter => (candle.OpenPrice + candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 4m,
-			AppliedPrice.TrendFollow0 => (2m * candle.ClosePrice + candle.HighPrice + candle.LowPrice) / 4m,
-			AppliedPrice.TrendFollow1 => (2m * candle.ClosePrice + candle.OpenPrice + candle.HighPrice + candle.LowPrice) / 5m,
-			AppliedPrice.Demark =>
+			AppliedPrices.Close => candle.ClosePrice,
+			AppliedPrices.Open => candle.OpenPrice,
+			AppliedPrices.High => candle.HighPrice,
+			AppliedPrices.Low => candle.LowPrice,
+			AppliedPrices.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+			AppliedPrices.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+			AppliedPrices.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice + candle.ClosePrice) / 4m,
+			AppliedPrices.Simplified => (candle.OpenPrice + candle.ClosePrice) / 2m,
+			AppliedPrices.Quarter => (candle.OpenPrice + candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 4m,
+			AppliedPrices.TrendFollow0 => (2m * candle.ClosePrice + candle.HighPrice + candle.LowPrice) / 4m,
+			AppliedPrices.TrendFollow1 => (2m * candle.ClosePrice + candle.OpenPrice + candle.HighPrice + candle.LowPrice) / 5m,
+			AppliedPrices.Demark =>
 				candle.OpenPrice <= candle.ClosePrice
 					? (2m * candle.LowPrice + candle.HighPrice + candle.ClosePrice) / 4m
 					: (2m * candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 4m,
@@ -522,13 +522,13 @@ public class ExpColorPemaDigitTmPlusStrategy : Strategy
 
 		switch (MoneyMode)
 		{
-			case MoneyManagementMode.Lot:
+			case MoneyManagementModes.Lot:
 				return mmValue;
-			case MoneyManagementMode.Balance:
-			case MoneyManagementMode.FreeMargin:
+			case MoneyManagementModes.Balance:
+			case MoneyManagementModes.FreeMargin:
 				return capital > 0m ? capital * mmValue / price : 0m;
-			case MoneyManagementMode.LossBalance:
-			case MoneyManagementMode.LossFreeMargin:
+			case MoneyManagementModes.LossBalance:
+			case MoneyManagementModes.LossFreeMargin:
 				if (stopDistance > 0m)
 					return capital > 0m ? capital * mmValue / stopDistance : 0m;
 
@@ -604,7 +604,7 @@ public class ExpColorPemaDigitTmPlusStrategy : Strategy
 		}
 	}
 
-	public enum MoneyManagementMode
+	public enum MoneyManagementModes
 	{
 		FreeMargin,
 		Balance,
@@ -613,7 +613,7 @@ public class ExpColorPemaDigitTmPlusStrategy : Strategy
 		Lot
 	}
 
-	public enum AppliedPrice
+	public enum AppliedPrices
 	{
 		Close,
 		Open,
@@ -629,7 +629,7 @@ public class ExpColorPemaDigitTmPlusStrategy : Strategy
 		Demark
 	}
 
-	private enum TrendState
+	private enum TrendStates
 	{
 		Down,
 		Flat,

--- a/API/3184_Exp_ColorPEMA_Digit_Tm_Plus_MMRec_Duplex/CS/ExpColorPemaDigitTmPlusMmrecDuplexStrategy.cs
+++ b/API/3184_Exp_ColorPEMA_Digit_Tm_Plus_MMRec_Duplex/CS/ExpColorPemaDigitTmPlusMmrecDuplexStrategy.cs
@@ -25,8 +25,8 @@ private readonly StrategyParam<DataType> _longCandleType;
 private readonly StrategyParam<DataType> _shortCandleType;
 private readonly StrategyParam<decimal> _longEmaLength;
 private readonly StrategyParam<decimal> _shortEmaLength;
-private readonly StrategyParam<AppliedPrice> _longPriceMode;
-private readonly StrategyParam<AppliedPrice> _shortPriceMode;
+private readonly StrategyParam<AppliedPrices> _longPriceMode;
+private readonly StrategyParam<AppliedPrices> _shortPriceMode;
 private readonly StrategyParam<int> _longDigits;
 private readonly StrategyParam<int> _shortDigits;
 private readonly StrategyParam<int> _longSignalBar;
@@ -73,10 +73,10 @@ _shortEmaLength = Param(nameof(ShortEmaLength), 50.01m)
 .SetCanOptimize(true)
 .SetOptimize(20m, 100m, 5m);
 
-_longPriceMode = Param(nameof(LongPriceMode), AppliedPrice.Close)
+_longPriceMode = Param(nameof(LongPriceMode), AppliedPrices.Close)
 .SetDisplay("Long Price Mode", "Price source for long pentuple EMA", "Indicators");
 
-_shortPriceMode = Param(nameof(ShortPriceMode), AppliedPrice.Close)
+_shortPriceMode = Param(nameof(ShortPriceMode), AppliedPrices.Close)
 .SetDisplay("Short Price Mode", "Price source for short pentuple EMA", "Indicators");
 
 _longDigits = Param(nameof(LongDigits), 2)
@@ -175,7 +175,7 @@ set => _shortEmaLength.Value = value;
 /// <summary>
 /// Price selection mode for the long stream.
 /// </summary>
-public AppliedPrice LongPriceMode
+public AppliedPrices LongPriceMode
 {
 get => _longPriceMode.Value;
 set => _longPriceMode.Value = value;
@@ -184,7 +184,7 @@ set => _longPriceMode.Value = value;
 /// <summary>
 /// Price selection mode for the short stream.
 /// </summary>
-public AppliedPrice ShortPriceMode
+public AppliedPrices ShortPriceMode
 {
 get => _shortPriceMode.Value;
 set => _shortPriceMode.Value = value;
@@ -355,14 +355,14 @@ Volume = TradeVolume;
 _longPema = new PentupleExponentialMovingAverageIndicator
 {
 Length = LongEmaLength,
-AppliedPrice = LongPriceMode,
+AppliedPrices = LongPriceMode,
 Digits = LongDigits
 };
 
 _shortPema = new PentupleExponentialMovingAverageIndicator
 {
 Length = ShortEmaLength,
-AppliedPrice = ShortPriceMode,
+AppliedPrices = ShortPriceMode,
 Digits = ShortDigits
 };
 
@@ -527,7 +527,7 @@ return index >= 0 && index < source.Count ? source[index] : IndicatorColor.Neutr
 /// <summary>
 /// Enumeration for applied price selection.
 /// </summary>
-public enum AppliedPrice
+public enum AppliedPrices
 {
 /// <summary>
 /// Candle close price.
@@ -622,7 +622,7 @@ public decimal Length { get; set; } = 50.01m;
 /// <summary>
 /// Gets or sets the applied price mode.
 /// </summary>
-public ExpColorPemaDigitTmPlusMmrecDuplexStrategy.AppliedPrice AppliedPrice { get; set; } = ExpColorPemaDigitTmPlusMmrecDuplexStrategy.AppliedPrice.Close;
+public ExpColorPemaDigitTmPlusMmrecDuplexStrategy.AppliedPrices AppliedPrices { get; set; } = ExpColorPemaDigitTmPlusMmrecDuplexStrategy.AppliedPrices.Close;
 
 /// <summary>
 /// Gets or sets rounding digits.
@@ -681,20 +681,20 @@ return previous is null ? value : previous.Value + alpha * (value - previous.Val
 
 private decimal GetAppliedPrice(ICandleMessage candle)
 {
-return AppliedPrice switch
+return AppliedPrices switch
 {
-ExpColorPemaDigitTmPlusMmrecDuplexStrategy.AppliedPrice.Close => candle.ClosePrice,
-ExpColorPemaDigitTmPlusMmrecDuplexStrategy.AppliedPrice.Open => candle.OpenPrice,
-ExpColorPemaDigitTmPlusMmrecDuplexStrategy.AppliedPrice.High => candle.HighPrice,
-ExpColorPemaDigitTmPlusMmrecDuplexStrategy.AppliedPrice.Low => candle.LowPrice,
-ExpColorPemaDigitTmPlusMmrecDuplexStrategy.AppliedPrice.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-ExpColorPemaDigitTmPlusMmrecDuplexStrategy.AppliedPrice.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-ExpColorPemaDigitTmPlusMmrecDuplexStrategy.AppliedPrice.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
-ExpColorPemaDigitTmPlusMmrecDuplexStrategy.AppliedPrice.Simple => (candle.OpenPrice + candle.ClosePrice) / 2m,
-ExpColorPemaDigitTmPlusMmrecDuplexStrategy.AppliedPrice.Quarter => (candle.OpenPrice + candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 4m,
-ExpColorPemaDigitTmPlusMmrecDuplexStrategy.AppliedPrice.TrendFollow0 => candle.ClosePrice > candle.OpenPrice ? candle.HighPrice : candle.ClosePrice < candle.OpenPrice ? candle.LowPrice : candle.ClosePrice,
-ExpColorPemaDigitTmPlusMmrecDuplexStrategy.AppliedPrice.TrendFollow1 => candle.ClosePrice > candle.OpenPrice ? (candle.HighPrice + candle.ClosePrice) / 2m : candle.ClosePrice < candle.OpenPrice ? (candle.LowPrice + candle.ClosePrice) / 2m : candle.ClosePrice,
-ExpColorPemaDigitTmPlusMmrecDuplexStrategy.AppliedPrice.Demark => CalculateDemarkPrice(candle),
+ExpColorPemaDigitTmPlusMmrecDuplexStrategy.AppliedPrices.Close => candle.ClosePrice,
+ExpColorPemaDigitTmPlusMmrecDuplexStrategy.AppliedPrices.Open => candle.OpenPrice,
+ExpColorPemaDigitTmPlusMmrecDuplexStrategy.AppliedPrices.High => candle.HighPrice,
+ExpColorPemaDigitTmPlusMmrecDuplexStrategy.AppliedPrices.Low => candle.LowPrice,
+ExpColorPemaDigitTmPlusMmrecDuplexStrategy.AppliedPrices.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+ExpColorPemaDigitTmPlusMmrecDuplexStrategy.AppliedPrices.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+ExpColorPemaDigitTmPlusMmrecDuplexStrategy.AppliedPrices.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
+ExpColorPemaDigitTmPlusMmrecDuplexStrategy.AppliedPrices.Simple => (candle.OpenPrice + candle.ClosePrice) / 2m,
+ExpColorPemaDigitTmPlusMmrecDuplexStrategy.AppliedPrices.Quarter => (candle.OpenPrice + candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 4m,
+ExpColorPemaDigitTmPlusMmrecDuplexStrategy.AppliedPrices.TrendFollow0 => candle.ClosePrice > candle.OpenPrice ? candle.HighPrice : candle.ClosePrice < candle.OpenPrice ? candle.LowPrice : candle.ClosePrice,
+ExpColorPemaDigitTmPlusMmrecDuplexStrategy.AppliedPrices.TrendFollow1 => candle.ClosePrice > candle.OpenPrice ? (candle.HighPrice + candle.ClosePrice) / 2m : candle.ClosePrice < candle.OpenPrice ? (candle.LowPrice + candle.ClosePrice) / 2m : candle.ClosePrice,
+ExpColorPemaDigitTmPlusMmrecDuplexStrategy.AppliedPrices.Demark => CalculateDemarkPrice(candle),
 _ => candle.ClosePrice,
 };
 }

--- a/API/3186_AutoSet_StopLoss_TakeProfit/CS/AutoSetStopLossTakeProfitStrategy.cs
+++ b/API/3186_AutoSet_StopLoss_TakeProfit/CS/AutoSetStopLossTakeProfitStrategy.cs
@@ -28,7 +28,7 @@ public class AutoSetStopLossTakeProfitStrategy : Strategy
 
 	private readonly StrategyParam<int> _stopLossPips;
 	private readonly StrategyParam<int> _takeProfitPips;
-	private readonly StrategyParam<TradeDirection> _tradeDirection;
+	private readonly StrategyParam<TradeDirections> _tradeDirection;
 
 	private decimal? _bestBid;
 	private decimal? _bestAsk;
@@ -52,7 +52,7 @@ public class AutoSetStopLossTakeProfitStrategy : Strategy
 			.SetDisplay("Take profit (pips)", "Distance from price to the protective take profit in MetaTrader pips.", "Risk")
 			.SetCanOptimize(true);
 
-		_tradeDirection = Param(nameof(DirectionFilter), TradeDirection.Buy)
+		_tradeDirection = Param(nameof(DirectionFilter), TradeDirections.Buy)
 			.SetDisplay("Managed side", "Which position direction should receive automatic stop/take placement.", "Execution");
 	}
 
@@ -76,7 +76,7 @@ public class AutoSetStopLossTakeProfitStrategy : Strategy
 		}
 	}
 
-	public TradeDirection DirectionFilter
+	public TradeDirections DirectionFilter
 	{
 		get => _tradeDirection.Value;
 		set
@@ -392,9 +392,9 @@ public class AutoSetStopLossTakeProfitStrategy : Strategy
 	{
 		return DirectionFilter switch
 		{
-			TradeDirection.Buy => isLong,
-			TradeDirection.Sell => !isLong,
-			TradeDirection.BuySell => true,
+			TradeDirections.Buy => isLong,
+			TradeDirections.Sell => !isLong,
+			TradeDirections.BuySell => true,
 			_ => true,
 		};
 	}
@@ -421,7 +421,7 @@ public class AutoSetStopLossTakeProfitStrategy : Strategy
 		};
 	}
 
-	public enum TradeDirection
+	public enum TradeDirections
 	{
 		Buy,
 		Sell,

--- a/API/3192_JS_Signal_Baes/CS/JsSignalBaesStrategy.cs
+++ b/API/3192_JS_Signal_Baes/CS/JsSignalBaesStrategy.cs
@@ -25,7 +25,7 @@ public class JsSignalBaesStrategy : Strategy
 	private readonly StrategyParam<int> _cciPeriod;
 	private readonly StrategyParam<int> _fastMaPeriod;
 	private readonly StrategyParam<int> _slowMaPeriod;
-	private readonly StrategyParam<MovingAverageKind> _maMethod;
+	private readonly StrategyParam<MovingAverageKinds> _maMethod;
 	private readonly StrategyParam<int> _macdFastPeriod;
 	private readonly StrategyParam<int> _macdSlowPeriod;
 	private readonly StrategyParam<int> _macdSignalPeriod;
@@ -74,7 +74,7 @@ public int SlowMaPeriod
 /// <summary>
 /// Smoothing method used by moving averages.
 /// </summary>
-public MovingAverageKind MaMethod
+public MovingAverageKinds MaMethod
 {
 	get => _maMethod.Value;
 	set => _maMethod.Value = value;
@@ -226,7 +226,7 @@ public JsSignalBaesStrategy()
 	.SetDisplay("Slow MA", "Slow moving average length", "Moving Averages")
 	.SetCanOptimize(true);
 
-	_maMethod = Param(nameof(MaMethod), MovingAverageKind.LinearWeighted)
+	_maMethod = Param(nameof(MaMethod), MovingAverageKinds.LinearWeighted)
 	.SetDisplay("MA Method", "Smoothing method for the two averages", "Moving Averages");
 
 	_macdFastPeriod = Param(nameof(MacdFastPeriod), 8)
@@ -377,14 +377,14 @@ var stochastic = new StochasticOscillator
 return new TimeframeState(dataType, fastMa, slowMa, macd, rsi, cci, stochastic);
 }
 
-private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageKind type, int length)
+private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageKinds type, int length)
 {
 	return type switch
 	{
-		MovingAverageKind.Simple => new SimpleMovingAverage { Length = length },
-		MovingAverageKind.Exponential => new ExponentialMovingAverage { Length = length },
-		MovingAverageKind.Smoothed => new SmoothedMovingAverage { Length = length },
-		MovingAverageKind.LinearWeighted => new WeightedMovingAverage { Length = length },
+		MovingAverageKinds.Simple => new SimpleMovingAverage { Length = length },
+		MovingAverageKinds.Exponential => new ExponentialMovingAverage { Length = length },
+		MovingAverageKinds.Smoothed => new SmoothedMovingAverage { Length = length },
+		MovingAverageKinds.LinearWeighted => new WeightedMovingAverage { Length = length },
 		_ => new SimpleMovingAverage { Length = length }
 	};
 }
@@ -448,7 +448,7 @@ private void EvaluateSignals()
 /// <summary>
 /// Moving average types supported by the original expert advisor.
 /// </summary>
-public enum MovingAverageKind
+public enum MovingAverageKinds
 {
 	Simple,
 	Exponential,

--- a/API/3194_Starter_Triple_Stochastic/CS/StarterTripleStochasticStrategy.cs
+++ b/API/3194_Starter_Triple_Stochastic/CS/StarterTripleStochasticStrategy.cs
@@ -24,15 +24,15 @@ public class StarterTripleStochasticStrategy : Strategy
 	private readonly StrategyParam<int> _takeProfitPips;
 	private readonly StrategyParam<int> _trailingStopPips;
 	private readonly StrategyParam<int> _trailingStepPips;
-	private readonly StrategyParam<MoneyManagementMode> _moneyMode;
+	private readonly StrategyParam<MoneyManagementModes> _moneyMode;
 	private readonly StrategyParam<decimal> _moneyValue;
 	private readonly StrategyParam<DataType> _fastCandleType;
 	private readonly StrategyParam<DataType> _normalCandleType;
 	private readonly StrategyParam<DataType> _slowCandleType;
 	private readonly StrategyParam<int> _maPeriod;
 	private readonly StrategyParam<int> _maShift;
-	private readonly StrategyParam<MovingAverageMethod> _maMethod;
-	private readonly StrategyParam<AppliedPriceType> _maPriceType;
+	private readonly StrategyParam<MovingAverageMethods> _maMethod;
+	private readonly StrategyParam<AppliedPriceTypes> _maPriceType;
 	private readonly StrategyParam<int> _stochKPeriod;
 	private readonly StrategyParam<int> _stochDPeriod;
 	private readonly StrategyParam<int> _stochSlowing;
@@ -87,7 +87,7 @@ public class StarterTripleStochasticStrategy : Strategy
 		.SetRange(0, 500)
 		.SetDisplay("Trailing Step (pips)", "Minimum advance before trailing stop moves", "Risk");
 
-		_moneyMode = Param(nameof(MoneyMode), MoneyManagementMode.RiskPercent)
+		_moneyMode = Param(nameof(MoneyMode), MoneyManagementModes.RiskPercent)
 		.SetDisplay("Money Mode", "Choose fixed volume or risk based sizing", "Money Management");
 
 		_moneyValue = Param(nameof(MoneyValue), 3m)
@@ -111,10 +111,10 @@ public class StarterTripleStochasticStrategy : Strategy
 		.SetRange(0, 20)
 		.SetDisplay("MA Shift", "Horizontal shift in completed bars", "Indicators");
 
-		_maMethod = Param(nameof(MaMethod), MovingAverageMethod.Simple)
+		_maMethod = Param(nameof(MaMethod), MovingAverageMethods.Simple)
 		.SetDisplay("MA Method", "Moving average smoothing method", "Indicators");
 
-		_maPriceType = Param(nameof(MaPriceType), AppliedPriceType.Close)
+		_maPriceType = Param(nameof(MaPriceType), AppliedPriceTypes.Close)
 		.SetDisplay("MA Price", "Price source for the moving averages", "Indicators");
 
 		_stochKPeriod = Param(nameof(StochasticKPeriod), 5)
@@ -175,7 +175,7 @@ public class StarterTripleStochasticStrategy : Strategy
 	/// <summary>
 	/// Money management mode replicating the MetaTrader EA behaviour.
 	/// </summary>
-	public MoneyManagementMode MoneyMode
+	public MoneyManagementModes MoneyMode
 	{
 		get => _moneyMode.Value;
 		set => _moneyMode.Value = value;
@@ -238,7 +238,7 @@ public class StarterTripleStochasticStrategy : Strategy
 	/// <summary>
 	/// Moving average smoothing method.
 	/// </summary>
-	public MovingAverageMethod MaMethod
+	public MovingAverageMethods MaMethod
 	{
 		get => _maMethod.Value;
 		set => _maMethod.Value = value;
@@ -247,7 +247,7 @@ public class StarterTripleStochasticStrategy : Strategy
 	/// <summary>
 	/// Price source fed into the moving average.
 	/// </summary>
-	public AppliedPriceType MaPriceType
+	public AppliedPriceTypes MaPriceType
 	{
 		get => _maPriceType.Value;
 		set => _maPriceType.Value = value;
@@ -617,8 +617,8 @@ public class StarterTripleStochasticStrategy : Strategy
 	{
 		return MoneyMode switch
 		{
-			MoneyManagementMode.FixedLot => MoneyValue,
-			MoneyManagementMode.RiskPercent => CalculateRiskVolume(),
+			MoneyManagementModes.FixedLot => MoneyValue,
+			MoneyManagementModes.RiskPercent => CalculateRiskVolume(),
 			_ => MoneyValue
 		};
 	}
@@ -652,29 +652,29 @@ public class StarterTripleStochasticStrategy : Strategy
 		return step;
 	}
 
-	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPriceType priceType)
+	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPriceTypes priceType)
 	{
 		return priceType switch
 		{
-			AppliedPriceType.Close => candle.ClosePrice,
-			AppliedPriceType.Open => candle.OpenPrice,
-			AppliedPriceType.High => candle.HighPrice,
-			AppliedPriceType.Low => candle.LowPrice,
-			AppliedPriceType.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-			AppliedPriceType.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-			AppliedPriceType.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice * 2m) / 4m,
+			AppliedPriceTypes.Close => candle.ClosePrice,
+			AppliedPriceTypes.Open => candle.OpenPrice,
+			AppliedPriceTypes.High => candle.HighPrice,
+			AppliedPriceTypes.Low => candle.LowPrice,
+			AppliedPriceTypes.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+			AppliedPriceTypes.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+			AppliedPriceTypes.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice * 2m) / 4m,
 			_ => candle.ClosePrice
 		};
 	}
 
-	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageMethod method, int length)
+	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageMethods method, int length)
 	{
 		return method switch
 		{
-			MovingAverageMethod.Simple => new SimpleMovingAverage { Length = length },
-			MovingAverageMethod.Exponential => new ExponentialMovingAverage { Length = length },
-			MovingAverageMethod.Smoothed => new SmoothedMovingAverage { Length = length },
-			MovingAverageMethod.Weighted => new WeightedMovingAverage { Length = length },
+			MovingAverageMethods.Simple => new SimpleMovingAverage { Length = length },
+			MovingAverageMethods.Exponential => new ExponentialMovingAverage { Length = length },
+			MovingAverageMethods.Smoothed => new SmoothedMovingAverage { Length = length },
+			MovingAverageMethods.Weighted => new WeightedMovingAverage { Length = length },
 			_ => new SimpleMovingAverage { Length = length }
 		};
 	}
@@ -692,7 +692,7 @@ public class StarterTripleStochasticStrategy : Strategy
 	/// <summary>
 	/// Money management modes supported by the strategy.
 	/// </summary>
-	public enum MoneyManagementMode
+	public enum MoneyManagementModes
 	{
 		FixedLot,
 		RiskPercent,
@@ -701,7 +701,7 @@ public class StarterTripleStochasticStrategy : Strategy
 	/// <summary>
 	/// Moving average smoothing modes matching the MetaTrader enumerations.
 	/// </summary>
-	public enum MovingAverageMethod
+	public enum MovingAverageMethods
 	{
 		Simple,
 		Exponential,
@@ -712,7 +712,7 @@ public class StarterTripleStochasticStrategy : Strategy
 	/// <summary>
 	/// Price types compatible with the MetaTrader applied price options.
 	/// </summary>
-	public enum AppliedPriceType
+	public enum AppliedPriceTypes
 	{
 		Close,
 		Open,

--- a/API/3199_BladeRunner/CS/BladeRunnerStrategy.cs
+++ b/API/3199_BladeRunner/CS/BladeRunnerStrategy.cs
@@ -53,7 +53,7 @@ public class BladeRunnerStrategy : Strategy
 	private decimal? _macdMain;
 	private decimal? _macdSignal;
 
-	private FractalDirection _latestFractalDirection = FractalDirection.None;
+	private FractalDirections _latestFractalDirection = FractalDirections.None;
 	private decimal? _latestFractalPrice;
 
 	/// <summary>
@@ -358,7 +358,7 @@ public class BladeRunnerStrategy : Strategy
 
 			if (validationOpen < center.High && validationOpen < validationMa)
 			{
-				_latestFractalDirection = FractalDirection.Upper;
+				_latestFractalDirection = FractalDirections.Upper;
 				_latestFractalPrice = center.High;
 			}
 		}
@@ -369,7 +369,7 @@ public class BladeRunnerStrategy : Strategy
 
 			if (validationOpen > center.Low && validationOpen > validationMa)
 			{
-				_latestFractalDirection = FractalDirection.Lower;
+				_latestFractalDirection = FractalDirections.Lower;
 				_latestFractalPrice = center.Low;
 			}
 		}
@@ -420,20 +420,20 @@ public class BladeRunnerStrategy : Strategy
 		if (!momentumOk)
 			return;
 
-		if (_latestFractalDirection == FractalDirection.Upper && fast > slow && macd > macdSignal)
+		if (_latestFractalDirection == FractalDirections.Upper && fast > slow && macd > macdSignal)
 		{
 			if (_latestFractalPrice is decimal level && candle.ClosePrice > level)
 			{
 				HandleLongEntry();
-				_latestFractalDirection = FractalDirection.None;
+				_latestFractalDirection = FractalDirections.None;
 			}
 		}
-		else if (_latestFractalDirection == FractalDirection.Lower && fast < slow && macd < macdSignal)
+		else if (_latestFractalDirection == FractalDirections.Lower && fast < slow && macd < macdSignal)
 		{
 			if (_latestFractalPrice is decimal level && candle.ClosePrice < level)
 			{
 				HandleShortEntry();
-				_latestFractalDirection = FractalDirection.None;
+				_latestFractalDirection = FractalDirections.None;
 			}
 		}
 	}
@@ -517,7 +517,7 @@ public class BladeRunnerStrategy : Strategy
 		public decimal Close { get; }
 	}
 
-	private enum FractalDirection
+	private enum FractalDirections
 	{
 		None,
 		Upper,

--- a/API/3201_Ilan_IMA/CS/IlanImaStrategy.cs
+++ b/API/3201_Ilan_IMA/CS/IlanImaStrategy.cs
@@ -21,7 +21,7 @@ public class IlanImaStrategy : Strategy
 {
 	private readonly StrategyParam<int> _maPeriod;
 	private readonly StrategyParam<int> _maShift;
-	private readonly StrategyParam<MovingAverageMethod> _maMethod;
+	private readonly StrategyParam<MovingAverageMethods> _maMethod;
 	private readonly StrategyParam<CandlePrice> _priceMode;
 	private readonly StrategyParam<decimal> _stopLossPips;
 	private readonly StrategyParam<decimal> _takeProfitPips;
@@ -62,7 +62,7 @@ public class IlanImaStrategy : Strategy
 	/// <summary>
 	/// Moving-average smoothing method.
 	/// </summary>
-	public MovingAverageMethod MaMethod
+	public MovingAverageMethods MaMethod
 	{
 		get => _maMethod.Value;
 		set => _maMethod.Value = value;
@@ -184,7 +184,7 @@ public class IlanImaStrategy : Strategy
 			.SetCanOptimize(true)
 			.SetOptimize(0, 10, 1);
 
-		_maMethod = Param(nameof(MaMethod), MovingAverageMethod.Weighted)
+		_maMethod = Param(nameof(MaMethod), MovingAverageMethods.Weighted)
 			.SetDisplay("MA Method", "Moving average smoothing type", "Indicators");
 
 		_priceMode = Param(nameof(PriceMode), CandlePrice.Weighted)
@@ -587,13 +587,13 @@ public class IlanImaStrategy : Strategy
 		return point.Value;
 	}
 
-	private LengthIndicator<decimal> CreateMovingAverage(MovingAverageMethod method, int length)
+	private LengthIndicator<decimal> CreateMovingAverage(MovingAverageMethods method, int length)
 	{
 		return method switch
 		{
-			MovingAverageMethod.Simple => new SimpleMovingAverage { Length = length },
-			MovingAverageMethod.Exponential => new ExponentialMovingAverage { Length = length },
-			MovingAverageMethod.Smoothed => new SmoothedMovingAverage { Length = length },
+			MovingAverageMethods.Simple => new SimpleMovingAverage { Length = length },
+			MovingAverageMethods.Exponential => new ExponentialMovingAverage { Length = length },
+			MovingAverageMethods.Smoothed => new SmoothedMovingAverage { Length = length },
 			_ => new WeightedMovingAverage { Length = length },
 		};
 	}
@@ -601,7 +601,7 @@ public class IlanImaStrategy : Strategy
 	/// <summary>
 	/// Supported moving-average modes that mirror the MetaTrader options.
 	/// </summary>
-	public enum MovingAverageMethod
+	public enum MovingAverageMethods
 	{
 		Simple,
 		Exponential,

--- a/API/3204_Plateau/CS/PlateauStrategy.cs
+++ b/API/3204_Plateau/CS/PlateauStrategy.cs
@@ -16,7 +16,7 @@ namespace StockSharp.Samples.Strategies;
 /// <summary>
 /// Money management mode for Plateau strategy.
 /// </summary>
-public enum PlateauMoneyManagementMode
+public enum PlateauMoneyManagementModes
 {
 	/// <summary>Use fixed lot size for every order.</summary>
 	FixedLot,
@@ -29,7 +29,7 @@ public enum PlateauMoneyManagementMode
 /// Price source used for moving averages and Bollinger Bands.
 /// Matches the input price options from the original MQL5 expert.
 /// </summary>
-public enum PlateauAppliedPrice
+public enum PlateauAppliedPrices
 {
 	/// <summary>Close price of the candle.</summary>
 	Close,
@@ -56,7 +56,7 @@ public enum PlateauAppliedPrice
 /// <summary>
 /// Moving average method equivalent to the MQL5 implementation.
 /// </summary>
-public enum PlateauMovingAverageMethod
+public enum PlateauMovingAverageMethods
 {
 	/// <summary>Simple moving average.</summary>
 	Simple,
@@ -83,17 +83,17 @@ public class PlateauStrategy : Strategy
 	private readonly StrategyParam<decimal> _takeProfitPips;
 	private readonly StrategyParam<decimal> _trailingStopPips;
 	private readonly StrategyParam<decimal> _trailingStepPips;
-	private readonly StrategyParam<PlateauMoneyManagementMode> _moneyMode;
+	private readonly StrategyParam<PlateauMoneyManagementModes> _moneyMode;
 	private readonly StrategyParam<decimal> _moneyValue;
 	private readonly StrategyParam<int> _fastMaPeriod;
 	private readonly StrategyParam<int> _slowMaPeriod;
 	private readonly StrategyParam<int> _maShift;
-	private readonly StrategyParam<PlateauMovingAverageMethod> _maMethod;
-	private readonly StrategyParam<PlateauAppliedPrice> _maAppliedPrice;
+	private readonly StrategyParam<PlateauMovingAverageMethods> _maMethod;
+	private readonly StrategyParam<PlateauAppliedPrices> _maAppliedPrice;
 	private readonly StrategyParam<int> _bandsPeriod;
 	private readonly StrategyParam<int> _bandsShift;
 	private readonly StrategyParam<decimal> _bandsDeviation;
-	private readonly StrategyParam<PlateauAppliedPrice> _bandsAppliedPrice;
+	private readonly StrategyParam<PlateauAppliedPrices> _bandsAppliedPrice;
 	private readonly StrategyParam<bool> _reverseSignals;
 	private readonly StrategyParam<bool> _closeOpposite;
 	private readonly StrategyParam<bool> _printLog;
@@ -158,7 +158,7 @@ public class PlateauStrategy : Strategy
 	/// <summary>
 	/// Money management mode (fixed lot or risk percentage).
 	/// </summary>
-	public PlateauMoneyManagementMode MoneyMode
+	public PlateauMoneyManagementModes MoneyMode
 	{
 		get => _moneyMode.Value;
 		set => _moneyMode.Value = value;
@@ -203,7 +203,7 @@ public class PlateauStrategy : Strategy
 	/// <summary>
 	/// Method used to calculate the moving averages.
 	/// </summary>
-	public PlateauMovingAverageMethod MaMethod
+	public PlateauMovingAverageMethods MaMethod
 	{
 		get => _maMethod.Value;
 		set => _maMethod.Value = value;
@@ -212,7 +212,7 @@ public class PlateauStrategy : Strategy
 	/// <summary>
 	/// Applied price for the moving averages.
 	/// </summary>
-	public PlateauAppliedPrice MaAppliedPrice
+	public PlateauAppliedPrices MaAppliedPrice
 	{
 		get => _maAppliedPrice.Value;
 		set => _maAppliedPrice.Value = value;
@@ -248,7 +248,7 @@ public class PlateauStrategy : Strategy
 	/// <summary>
 	/// Applied price used for Bollinger Bands calculations.
 	/// </summary>
-	public PlateauAppliedPrice BandsAppliedPrice
+	public PlateauAppliedPrices BandsAppliedPrice
 	{
 		get => _bandsAppliedPrice.Value;
 		set => _bandsAppliedPrice.Value = value;
@@ -320,7 +320,7 @@ public class PlateauStrategy : Strategy
 			.SetDisplay("Trailing Step", "Minimal trailing step in pips", "Risk")
 			.SetCanOptimize(true);
 
-		_moneyMode = Param(nameof(MoneyMode), PlateauMoneyManagementMode.RiskPercent)
+		_moneyMode = Param(nameof(MoneyMode), PlateauMoneyManagementModes.RiskPercent)
 			.SetDisplay("Money Mode", "Choose between fixed lot or risk percent", "Money Management");
 
 		_moneyValue = Param(nameof(MoneyValue), 3m)
@@ -338,10 +338,10 @@ public class PlateauStrategy : Strategy
 		_maShift = Param(nameof(MaShift), 0)
 			.SetDisplay("MA Shift", "Horizontal shift applied to moving averages", "Indicators");
 
-		_maMethod = Param(nameof(MaMethod), PlateauMovingAverageMethod.LinearWeighted)
+		_maMethod = Param(nameof(MaMethod), PlateauMovingAverageMethods.LinearWeighted)
 			.SetDisplay("MA Method", "Moving average smoothing method", "Indicators");
 
-		_maAppliedPrice = Param(nameof(MaAppliedPrice), PlateauAppliedPrice.Typical)
+		_maAppliedPrice = Param(nameof(MaAppliedPrice), PlateauAppliedPrices.Typical)
 			.SetDisplay("MA Price", "Applied price for moving averages", "Indicators");
 
 		_bandsPeriod = Param(nameof(BandsPeriod), 150)
@@ -355,7 +355,7 @@ public class PlateauStrategy : Strategy
 			.SetDisplay("Bands Deviation", "Bollinger Bands deviation multiplier", "Indicators")
 			.SetCanOptimize(true);
 
-		_bandsAppliedPrice = Param(nameof(BandsAppliedPrice), PlateauAppliedPrice.Typical)
+		_bandsAppliedPrice = Param(nameof(BandsAppliedPrice), PlateauAppliedPrices.Typical)
 			.SetDisplay("Bands Price", "Applied price for Bollinger Bands", "Indicators");
 
 		_reverseSignals = Param(nameof(ReverseSignals), false)
@@ -414,7 +414,7 @@ public class PlateauStrategy : Strategy
 		_trailingStopOffset = TrailingStopPips * _pipSize;
 		_trailingStepOffset = TrailingStepPips * _pipSize;
 
-		if (MoneyMode == PlateauMoneyManagementMode.FixedLot && MoneyValue > 0m)
+		if (MoneyMode == PlateauMoneyManagementModes.FixedLot && MoneyValue > 0m)
 			Volume = MoneyValue;
 
 		StartProtection();
@@ -644,10 +644,10 @@ public class PlateauStrategy : Strategy
 
 	private decimal CalculateOrderVolume()
 	{
-	if (MoneyMode == PlateauMoneyManagementMode.FixedLot)
+	if (MoneyMode == PlateauMoneyManagementModes.FixedLot)
 	return MoneyValue;
 
-	if (MoneyMode != PlateauMoneyManagementMode.RiskPercent)
+	if (MoneyMode != PlateauMoneyManagementModes.RiskPercent)
 	return Volume;
 
 	if (MoneyValue <= 0m || _stopLossOffset <= 0m)
@@ -741,29 +741,29 @@ public class PlateauStrategy : Strategy
 	return (bits[3] >> 16) & 0xFF;
 	}
 
-	private static decimal GetAppliedPrice(ICandleMessage candle, PlateauAppliedPrice price)
+	private static decimal GetAppliedPrice(ICandleMessage candle, PlateauAppliedPrices price)
 	{
 	return price switch
 	{
-	PlateauAppliedPrice.Close => candle.ClosePrice,
-	PlateauAppliedPrice.Open => candle.OpenPrice,
-	PlateauAppliedPrice.High => candle.HighPrice,
-	PlateauAppliedPrice.Low => candle.LowPrice,
-	PlateauAppliedPrice.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-	PlateauAppliedPrice.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-	PlateauAppliedPrice.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice + candle.ClosePrice) / 4m,
+	PlateauAppliedPrices.Close => candle.ClosePrice,
+	PlateauAppliedPrices.Open => candle.OpenPrice,
+	PlateauAppliedPrices.High => candle.HighPrice,
+	PlateauAppliedPrices.Low => candle.LowPrice,
+	PlateauAppliedPrices.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+	PlateauAppliedPrices.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+	PlateauAppliedPrices.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice + candle.ClosePrice) / 4m,
 	_ => candle.ClosePrice,
 	};
 	}
 
-	private static IIndicator CreateMovingAverage(PlateauMovingAverageMethod method, int period)
+	private static IIndicator CreateMovingAverage(PlateauMovingAverageMethods method, int period)
 	{
 	return method switch
 	{
-	PlateauMovingAverageMethod.Simple => new SimpleMovingAverage { Length = Math.Max(1, period) },
-	PlateauMovingAverageMethod.Exponential => new ExponentialMovingAverage { Length = Math.Max(1, period) },
-	PlateauMovingAverageMethod.Smoothed => new SmoothedMovingAverage { Length = Math.Max(1, period) },
-	PlateauMovingAverageMethod.LinearWeighted => new WeightedMovingAverage { Length = Math.Max(1, period) },
+	PlateauMovingAverageMethods.Simple => new SimpleMovingAverage { Length = Math.Max(1, period) },
+	PlateauMovingAverageMethods.Exponential => new ExponentialMovingAverage { Length = Math.Max(1, period) },
+	PlateauMovingAverageMethods.Smoothed => new SmoothedMovingAverage { Length = Math.Max(1, period) },
+	PlateauMovingAverageMethods.LinearWeighted => new WeightedMovingAverage { Length = Math.Max(1, period) },
 	_ => new WeightedMovingAverage { Length = Math.Max(1, period) },
 	};
 	}

--- a/API/3207_MATrend/CS/MaTrendStrategy.cs
+++ b/API/3207_MATrend/CS/MaTrendStrategy.cs
@@ -27,8 +27,8 @@ public class MaTrendStrategy : Strategy
 	private readonly StrategyParam<int> _trailingStepPips;
 	private readonly StrategyParam<int> _maPeriod;
 	private readonly StrategyParam<int> _maShift;
-	private readonly StrategyParam<MovingAverageKind> _maMethod;
-	private readonly StrategyParam<AppliedPriceMode> _appliedPrice;
+	private readonly StrategyParam<MovingAverageKinds> _maMethod;
+	private readonly StrategyParam<AppliedPriceModes> _appliedPrice;
 	private readonly StrategyParam<bool> _onlyOnePosition;
 	private readonly StrategyParam<bool> _reverseSignals;
 	private readonly StrategyParam<bool> _closeOpposite;
@@ -79,10 +79,10 @@ public class MaTrendStrategy : Strategy
 			.SetNotNegative()
 			.SetDisplay("MA Shift", "Forward shift (in bars) applied to the moving average.", "Indicator");
 
-		_maMethod = Param(nameof(MaMethod), MovingAverageKind.Weighted)
+		_maMethod = Param(nameof(MaMethod), MovingAverageKinds.Weighted)
 			.SetDisplay("MA Method", "Moving average calculation mode.", "Indicator");
 
-		_appliedPrice = Param(nameof(AppliedPrice), AppliedPriceMode.Weighted)
+		_appliedPrice = Param(nameof(AppliedPrice), AppliedPriceModes.Weighted)
 			.SetDisplay("Applied Price", "Candle price source fed into the moving average.", "Indicator");
 
 		_onlyOnePosition = Param(nameof(OnlyOnePosition), false)
@@ -164,7 +164,7 @@ public class MaTrendStrategy : Strategy
 	/// <summary>
 	/// Moving average calculation method.
 	/// </summary>
-	public MovingAverageKind MaMethod
+	public MovingAverageKinds MaMethod
 	{
 		get => _maMethod.Value;
 		set => _maMethod.Value = value;
@@ -173,7 +173,7 @@ public class MaTrendStrategy : Strategy
 	/// <summary>
 	/// Candle price source passed into the moving average.
 	/// </summary>
-	public AppliedPriceMode AppliedPrice
+	public AppliedPriceModes AppliedPrice
 	{
 		get => _appliedPrice.Value;
 		set => _appliedPrice.Value = value;
@@ -486,28 +486,28 @@ public class MaTrendStrategy : Strategy
 		return digits;
 	}
 
-	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPriceMode mode)
+	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPriceModes mode)
 	{
 		return mode switch
 		{
-			AppliedPriceMode.Open => candle.OpenPrice,
-			AppliedPriceMode.High => candle.HighPrice,
-			AppliedPriceMode.Low => candle.LowPrice,
-			AppliedPriceMode.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-			AppliedPriceMode.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-			AppliedPriceMode.Weighted => (candle.ClosePrice * 2m + candle.HighPrice + candle.LowPrice) / 4m,
+			AppliedPriceModes.Open => candle.OpenPrice,
+			AppliedPriceModes.High => candle.HighPrice,
+			AppliedPriceModes.Low => candle.LowPrice,
+			AppliedPriceModes.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+			AppliedPriceModes.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+			AppliedPriceModes.Weighted => (candle.ClosePrice * 2m + candle.HighPrice + candle.LowPrice) / 4m,
 			_ => candle.ClosePrice,
 		};
 	}
 
-	private static MovingAverage CreateMovingAverage(MovingAverageKind kind, int length)
+	private static MovingAverage CreateMovingAverage(MovingAverageKinds kind, int length)
 	{
 		return kind switch
 		{
-			MovingAverageKind.Simple => new SimpleMovingAverage { Length = length },
-			MovingAverageKind.Exponential => new ExponentialMovingAverage { Length = length },
-			MovingAverageKind.Smoothed => new SmoothedMovingAverage { Length = length },
-			MovingAverageKind.Weighted => new WeightedMovingAverage { Length = length },
+			MovingAverageKinds.Simple => new SimpleMovingAverage { Length = length },
+			MovingAverageKinds.Exponential => new ExponentialMovingAverage { Length = length },
+			MovingAverageKinds.Smoothed => new SmoothedMovingAverage { Length = length },
+			MovingAverageKinds.Weighted => new WeightedMovingAverage { Length = length },
 			_ => new WeightedMovingAverage { Length = length },
 		};
 	}
@@ -516,7 +516,7 @@ public class MaTrendStrategy : Strategy
 /// <summary>
 /// Moving average methods supported by <see cref="MaTrendStrategy"/>.
 /// </summary>
-public enum MovingAverageKind
+public enum MovingAverageKinds
 {
 	/// <summary>
 	/// Simple moving average.
@@ -539,7 +539,7 @@ public enum MovingAverageKind
 /// <summary>
 /// Candle price modes compatible with <see cref="MaTrendStrategy"/>.
 /// </summary>
-public enum AppliedPriceMode
+public enum AppliedPriceModes
 {
 	/// <summary>
 	/// Close price of the candle.

--- a/API/3210_Back_Kick/CS/BackKickStrategy.cs
+++ b/API/3210_Back_Kick/CS/BackKickStrategy.cs
@@ -302,14 +302,14 @@ public class BackKickStrategy : Strategy
 		// Stop loss check for the long leg.
 		if (position.StopPrice is decimal stop && stop > 0m && price <= stop)
 		{
-			ClosePosition(position, CloseReason.StopLoss);
+			ClosePosition(position, CloseReasons.StopLoss);
 			return;
 		}
 
 		// Take profit check for the long leg.
 		if (position.TakePrice is decimal take && take > 0m && price >= take)
 		{
-			ClosePosition(position, CloseReason.TakeProfit);
+			ClosePosition(position, CloseReasons.TakeProfit);
 		}
 	}
 
@@ -329,14 +329,14 @@ public class BackKickStrategy : Strategy
 		// Stop loss check for the short leg.
 		if (position.StopPrice is decimal stop && stop > 0m && price >= stop)
 		{
-			ClosePosition(position, CloseReason.StopLoss);
+			ClosePosition(position, CloseReasons.StopLoss);
 			return;
 		}
 
 		// Take profit check for the short leg.
 		if (position.TakePrice is decimal take && take > 0m && price <= take)
 		{
-			ClosePosition(position, CloseReason.TakeProfit);
+			ClosePosition(position, CloseReasons.TakeProfit);
 		}
 	}
 
@@ -347,7 +347,7 @@ public class BackKickStrategy : Strategy
 			Position = position,
 			IsEntry = true,
 			RemainingVolume = order.Volume,
-			CloseReason = CloseReason.None
+			CloseReasons = CloseReasons.None
 		};
 
 		_pendingEntryOrders++;
@@ -355,14 +355,14 @@ public class BackKickStrategy : Strategy
 		RegisterOrder(order);
 	}
 
-	private void RegisterExitOrder(Order order, PositionState position, CloseReason reason)
+	private void RegisterExitOrder(Order order, PositionState position, CloseReasons reason)
 	{
 		_pendingOrders[order] = new PendingOrderInfo
 		{
 			Position = position,
 			IsEntry = false,
 			RemainingVolume = order.Volume,
-			CloseReason = reason
+			CloseReasons = reason
 		};
 
 		RegisterOrder(order);
@@ -381,7 +381,7 @@ public class BackKickStrategy : Strategy
 		};
 	}
 
-	private void ClosePosition(PositionState position, CloseReason reason)
+	private void ClosePosition(PositionState position, CloseReasons reason)
 	{
 		if (Security == null || Portfolio == null)
 		{
@@ -401,7 +401,7 @@ public class BackKickStrategy : Strategy
 		}
 
 		var exitSide = position.Side == Sides.Buy ? Sides.Sell : Sides.Buy;
-		var order = CreateMarketOrder(exitSide, volume, reason == CloseReason.TakeProfit ? "BackKick:TakeProfit" : "BackKick:StopLoss");
+		var order = CreateMarketOrder(exitSide, volume, reason == CloseReasons.TakeProfit ? "BackKick:TakeProfit" : "BackKick:StopLoss");
 
 		position.IsClosing = true;
 		RegisterExitOrder(order, position, reason);
@@ -481,7 +481,7 @@ public class BackKickStrategy : Strategy
 		else
 		{
 			ReleasePosition(position);
-			LogTrade($"{position.Side} exit filled at {averagePrice} with volume {info.FilledVolume} ({info.CloseReason})");
+			LogTrade($"{position.Side} exit filled at {averagePrice} with volume {info.FilledVolume} ({info.CloseReasons})");
 		}
 	}
 
@@ -562,7 +562,7 @@ public class BackKickStrategy : Strategy
 		}
 	}
 
-	private enum CloseReason
+	private enum CloseReasons
 	{
 		None,
 		StopLoss,
@@ -587,7 +587,7 @@ public class BackKickStrategy : Strategy
 		public decimal RemainingVolume { get; set; }
 		public decimal FilledVolume { get; set; }
 		public decimal WeightedPrice { get; set; }
-		public CloseReason CloseReason { get; init; }
+		public CloseReasons CloseReasons { get; init; }
 	}
 }
 

--- a/API/3211_MA_Trend_2/CS/MaTrend2Strategy.cs
+++ b/API/3211_MA_Trend_2/CS/MaTrend2Strategy.cs
@@ -25,14 +25,14 @@ public class MaTrend2Strategy : Strategy
 	private readonly StrategyParam<int> _takeProfitPips;
 	private readonly StrategyParam<int> _trailingStopPips;
 	private readonly StrategyParam<int> _trailingStepPips;
-	private readonly StrategyParam<LotManagementMode> _lotMode;
+	private readonly StrategyParam<LotManagementModes> _lotMode;
 	private readonly StrategyParam<decimal> _lotOrRiskValue;
 	private readonly StrategyParam<int> _maPeriod;
 	private readonly StrategyParam<int> _maShift;
-	private readonly StrategyParam<MovingAverageMethod> _maMethod;
+	private readonly StrategyParam<MovingAverageMethods> _maMethod;
 	private readonly StrategyParam<CandlePrice> _maPrice;
 	private readonly StrategyParam<DataType> _candleType;
-	private readonly StrategyParam<TradingDirection> _tradingDirection;
+	private readonly StrategyParam<TradingDirections> _tradingDirection;
 	private readonly StrategyParam<bool> _onlyOnePosition;
 	private readonly StrategyParam<bool> _reverseSignals;
 	private readonly StrategyParam<bool> _closeOpposite;
@@ -82,7 +82,7 @@ public class MaTrend2Strategy : Strategy
 	/// <summary>
 	/// Lot sizing mode used by the strategy.
 	/// </summary>
-	public LotManagementMode LotMode
+	public LotManagementModes LotMode
 	{
 		get => _lotMode.Value;
 		set => _lotMode.Value = value;
@@ -118,7 +118,7 @@ public class MaTrend2Strategy : Strategy
 	/// <summary>
 	/// Moving average smoothing method.
 	/// </summary>
-	public MovingAverageMethod MaMethod
+	public MovingAverageMethods MaMethod
 	{
 		get => _maMethod.Value;
 		set => _maMethod.Value = value;
@@ -145,7 +145,7 @@ public class MaTrend2Strategy : Strategy
 	/// <summary>
 	/// Allowed trade direction.
 	/// </summary>
-	public TradingDirection Direction
+	public TradingDirections Direction
 	{
 		get => _tradingDirection.Value;
 		set => _tradingDirection.Value = value;
@@ -199,7 +199,7 @@ public class MaTrend2Strategy : Strategy
 			.SetDisplay("Trailing Step (pips)", "Minimal improvement before adjusting the trailing stop", "Risk")
 			.SetNotNegative();
 
-		_lotMode = Param(nameof(LotMode), LotManagementMode.RiskPercent)
+		_lotMode = Param(nameof(LotMode), LotManagementModes.RiskPercent)
 			.SetDisplay("Lot Mode", "Fixed lot or percent risk sizing", "Risk");
 
 		_lotOrRiskValue = Param(nameof(LotOrRiskValue), 3m)
@@ -214,7 +214,7 @@ public class MaTrend2Strategy : Strategy
 			.SetDisplay("MA Shift", "Bars between the current candle and the MA sample", "Indicators")
 			.SetNotNegative();
 
-		_maMethod = Param(nameof(MaMethod), MovingAverageMethod.LinearWeighted)
+		_maMethod = Param(nameof(MaMethod), MovingAverageMethods.LinearWeighted)
 			.SetDisplay("MA Method", "Moving average smoothing method", "Indicators");
 
 		_maPrice = Param(nameof(MaPrice), CandlePrice.Weighted)
@@ -223,7 +223,7 @@ public class MaTrend2Strategy : Strategy
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(1).TimeFrame())
 			.SetDisplay("Candle Type", "Primary candle series", "General");
 
-		_tradingDirection = Param(nameof(Direction), TradingDirection.Both)
+		_tradingDirection = Param(nameof(Direction), TradingDirections.Both)
 			.SetDisplay("Direction", "Allowed trade direction", "Execution");
 
 		_onlyOnePosition = Param(nameof(OnlyOnePosition), false)
@@ -318,8 +318,8 @@ public class MaTrend2Strategy : Strategy
 		var reference = _maHistory[referenceIndex];
 		var closePrice = candle.ClosePrice;
 
-		var allowLong = Direction is TradingDirection.Both or TradingDirection.BuyOnly;
-		var allowShort = Direction is TradingDirection.Both or TradingDirection.SellOnly;
+		var allowLong = Direction is TradingDirections.Both or TradingDirections.BuyOnly;
+		var allowShort = Direction is TradingDirections.Both or TradingDirections.SellOnly;
 
 		var buySignal = !ReverseSignals ? closePrice > reference : closePrice < reference;
 		var sellSignal = !ReverseSignals ? closePrice < reference : closePrice > reference;
@@ -393,7 +393,7 @@ public class MaTrend2Strategy : Strategy
 	private decimal CalculateOrderVolume(decimal entryPrice, bool isLong)
 	{
 		var mode = LotMode;
-		if (mode == LotManagementMode.FixedVolume)
+		if (mode == LotManagementModes.FixedVolume)
 			return NormalizeVolume(LotOrRiskValue);
 
 		var stopDistance = StopLossPips * _pipSize;
@@ -540,14 +540,14 @@ public class MaTrend2Strategy : Strategy
 		return digits;
 	}
 
-	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageMethod method, int length, CandlePrice price)
+	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageMethods method, int length, CandlePrice price)
 	{
 		LengthIndicator<decimal> indicator = method switch
 		{
-			MovingAverageMethod.Simple => new SimpleMovingAverage(),
-			MovingAverageMethod.Exponential => new ExponentialMovingAverage(),
-			MovingAverageMethod.Smoothed => new SmoothedMovingAverage(),
-			MovingAverageMethod.LinearWeighted => new WeightedMovingAverage(),
+			MovingAverageMethods.Simple => new SimpleMovingAverage(),
+			MovingAverageMethods.Exponential => new ExponentialMovingAverage(),
+			MovingAverageMethods.Smoothed => new SmoothedMovingAverage(),
+			MovingAverageMethods.LinearWeighted => new WeightedMovingAverage(),
 			_ => new SimpleMovingAverage(),
 		};
 
@@ -575,7 +575,7 @@ public class MaTrend2Strategy : Strategy
 	/// <summary>
 	/// Defines the lot sizing modes supported by the strategy.
 	/// </summary>
-	public enum LotManagementMode
+	public enum LotManagementModes
 	{
 		/// <summary>
 		/// Use the parameter value as a direct volume.
@@ -591,7 +591,7 @@ public class MaTrend2Strategy : Strategy
 	/// <summary>
 	/// Trade direction filters.
 	/// </summary>
-	public enum TradingDirection
+	public enum TradingDirections
 	{
 		/// <summary>
 		/// Long trades only.
@@ -612,7 +612,7 @@ public class MaTrend2Strategy : Strategy
 	/// <summary>
 	/// Supported moving average smoothing methods.
 	/// </summary>
-	public enum MovingAverageMethod
+	public enum MovingAverageMethods
 	{
 		/// <summary>
 		/// Simple moving average.

--- a/API/3219_Exp_CronexMFI/CS/ExpCronexMfiStrategy.cs
+++ b/API/3219_Exp_CronexMFI/CS/ExpCronexMfiStrategy.cs
@@ -24,7 +24,7 @@ public class ExpCronexMfiStrategy : Strategy
 	private readonly StrategyParam<int> _fastPeriod;
 	private readonly StrategyParam<int> _slowPeriod;
 	private readonly StrategyParam<int> _signalShift;
-	private readonly StrategyParam<SmoothingMethod> _smoothing;
+	private readonly StrategyParam<SmoothingMethods> _smoothing;
 	private readonly StrategyParam<bool> _enableLongEntries;
 	private readonly StrategyParam<bool> _enableShortEntries;
 	private readonly StrategyParam<bool> _enableLongExits;
@@ -39,7 +39,7 @@ public class ExpCronexMfiStrategy : Strategy
 	/// <summary>
 	/// Available smoothing options for the Cronex MFI lines.
 	/// </summary>
-	public enum SmoothingMethod
+	public enum SmoothingMethods
 	{
 		/// <summary>
 		/// Simple moving average (SMA).
@@ -131,7 +131,7 @@ public class ExpCronexMfiStrategy : Strategy
 	/// <summary>
 	/// Gets or sets the smoothing method applied to both Cronex lines.
 	/// </summary>
-	public SmoothingMethod Smoothing
+	public SmoothingMethods Smoothing
 	{
 		get => _smoothing.Value;
 		set => _smoothing.Value = value;
@@ -210,7 +210,7 @@ public class ExpCronexMfiStrategy : Strategy
 			.SetCanOptimize(true)
 			.SetOptimize(0, 3, 1);
 
-		_smoothing = Param(nameof(Smoothing), SmoothingMethod.Simple)
+		_smoothing = Param(nameof(Smoothing), SmoothingMethods.Simple)
 			.SetDisplay("Smoothing", "Moving-average algorithm applied to both Cronex lines", "Indicators");
 
 		_enableLongEntries = Param(nameof(EnableLongEntries), true)
@@ -354,20 +354,20 @@ public class ExpCronexMfiStrategy : Strategy
 		}
 	}
 
-	private static LengthIndicator<decimal> CreateSmoother(SmoothingMethod method, int length)
+	private static LengthIndicator<decimal> CreateSmoother(SmoothingMethods method, int length)
 	{
 		return method switch
 		{
-			SmoothingMethod.Simple => new SimpleMovingAverage { Length = length },
-			SmoothingMethod.Exponential => new ExponentialMovingAverage { Length = length },
-			SmoothingMethod.Smoothed => new SmoothedMovingAverage { Length = length },
-			SmoothingMethod.Weighted => new WeightedMovingAverage { Length = length },
-			SmoothingMethod.DoubleExponential => new DoubleExponentialMovingAverage { Length = length },
-			SmoothingMethod.TripleExponential => new TripleExponentialMovingAverage { Length = length },
-			SmoothingMethod.Hull => new HullMovingAverage { Length = length },
-			SmoothingMethod.ZeroLagExponential => new ZeroLagExponentialMovingAverage { Length = length },
-			SmoothingMethod.ArnaudLegoux => new ArnaudLegouxMovingAverage { Length = length },
-			SmoothingMethod.KaufmanAdaptive => new KaufmanAdaptiveMovingAverage { Length = length },
+			SmoothingMethods.Simple => new SimpleMovingAverage { Length = length },
+			SmoothingMethods.Exponential => new ExponentialMovingAverage { Length = length },
+			SmoothingMethods.Smoothed => new SmoothedMovingAverage { Length = length },
+			SmoothingMethods.Weighted => new WeightedMovingAverage { Length = length },
+			SmoothingMethods.DoubleExponential => new DoubleExponentialMovingAverage { Length = length },
+			SmoothingMethods.TripleExponential => new TripleExponentialMovingAverage { Length = length },
+			SmoothingMethods.Hull => new HullMovingAverage { Length = length },
+			SmoothingMethods.ZeroLagExponential => new ZeroLagExponentialMovingAverage { Length = length },
+			SmoothingMethods.ArnaudLegoux => new ArnaudLegouxMovingAverage { Length = length },
+			SmoothingMethods.KaufmanAdaptive => new KaufmanAdaptiveMovingAverage { Length = length },
 			_ => new SimpleMovingAverage { Length = length },
 		};
 	}

--- a/API/3220_Cronex_RSI/CS/CronexRsiStrategy.cs
+++ b/API/3220_Cronex_RSI/CS/CronexRsiStrategy.cs
@@ -23,8 +23,8 @@ public class CronexRsiStrategy : Strategy
 	private readonly StrategyParam<int> _fastPeriod;
 	private readonly StrategyParam<int> _slowPeriod;
 	private readonly StrategyParam<int> _signalShift;
-	private readonly StrategyParam<CronexSmoothingMethod> _smoothingMethod;
-	private readonly StrategyParam<AppliedPriceType> _appliedPrice;
+	private readonly StrategyParam<CronexSmoothingMethods> _smoothingMethod;
+	private readonly StrategyParam<AppliedPriceTypes> _appliedPrice;
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<decimal> _tradeVolume;
 	private readonly StrategyParam<bool> _enableLongEntry;
@@ -78,7 +78,7 @@ public class CronexRsiStrategy : Strategy
 	/// <summary>
 	/// Smoothing method replicated from the Cronex RSI indicator.
 	/// </summary>
-	public CronexSmoothingMethod SmoothingMethod
+	public CronexSmoothingMethods SmoothingMethod
 	{
 		get => _smoothingMethod.Value;
 		set => _smoothingMethod.Value = value;
@@ -87,7 +87,7 @@ public class CronexRsiStrategy : Strategy
 	/// <summary>
 	/// Applied price used for RSI calculations.
 	/// </summary>
-	public AppliedPriceType AppliedPrice
+	public AppliedPriceTypes AppliedPrice
 	{
 		get => _appliedPrice.Value;
 		set => _appliedPrice.Value = value;
@@ -171,10 +171,10 @@ public class CronexRsiStrategy : Strategy
 			.SetNotNegative()
 			.SetDisplay("Signal Shift", "Number of completed bars used for confirmation", "Trading");
 
-		_smoothingMethod = Param(nameof(SmoothingMethod), CronexSmoothingMethod.Simple)
+		_smoothingMethod = Param(nameof(SmoothingMethod), CronexSmoothingMethods.Simple)
 			.SetDisplay("Smoothing Method", "Moving average type applied to the RSI", "Indicators");
 
-		_appliedPrice = Param(nameof(AppliedPrice), AppliedPriceType.Close)
+		_appliedPrice = Param(nameof(AppliedPrice), AppliedPriceTypes.Close)
 			.SetDisplay("Applied Price", "Price component passed to the RSI", "Indicators");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(4).TimeFrame())
@@ -380,28 +380,28 @@ public class CronexRsiStrategy : Strategy
 		return true;
 	}
 
-	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPriceType type)
+	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPriceTypes type)
 	{
 		return type switch
 		{
-			AppliedPriceType.Open => candle.OpenPrice,
-			AppliedPriceType.High => candle.HighPrice,
-			AppliedPriceType.Low => candle.LowPrice,
-			AppliedPriceType.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-			AppliedPriceType.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-			AppliedPriceType.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
+			AppliedPriceTypes.Open => candle.OpenPrice,
+			AppliedPriceTypes.High => candle.HighPrice,
+			AppliedPriceTypes.Low => candle.LowPrice,
+			AppliedPriceTypes.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+			AppliedPriceTypes.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+			AppliedPriceTypes.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
 			_ => candle.ClosePrice,
 		};
 	}
 
-	private static LengthIndicator<decimal> CreateSmoothingIndicator(CronexSmoothingMethod method, int length)
+	private static LengthIndicator<decimal> CreateSmoothingIndicator(CronexSmoothingMethods method, int length)
 	{
 		return method switch
 		{
-			CronexSmoothingMethod.Exponential => new ExponentialMovingAverage { Length = length },
-			CronexSmoothingMethod.Smoothed => new SmoothedMovingAverage { Length = length },
-			CronexSmoothingMethod.LinearWeighted => new LinearWeightedMovingAverage { Length = length },
-			CronexSmoothingMethod.VolumeWeighted => new VolumeWeightedMovingAverage { Length = length },
+			CronexSmoothingMethods.Exponential => new ExponentialMovingAverage { Length = length },
+			CronexSmoothingMethods.Smoothed => new SmoothedMovingAverage { Length = length },
+			CronexSmoothingMethods.LinearWeighted => new LinearWeightedMovingAverage { Length = length },
+			CronexSmoothingMethods.VolumeWeighted => new VolumeWeightedMovingAverage { Length = length },
 			_ => new SimpleMovingAverage { Length = length },
 		};
 	}
@@ -410,7 +410,7 @@ public class CronexRsiStrategy : Strategy
 /// <summary>
 /// Moving average methods available in the Cronex RSI indicator.
 /// </summary>
-public enum CronexSmoothingMethod
+public enum CronexSmoothingMethods
 {
 /// <summary>
 /// Simple moving average.
@@ -441,7 +441,7 @@ VolumeWeighted,
 /// <summary>
 /// Applied price selection matching the MQL5 Cronex RSI inputs.
 /// </summary>
-public enum AppliedPriceType
+public enum AppliedPriceTypes
 {
 /// <summary>
 /// Close price.

--- a/API/3224_Cronex_AC/CS/CronexAcStrategy.cs
+++ b/API/3224_Cronex_AC/CS/CronexAcStrategy.cs
@@ -19,7 +19,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class CronexAcStrategy : Strategy
 {
-	private readonly StrategyParam<CronexMovingAverageType> _smoothingType;
+	private readonly StrategyParam<CronexMovingAverageTypes> _smoothingType;
 	private readonly StrategyParam<int> _fastPeriod;
 	private readonly StrategyParam<int> _slowPeriod;
 	private readonly StrategyParam<int> _signalBar;
@@ -35,7 +35,7 @@ public class CronexAcStrategy : Strategy
 	/// <summary>
 	/// Type of smoothing applied to the Accelerator Oscillator.
 	/// </summary>
-	public CronexMovingAverageType SmoothingType
+	public CronexMovingAverageTypes SmoothingType
 	{
 		get => _smoothingType.Value;
 		set => _smoothingType.Value = value;
@@ -118,7 +118,7 @@ public class CronexAcStrategy : Strategy
 	/// </summary>
 	public CronexAcStrategy()
 	{
-		_smoothingType = Param(nameof(SmoothingType), CronexMovingAverageType.Simple)
+		_smoothingType = Param(nameof(SmoothingType), CronexMovingAverageTypes.Simple)
 			.SetDisplay("Smoothing", "Moving average type for smoothing", "Indicators");
 
 		_fastPeriod = Param(nameof(FastPeriod), 14)
@@ -267,14 +267,14 @@ public class CronexAcStrategy : Strategy
 		_slowHistory[0] = slowValue;
 	}
 
-	private static LengthIndicator<decimal> CreateMovingAverage(CronexMovingAverageType type, int length)
+	private static LengthIndicator<decimal> CreateMovingAverage(CronexMovingAverageTypes type, int length)
 	{
 		return type switch
 		{
-			CronexMovingAverageType.Simple => new SimpleMovingAverage { Length = length },
-			CronexMovingAverageType.Exponential => new ExponentialMovingAverage { Length = length },
-			CronexMovingAverageType.Smoothed => new SmoothedMovingAverage { Length = length },
-			CronexMovingAverageType.Weighted => new WeightedMovingAverage { Length = length },
+			CronexMovingAverageTypes.Simple => new SimpleMovingAverage { Length = length },
+			CronexMovingAverageTypes.Exponential => new ExponentialMovingAverage { Length = length },
+			CronexMovingAverageTypes.Smoothed => new SmoothedMovingAverage { Length = length },
+			CronexMovingAverageTypes.Weighted => new WeightedMovingAverage { Length = length },
 			_ => new SimpleMovingAverage { Length = length },
 		};
 	}
@@ -283,7 +283,7 @@ public class CronexAcStrategy : Strategy
 /// <summary>
 /// Moving average algorithms supported by Cronex AC strategy.
 /// </summary>
-public enum CronexMovingAverageType
+public enum CronexMovingAverageTypes
 {
 	/// <summary>
 	/// Simple moving average.

--- a/API/3231_Exp_CronexChaikin/CS/ExpCronexChaikinStrategy.cs
+++ b/API/3231_Exp_CronexChaikin/CS/ExpCronexChaikinStrategy.cs
@@ -23,14 +23,14 @@ namespace StockSharp.Samples.Strategies;
 public class ExpCronexChaikinStrategy : Strategy
 {
 	private readonly StrategyParam<DataType> _candleType;
-	private readonly StrategyParam<ChaikinAverageMethod> _chaikinMethod;
+	private readonly StrategyParam<ChaikinAverageMethods> _chaikinMethod;
 	private readonly StrategyParam<int> _chaikinFastPeriod;
 	private readonly StrategyParam<int> _chaikinSlowPeriod;
-	private readonly StrategyParam<CronexSmoothingMethod> _smoothingMethod;
+	private readonly StrategyParam<CronexSmoothingMethods> _smoothingMethod;
 	private readonly StrategyParam<int> _fastPeriod;
 	private readonly StrategyParam<int> _slowPeriod;
 	private readonly StrategyParam<int> _phase;
-	private readonly StrategyParam<CronexVolumeType> _volumeType;
+	private readonly StrategyParam<CronexVolumeTypes> _volumeType;
 	private readonly StrategyParam<int> _signalBar;
 	private readonly StrategyParam<bool> _buyOpenEnabled;
 	private readonly StrategyParam<bool> _sellOpenEnabled;
@@ -61,7 +61,7 @@ public class ExpCronexChaikinStrategy : Strategy
 	/// <summary>
 	/// Moving average method applied to the accumulation/distribution line.
 	/// </summary>
-	public ChaikinAverageMethod ChaikinMethod
+	public ChaikinAverageMethods ChaikinMethod
 	{
 		get => _chaikinMethod.Value;
 		set => _chaikinMethod.Value = value;
@@ -88,7 +88,7 @@ public class ExpCronexChaikinStrategy : Strategy
 	/// <summary>
 	/// Cronex smoothing method applied to the Chaikin oscillator.
 	/// </summary>
-	public CronexSmoothingMethod SmoothingMethod
+	public CronexSmoothingMethods SmoothingMethod
 	{
 		get => _smoothingMethod.Value;
 		set => _smoothingMethod.Value = value;
@@ -124,7 +124,7 @@ public class ExpCronexChaikinStrategy : Strategy
 	/// <summary>
 	/// Volume source used in the accumulation/distribution calculation.
 	/// </summary>
-	public CronexVolumeType VolumeSource
+	public CronexVolumeTypes VolumeSource
 	{
 		get => _volumeType.Value;
 		set => _volumeType.Value = value;
@@ -203,7 +203,7 @@ public class ExpCronexChaikinStrategy : Strategy
 		_candleType = Param(nameof(CandleType), DataType.TimeFrame(TimeSpan.FromHours(4)))
 			.SetDisplay("Indicator Timeframe", "Time frame used for Cronex Chaikin calculations", "General");
 
-		_chaikinMethod = Param(nameof(ChaikinMethod), ChaikinAverageMethod.Exponential)
+		_chaikinMethod = Param(nameof(ChaikinMethod), ChaikinAverageMethods.Exponential)
 			.SetDisplay("Chaikin MA", "Moving-average method for the accumulation/distribution line", "Chaikin");
 
 		_chaikinFastPeriod = Param(nameof(ChaikinFastPeriod), 3)
@@ -216,7 +216,7 @@ public class ExpCronexChaikinStrategy : Strategy
 			.SetDisplay("Chaikin Slow", "Slow averaging period for Chaikin oscillator", "Chaikin")
 			.SetCanOptimize(true);
 
-		_smoothingMethod = Param(nameof(SmoothingMethod), CronexSmoothingMethod.Simple)
+		_smoothingMethod = Param(nameof(SmoothingMethod), CronexSmoothingMethods.Simple)
 			.SetDisplay("Cronex Method", "Smoothing algorithm applied to Chaikin values", "Cronex");
 
 		_fastPeriod = Param(nameof(FastPeriod), 14)
@@ -234,7 +234,7 @@ public class ExpCronexChaikinStrategy : Strategy
 			.SetCanOptimize(true)
 			.SetOptimize(-100, 100, 5);
 
-		_volumeType = Param(nameof(VolumeSource), CronexVolumeType.Tick)
+		_volumeType = Param(nameof(VolumeSource), CronexVolumeTypes.Tick)
 			.SetDisplay("Volume Source", "Volume applied inside the accumulation/distribution formula", "Chaikin");
 
 		_signalBar = Param(nameof(SignalBar), 1)
@@ -429,8 +429,8 @@ public class ExpCronexChaikinStrategy : Strategy
 	{
 		return VolumeSource switch
 		{
-			CronexVolumeType.Tick => candle.TotalTicks.HasValue ? (decimal)candle.TotalTicks.Value : candle.TotalVolume ?? 0m,
-			CronexVolumeType.Real => candle.TotalVolume ?? (candle.TotalTicks.HasValue ? (decimal)candle.TotalTicks.Value : 0m),
+			CronexVolumeTypes.Tick => candle.TotalTicks.HasValue ? (decimal)candle.TotalTicks.Value : candle.TotalVolume ?? 0m,
+			CronexVolumeTypes.Real => candle.TotalVolume ?? (candle.TotalTicks.HasValue ? (decimal)candle.TotalTicks.Value : 0m),
 			_ => candle.TotalVolume ?? 0m,
 		};
 	}
@@ -449,36 +449,36 @@ public class ExpCronexChaikinStrategy : Strategy
 		return multiplier * volume;
 	}
 
-	private static LengthIndicator<decimal> CreateChaikinAverage(ChaikinAverageMethod method, int length)
+	private static LengthIndicator<decimal> CreateChaikinAverage(ChaikinAverageMethods method, int length)
 	{
 		var normalized = Math.Max(1, length);
 
 		return method switch
 		{
-			ChaikinAverageMethod.Simple => new SimpleMovingAverage { Length = normalized },
-			ChaikinAverageMethod.Exponential => new ExponentialMovingAverage { Length = normalized },
-			ChaikinAverageMethod.Smoothed => new SmoothedMovingAverage { Length = normalized },
-			ChaikinAverageMethod.LinearWeighted => new WeightedMovingAverage { Length = normalized },
+			ChaikinAverageMethods.Simple => new SimpleMovingAverage { Length = normalized },
+			ChaikinAverageMethods.Exponential => new ExponentialMovingAverage { Length = normalized },
+			ChaikinAverageMethods.Smoothed => new SmoothedMovingAverage { Length = normalized },
+			ChaikinAverageMethods.LinearWeighted => new WeightedMovingAverage { Length = normalized },
 			_ => new ExponentialMovingAverage { Length = normalized },
 		};
 	}
 
-	private static LengthIndicator<decimal> CreateCronexSmoother(CronexSmoothingMethod method, int length, int phase)
+	private static LengthIndicator<decimal> CreateCronexSmoother(CronexSmoothingMethods method, int length, int phase)
 	{
 		var normalized = Math.Max(1, length);
 
 		return method switch
 		{
-			CronexSmoothingMethod.Simple => new SimpleMovingAverage { Length = normalized },
-			CronexSmoothingMethod.Exponential => new ExponentialMovingAverage { Length = normalized },
-			CronexSmoothingMethod.Smoothed => new SmoothedMovingAverage { Length = normalized },
-			CronexSmoothingMethod.LinearWeighted => new WeightedMovingAverage { Length = normalized },
-			CronexSmoothingMethod.Jjma => CreateJurik(normalized, phase),
-			CronexSmoothingMethod.JurX => CreateJurik(normalized, phase),
-			CronexSmoothingMethod.ParMa => new ExponentialMovingAverage { Length = normalized },
-			CronexSmoothingMethod.T3 => new TripleExponentialMovingAverage { Length = normalized },
-			CronexSmoothingMethod.Vidya => new ExponentialMovingAverage { Length = normalized },
-			CronexSmoothingMethod.Ama => new KaufmanAdaptiveMovingAverage { Length = normalized },
+			CronexSmoothingMethods.Simple => new SimpleMovingAverage { Length = normalized },
+			CronexSmoothingMethods.Exponential => new ExponentialMovingAverage { Length = normalized },
+			CronexSmoothingMethods.Smoothed => new SmoothedMovingAverage { Length = normalized },
+			CronexSmoothingMethods.LinearWeighted => new WeightedMovingAverage { Length = normalized },
+			CronexSmoothingMethods.Jjma => CreateJurik(normalized, phase),
+			CronexSmoothingMethods.JurX => CreateJurik(normalized, phase),
+			CronexSmoothingMethods.ParMa => new ExponentialMovingAverage { Length = normalized },
+			CronexSmoothingMethods.T3 => new TripleExponentialMovingAverage { Length = normalized },
+			CronexSmoothingMethods.Vidya => new ExponentialMovingAverage { Length = normalized },
+			CronexSmoothingMethods.Ama => new KaufmanAdaptiveMovingAverage { Length = normalized },
 			_ => new SimpleMovingAverage { Length = normalized },
 		};
 	}
@@ -543,7 +543,7 @@ public class ExpCronexChaikinStrategy : Strategy
 /// <summary>
 /// Moving average methods available for the Chaikin oscillator calculation.
 /// </summary>
-public enum ChaikinAverageMethod
+public enum ChaikinAverageMethods
 {
 	/// <summary>
 	/// Simple moving average.
@@ -569,7 +569,7 @@ public enum ChaikinAverageMethod
 /// <summary>
 /// Cronex smoothing algorithms supported by the strategy.
 /// </summary>
-public enum CronexSmoothingMethod
+public enum CronexSmoothingMethods
 {
 	/// <summary>
 	/// Simple moving average (SMA).
@@ -625,7 +625,7 @@ public enum CronexSmoothingMethod
 /// <summary>
 /// Volume source applied to the accumulation/distribution formula.
 /// </summary>
-public enum CronexVolumeType
+public enum CronexVolumeTypes
 {
 	/// <summary>
 	/// Use tick volume when available.

--- a/API/3232_The_Predator/CS/ThePredatorStrategy.cs
+++ b/API/3232_The_Predator/CS/ThePredatorStrategy.cs
@@ -19,7 +19,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class ThePredatorStrategy : Strategy
 {
-	private readonly StrategyParam<PredatorMode> _mode;
+	private readonly StrategyParam<PredatorModes> _mode;
 	private readonly StrategyParam<int> _fastMaLength;
 	private readonly StrategyParam<int> _slowMaLength;
 	private readonly StrategyParam<int> _dmiPeriod;
@@ -61,7 +61,7 @@ public class ThePredatorStrategy : Strategy
 	/// <summary>
 	/// Available entry templates taken from the original expert.
 	/// </summary>
-	public enum PredatorMode
+	public enum PredatorModes
 	{
 		Strategy1,
 		Strategy2
@@ -72,7 +72,7 @@ public class ThePredatorStrategy : Strategy
 	/// </summary>
 	public ThePredatorStrategy()
 	{
-		_mode = Param(nameof(Mode), PredatorMode.Strategy1)
+		_mode = Param(nameof(Mode), PredatorModes.Strategy1)
 			.SetDisplay("Mode", "Select entry template", "General");
 
 		_fastMaLength = Param(nameof(FastMaLength), 1)
@@ -158,7 +158,7 @@ public class ThePredatorStrategy : Strategy
 	/// <summary>
 	/// Selected template.
 	/// </summary>
-	public PredatorMode Mode
+	public PredatorModes Mode
 	{
 		get => _mode.Value;
 		set => _mode.Value = value;
@@ -474,14 +474,14 @@ public class ThePredatorStrategy : Strategy
 
 	switch (Mode)
 	{
-		case PredatorMode.Strategy1:
+		case PredatorModes.Strategy1:
 		{
 			longSignal = adx > AdxThreshold && diPlus > diMinus && fast > slow && longMomentum && macd > macdSignal;
 			shortSignal = adx > AdxThreshold && diMinus > diPlus && fast < slow && shortMomentum && macd < macdSignal;
 			break;
 		}
 
-		case PredatorMode.Strategy2:
+		case PredatorModes.Strategy2:
 		{
 			var hasPrevious = _hasPrevCandle;
 			var buyBandCheck = hasPrevious && _prevClose >= _prevTightLower;

--- a/API/3239_Exp_XPVT/CS/ExpXpvtStrategy.cs
+++ b/API/3239_Exp_XPVT/CS/ExpXpvtStrategy.cs
@@ -30,11 +30,11 @@ public class ExpXpvtStrategy : Strategy
         private readonly StrategyParam<bool> _allowBuyClose;
         private readonly StrategyParam<bool> _allowSellClose;
         private readonly StrategyParam<DataType> _candleType;
-        private readonly StrategyParam<AppliedVolumeOption> _volumeSource;
-        private readonly StrategyParam<SmoothingMethod> _smoothingMethod;
+        private readonly StrategyParam<AppliedVolumeOptions> _volumeSource;
+        private readonly StrategyParam<SmoothingMethods> _smoothingMethod;
         private readonly StrategyParam<int> _smoothingLength;
         private readonly StrategyParam<int> _smoothingPhase;
-        private readonly StrategyParam<AppliedPriceOption> _priceSource;
+        private readonly StrategyParam<AppliedPriceOptions> _priceSource;
         private readonly StrategyParam<int> _signalBar;
 
         private LengthIndicator<decimal> _signalSmoother = null!;
@@ -75,10 +75,10 @@ public class ExpXpvtStrategy : Strategy
                 _candleType = Param(nameof(CandleType), TimeSpan.FromHours(4).TimeFrame())
                         .SetDisplay("Candle Type", "Timeframe used for Price and Volume Trend", "Data");
 
-                _volumeSource = Param(nameof(VolumeSource), AppliedVolumeOption.TickVolume)
+                _volumeSource = Param(nameof(VolumeSource), AppliedVolumeOptions.TickVolume)
                         .SetDisplay("Volume Source", "Volume applied inside Price and Volume Trend", "Indicator");
 
-                _smoothingMethod = Param(nameof(Smoothing), SmoothingMethod.Exponential)
+                _smoothingMethod = Param(nameof(Smoothing), SmoothingMethods.Exponential)
                         .SetDisplay("Smoothing Method", "Moving average applied to the PVT signal", "Indicator");
 
                 _smoothingLength = Param(nameof(SmoothingLength), 5)
@@ -88,7 +88,7 @@ public class ExpXpvtStrategy : Strategy
                 _smoothingPhase = Param(nameof(SmoothingPhase), 15)
                         .SetDisplay("Smoothing Phase", "Phase parameter used by Jurik-style averages", "Indicator");
 
-                _priceSource = Param(nameof(PriceSource), AppliedPriceOption.Close)
+                _priceSource = Param(nameof(PriceSource), AppliedPriceOptions.Close)
                         .SetDisplay("Applied Price", "Price used to build Price and Volume Trend", "Indicator");
 
                 _signalBar = Param(nameof(SignalBar), 1)
@@ -171,7 +171,7 @@ public class ExpXpvtStrategy : Strategy
         /// <summary>
         /// Volume source applied to the PVT calculation.
         /// </summary>
-        public AppliedVolumeOption VolumeSource
+        public AppliedVolumeOptions VolumeSource
         {
                 get => _volumeSource.Value;
                 set => _volumeSource.Value = value;
@@ -180,7 +180,7 @@ public class ExpXpvtStrategy : Strategy
         /// <summary>
         /// Moving average applied to the PVT signal.
         /// </summary>
-        public SmoothingMethod Smoothing
+        public SmoothingMethods Smoothing
         {
                 get => _smoothingMethod.Value;
                 set => _smoothingMethod.Value = value;
@@ -207,7 +207,7 @@ public class ExpXpvtStrategy : Strategy
         /// <summary>
         /// Price used to build Price and Volume Trend.
         /// </summary>
-        public AppliedPriceOption PriceSource
+        public AppliedPriceOptions PriceSource
         {
                 get => _priceSource.Value;
                 set => _priceSource.Value = value;
@@ -359,30 +359,30 @@ public class ExpXpvtStrategy : Strategy
                         SetStopLoss(StopLossPoints, referencePrice, resultingPosition);
         }
 
-        private static decimal GetPrice(ICandleMessage candle, AppliedPriceOption price)
+        private static decimal GetPrice(ICandleMessage candle, AppliedPriceOptions price)
         {
                 return price switch
                 {
-                        AppliedPriceOption.Close => candle.ClosePrice,
-                        AppliedPriceOption.Open => candle.OpenPrice,
-                        AppliedPriceOption.High => candle.HighPrice,
-                        AppliedPriceOption.Low => candle.LowPrice,
-                        AppliedPriceOption.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-                        AppliedPriceOption.Typical => (candle.ClosePrice + candle.HighPrice + candle.LowPrice) / 3m,
-                        AppliedPriceOption.Weighted => (2m * candle.ClosePrice + candle.HighPrice + candle.LowPrice) / 4m,
-                        AppliedPriceOption.Simple => (candle.OpenPrice + candle.ClosePrice) / 2m,
-                        AppliedPriceOption.Quarter => (candle.OpenPrice + candle.ClosePrice + candle.HighPrice + candle.LowPrice) / 4m,
-                        AppliedPriceOption.TrendFollow0 => candle.ClosePrice > candle.OpenPrice
+                        AppliedPriceOptions.Close => candle.ClosePrice,
+                        AppliedPriceOptions.Open => candle.OpenPrice,
+                        AppliedPriceOptions.High => candle.HighPrice,
+                        AppliedPriceOptions.Low => candle.LowPrice,
+                        AppliedPriceOptions.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+                        AppliedPriceOptions.Typical => (candle.ClosePrice + candle.HighPrice + candle.LowPrice) / 3m,
+                        AppliedPriceOptions.Weighted => (2m * candle.ClosePrice + candle.HighPrice + candle.LowPrice) / 4m,
+                        AppliedPriceOptions.Simple => (candle.OpenPrice + candle.ClosePrice) / 2m,
+                        AppliedPriceOptions.Quarter => (candle.OpenPrice + candle.ClosePrice + candle.HighPrice + candle.LowPrice) / 4m,
+                        AppliedPriceOptions.TrendFollow0 => candle.ClosePrice > candle.OpenPrice
                                 ? candle.HighPrice
                                 : candle.ClosePrice < candle.OpenPrice
                                         ? candle.LowPrice
                                         : candle.ClosePrice,
-                        AppliedPriceOption.TrendFollow1 => candle.ClosePrice > candle.OpenPrice
+                        AppliedPriceOptions.TrendFollow1 => candle.ClosePrice > candle.OpenPrice
                                 ? (candle.HighPrice + candle.ClosePrice) / 2m
                                 : candle.ClosePrice < candle.OpenPrice
                                         ? (candle.LowPrice + candle.ClosePrice) / 2m
                                         : candle.ClosePrice,
-                        AppliedPriceOption.Demark =>
+                        AppliedPriceOptions.Demark =>
                                 DemarkPrice(candle.OpenPrice, candle.HighPrice, candle.LowPrice, candle.ClosePrice),
                         _ => candle.ClosePrice,
                 };
@@ -402,14 +402,14 @@ public class ExpXpvtStrategy : Strategy
                 return ((result - low) + (result - high)) / 2m;
         }
 
-        private static decimal GetVolume(ICandleMessage candle, AppliedVolumeOption volumeSource)
+        private static decimal GetVolume(ICandleMessage candle, AppliedVolumeOptions volumeSource)
         {
                 return volumeSource switch
                 {
-                        AppliedVolumeOption.TickVolume => candle.TotalTicks.HasValue
+                        AppliedVolumeOptions.TickVolume => candle.TotalTicks.HasValue
                                 ? candle.TotalTicks.Value
                                 : candle.TotalVolume ?? 0m,
-                        AppliedVolumeOption.RealVolume => candle.TotalVolume ?? (candle.TotalTicks.HasValue
+                        AppliedVolumeOptions.RealVolume => candle.TotalVolume ?? (candle.TotalTicks.HasValue
                                 ? candle.TotalTicks.Value
                                 : 0m),
                         _ => candle.TotalVolume ?? 0m,
@@ -425,22 +425,22 @@ public class ExpXpvtStrategy : Strategy
                         history.RemoveAt(0);
         }
 
-        private static LengthIndicator<decimal> CreateSmoother(SmoothingMethod method, int length, int phase)
+        private static LengthIndicator<decimal> CreateSmoother(SmoothingMethods method, int length, int phase)
         {
                 var normalizedLength = Math.Max(1, length);
 
                 return method switch
                 {
-                        SmoothingMethod.Simple => new SimpleMovingAverage { Length = normalizedLength },
-                        SmoothingMethod.Exponential => new ExponentialMovingAverage { Length = normalizedLength },
-                        SmoothingMethod.Smoothed => new SmoothedMovingAverage { Length = normalizedLength },
-                        SmoothingMethod.LinearWeighted => new WeightedMovingAverage { Length = normalizedLength },
-                        SmoothingMethod.Jjma => CreateJurik(normalizedLength, phase),
-                        SmoothingMethod.Jurx => CreateJurik(normalizedLength, phase),
-                        SmoothingMethod.Parabolic => new ExponentialMovingAverage { Length = normalizedLength },
-                        SmoothingMethod.TripleExponential => new TripleExponentialMovingAverage { Length = normalizedLength },
-                        SmoothingMethod.Vidya => new ExponentialMovingAverage { Length = normalizedLength },
-                        SmoothingMethod.Adaptive => new KaufmanAdaptiveMovingAverage { Length = normalizedLength },
+                        SmoothingMethods.Simple => new SimpleMovingAverage { Length = normalizedLength },
+                        SmoothingMethods.Exponential => new ExponentialMovingAverage { Length = normalizedLength },
+                        SmoothingMethods.Smoothed => new SmoothedMovingAverage { Length = normalizedLength },
+                        SmoothingMethods.LinearWeighted => new WeightedMovingAverage { Length = normalizedLength },
+                        SmoothingMethods.Jjma => CreateJurik(normalizedLength, phase),
+                        SmoothingMethods.Jurx => CreateJurik(normalizedLength, phase),
+                        SmoothingMethods.Parabolic => new ExponentialMovingAverage { Length = normalizedLength },
+                        SmoothingMethods.TripleExponential => new TripleExponentialMovingAverage { Length = normalizedLength },
+                        SmoothingMethods.Vidya => new ExponentialMovingAverage { Length = normalizedLength },
+                        SmoothingMethods.Adaptive => new KaufmanAdaptiveMovingAverage { Length = normalizedLength },
                         _ => new SimpleMovingAverage { Length = normalizedLength },
                 };
         }
@@ -461,7 +461,7 @@ public class ExpXpvtStrategy : Strategy
         /// <summary>
         /// Volume source options used by the strategy.
         /// </summary>
-        public enum AppliedVolumeOption
+        public enum AppliedVolumeOptions
         {
                 /// <summary>
                 /// Use tick volume (fallback to real volume if unavailable).
@@ -477,7 +477,7 @@ public class ExpXpvtStrategy : Strategy
         /// <summary>
         /// Moving average smoothing method applied to PVT.
         /// </summary>
-        public enum SmoothingMethod
+        public enum SmoothingMethods
         {
                 /// <summary>
                 /// Simple moving average.
@@ -533,7 +533,7 @@ public class ExpXpvtStrategy : Strategy
         /// <summary>
         /// Price source choices for the PVT calculation.
         /// </summary>
-        public enum AppliedPriceOption
+        public enum AppliedPriceOptions
         {
                 /// <summary>
                 /// Close price.

--- a/API/3240_Exp_BlauHlm/CS/ExpBlauHlmStrategy.cs
+++ b/API/3240_Exp_BlauHlm/CS/ExpBlauHlmStrategy.cs
@@ -21,7 +21,7 @@ namespace StockSharp.Samples.Strategies;
 public class ExpBlauHlmStrategy : Strategy
 {
 	private readonly StrategyParam<DataType> _candleType;
-	private readonly StrategyParam<SmoothMethod> _smoothingMethod;
+	private readonly StrategyParam<SmoothMethods> _smoothingMethod;
 	private readonly StrategyParam<int> _xLength;
 	private readonly StrategyParam<int> _firstLength;
 	private readonly StrategyParam<int> _secondLength;
@@ -29,7 +29,7 @@ public class ExpBlauHlmStrategy : Strategy
 	private readonly StrategyParam<int> _fourthLength;
 	private readonly StrategyParam<int> _phase;
 	private readonly StrategyParam<int> _signalBar;
-	private readonly StrategyParam<Mode> _mode;
+	private readonly StrategyParam<Modes> _mode;
 	private readonly StrategyParam<bool> _buyOpen;
 	private readonly StrategyParam<bool> _sellOpen;
 	private readonly StrategyParam<bool> _buyClose;
@@ -41,7 +41,7 @@ public class ExpBlauHlmStrategy : Strategy
 	/// Enumeration of available smoothing techniques.
 	/// Unsupported options from the original library fall back to EMA.
 	/// </summary>
-	public enum SmoothMethod
+	public enum SmoothMethods
 	{
 		Simple,
 		Exponential,
@@ -55,7 +55,7 @@ public class ExpBlauHlmStrategy : Strategy
 	/// <summary>
 	/// Operating modes reproduced from the expert advisor.
 	/// </summary>
-	public enum Mode
+	public enum Modes
 	{
 		Breakdown,
 		Twist,
@@ -137,7 +137,7 @@ public class ExpBlauHlmStrategy : Strategy
 	/// <summary>
 	/// Operating mode of the strategy.
 	/// </summary>
-	public Mode EntryMode
+	public Modes EntryMode
 	{
 		get => _entryMode.Value;
 		set => _entryMode.Value = value;
@@ -146,7 +146,7 @@ public class ExpBlauHlmStrategy : Strategy
 	/// <summary>
 	/// Selected smoothing method.
 	/// </summary>
-	public SmoothMethod SmoothingMethod
+	public SmoothMethods SmoothingMethod
 	{
 		get => _smoothingMethod.Value;
 		set => _smoothingMethod.Value = value;
@@ -195,7 +195,7 @@ public class ExpBlauHlmStrategy : Strategy
 		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(4).TimeFrame())
 			.SetDisplay("Candle Type", "Timeframe used for the oscillator", "Data");
 	
-		_smoothingMethod = Param(nameof(SmoothingMethod), SmoothMethod.Exponential)
+		_smoothingMethod = Param(nameof(SmoothingMethod), SmoothMethods.Exponential)
 			.SetDisplay("Smoothing", "XMA smoothing mode", "Indicator");
 	
 		_xLength = Param(nameof(XLength), 2)
@@ -225,8 +225,8 @@ public class ExpBlauHlmStrategy : Strategy
 			.SetNotNegative()
 			.SetDisplay("Signal Bar", "Offset applied to historical values", "Trading");
 	
-		_mode = Param(nameof(EntryMode), Mode.Twist)
-			.SetDisplay("Mode", "Trading logic used for entries", "Trading");
+		_mode = Param(nameof(EntryMode), Modes.Twist)
+			.SetDisplay("Modes", "Trading logic used for entries", "Trading");
 	
 		_buyOpen = Param(nameof(BuyOpen), true)
 			.SetDisplay("Allow Long", "Enable long entries", "Trading");
@@ -298,7 +298,7 @@ public class ExpBlauHlmStrategy : Strategy
 
 		switch (EntryMode)
 		{
-			case Mode.Breakdown:
+			case Modes.Breakdown:
 			{
 				if (!_calculator.TryGetHistogram(SignalBar, out var hist0) ||
 					!_calculator.TryGetHistogram(SignalBar + 1, out var hist1))
@@ -325,7 +325,7 @@ public class ExpBlauHlmStrategy : Strategy
 				break;
 			}
 
-			case Mode.Twist:
+			case Modes.Twist:
 			{
 				if (!_calculator.TryGetHistogram(SignalBar, out var hist0) ||
 					!_calculator.TryGetHistogram(SignalBar + 1, out var hist1) ||
@@ -353,7 +353,7 @@ public class ExpBlauHlmStrategy : Strategy
 				break;
 			}
 
-			case Mode.CloudTwist:
+			case Modes.CloudTwist:
 			{
 				if (!_calculator.TryGetUpSeries(SignalBar, out var up0) ||
 					!_calculator.TryGetUpSeries(SignalBar + 1, out var up1) ||
@@ -403,7 +403,7 @@ public class ExpBlauHlmStrategy : Strategy
 
 	private sealed class BlauHlmCalculator
 	{
-		private readonly SmoothMethod _method;
+		private readonly SmoothMethods _method;
 		private readonly int _xLength;
 		private readonly int _phase;
 		private readonly LengthIndicator<decimal> _ma1;
@@ -418,7 +418,7 @@ public class ExpBlauHlmStrategy : Strategy
 		private int _historyLimit = 16;
 
 		public BlauHlmCalculator(
-			SmoothMethod method,
+			SmoothMethods method,
 			int xLength,
 			int firstLength,
 			int secondLength,
@@ -522,17 +522,17 @@ public class ExpBlauHlmStrategy : Strategy
 			return true;
 		}
 
-		private LengthIndicator<decimal> CreateMovingAverage(SmoothMethod method, int length, int phase)
+		private LengthIndicator<decimal> CreateMovingAverage(SmoothMethods method, int length, int phase)
 		{
 			return method switch
 			{
-				SmoothMethod.Simple => new SimpleMovingAverage { Length = length },
-				SmoothMethod.Exponential => new ExponentialMovingAverage { Length = length },
-				SmoothMethod.Smoothed => new SmoothedMovingAverage { Length = length },
-				SmoothMethod.LinearWeighted => new WeightedMovingAverage { Length = length },
-				SmoothMethod.Jurik => new JurikMovingAverage { Length = length, Phase = phase },
-				SmoothMethod.TripleExponential => new TripleExponentialMovingAverage { Length = length },
-				SmoothMethod.Adaptive => new KaufmanAdaptiveMovingAverage { Length = length },
+				SmoothMethods.Simple => new SimpleMovingAverage { Length = length },
+				SmoothMethods.Exponential => new ExponentialMovingAverage { Length = length },
+				SmoothMethods.Smoothed => new SmoothedMovingAverage { Length = length },
+				SmoothMethods.LinearWeighted => new WeightedMovingAverage { Length = length },
+				SmoothMethods.Jurik => new JurikMovingAverage { Length = length, Phase = phase },
+				SmoothMethods.TripleExponential => new TripleExponentialMovingAverage { Length = length },
+				SmoothMethods.Adaptive => new KaufmanAdaptiveMovingAverage { Length = length },
 				_ => new ExponentialMovingAverage { Length = length },
 			};
 		}

--- a/API/3242_Day_Trading_Trend_Pullback/CS/DayTradingTrendPullbackStrategy.cs
+++ b/API/3242_Day_Trading_Trend_Pullback/CS/DayTradingTrendPullbackStrategy.cs
@@ -267,11 +267,11 @@ public class DayTradingTrendPullbackStrategy : Strategy
 
 		if (IsFormedAndOnlineAndAllowTrading())
 		{
-			if (macdRelation == MacdRelation.Bullish && hasBullTrend && structureBullish && hasBullPullback && hasMomentumImpulse)
+			if (macdRelation == MacdRelations.Bullish && hasBullTrend && structureBullish && hasBullPullback && hasMomentumImpulse)
 			{
 				TryEnterLong(candle);
 			}
-			else if (macdRelation == MacdRelation.Bearish && hasBearTrend && structureBearish && hasBearPullback && hasMomentumImpulse)
+			else if (macdRelation == MacdRelations.Bearish && hasBearTrend && structureBearish && hasBearPullback && hasMomentumImpulse)
 			{
 				TryEnterShort(candle);
 			}
@@ -545,21 +545,21 @@ public class DayTradingTrendPullbackStrategy : Strategy
 		}
 	}
 
-	private MacdRelation GetMacdRelation()
+	private MacdRelations GetMacdRelation()
 	{
 		if (_macdMain is not decimal macd || _macdSignal is not decimal signal)
-			return MacdRelation.None;
+			return MacdRelations.None;
 
 		if (macd > signal)
-			return MacdRelation.Bullish;
+			return MacdRelations.Bullish;
 
 		if (macd < signal)
-			return MacdRelation.Bearish;
+			return MacdRelations.Bearish;
 
-		return MacdRelation.None;
+		return MacdRelations.None;
 	}
 
-	private enum MacdRelation
+	private enum MacdRelations
 	{
 		None,
 		Bullish,

--- a/API/3243_JBrainTrend1Stop/CS/JBrainTrend1StopStrategy.cs
+++ b/API/3243_JBrainTrend1Stop/CS/JBrainTrend1StopStrategy.cs
@@ -248,7 +248,7 @@ public class JBrainTrend1StopStrategy : Strategy
 		ProcessPendingSignals();
 
 		var signal = UpdateState(data);
-		if (signal == SignalType.None)
+		if (signal == SignalTypes.None)
 			return;
 
 		if (SignalBar <= 0)
@@ -323,22 +323,22 @@ public class JBrainTrend1StopStrategy : Strategy
 		}
 	}
 
-	private SignalType UpdateState(IndicatorData data)
+	private SignalTypes UpdateState(IndicatorData data)
 	{
 		if (_prevJmaClose is null)
 		{
 			_prevJmaClose = data.JmaClose;
-			return SignalType.None;
+			return SignalTypes.None;
 		}
 
 		if (_prevPrevJmaClose is null)
 		{
 			_prevPrevJmaClose = _prevJmaClose;
 			_prevJmaClose = data.JmaClose;
-			return SignalType.None;
+			return SignalTypes.None;
 		}
 
-		var signal = SignalType.None;
+		var signal = SignalTypes.None;
 		var range = data.Atr / RangeDivisor;
 		var range1 = data.AtrExtended * RangeMultiplier;
 		var val3 = Math.Abs(data.JmaClose - _prevPrevJmaClose.Value);
@@ -349,13 +349,13 @@ public class JBrainTrend1StopStrategy : Strategy
 			{
 				_trendState = -1;
 				_trailStop = data.JmaHigh + range1 / 4m;
-				signal = SignalType.Sell;
+				signal = SignalTypes.Sell;
 			}
 			else if (data.Stochastic > UpperThreshold && _trendState != 1)
 			{
 				_trendState = 1;
 				_trailStop = data.JmaLow - range1 / 4m;
-				signal = SignalType.Buy;
+				signal = SignalTypes.Buy;
 			}
 		}
 		else if (_trendState == -1)
@@ -377,14 +377,14 @@ public class JBrainTrend1StopStrategy : Strategy
 		return signal;
 	}
 
-	private void ExecuteSignal(SignalType type)
+	private void ExecuteSignal(SignalTypes type)
 	{
 		if (!IsFormedAndOnlineAndAllowTrading())
 			return;
 
 		switch (type)
 		{
-			case SignalType.Buy:
+			case SignalTypes.Buy:
 				if (SellClose && Position < 0)
 					BuyMarket(Math.Abs(Position));
 
@@ -392,7 +392,7 @@ public class JBrainTrend1StopStrategy : Strategy
 					BuyMarket();
 				break;
 
-			case SignalType.Sell:
+			case SignalTypes.Sell:
 				if (BuyClose && Position > 0)
 					SellMarket(Position);
 
@@ -417,9 +417,9 @@ public class JBrainTrend1StopStrategy : Strategy
 
 	private readonly record struct IndicatorData(decimal Atr, decimal AtrExtended, decimal Stochastic, decimal JmaHigh, decimal JmaLow, decimal JmaClose);
 
-	private readonly record struct PendingSignal(SignalType Type, int RemainingBars);
+	private readonly record struct PendingSignal(SignalTypes Type, int RemainingBars);
 
-	private enum SignalType
+	private enum SignalTypes
 	{
 		None,
 		Buy,

--- a/API/3246_Ea_Vishal_Eurgbp_H4/CS/EaVishalEurgbpH4Strategy.cs
+++ b/API/3246_Ea_Vishal_Eurgbp_H4/CS/EaVishalEurgbpH4Strategy.cs
@@ -287,7 +287,7 @@ public class EaVishalEurgbpH4Strategy : Strategy
 			}
 			else
 			{
-				UpdateTrailingStop(PositionSide.Long, candle);
+				UpdateTrailingStop(PositionSides.Long, candle);
 				if (TryExitLongByRisk(candle))
 				{
 					ResetProtection();
@@ -302,7 +302,7 @@ public class EaVishalEurgbpH4Strategy : Strategy
 			}
 			else
 			{
-				UpdateTrailingStop(PositionSide.Short, candle);
+				UpdateTrailingStop(PositionSides.Short, candle);
 				if (TryExitShortByRisk(candle))
 				{
 					ResetProtection();
@@ -454,7 +454,7 @@ public class EaVishalEurgbpH4Strategy : Strategy
 		SellMarket(Volume);
 	}
 
-	private void UpdateTrailingStop(PositionSide side, ICandleMessage candle)
+	private void UpdateTrailingStop(PositionSides side, ICandleMessage candle)
 	{
 		if (!UseTrailingStop || StopLossPips <= 0 || _pipSize <= 0m)
 			return;
@@ -463,7 +463,7 @@ public class EaVishalEurgbpH4Strategy : Strategy
 
 		switch (side)
 		{
-			case PositionSide.Long when _prevHigh1 is decimal prevHigh:
+			case PositionSides.Long when _prevHigh1 is decimal prevHigh:
 			{
 				var desiredStop = prevHigh - distance;
 				if (_longStopPrice is not decimal currentStop || desiredStop > currentStop)
@@ -472,7 +472,7 @@ public class EaVishalEurgbpH4Strategy : Strategy
 				}
 				break;
 			}
-			case PositionSide.Short when _prevLow1 is decimal prevLow:
+			case PositionSides.Short when _prevLow1 is decimal prevLow:
 			{
 				var desiredStop = prevLow + distance;
 				if (_shortStopPrice is not decimal currentStop || desiredStop < currentStop)
@@ -503,7 +503,7 @@ public class EaVishalEurgbpH4Strategy : Strategy
 		return step;
 	}
 
-	private enum PositionSide
+	private enum PositionSides
 	{
 		Long,
 		Short

--- a/API/3249_800BB/CS/EightHundredBbStrategy.cs
+++ b/API/3249_800BB/CS/EightHundredBbStrategy.cs
@@ -33,7 +33,7 @@ public class EightHundredBbStrategy : Strategy
 	private decimal? _previousUpperBand;
 	private decimal? _previousLowerBand;
 	private decimal? _previousOpen;
-	private PriceStatus _previousStatus = PriceStatus.Nothing;
+	private PriceStatuses _previousStatus = PriceStatuses.Nothing;
 
 	private decimal? _longStopPrice;
 	private decimal? _longTakePrice;
@@ -153,7 +153,7 @@ public class EightHundredBbStrategy : Strategy
 		_previousUpperBand = null;
 		_previousLowerBand = null;
 		_previousOpen = null;
-		_previousStatus = PriceStatus.Nothing;
+		_previousStatus = PriceStatuses.Nothing;
 
 		_longStopPrice = null;
 		_longTakePrice = null;
@@ -225,12 +225,12 @@ public class EightHundredBbStrategy : Strategy
 		UpdatePreviousValues(candle, upperBand, lowerBand);
 	}
 
-	private void TryEnterLong(ICandleMessage candle, decimal prevLowerBand, decimal prevOpen, PriceStatus prevStatus, decimal atrValue)
+	private void TryEnterLong(ICandleMessage candle, decimal prevLowerBand, decimal prevOpen, PriceStatuses prevStatus, decimal atrValue)
 	{
 		if (candle.OpenPrice < prevLowerBand)
 			return;
 
-		var crossedBelow = prevOpen <= prevLowerBand || prevStatus == PriceStatus.CrossedBelowLower;
+		var crossedBelow = prevOpen <= prevLowerBand || prevStatus == PriceStatuses.CrossedBelowLower;
 		if (!crossedBelow)
 			return;
 
@@ -256,12 +256,12 @@ public class EightHundredBbStrategy : Strategy
 		_shortTakePrice = null;
 	}
 
-	private void TryEnterShort(ICandleMessage candle, decimal prevUpperBand, decimal prevOpen, PriceStatus prevStatus, decimal atrValue)
+	private void TryEnterShort(ICandleMessage candle, decimal prevUpperBand, decimal prevOpen, PriceStatuses prevStatus, decimal atrValue)
 	{
 		if (candle.OpenPrice > prevUpperBand)
 			return;
 
-		var crossedAbove = prevOpen >= prevUpperBand || prevStatus == PriceStatus.CrossedAboveUpper;
+		var crossedAbove = prevOpen >= prevUpperBand || prevStatus == PriceStatuses.CrossedAboveUpper;
 		if (!crossedAbove)
 			return;
 
@@ -323,15 +323,15 @@ public class EightHundredBbStrategy : Strategy
 
 		if (candle.OpenPrice > upperBand || candle.ClosePrice > upperBand)
 		{
-			_previousStatus = PriceStatus.CrossedAboveUpper;
+			_previousStatus = PriceStatuses.CrossedAboveUpper;
 		}
 		else if (candle.OpenPrice < lowerBand || candle.ClosePrice < lowerBand)
 		{
-			_previousStatus = PriceStatus.CrossedBelowLower;
+			_previousStatus = PriceStatuses.CrossedBelowLower;
 		}
 		else
 		{
-			_previousStatus = PriceStatus.Nothing;
+			_previousStatus = PriceStatuses.Nothing;
 		}
 	}
 
@@ -422,7 +422,7 @@ public class EightHundredBbStrategy : Strategy
 			_pipValueMoney = stepPrice;
 	}
 
-	private enum PriceStatus
+	private enum PriceStatuses
 	{
 		Nothing,
 		CrossedBelowLower,

--- a/API/3268_RSI_Booster/CS/RsiBoosterStrategy.cs
+++ b/API/3268_RSI_Booster/CS/RsiBoosterStrategy.cs
@@ -31,9 +31,9 @@ public class RsiBoosterStrategy : Strategy
 	private readonly StrategyParam<bool> _returnOrderEnabled;
 	private readonly StrategyParam<int> _returnOrdersMax;
 	private readonly StrategyParam<int> _firstRsiPeriod;
-	private readonly StrategyParam<AppliedPriceType> _firstRsiPrice;
+	private readonly StrategyParam<AppliedPriceTypes> _firstRsiPrice;
 	private readonly StrategyParam<int> _secondRsiPeriod;
-	private readonly StrategyParam<AppliedPriceType> _secondRsiPrice;
+	private readonly StrategyParam<AppliedPriceTypes> _secondRsiPrice;
 	private readonly StrategyParam<DataType> _candleType;
 
 	private RelativeStrengthIndex _firstRsi = null!;
@@ -92,13 +92,13 @@ public class RsiBoosterStrategy : Strategy
 		_firstRsiPeriod = Param(nameof(FirstRsiPeriod), 14)
 		.SetDisplay("Fast RSI Period", "Calculation period for the fast RSI", LocalizedStrings.StrIndicators);
 
-		_firstRsiPrice = Param(nameof(FirstRsiPrice), AppliedPriceType.Close)
+		_firstRsiPrice = Param(nameof(FirstRsiPrice), AppliedPriceTypes.Close)
 		.SetDisplay("Fast RSI Price", "Price source for the fast RSI", LocalizedStrings.StrIndicators);
 
 		_secondRsiPeriod = Param(nameof(SecondRsiPeriod), 14)
 		.SetDisplay("Delayed RSI Period", "Calculation period for the delayed RSI", LocalizedStrings.StrIndicators);
 
-		_secondRsiPrice = Param(nameof(SecondRsiPrice), AppliedPriceType.Close)
+		_secondRsiPrice = Param(nameof(SecondRsiPrice), AppliedPriceTypes.Close)
 		.SetDisplay("Delayed RSI Price", "Price source for the delayed RSI", LocalizedStrings.StrIndicators);
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(1).TimeFrame())
@@ -190,7 +190,7 @@ public class RsiBoosterStrategy : Strategy
 	/// <summary>
 	/// Price source for the fast RSI.
 	/// </summary>
-	public AppliedPriceType FirstRsiPrice
+	public AppliedPriceTypes FirstRsiPrice
 	{
 		get => _firstRsiPrice.Value;
 		set => _firstRsiPrice.Value = value;
@@ -208,7 +208,7 @@ public class RsiBoosterStrategy : Strategy
 	/// <summary>
 	/// Price source for the delayed RSI.
 	/// </summary>
-	public AppliedPriceType SecondRsiPrice
+	public AppliedPriceTypes SecondRsiPrice
 	{
 		get => _secondRsiPrice.Value;
 		set => _secondRsiPrice.Value = value;
@@ -555,17 +555,17 @@ public class RsiBoosterStrategy : Strategy
 		return 0.0001m;
 	}
 
-	private static decimal GetPrice(ICandleMessage candle, AppliedPriceType type)
+	private static decimal GetPrice(ICandleMessage candle, AppliedPriceTypes type)
 	{
 		return type switch
 		{
-			AppliedPriceType.Close => candle.ClosePrice,
-			AppliedPriceType.Open => candle.OpenPrice,
-			AppliedPriceType.High => candle.HighPrice,
-			AppliedPriceType.Low => candle.LowPrice,
-			AppliedPriceType.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-			AppliedPriceType.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-			AppliedPriceType.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
+			AppliedPriceTypes.Close => candle.ClosePrice,
+			AppliedPriceTypes.Open => candle.OpenPrice,
+			AppliedPriceTypes.High => candle.HighPrice,
+			AppliedPriceTypes.Low => candle.LowPrice,
+			AppliedPriceTypes.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+			AppliedPriceTypes.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+			AppliedPriceTypes.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
 			_ => candle.ClosePrice
 		};
 	}
@@ -573,7 +573,7 @@ public class RsiBoosterStrategy : Strategy
 	/// <summary>
 	/// Price sources compatible with MetaTrader applied price modes.
 	/// </summary>
-	public enum AppliedPriceType
+	public enum AppliedPriceTypes
 	{
 		/// <summary>
 		/// Close price of the candle.

--- a/API/3276_Lavika100/CS/Lavika100Strategy.cs
+++ b/API/3276_Lavika100/CS/Lavika100Strategy.cs
@@ -30,7 +30,7 @@ public class Lavika100Strategy : Strategy
 	private readonly StrategyParam<decimal> _trailingStepPoints;
 	private readonly StrategyParam<decimal> _fixedVolume;
 	private readonly StrategyParam<decimal> _riskPercent;
-	private readonly StrategyParam<MoneyManagementMode> _moneyMode;
+	private readonly StrategyParam<MoneyManagementModes> _moneyMode;
 	private readonly StrategyParam<bool> _onlyOnePosition;
 	private readonly StrategyParam<bool> _reverseSignals;
 	private readonly StrategyParam<bool> _closeOpposite;
@@ -51,7 +51,7 @@ public class Lavika100Strategy : Strategy
 	/// <summary>
 	/// Available money management modes.
 	/// </summary>
-	public enum MoneyManagementMode
+	public enum MoneyManagementModes
 	{
 		/// <summary>
 		/// Use the configured fixed volume for every trade.
@@ -115,7 +115,7 @@ public Lavika100Strategy()
 	.SetRange(0m, 100m)
 	.SetDisplay("Risk Percent", "Percent of portfolio value to risk per trade when RiskPercent mode is selected.", "Trading");
 
-	_moneyMode = Param(nameof(MoneyMode), MoneyManagementMode.RiskPercent)
+	_moneyMode = Param(nameof(MoneyMode), MoneyManagementModes.RiskPercent)
 	.SetDisplay("Money Mode", "Choose between fixed lots or percent risk sizing.", "Trading");
 
 	_onlyOnePosition = Param(nameof(OnlyOnePosition), true)
@@ -219,7 +219,7 @@ public decimal TrailingStepPoints
 }
 
 /// <summary>
-/// Fixed lot size used when <see cref="MoneyMode"/> is <see cref="MoneyManagementMode.FixedLot"/>.
+/// Fixed lot size used when <see cref="MoneyMode"/> is <see cref="MoneyManagementModes.FixedLot"/>.
 /// </summary>
 public decimal FixedVolume
 {
@@ -228,7 +228,7 @@ public decimal FixedVolume
 }
 
 /// <summary>
-/// Risk percentage applied when <see cref="MoneyMode"/> is <see cref="MoneyManagementMode.RiskPercent"/>.
+/// Risk percentage applied when <see cref="MoneyMode"/> is <see cref="MoneyManagementModes.RiskPercent"/>.
 /// </summary>
 public decimal RiskPercent
 {
@@ -239,7 +239,7 @@ public decimal RiskPercent
 /// <summary>
 /// Selects the position sizing approach.
 /// </summary>
-public MoneyManagementMode MoneyMode
+public MoneyManagementModes MoneyMode
 {
 	get => _moneyMode.Value;
 	set => _moneyMode.Value = value;
@@ -441,7 +441,7 @@ private decimal CalculateVolume()
 {
 	var volume = FixedVolume;
 
-	if (MoneyMode == MoneyManagementMode.RiskPercent)
+	if (MoneyMode == MoneyManagementModes.RiskPercent)
 	{
 		if (Portfolio is null)
 		return 0m;

--- a/API/3286_Zone_Recovery_Button/CS/ZoneRecoveryButtonStrategy.cs
+++ b/API/3286_Zone_Recovery_Button/CS/ZoneRecoveryButtonStrategy.cs
@@ -21,7 +21,7 @@ namespace StockSharp.Samples.Strategies;
 public class ZoneRecoveryButtonStrategy : Strategy
 {
 	private readonly StrategyParam<DataType> _candleType;
-	private readonly StrategyParam<ZoneRecoveryStartDirection> _startDirection;
+	private readonly StrategyParam<ZoneRecoveryStartDirections> _startDirection;
 	private readonly StrategyParam<bool> _autoRestart;
 	private readonly StrategyParam<decimal> _takeProfitPips;
 	private readonly StrategyParam<decimal> _zoneRecoveryPips;
@@ -42,7 +42,7 @@ public class ZoneRecoveryButtonStrategy : Strategy
 
 	private readonly List<TradeStep> _steps = new();
 
-	private ZoneRecoveryStartDirection _currentDirection;
+	private ZoneRecoveryStartDirections _currentDirection;
 	private bool _isLongCycle;
 	private decimal _cycleBasePrice;
 	private int _nextStepIndex;
@@ -57,7 +57,7 @@ public class ZoneRecoveryButtonStrategy : Strategy
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
 			.SetDisplay("Candle Type", "Time frame used for monitoring price", "General");
 
-		_startDirection = Param(nameof(StartDirection), ZoneRecoveryStartDirection.Buy)
+		_startDirection = Param(nameof(StartDirection), ZoneRecoveryStartDirections.Buy)
 			.SetDisplay("Start Direction", "Initial manual button emulation", "General");
 
 		_autoRestart = Param(nameof(AutoRestart), true)
@@ -135,7 +135,7 @@ public class ZoneRecoveryButtonStrategy : Strategy
 	/// <summary>
 	/// Initial direction that mimics pressing the BUY or SELL button.
 	/// </summary>
-	public ZoneRecoveryStartDirection StartDirection
+	public ZoneRecoveryStartDirections StartDirection
 	{
 		get => _startDirection.Value;
 		set => _startDirection.Value = value;
@@ -309,7 +309,7 @@ public class ZoneRecoveryButtonStrategy : Strategy
 		base.OnReseted();
 
 		_steps.Clear();
-		_currentDirection = ZoneRecoveryStartDirection.None;
+		_currentDirection = ZoneRecoveryStartDirections.None;
 		_isLongCycle = false;
 		_cycleBasePrice = 0m;
 		_nextStepIndex = 0;
@@ -359,13 +359,13 @@ public class ZoneRecoveryButtonStrategy : Strategy
 
 	private void TryStartCycle(decimal price)
 	{
-		if (_currentDirection == ZoneRecoveryStartDirection.None)
+		if (_currentDirection == ZoneRecoveryStartDirections.None)
 			return;
 
 		if (!IsFormedAndOnlineAndAllowTrading())
 			return;
 
-		StartCycle(_currentDirection == ZoneRecoveryStartDirection.Buy, price);
+		StartCycle(_currentDirection == ZoneRecoveryStartDirections.Buy, price);
 	}
 
 	private void StartCycle(bool isLong, decimal price)
@@ -594,7 +594,7 @@ public class ZoneRecoveryButtonStrategy : Strategy
 
 		if (!AutoRestart)
 		{
-			_currentDirection = ZoneRecoveryStartDirection.None;
+			_currentDirection = ZoneRecoveryStartDirections.None;
 		}
 	}
 
@@ -627,7 +627,7 @@ public class ZoneRecoveryButtonStrategy : Strategy
 /// <summary>
 /// Available start directions for the recovery cycle.
 /// </summary>
-public enum ZoneRecoveryStartDirection
+public enum ZoneRecoveryStartDirections
 {
 	/// <summary>
 	/// Do not open any trades automatically.

--- a/API/3291_TargetEA_Manager/CS/TargetEaManagerStrategy.cs
+++ b/API/3291_TargetEA_Manager/CS/TargetEaManagerStrategy.cs
@@ -19,12 +19,12 @@ using StockSharp.Messages;
 /// </summary>
 public class TargetEaManagerStrategy : Strategy
 {
-	private readonly StrategyParam<ManageMode> _manageMode;
+	private readonly StrategyParam<ManageModes> _manageMode;
 	private readonly StrategyParam<bool> _closeBuyOrders;
 	private readonly StrategyParam<bool> _closeSellOrders;
 	private readonly StrategyParam<bool> _cancelBuyPendings;
 	private readonly StrategyParam<bool> _cancelSellPendings;
-	private readonly StrategyParam<TargetCalculationMode> _targetMode;
+	private readonly StrategyParam<TargetCalculationModes> _targetMode;
 	private readonly StrategyParam<bool> _closeInProfit;
 	private readonly StrategyParam<decimal> _profitTargetPips;
 	private readonly StrategyParam<decimal> _profitTargetCurrency;
@@ -42,13 +42,13 @@ public class TargetEaManagerStrategy : Strategy
 	private decimal _longAveragePrice;
 	private decimal _shortAveragePrice;
 
-	private enum ManageMode
+	private enum ManageModes
 	{
 		Separate,
 		Combined
 	}
 
-	private enum TargetCalculationMode
+	private enum TargetCalculationModes
 	{
 		Pips,
 		CurrencyPerLot,
@@ -57,7 +57,7 @@ public class TargetEaManagerStrategy : Strategy
 
 	public TargetEaManagerStrategy()
 	{
-		_manageMode = Param(nameof(ManageBuySellOrders), ManageMode.Separate)
+		_manageMode = Param(nameof(ManageBuySellOrders), ManageModes.Separate)
 			.SetDisplay("Manage buy/sell", "Decide whether buy and sell orders are handled separately or as one basket.", "General");
 
 		_closeBuyOrders = Param(nameof(CloseBuyOrders), true)
@@ -72,7 +72,7 @@ public class TargetEaManagerStrategy : Strategy
 		_cancelSellPendings = Param(nameof(DeleteSellPendingPositions), true)
 			.SetDisplay("Cancel sell pendings", "Cancel active sell pending orders when the basket closes.", "General");
 
-		_targetMode = Param(nameof(TypeTargetUse), TargetCalculationMode.PercentageOfBalance)
+		_targetMode = Param(nameof(TypeTargetUse), TargetCalculationModes.PercentageOfBalance)
 			.SetDisplay("Target mode", "Select the metric used to measure floating profit and loss.", "Targets");
 
 		_closeInProfit = Param(nameof(CloseInProfit), true)
@@ -100,7 +100,7 @@ public class TargetEaManagerStrategy : Strategy
 			.SetDisplay("Loss target (%)", "Percentage drawdown of balance that forces liquidation.", "Targets");
 	}
 
-	public ManageMode ManageBuySellOrders
+	public ManageModes ManageBuySellOrders
 	{
 		get => _manageMode.Value;
 		set => _manageMode.Value = value;
@@ -130,7 +130,7 @@ public class TargetEaManagerStrategy : Strategy
 		set => _cancelSellPendings.Value = value;
 	}
 
-	public TargetCalculationMode TypeTargetUse
+	public TargetCalculationModes TypeTargetUse
 	{
 		get => _targetMode.Value;
 		set => _targetMode.Value = value;
@@ -267,15 +267,15 @@ public class TargetEaManagerStrategy : Strategy
 
 		switch (TypeTargetUse)
 		{
-			case TargetCalculationMode.Pips:
+			case TargetCalculationModes.Pips:
 				HandleTargets(longPips, shortPips, totalPips, totalVolume);
 				break;
 
-			case TargetCalculationMode.CurrencyPerLot:
+			case TargetCalculationModes.CurrencyPerLot:
 				HandleCurrencyTargets(longProfit, shortProfit, totalProfit, totalVolume);
 				break;
 
-			case TargetCalculationMode.PercentageOfBalance:
+			case TargetCalculationModes.PercentageOfBalance:
 				HandlePercentageTargets(longProfit, shortProfit, totalProfit, totalVolume, balance);
 				break;
 		}
@@ -332,7 +332,7 @@ public class TargetEaManagerStrategy : Strategy
 	{
 		switch (ManageBuySellOrders)
 		{
-			case ManageMode.Separate:
+			case ManageModes.Separate:
 				if (CloseBuyOrders && _longVolume > 0m)
 				{
 					var target = perLot ? threshold * _longVolume : threshold;
@@ -357,7 +357,7 @@ public class TargetEaManagerStrategy : Strategy
 				}
 				break;
 
-			case ManageMode.Combined:
+			case ManageModes.Combined:
 				if (totalVolume <= 0m)
 					return;
 
@@ -385,7 +385,7 @@ public class TargetEaManagerStrategy : Strategy
 	{
 		switch (ManageBuySellOrders)
 		{
-			case ManageMode.Separate:
+			case ManageModes.Separate:
 				if (CloseBuyOrders && _longVolume > 0m)
 				{
 					var target = perLot ? threshold * _longVolume : threshold;
@@ -410,7 +410,7 @@ public class TargetEaManagerStrategy : Strategy
 				}
 				break;
 
-			case ManageMode.Combined:
+			case ManageModes.Combined:
 				if (totalVolume <= 0m)
 					return;
 

--- a/API/3293_Check_Execution/CS/CheckExecutionStrategy.cs
+++ b/API/3293_Check_Execution/CS/CheckExecutionStrategy.cs
@@ -21,7 +21,7 @@ namespace StockSharp.Samples.Strategies;
 public class CheckExecutionStrategy : Strategy
 {
 	private readonly StrategyParam<int> _iterations;
-	private readonly StrategyParam<CheckExecutionOrderType> _orderMode;
+	private readonly StrategyParam<CheckExecutionOrderTypes> _orderMode;
 	private readonly StrategyParam<decimal> _pendingOffset;
 	private readonly StrategyParam<decimal> _stopLossOffset;
 
@@ -43,7 +43,7 @@ public class CheckExecutionStrategy : Strategy
 		.SetDisplay("Iterations", "Number of modify attempts (1-500).", "General")
 		.SetCanOptimize(true);
 
-		_orderMode = Param(nameof(OrderMode), CheckExecutionOrderType.Pending)
+		_orderMode = Param(nameof(OrderMode), CheckExecutionOrderTypes.Pending)
 		.SetDisplay("Order Mode", "Select pending or market order workflow.", "General");
 
 		_pendingOffset = Param(nameof(PendingOffset), 100m)
@@ -68,7 +68,7 @@ public class CheckExecutionStrategy : Strategy
 		}
 	}
 
-	public CheckExecutionOrderType OrderMode
+	public CheckExecutionOrderTypes OrderMode
 	{
 		get => _orderMode.Value;
 		set => _orderMode.Value = value;
@@ -138,7 +138,7 @@ public class CheckExecutionStrategy : Strategy
 		if (!IsFormedAndOnlineAndAllowTrading())
 		return;
 
-		if (OrderMode == CheckExecutionOrderType.Pending)
+		if (OrderMode == CheckExecutionOrderTypes.Pending)
 		{
 			HandlePendingWorkflow(askPrice, priceStep);
 		}
@@ -259,7 +259,7 @@ public class CheckExecutionStrategy : Strategy
 
 		if (order == _pendingOrder)
 		{
-			if (OrderMode == CheckExecutionOrderType.Market && order.State == OrderStates.Done)
+			if (OrderMode == CheckExecutionOrderTypes.Market && order.State == OrderStates.Done)
 			{
 				_pendingOrder = null;
 			}
@@ -306,7 +306,7 @@ public class CheckExecutionStrategy : Strategy
 
 	private void FinalizeCheck()
 	{
-		if (OrderMode == CheckExecutionOrderType.Pending)
+		if (OrderMode == CheckExecutionOrderTypes.Pending)
 		{
 			CancelOrderIfActive(ref _pendingOrder);
 		}
@@ -404,7 +404,7 @@ public class CheckExecutionStrategy : Strategy
 	}
 }
 
-public enum CheckExecutionOrderType
+public enum CheckExecutionOrderTypes
 {
 	Pending,
 	Market

--- a/API/3294_HistoryInfoEA/CS/HistoryInfoEaStrategy.cs
+++ b/API/3294_HistoryInfoEA/CS/HistoryInfoEaStrategy.cs
@@ -16,7 +16,7 @@ namespace StockSharp.Samples.Strategies;
 /// <summary>
 /// Determines how trades should be filtered before aggregating statistics.
 /// </summary>
-public enum HistoryInfoFilterType
+public enum HistoryInfoFilterTypes
 {
 	/// <summary>
 	/// Count trades whose <see cref="Order.UserOrderId"/> equals <see cref="HistoryInfoEaStrategy.MagicNumber"/>.
@@ -39,7 +39,7 @@ public enum HistoryInfoFilterType
 /// </summary>
 public class HistoryInfoEaStrategy : Strategy
 {
-	private readonly StrategyParam<HistoryInfoFilterType> _filterType;
+	private readonly StrategyParam<HistoryInfoFilterTypes> _filterType;
 	private readonly StrategyParam<string> _magicNumberParam;
 	private readonly StrategyParam<string> _orderCommentParam;
 	private readonly StrategyParam<string> _securityIdParam;
@@ -60,14 +60,14 @@ public class HistoryInfoEaStrategy : Strategy
 	/// <summary>
 	/// Trade filtering mode that controls which deals enter the summary.
 	/// </summary>
-	public HistoryInfoFilterType FilterType
+	public HistoryInfoFilterTypes FilterType
 	{
 		get => _filterType.Value;
 		set => _filterType.Value = value;
 	}
 
 	/// <summary>
-	/// Expected <see cref="Order.UserOrderId"/> when <see cref="FilterType"/> equals <see cref="HistoryInfoFilterType.CountByUserOrderId"/>.
+	/// Expected <see cref="Order.UserOrderId"/> when <see cref="FilterType"/> equals <see cref="HistoryInfoFilterTypes.CountByUserOrderId"/>.
 	/// </summary>
 	public string MagicNumber
 	{
@@ -98,7 +98,7 @@ public class HistoryInfoEaStrategy : Strategy
 	/// </summary>
 	public HistoryInfoEaStrategy()
 	{
-		_filterType = Param(nameof(FilterType), HistoryInfoFilterType.CountBySecurity)
+		_filterType = Param(nameof(FilterType), HistoryInfoFilterTypes.CountBySecurity)
 		.SetDisplay("Filter Type", "How trades are selected for aggregation", "General");
 
 		_magicNumberParam = Param(nameof(MagicNumber), string.Empty)
@@ -159,9 +159,9 @@ public class HistoryInfoEaStrategy : Strategy
 
 		return FilterType switch
 		{
-			HistoryInfoFilterType.CountByUserOrderId => !MagicNumber.IsEmpty() && order.UserOrderId.EqualsIgnoreCase(MagicNumber),
-			HistoryInfoFilterType.CountByComment => !OrderComment.IsEmpty() && order.Comment != null && order.Comment.StartsWith(OrderComment, StringComparison.Ordinal),
-			HistoryInfoFilterType.CountBySecurity => !SecurityId.IsEmpty() && order.Security?.Id != null && order.Security.Id.EqualsIgnoreCase(SecurityId),
+			HistoryInfoFilterTypes.CountByUserOrderId => !MagicNumber.IsEmpty() && order.UserOrderId.EqualsIgnoreCase(MagicNumber),
+			HistoryInfoFilterTypes.CountByComment => !OrderComment.IsEmpty() && order.Comment != null && order.Comment.StartsWith(OrderComment, StringComparison.Ordinal),
+			HistoryInfoFilterTypes.CountBySecurity => !SecurityId.IsEmpty() && order.Security?.Id != null && order.Security.Id.EqualsIgnoreCase(SecurityId),
 			_ => false
 		};
 	}

--- a/API/3312_Awesome_Oscillator_Trader/CS/AwesomeOscillatorTraderStrategy.cs
+++ b/API/3312_Awesome_Oscillator_Trader/CS/AwesomeOscillatorTraderStrategy.cs
@@ -21,7 +21,7 @@ namespace StockSharp.Samples.Strategies;
 public class AwesomeOscillatorTraderStrategy : Strategy
 {
 	private readonly StrategyParam<bool> _closeOnReversal;
-	private readonly StrategyParam<ProfitCloseMode> _profitFilter;
+	private readonly StrategyParam<ProfitCloseModes> _profitFilter;
 	private readonly StrategyParam<int> _bollingerPeriod;
 	private readonly StrategyParam<decimal> _bollingerSigma;
 	private readonly StrategyParam<decimal> _bollingerSpreadLower;
@@ -67,7 +67,7 @@ public class AwesomeOscillatorTraderStrategy : Strategy
 	/// <summary>
 	/// How to filter position exits based on profit when signals reverse.
 	/// </summary>
-	public ProfitCloseMode ProfitFilter
+	public ProfitCloseModes ProfitFilter
 	{
 		get => _profitFilter.Value;
 		set => _profitFilter.Value = value;
@@ -111,7 +111,7 @@ public class AwesomeOscillatorTraderStrategy : Strategy
 		_closeOnReversal = Param(nameof(CloseOnReversal), true)
 			.SetDisplay("Close On Reversal", "Close trades when the opposite AO setup appears", "Risk");
 
-		_profitFilter = Param(nameof(ProfitFilter), ProfitCloseMode.OnlyProfitable)
+		_profitFilter = Param(nameof(ProfitFilter), ProfitCloseModes.OnlyProfitable)
 			.SetDisplay("Profit Filter", "Filter which positions can be closed by signals", "Risk");
 
 		_bollingerPeriod = Param(nameof(BollingerPeriod), 20)
@@ -654,9 +654,9 @@ public class AwesomeOscillatorTraderStrategy : Strategy
 	{
 	return ProfitFilter switch
 	{
-	ProfitCloseMode.Any => true,
-	ProfitCloseMode.OnlyProfitable => profit >= 0m,
-	ProfitCloseMode.OnlyLosing => profit <= 0m,
+	ProfitCloseModes.Any => true,
+	ProfitCloseModes.OnlyProfitable => profit >= 0m,
+	ProfitCloseModes.OnlyLosing => profit <= 0m,
 	_ => true,
 	};
 	}
@@ -674,7 +674,7 @@ public class AwesomeOscillatorTraderStrategy : Strategy
 	/// <summary>
 	/// Profit filter options used when closing trades on reversals.
 	/// </summary>
-	public enum ProfitCloseMode
+	public enum ProfitCloseModes
 	{
 	/// <summary>
 	/// Close trades regardless of their current profit.

--- a/API/3319_CorrTime/CS/CorrTimeStrategy.cs
+++ b/API/3319_CorrTime/CS/CorrTimeStrategy.cs
@@ -16,7 +16,7 @@ namespace StockSharp.Samples.Strategies;
 /// <summary>
 /// Trading modes supported by the CorrTime strategy.
 /// </summary>
-public enum CorrTimeTradeMode
+public enum CorrTimeTradeModes
 {
 	/// <summary>
 	/// Follow the direction of the correlation trend.
@@ -37,7 +37,7 @@ public enum CorrTimeTradeMode
 /// <summary>
 /// Correlation estimators replicated from the original include file.
 /// </summary>
-public enum CorrTimeCorrelationType
+public enum CorrTimeCorrelationTypes
 {
 	/// <summary>
 	/// Pearson correlation between price and time ranks.
@@ -77,10 +77,10 @@ public class CorrTimeStrategy : Strategy
 	private readonly StrategyParam<decimal> _bollingerSpreadMax;
 	private readonly StrategyParam<int> _adxPeriod;
 	private readonly StrategyParam<decimal> _adxLevel;
-	private readonly StrategyParam<CorrTimeTradeMode> _tradeMode;
+	private readonly StrategyParam<CorrTimeTradeModes> _tradeMode;
 	private readonly StrategyParam<int> _correlationRangeTrend;
 	private readonly StrategyParam<int> _correlationRangeReverse;
-	private readonly StrategyParam<CorrTimeCorrelationType> _correlationType;
+	private readonly StrategyParam<CorrTimeCorrelationTypes> _correlationType;
 	private readonly StrategyParam<decimal> _corrLimitTrendBuy;
 	private readonly StrategyParam<decimal> _corrLimitTrendSell;
 	private readonly StrategyParam<decimal> _corrLimitReverseBuy;
@@ -136,7 +136,7 @@ public class CorrTimeStrategy : Strategy
 		_adxLevel = Param(nameof(AdxLevel), 22m)
 			.SetDisplay("ADX Level", "Minimal ADX value required to evaluate signals", "Filters");
 
-		_tradeMode = Param(nameof(TradeMode), CorrTimeTradeMode.Reverse)
+		_tradeMode = Param(nameof(TradeMode), CorrTimeTradeModes.Reverse)
 			.SetDisplay("Trade Mode", "Match the original Trend/Reverse/Both selector", "Signals");
 
 		_correlationRangeTrend = Param(nameof(CorrelationRangeTrend), 40)
@@ -147,7 +147,7 @@ public class CorrTimeStrategy : Strategy
 			.SetGreaterThanZero()
 			.SetDisplay("Reverse Range", "Lookback for correlation based reversal signals", "Signals");
 
-		_correlationType = Param(nameof(CorrelationType), CorrTimeCorrelationType.Fechner)
+		_correlationType = Param(nameof(CorrelationType), CorrTimeCorrelationTypes.Fechner)
 			.SetDisplay("Correlation Type", "Estimator used to measure the price-time link", "Signals");
 
 		_corrLimitTrendBuy = Param(nameof(CorrLimitTrendBuy), 0.90m)
@@ -269,7 +269,7 @@ public class CorrTimeStrategy : Strategy
 	/// <summary>
 	/// Selected trading mode (trend, reverse or both).
 	/// </summary>
-	public CorrTimeTradeMode TradeMode
+	public CorrTimeTradeModes TradeMode
 	{
 		get => _tradeMode.Value;
 		set => _tradeMode.Value = value;
@@ -296,7 +296,7 @@ public class CorrTimeStrategy : Strategy
 	/// <summary>
 	/// Correlation estimator applied to the closing prices.
 	/// </summary>
-	public CorrTimeCorrelationType CorrelationType
+	public CorrTimeCorrelationTypes CorrelationType
 	{
 		get => _correlationType.Value;
 		set => _correlationType.Value = value;
@@ -455,7 +455,7 @@ public class CorrTimeStrategy : Strategy
 		var buySignal = false;
 		var sellSignal = false;
 
-		if ((TradeMode == CorrTimeTradeMode.TrendFollow || TradeMode == CorrTimeTradeMode.Both)
+		if ((TradeMode == CorrTimeTradeModes.TrendFollow || TradeMode == CorrTimeTradeModes.Both)
 			&& TryGetCorrelationTriplet(CorrelationRangeTrend, out var trendCurrent, out var trendPrevious, out var trendBefore))
 		{
 			if (trendBefore < trendPrevious && trendPrevious < CorrLimitTrendBuy && trendCurrent > CorrLimitTrendBuy)
@@ -465,7 +465,7 @@ public class CorrTimeStrategy : Strategy
 				sellSignal = true;
 		}
 
-		if ((TradeMode == CorrTimeTradeMode.Reverse || TradeMode == CorrTimeTradeMode.Both)
+		if ((TradeMode == CorrTimeTradeModes.Reverse || TradeMode == CorrTimeTradeModes.Both)
 			&& TryGetCorrelationTriplet(CorrelationRangeReverse, out var reverseCurrent, out var reversePrevious, out var reverseBefore))
 		{
 			if (reverseBefore < reversePrevious && reversePrevious < -CorrLimitReverseBuy && reverseCurrent > -CorrLimitReverseBuy)
@@ -558,10 +558,10 @@ public class CorrTimeStrategy : Strategy
 
 		return CorrelationType switch
 		{
-			CorrTimeCorrelationType.Pearson => CalculatePearson(buffer),
-			CorrTimeCorrelationType.Spearman => CalculateSpearman(buffer),
-			CorrTimeCorrelationType.Kendall => CalculateKendall(buffer),
-			CorrTimeCorrelationType.Fechner => CalculateFechner(buffer),
+			CorrTimeCorrelationTypes.Pearson => CalculatePearson(buffer),
+			CorrTimeCorrelationTypes.Spearman => CalculateSpearman(buffer),
+			CorrTimeCorrelationTypes.Kendall => CalculateKendall(buffer),
+			CorrTimeCorrelationTypes.Fechner => CalculateFechner(buffer),
 			_ => 0m,
 		};
 	}

--- a/API/3330_Gridder_EA/CS/GridderEaStrategy.cs
+++ b/API/3330_Gridder_EA/CS/GridderEaStrategy.cs
@@ -29,8 +29,8 @@ public class GridderEaStrategy : Strategy
 	private readonly StrategyParam<int> _maxOrdersPerSide;
 	private readonly StrategyParam<bool> _allowLong;
 	private readonly StrategyParam<bool> _allowShort;
-	private readonly StrategyParam<StepProgression> _stepMode;
-	private readonly StrategyParam<LotProgression> _lotMode;
+	private readonly StrategyParam<StepProgressions> _stepMode;
+	private readonly StrategyParam<LotProgressions> _lotMode;
 	private readonly StrategyParam<bool> _useEmergencyMode;
 	private readonly StrategyParam<int> _emergencyOrdersTrigger;
 	private readonly StrategyParam<decimal> _hedgeVolumeFactor;
@@ -93,10 +93,10 @@ public class GridderEaStrategy : Strategy
 		_allowShort = Param(nameof(AllowShort), true)
 		.SetDisplay("Allow Short", "Enable short side trading", "Trading");
 
-		_stepMode = Param(nameof(StepMode), StepProgression.Geometric)
+		_stepMode = Param(nameof(StepMode), StepProgressions.Geometric)
 		.SetDisplay("Step Mode", "Rule used to increase the grid spacing", "Grid");
 
-		_lotMode = Param(nameof(LotMode), LotProgression.Geometric)
+		_lotMode = Param(nameof(LotMode), LotProgressions.Geometric)
 		.SetDisplay("Lot Mode", "Rule used to increase the order volume", "Trading");
 
 		_useEmergencyMode = Param(nameof(UseEmergencyMode), true)
@@ -198,7 +198,7 @@ public class GridderEaStrategy : Strategy
 	/// <summary>
 	/// Step progression mode.
 	/// </summary>
-	public StepProgression StepMode
+	public StepProgressions StepMode
 	{
 		get => _stepMode.Value;
 		set => _stepMode.Value = value;
@@ -207,7 +207,7 @@ public class GridderEaStrategy : Strategy
 	/// <summary>
 	/// Volume progression mode.
 	/// </summary>
-	public LotProgression LotMode
+	public LotProgressions LotMode
 	{
 		get => _lotMode.Value;
 		set => _lotMode.Value = value;
@@ -517,11 +517,11 @@ public class GridderEaStrategy : Strategy
 	{
 		switch (LotMode)
 		{
-			case LotProgression.Static:
+			case LotProgressions.Static:
 				return 1m;
-			case LotProgression.Geometric:
+			case LotProgressions.Geometric:
 				return (decimal)Math.Pow((double)VolumeMultiplier, level);
-			case LotProgression.Exponential:
+			case LotProgressions.Exponential:
 				return (decimal)Math.Pow((double)VolumeMultiplier, level * (level + 1) / 2.0);
 			default:
 				return 1m;
@@ -532,11 +532,11 @@ public class GridderEaStrategy : Strategy
 	{
 		switch (StepMode)
 		{
-			case StepProgression.Static:
+			case StepProgressions.Static:
 				return baseStep;
-			case StepProgression.Geometric:
+			case StepProgressions.Geometric:
 				return baseStep * (decimal)Math.Pow((double)StepMultiplier, level - 1);
-			case StepProgression.Exponential:
+			case StepProgressions.Exponential:
 				return baseStep * (decimal)Math.Pow((double)StepMultiplier, level * (level - 1) / 2.0);
 			default:
 				return baseStep;
@@ -615,7 +615,7 @@ public class GridderEaStrategy : Strategy
 	/// <summary>
 	/// Step progression modes mirroring the MetaTrader implementation.
 	/// </summary>
-	public enum StepProgression
+	public enum StepProgressions
 	{
 		Static,
 		Geometric,
@@ -625,7 +625,7 @@ public class GridderEaStrategy : Strategy
 	/// <summary>
 	/// Lot progression modes mirroring the MetaTrader implementation.
 	/// </summary>
-	public enum LotProgression
+	public enum LotProgressions
 	{
 		Static,
 		Geometric,

--- a/API/3337_5Minutes_Scalping_EA_V11/CS/FiveMinutesScalpingEaV11Strategy.cs
+++ b/API/3337_5Minutes_Scalping_EA_V11/CS/FiveMinutesScalpingEaV11Strategy.cs
@@ -21,7 +21,7 @@ public class FiveMinutesScalpingEaV11Strategy : Strategy
 {
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<int> _indicatorShift;
-	private readonly StrategyParam<SignalMode> _signalMode;
+	private readonly StrategyParam<SignalModes> _signalMode;
 	private readonly StrategyParam<bool> _useIndicator1;
 	private readonly StrategyParam<bool> _useIndicator2;
 	private readonly StrategyParam<bool> _useIndicator3;
@@ -30,7 +30,7 @@ public class FiveMinutesScalpingEaV11Strategy : Strategy
 	private readonly StrategyParam<int> _period1;
 	private readonly StrategyParam<int> _period2;
 	private readonly StrategyParam<int> _period3;
-	private readonly StrategyParam<PriceMode> _priceMode3;
+	private readonly StrategyParam<PriceModes> _priceMode3;
 	private readonly StrategyParam<int> _period4;
 	private readonly StrategyParam<int> _period5;
 	private readonly StrategyParam<bool> _closeOnSignal;
@@ -89,7 +89,7 @@ public class FiveMinutesScalpingEaV11Strategy : Strategy
 		.SetOptimize(0, 3, 1)
 		.SetNotNegative();
 
-		_signalMode = Param(nameof(SignalMode), SignalMode.Normal)
+		_signalMode = Param(nameof(SignalModes), SignalModes.Normal)
 		.SetDisplay("Signal Direction", "Switches between normal and reversed signal interpretation", "General");
 
 		_useIndicator1 = Param(nameof(UseIndicator1), true)
@@ -119,7 +119,7 @@ public class FiveMinutesScalpingEaV11Strategy : Strategy
 		.SetDisplay("Fisher Period", "Lookback for the momentum Fisher transform", "Indicators")
 		.SetGreaterThanZero();
 
-		_priceMode3 = Param(nameof(PriceMode3), PriceMode.HighLow)
+		_priceMode3 = Param(nameof(PriceMode3), PriceModes.HighLow)
 		.SetDisplay("Fisher Price", "Price source for the Fisher momentum filter", "Indicators");
 
 		_period4 = Param(nameof(Period4), 14)
@@ -206,7 +206,7 @@ public class FiveMinutesScalpingEaV11Strategy : Strategy
 	/// <summary>
 	/// Determines if signals are interpreted normally or reversed.
 	/// </summary>
-	public SignalMode SignalMode
+	public SignalModes SignalModes
 	{
 		get => _signalMode.Value;
 		set => _signalMode.Value = value;
@@ -536,11 +536,11 @@ public class FiveMinutesScalpingEaV11Strategy : Strategy
 		return;
 
 		var shift = IndicatorShift;
-		var hull1 = UseIndicator1 ? GetHullDirection(_hullFastHistory, shift) : TrendDirection.Neutral;
-		var hull2 = UseIndicator2 ? GetHullDirection(_hullSlowHistory, shift) : TrendDirection.Neutral;
-		var fisherMomentum = UseIndicator3 ? GetFisherDirection(_fisherMomentumHistory, shift) : TrendDirection.Neutral;
-		var atrBreakout = UseIndicator4 ? GetAtrDirection(shift) : TrendDirection.Neutral;
-		var fisherTrend = UseIndicator5 ? GetFisherDirection(_fisherTrendHistory, shift) : TrendDirection.Neutral;
+		var hull1 = UseIndicator1 ? GetHullDirection(_hullFastHistory, shift) : TrendDirections.Neutral;
+		var hull2 = UseIndicator2 ? GetHullDirection(_hullSlowHistory, shift) : TrendDirections.Neutral;
+		var fisherMomentum = UseIndicator3 ? GetFisherDirection(_fisherMomentumHistory, shift) : TrendDirections.Neutral;
+		var atrBreakout = UseIndicator4 ? GetAtrDirection(shift) : TrendDirections.Neutral;
+		var fisherTrend = UseIndicator5 ? GetFisherDirection(_fisherTrendHistory, shift) : TrendDirections.Neutral;
 
 		var longCondition = EvaluateLongCondition(hull1, hull2, fisherMomentum, atrBreakout, fisherTrend);
 		var shortCondition = EvaluateShortCondition(hull1, hull2, fisherMomentum, atrBreakout, fisherTrend);
@@ -742,79 +742,79 @@ public class FiveMinutesScalpingEaV11Strategy : Strategy
 		ResetRiskState();
 	}
 
-	private bool EvaluateLongCondition(TrendDirection hull1, TrendDirection hull2, TrendDirection fisherMomentum, TrendDirection atrBreakout, TrendDirection fisherTrend)
+	private bool EvaluateLongCondition(TrendDirections hull1, TrendDirections hull2, TrendDirections fisherMomentum, TrendDirections atrBreakout, TrendDirections fisherTrend)
 	{
-		var upHull1 = !UseIndicator1 || hull1 == TrendDirection.Up;
-		var upHull2 = !UseIndicator2 || hull2 == TrendDirection.Up;
-		var upFisherMomentum = !UseIndicator3 || fisherMomentum == TrendDirection.Up;
-		var upAtr = !UseIndicator4 || atrBreakout == TrendDirection.Up;
-		var upTrend = !UseIndicator5 || fisherTrend == TrendDirection.Up;
+		var upHull1 = !UseIndicator1 || hull1 == TrendDirections.Up;
+		var upHull2 = !UseIndicator2 || hull2 == TrendDirections.Up;
+		var upFisherMomentum = !UseIndicator3 || fisherMomentum == TrendDirections.Up;
+		var upAtr = !UseIndicator4 || atrBreakout == TrendDirections.Up;
+		var upTrend = !UseIndicator5 || fisherTrend == TrendDirections.Up;
 
-		var downHull1 = !UseIndicator1 || hull1 == TrendDirection.Down;
-		var downHull2 = !UseIndicator2 || hull2 == TrendDirection.Down;
-		var downFisherMomentum = !UseIndicator3 || fisherMomentum == TrendDirection.Down;
-		var downAtr = !UseIndicator4 || atrBreakout == TrendDirection.Down;
-		var downTrend = !UseIndicator5 || fisherTrend == TrendDirection.Down;
+		var downHull1 = !UseIndicator1 || hull1 == TrendDirections.Down;
+		var downHull2 = !UseIndicator2 || hull2 == TrendDirections.Down;
+		var downFisherMomentum = !UseIndicator3 || fisherMomentum == TrendDirections.Down;
+		var downAtr = !UseIndicator4 || atrBreakout == TrendDirections.Down;
+		var downTrend = !UseIndicator5 || fisherTrend == TrendDirections.Down;
 
-		return SignalMode == SignalMode.Normal
+		return SignalModes == SignalModes.Normal
 		? upHull1 && upHull2 && upFisherMomentum && upAtr && upTrend
 		: downHull1 && downHull2 && downFisherMomentum && downAtr && downTrend;
 	}
 
-	private bool EvaluateShortCondition(TrendDirection hull1, TrendDirection hull2, TrendDirection fisherMomentum, TrendDirection atrBreakout, TrendDirection fisherTrend)
+	private bool EvaluateShortCondition(TrendDirections hull1, TrendDirections hull2, TrendDirections fisherMomentum, TrendDirections atrBreakout, TrendDirections fisherTrend)
 	{
-		var downHull1 = !UseIndicator1 || hull1 == TrendDirection.Down;
-		var downHull2 = !UseIndicator2 || hull2 == TrendDirection.Down;
-		var downFisherMomentum = !UseIndicator3 || fisherMomentum == TrendDirection.Down;
-		var downAtr = !UseIndicator4 || atrBreakout == TrendDirection.Down;
-		var downTrend = !UseIndicator5 || fisherTrend == TrendDirection.Down;
+		var downHull1 = !UseIndicator1 || hull1 == TrendDirections.Down;
+		var downHull2 = !UseIndicator2 || hull2 == TrendDirections.Down;
+		var downFisherMomentum = !UseIndicator3 || fisherMomentum == TrendDirections.Down;
+		var downAtr = !UseIndicator4 || atrBreakout == TrendDirections.Down;
+		var downTrend = !UseIndicator5 || fisherTrend == TrendDirections.Down;
 
-		var upHull1 = !UseIndicator1 || hull1 == TrendDirection.Up;
-		var upHull2 = !UseIndicator2 || hull2 == TrendDirection.Up;
-		var upFisherMomentum = !UseIndicator3 || fisherMomentum == TrendDirection.Up;
-		var upAtr = !UseIndicator4 || atrBreakout == TrendDirection.Up;
-		var upTrend = !UseIndicator5 || fisherTrend == TrendDirection.Up;
+		var upHull1 = !UseIndicator1 || hull1 == TrendDirections.Up;
+		var upHull2 = !UseIndicator2 || hull2 == TrendDirections.Up;
+		var upFisherMomentum = !UseIndicator3 || fisherMomentum == TrendDirections.Up;
+		var upAtr = !UseIndicator4 || atrBreakout == TrendDirections.Up;
+		var upTrend = !UseIndicator5 || fisherTrend == TrendDirections.Up;
 
-		return SignalMode == SignalMode.Normal
+		return SignalModes == SignalModes.Normal
 		? downHull1 && downHull2 && downFisherMomentum && downAtr && downTrend
 		: upHull1 && upHull2 && upFisherMomentum && upAtr && upTrend;
 	}
 
-	private TrendDirection GetHullDirection(List<decimal> history, int shift)
+	private TrendDirections GetHullDirection(List<decimal> history, int shift)
 	{
 		var index = history.Count - 1 - shift;
 		if (index <= 0)
-		return TrendDirection.Neutral;
+		return TrendDirections.Neutral;
 
 		var current = history[index];
 		var previous = history[index - 1];
 
 		if (current > previous)
-		return TrendDirection.Up;
+		return TrendDirections.Up;
 		if (current < previous)
-		return TrendDirection.Down;
-		return TrendDirection.Neutral;
+		return TrendDirections.Down;
+		return TrendDirections.Neutral;
 	}
 
-	private TrendDirection GetFisherDirection(List<decimal> history, int shift)
+	private TrendDirections GetFisherDirection(List<decimal> history, int shift)
 	{
 		var index = history.Count - 1 - shift;
 		if (index < 0)
-		return TrendDirection.Neutral;
+		return TrendDirections.Neutral;
 
 		var value = history[index];
 		if (value > 0m)
-		return TrendDirection.Up;
+		return TrendDirections.Up;
 		if (value < 0m)
-		return TrendDirection.Down;
-		return TrendDirection.Neutral;
+		return TrendDirections.Down;
+		return TrendDirections.Neutral;
 	}
 
-	private TrendDirection GetAtrDirection(int shift)
+	private TrendDirections GetAtrDirection(int shift)
 	{
 		var index = _candleHistory.Count - 1 - shift;
 		if (index < 0 || index + 2 >= _candleHistory.Count)
-		return TrendDirection.Neutral;
+		return TrendDirections.Neutral;
 
 		var current = _candleHistory[index];
 		var previous1 = _candleHistory[index + 1];
@@ -834,9 +834,9 @@ public class FiveMinutesScalpingEaV11Strategy : Strategy
 		current.OpenPrice > previous2.ClosePrice - atrValue;
 
 		if (buyCondition == sellCondition)
-		return TrendDirection.Neutral;
+		return TrendDirections.Neutral;
 
-		return buyCondition ? TrendDirection.Up : TrendDirection.Down;
+		return buyCondition ? TrendDirections.Up : TrendDirections.Down;
 	}
 
 	private void StoreCandle(ICandleMessage candle)
@@ -910,22 +910,22 @@ public class FiveMinutesScalpingEaV11Strategy : Strategy
 	private int Period3 => _period3.Value;
 	private int Period4 => _period4.Value;
 	private int Period5 => _period5.Value;
-	private PriceMode PriceMode3 => _priceMode3.Value;
+	private PriceModes PriceMode3 => _priceMode3.Value;
 
-	private enum TrendDirection
+	private enum TrendDirections
 	{
 		Neutral = 0,
 		Up = 1,
 		Down = -1
 	}
 
-	public enum SignalMode
+	public enum SignalModes
 	{
 		Normal,
 		Reverse
 	}
 
-	public enum PriceMode
+	public enum PriceModes
 	{
 		HighLow,
 		Open,

--- a/API/3339_Compass_Line/CS/CompassLineStrategy.cs
+++ b/API/3339_Compass_Line/CS/CompassLineStrategy.cs
@@ -16,7 +16,7 @@ using StockSharp.Messages;
 /// <summary>
 /// Exit modes for Compass Line strategy.
 /// </summary>
-public enum CompassLineExitMode
+public enum CompassLineExitModes
 {
 	/// <summary>
 	/// Do not close positions on indicator signals.
@@ -122,9 +122,9 @@ public class CompassLineStrategy : Strategy
 	/// <summary>
 	/// Close logic selection.
 	/// </summary>
-	public CompassLineExitMode CloseMode
+	public CompassLineExitModes CloseMode
 	{
-		get => (CompassLineExitMode)_closeMode.Value;
+		get => (CompassLineExitModes)_closeMode.Value;
 		set => _closeMode.Value = (int)value;
 	}
 
@@ -197,7 +197,7 @@ public class CompassLineStrategy : Strategy
 			.SetGreaterThanZero()
 			.SetDisplay("Compass MA Period", "SMA period for Compass", "Compass");
 
-		_closeMode = Param(nameof(CloseMode), (int)CompassLineExitMode.None)
+		_closeMode = Param(nameof(CloseMode), (int)CompassLineExitModes.None)
 			.SetDisplay("Close Mode", "Signal based exit mode", "Risk");
 
 		_useTimeFilter = Param(nameof(UseTimeFilter), false)
@@ -417,9 +417,9 @@ public class CompassLineStrategy : Strategy
 	{
 		return CloseMode switch
 		{
-			CompassLineExitMode.BothIndicators => _followTrend < 0 && _compassTrend < 0,
-			CompassLineExitMode.FollowLineOnly => _followTrend < 0,
-			CompassLineExitMode.CompassOnly => _compassTrend < 0,
+			CompassLineExitModes.BothIndicators => _followTrend < 0 && _compassTrend < 0,
+			CompassLineExitModes.FollowLineOnly => _followTrend < 0,
+			CompassLineExitModes.CompassOnly => _compassTrend < 0,
 			_ => false,
 		};
 	}
@@ -428,9 +428,9 @@ public class CompassLineStrategy : Strategy
 	{
 		return CloseMode switch
 		{
-			CompassLineExitMode.BothIndicators => _followTrend > 0 && _compassTrend > 0,
-			CompassLineExitMode.FollowLineOnly => _followTrend > 0,
-			CompassLineExitMode.CompassOnly => _compassTrend > 0,
+			CompassLineExitModes.BothIndicators => _followTrend > 0 && _compassTrend > 0,
+			CompassLineExitModes.FollowLineOnly => _followTrend > 0,
+			CompassLineExitModes.CompassOnly => _compassTrend > 0,
 			_ => false,
 		};
 	}

--- a/API/3341_Histo_Scalper/CS/HistoScalperStrategy.cs
+++ b/API/3341_Histo_Scalper/CS/HistoScalperStrategy.cs
@@ -16,7 +16,7 @@ using StockSharp.Messages;
 /// <summary>
 /// Defines how indicator signals are interpreted.
 /// </summary>
-public enum SignalDirection
+public enum SignalDirections
 {
 	Straight,
 	Reverse,
@@ -41,35 +41,35 @@ public class HistoScalperStrategy : Strategy
 	private readonly StrategyParam<decimal> _stopLossPoints;
 
 	private readonly StrategyParam<bool> _useIndicator1;
-	private readonly StrategyParam<SignalDirection> _modeIndicator1;
+	private readonly StrategyParam<SignalDirections> _modeIndicator1;
 	private readonly StrategyParam<int> _periodIndicator1;
 
 	private readonly StrategyParam<bool> _useIndicator2;
-	private readonly StrategyParam<SignalDirection> _modeIndicator2;
+	private readonly StrategyParam<SignalDirections> _modeIndicator2;
 	private readonly StrategyParam<int> _periodIndicator2;
 	private readonly StrategyParam<int> _atrAveragePeriod;
 	private readonly StrategyParam<decimal> _atrPositiveThreshold;
 	private readonly StrategyParam<decimal> _atrNegativeThreshold;
 
 	private readonly StrategyParam<bool> _useIndicator3;
-	private readonly StrategyParam<SignalDirection> _modeIndicator3;
+	private readonly StrategyParam<SignalDirections> _modeIndicator3;
 	private readonly StrategyParam<int> _periodIndicator3;
 	private readonly StrategyParam<decimal> _bollingerDeviation;
 
 	private readonly StrategyParam<bool> _useIndicator4;
-	private readonly StrategyParam<SignalDirection> _modeIndicator4;
+	private readonly StrategyParam<SignalDirections> _modeIndicator4;
 	private readonly StrategyParam<int> _periodIndicator4;
 	private readonly StrategyParam<decimal> _bullsThreshold;
 	private readonly StrategyParam<decimal> _bearsThreshold;
 
 	private readonly StrategyParam<bool> _useIndicator5;
-	private readonly StrategyParam<SignalDirection> _modeIndicator5;
+	private readonly StrategyParam<SignalDirections> _modeIndicator5;
 	private readonly StrategyParam<int> _periodIndicator5;
 	private readonly StrategyParam<decimal> _cciBuyLevel;
 	private readonly StrategyParam<decimal> _cciSellLevel;
 
 	private readonly StrategyParam<bool> _useIndicator6;
-	private readonly StrategyParam<SignalDirection> _modeIndicator6;
+	private readonly StrategyParam<SignalDirections> _modeIndicator6;
 	private readonly StrategyParam<int> _fastPeriod;
 	private readonly StrategyParam<int> _slowPeriod;
 	private readonly StrategyParam<int> _signalPeriod;
@@ -77,13 +77,13 @@ public class HistoScalperStrategy : Strategy
 	private readonly StrategyParam<decimal> _macdNegativeThreshold;
 
 	private readonly StrategyParam<bool> _useIndicator7;
-	private readonly StrategyParam<SignalDirection> _modeIndicator7;
+	private readonly StrategyParam<SignalDirections> _modeIndicator7;
 	private readonly StrategyParam<int> _periodIndicator7;
 	private readonly StrategyParam<decimal> _rsiBuyLevel;
 	private readonly StrategyParam<decimal> _rsiSellLevel;
 
 	private readonly StrategyParam<bool> _useIndicator8;
-	private readonly StrategyParam<SignalDirection> _modeIndicator8;
+	private readonly StrategyParam<SignalDirections> _modeIndicator8;
 	private readonly StrategyParam<int> _kPeriod;
 	private readonly StrategyParam<int> _dPeriod;
 	private readonly StrategyParam<int> _slowing;
@@ -145,7 +145,7 @@ public class HistoScalperStrategy : Strategy
 		_useIndicator1 = Param(nameof(UseIndicator1), true)
 			.SetDisplay("Use ADX", "Enable directional index confirmation", "ADX");
 
-		_modeIndicator1 = Param(nameof(ModeIndicator1), SignalDirection.Straight)
+		_modeIndicator1 = Param(nameof(ModeIndicator1), SignalDirections.Straight)
 			.SetDisplay("ADX Mode", "Invert ADX decision if needed", "ADX");
 
 		_periodIndicator1 = Param(nameof(PeriodIndicator1), 14)
@@ -155,7 +155,7 @@ public class HistoScalperStrategy : Strategy
 		_useIndicator2 = Param(nameof(UseIndicator2), true)
 			.SetDisplay("Use ATR", "Enable ATR momentum filter", "ATR");
 
-		_modeIndicator2 = Param(nameof(ModeIndicator2), SignalDirection.Straight)
+		_modeIndicator2 = Param(nameof(ModeIndicator2), SignalDirections.Straight)
 			.SetDisplay("ATR Mode", "Invert ATR decision if needed", "ATR");
 
 		_periodIndicator2 = Param(nameof(PeriodIndicator2), 14)
@@ -177,7 +177,7 @@ public class HistoScalperStrategy : Strategy
 		_useIndicator3 = Param(nameof(UseIndicator3), true)
 			.SetDisplay("Use Bollinger", "Enable Bollinger band breakout filter", "Bollinger");
 
-		_modeIndicator3 = Param(nameof(ModeIndicator3), SignalDirection.Straight)
+		_modeIndicator3 = Param(nameof(ModeIndicator3), SignalDirections.Straight)
 			.SetDisplay("Bollinger Mode", "Invert Bollinger breakout direction", "Bollinger");
 
 		_periodIndicator3 = Param(nameof(PeriodIndicator3), 20)
@@ -191,7 +191,7 @@ public class HistoScalperStrategy : Strategy
 		_useIndicator4 = Param(nameof(UseIndicator4), true)
 			.SetDisplay("Use Bulls/Bears", "Enable bulls/bears power filter", "Power");
 
-		_modeIndicator4 = Param(nameof(ModeIndicator4), SignalDirection.Straight)
+		_modeIndicator4 = Param(nameof(ModeIndicator4), SignalDirections.Straight)
 			.SetDisplay("Power Mode", "Invert bulls/bears logic", "Power");
 
 		_periodIndicator4 = Param(nameof(PeriodIndicator4), 14)
@@ -207,7 +207,7 @@ public class HistoScalperStrategy : Strategy
 		_useIndicator5 = Param(nameof(UseIndicator5), true)
 			.SetDisplay("Use CCI", "Enable CCI filter", "CCI");
 
-		_modeIndicator5 = Param(nameof(ModeIndicator5), SignalDirection.Straight)
+		_modeIndicator5 = Param(nameof(ModeIndicator5), SignalDirections.Straight)
 			.SetDisplay("CCI Mode", "Invert CCI levels", "CCI");
 
 		_periodIndicator5 = Param(nameof(PeriodIndicator5), 14)
@@ -223,7 +223,7 @@ public class HistoScalperStrategy : Strategy
 		_useIndicator6 = Param(nameof(UseIndicator6), true)
 			.SetDisplay("Use MACD", "Enable MACD histogram filter", "MACD");
 
-		_modeIndicator6 = Param(nameof(ModeIndicator6), SignalDirection.Straight)
+		_modeIndicator6 = Param(nameof(ModeIndicator6), SignalDirections.Straight)
 			.SetDisplay("MACD Mode", "Invert MACD histogram", "MACD");
 
 		_fastPeriod = Param(nameof(FastPeriod), 12)
@@ -247,7 +247,7 @@ public class HistoScalperStrategy : Strategy
 		_useIndicator7 = Param(nameof(UseIndicator7), true)
 			.SetDisplay("Use RSI", "Enable RSI filter", "RSI");
 
-		_modeIndicator7 = Param(nameof(ModeIndicator7), SignalDirection.Straight)
+		_modeIndicator7 = Param(nameof(ModeIndicator7), SignalDirections.Straight)
 			.SetDisplay("RSI Mode", "Invert RSI logic", "RSI");
 
 		_periodIndicator7 = Param(nameof(PeriodIndicator7), 14)
@@ -263,7 +263,7 @@ public class HistoScalperStrategy : Strategy
 		_useIndicator8 = Param(nameof(UseIndicator8), true)
 			.SetDisplay("Use Stochastic", "Enable stochastic oscillator filter", "Stochastic");
 
-		_modeIndicator8 = Param(nameof(ModeIndicator8), SignalDirection.Straight)
+		_modeIndicator8 = Param(nameof(ModeIndicator8), SignalDirections.Straight)
 			.SetDisplay("Stochastic Mode", "Invert stochastic logic", "Stochastic");
 
 		_kPeriod = Param(nameof(KPeriod), 5)
@@ -357,7 +357,7 @@ public class HistoScalperStrategy : Strategy
 		set => _useIndicator1.Value = value;
 	}
 
-	public SignalDirection ModeIndicator1
+	public SignalDirections ModeIndicator1
 	{
 		get => _modeIndicator1.Value;
 		set => _modeIndicator1.Value = value;
@@ -375,7 +375,7 @@ public class HistoScalperStrategy : Strategy
 		set => _useIndicator2.Value = value;
 	}
 
-	public SignalDirection ModeIndicator2
+	public SignalDirections ModeIndicator2
 	{
 		get => _modeIndicator2.Value;
 		set => _modeIndicator2.Value = value;
@@ -411,7 +411,7 @@ public class HistoScalperStrategy : Strategy
 		set => _useIndicator3.Value = value;
 	}
 
-	public SignalDirection ModeIndicator3
+	public SignalDirections ModeIndicator3
 	{
 		get => _modeIndicator3.Value;
 		set => _modeIndicator3.Value = value;
@@ -435,7 +435,7 @@ public class HistoScalperStrategy : Strategy
 		set => _useIndicator4.Value = value;
 	}
 
-	public SignalDirection ModeIndicator4
+	public SignalDirections ModeIndicator4
 	{
 		get => _modeIndicator4.Value;
 		set => _modeIndicator4.Value = value;
@@ -465,7 +465,7 @@ public class HistoScalperStrategy : Strategy
 		set => _useIndicator5.Value = value;
 	}
 
-	public SignalDirection ModeIndicator5
+	public SignalDirections ModeIndicator5
 	{
 		get => _modeIndicator5.Value;
 		set => _modeIndicator5.Value = value;
@@ -495,7 +495,7 @@ public class HistoScalperStrategy : Strategy
 		set => _useIndicator6.Value = value;
 	}
 
-	public SignalDirection ModeIndicator6
+	public SignalDirections ModeIndicator6
 	{
 		get => _modeIndicator6.Value;
 		set => _modeIndicator6.Value = value;
@@ -537,7 +537,7 @@ public class HistoScalperStrategy : Strategy
 		set => _useIndicator7.Value = value;
 	}
 
-	public SignalDirection ModeIndicator7
+	public SignalDirections ModeIndicator7
 	{
 		get => _modeIndicator7.Value;
 		set => _modeIndicator7.Value = value;
@@ -567,7 +567,7 @@ public class HistoScalperStrategy : Strategy
 		set => _useIndicator8.Value = value;
 	}
 
-	public SignalDirection ModeIndicator8
+	public SignalDirections ModeIndicator8
 	{
 		get => _modeIndicator8.Value;
 		set => _modeIndicator8.Value = value;
@@ -1020,10 +1020,10 @@ public class HistoScalperStrategy : Strategy
 			6 => ModeIndicator6,
 			7 => ModeIndicator7,
 			8 => ModeIndicator8,
-			_ => SignalDirection.Straight,
+			_ => SignalDirections.Straight,
 		};
 
-		return mode == SignalDirection.Reverse ? -signal : signal;
+		return mode == SignalDirections.Reverse ? -signal : signal;
 	}
 
 	private bool IsWithinSession(TimeSpan time)

--- a/API/3352_Tokyo_Session/CS/TokyoSessionStrategy.cs
+++ b/API/3352_Tokyo_Session/CS/TokyoSessionStrategy.cs
@@ -13,7 +13,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-public enum TokyoSignalMode
+public enum TokyoSignalModes
 {
 	ContraryTrend,
 	AccordingTrend,
@@ -23,7 +23,7 @@ public class TokyoSessionStrategy : Strategy
 {
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<int> _brokerOffset;
-	private readonly StrategyParam<TokyoSignalMode> _signalMode;
+	private readonly StrategyParam<TokyoSignalModes> _signalMode;
 	private readonly StrategyParam<int> _timeSetLevels;
 	private readonly StrategyParam<int> _timeCheckLevels;
 	private readonly StrategyParam<int> _timeRecheckPrices;
@@ -75,7 +75,7 @@ public class TokyoSessionStrategy : Strategy
 		set => _brokerOffset.Value = value;
 	}
 
-	public TokyoSignalMode TypeOfSignals
+	public TokyoSignalModes TypeOfSignals
 	{
 		get => _signalMode.Value;
 		set => _signalMode.Value = value;
@@ -217,7 +217,7 @@ public class TokyoSessionStrategy : Strategy
 		.SetDisplay("Broker GMT Offset", "Difference between broker server and GMT time (hours)", "General")
 		.SetRange(-24, 24);
 
-		_signalMode = Param(nameof(TypeOfSignals), TokyoSignalMode.ContraryTrend)
+		_signalMode = Param(nameof(TypeOfSignals), TokyoSignalModes.ContraryTrend)
 		.SetDisplay("Signal Mode", "Choose between contrary or trend following entries", "Signals");
 
 		_timeSetLevels = Param(nameof(TimeSetLevels), 21)
@@ -482,11 +482,11 @@ public class TokyoSessionStrategy : Strategy
 
 		switch (TypeOfSignals)
 		{
-			case TokyoSignalMode.ContraryTrend:
+			case TokyoSignalModes.ContraryTrend:
 				canBuy = closePrice < _levelLow.Value - minDistance && (MaxDistanceOfLevel <= 0m || closePrice > _levelLow.Value - maxDistance) && _checkBarsBuy && _checkPricesBuy;
 				canSell = closePrice > _levelHigh.Value + minDistance && (MaxDistanceOfLevel <= 0m || closePrice < _levelHigh.Value + maxDistance) && _checkBarsSell && _checkPricesSell;
 				break;
-			case TokyoSignalMode.AccordingTrend:
+			case TokyoSignalModes.AccordingTrend:
 				canBuy = closePrice > _levelHigh.Value + minDistance && (MaxDistanceOfLevel <= 0m || closePrice < _levelHigh.Value + maxDistance) && _checkBarsSell && _checkPricesSell;
 				canSell = closePrice < _levelLow.Value - minDistance && (MaxDistanceOfLevel <= 0m || closePrice > _levelLow.Value - maxDistance) && _checkBarsBuy && _checkPricesBuy;
 				break;
@@ -529,7 +529,7 @@ public class TokyoSessionStrategy : Strategy
 
 		switch (TypeOfSignals)
 		{
-			case TokyoSignalMode.ContraryTrend:
+			case TokyoSignalModes.ContraryTrend:
 				if (Position > 0m && closePrice > _levelLow.Value + minDistance)
 				{
 					ExitPosition();
@@ -543,7 +543,7 @@ public class TokyoSessionStrategy : Strategy
 				}
 
 				break;
-			case TokyoSignalMode.AccordingTrend:
+			case TokyoSignalModes.AccordingTrend:
 				if (Position > 0m && closePrice < _levelHigh.Value - minDistance)
 				{
 					ExitPosition();

--- a/API/3354_Couple_Hedge/CS/CoupleHedgeStrategy.cs
+++ b/API/3354_Couple_Hedge/CS/CoupleHedgeStrategy.cs
@@ -23,7 +23,7 @@ public class CoupleHedgeStrategy : Strategy
 	/// <summary>
 	/// Operating mode for the strategy.
 	/// </summary>
-	public enum Oper
+	public enum Operations
 	{
 		StandByMode,
 		NormalOperation,
@@ -34,7 +34,7 @@ public class CoupleHedgeStrategy : Strategy
 	/// <summary>
 	/// Behaviour for opening additional orders while in drawdown.
 	/// </summary>
-	public enum StepMode
+	public enum StepModes
 	{
 		NotOpenInLoss,
 		OpenWithManualStep,
@@ -44,7 +44,7 @@ public class CoupleHedgeStrategy : Strategy
 	/// <summary>
 	/// Profit closing logic.
 	/// </summary>
-	public enum CloseProfitMode
+	public enum CloseProfitModes
 	{
 		TicketOrders,
 		BasketOrders,
@@ -54,7 +54,7 @@ public class CoupleHedgeStrategy : Strategy
 	/// <summary>
 	/// Loss closing logic.
 	/// </summary>
-	public enum CloseLossMode
+	public enum CloseLossModes
 	{
 		WholeTicket,
 		OnlyFirstOrder,
@@ -64,7 +64,7 @@ public class CoupleHedgeStrategy : Strategy
 	/// <summary>
 	/// Progression type for spacing between additional entries.
 	/// </summary>
-	public enum StepProgression
+	public enum StepProgressions
 	{
 		StaticalStep,
 		GeometricalStep,
@@ -74,7 +74,7 @@ public class CoupleHedgeStrategy : Strategy
 	/// <summary>
 	/// Progression type for order size scaling.
 	/// </summary>
-	public enum LotProgression
+	public enum LotProgressions
 	{
 		StaticalLot,
 		GeometricalLot,
@@ -84,7 +84,7 @@ public class CoupleHedgeStrategy : Strategy
 	/// <summary>
 	/// Which sides are allowed to trade.
 	/// </summary>
-	public enum SideMode
+	public enum SideModes
 	{
 		TradeOnlyPlus,
 		TradeOnlyMinus,
@@ -104,13 +104,13 @@ public class CoupleHedgeStrategy : Strategy
 		public decimal BaseVolume { get; set; }
 	}
 
-	private readonly StrategyParam<Oper> _typeOperation;
-	private readonly StrategyParam<StepMode> _openOrdersInLoss;
-	private readonly StrategyParam<CloseProfitMode> _typeCloseInProfit;
-	private readonly StrategyParam<CloseLossMode> _typeCloseInLoss;
-	private readonly StrategyParam<StepProgression> _stepOrdersProgress;
-	private readonly StrategyParam<LotProgression> _lotOrdersProgress;
-	private readonly StrategyParam<SideMode> _sideToOpenOrders;
+	private readonly StrategyParam<Operations> _typeOperation;
+	private readonly StrategyParam<StepModes> _openOrdersInLoss;
+	private readonly StrategyParam<CloseProfitModes> _typeCloseInProfit;
+	private readonly StrategyParam<CloseLossModes> _typeCloseInLoss;
+	private readonly StrategyParam<StepProgressions> _stepOrdersProgress;
+	private readonly StrategyParam<LotProgressions> _lotOrdersProgress;
+	private readonly StrategyParam<SideModes> _sideToOpenOrders;
 	private readonly StrategyParam<string> _currencyTrade;
 	private readonly StrategyParam<decimal> _stepOpenNextOrders;
 	private readonly StrategyParam<decimal> _targetCloseProfit;
@@ -134,31 +134,31 @@ public class CoupleHedgeStrategy : Strategy
 	/// </summary>
 	public CoupleHedgeStrategy()
 	{
-		_typeOperation = Param(nameof(TypeOperation), Oper.NormalOperation)
+		_typeOperation = Param(nameof(TypeOperation), Operations.NormalOperation)
 		.SetDisplay("Operation Mode", "Overall operating mode for the hedging engine", "Operation")
 		.SetCanOptimize(true);
 
-		_openOrdersInLoss = Param(nameof(OpenOrdersInLoss), StepMode.OpenWithAutoStep)
+		_openOrdersInLoss = Param(nameof(OpenOrdersInLoss), StepModes.OpenWithAutoStep)
 		.SetDisplay("Open Orders In Loss", "How additional orders are triggered during drawdown", "Grid")
 		.SetCanOptimize(true);
 
-		_typeCloseInProfit = Param(nameof(TypeCloseInProfit), CloseProfitMode.BasketOrders)
+		_typeCloseInProfit = Param(nameof(TypeCloseInProfit), CloseProfitModes.BasketOrders)
 		.SetDisplay("Profit Close Mode", "How profits trigger position exits", "Risk Management")
 		.SetCanOptimize(true);
 
-		_typeCloseInLoss = Param(nameof(TypeCloseInLoss), CloseLossMode.NotCloseInLoss)
+		_typeCloseInLoss = Param(nameof(TypeCloseInLoss), CloseLossModes.NotCloseInLoss)
 		.SetDisplay("Loss Close Mode", "How losses are handled", "Risk Management")
 		.SetCanOptimize(true);
 
-		_stepOrdersProgress = Param(nameof(StepOrdersProgress), StepProgression.GeometricalStep)
+		_stepOrdersProgress = Param(nameof(StepOrdersProgress), StepProgressions.GeometricalStep)
 		.SetDisplay("Step Progression", "Progression for distance between entries", "Grid")
 		.SetCanOptimize(true);
 
-		_lotOrdersProgress = Param(nameof(LotOrdersProgress), LotProgression.StaticalLot)
+		_lotOrdersProgress = Param(nameof(LotOrdersProgress), LotProgressions.StaticalLot)
 		.SetDisplay("Lot Progression", "How order sizes scale when adding layers", "Grid")
 		.SetCanOptimize(true);
 
-		_sideToOpenOrders = Param(nameof(SideToOpenOrders), SideMode.TradePlusAndMinus)
+		_sideToOpenOrders = Param(nameof(SideToOpenOrders), SideModes.TradePlusAndMinus)
 		.SetDisplay("Sides", "Allowed trading direction", "Operation")
 		.SetCanOptimize(true);
 
@@ -223,7 +223,7 @@ public class CoupleHedgeStrategy : Strategy
 	/// <summary>
 	/// Selected operation mode.
 	/// </summary>
-	public Oper TypeOperation
+	public Operations TypeOperation
 	{
 		get => _typeOperation.Value;
 		set => _typeOperation.Value = value;
@@ -232,7 +232,7 @@ public class CoupleHedgeStrategy : Strategy
 	/// <summary>
 	/// How to open additional orders when the basket is in loss.
 	/// </summary>
-	public StepMode OpenOrdersInLoss
+	public StepModes OpenOrdersInLoss
 	{
 		get => _openOrdersInLoss.Value;
 		set => _openOrdersInLoss.Value = value;
@@ -241,7 +241,7 @@ public class CoupleHedgeStrategy : Strategy
 	/// <summary>
 	/// Profit closing mode.
 	/// </summary>
-	public CloseProfitMode TypeCloseInProfit
+	public CloseProfitModes TypeCloseInProfit
 	{
 		get => _typeCloseInProfit.Value;
 		set => _typeCloseInProfit.Value = value;
@@ -250,7 +250,7 @@ public class CoupleHedgeStrategy : Strategy
 	/// <summary>
 	/// Loss closing mode.
 	/// </summary>
-	public CloseLossMode TypeCloseInLoss
+	public CloseLossModes TypeCloseInLoss
 	{
 		get => _typeCloseInLoss.Value;
 		set => _typeCloseInLoss.Value = value;
@@ -259,7 +259,7 @@ public class CoupleHedgeStrategy : Strategy
 	/// <summary>
 	/// Step progression.
 	/// </summary>
-	public StepProgression StepOrdersProgress
+	public StepProgressions StepOrdersProgress
 	{
 		get => _stepOrdersProgress.Value;
 		set => _stepOrdersProgress.Value = value;
@@ -268,7 +268,7 @@ public class CoupleHedgeStrategy : Strategy
 	/// <summary>
 	/// Lot progression.
 	/// </summary>
-	public LotProgression LotOrdersProgress
+	public LotProgressions LotOrdersProgress
 	{
 		get => _lotOrdersProgress.Value;
 		set => _lotOrdersProgress.Value = value;
@@ -277,7 +277,7 @@ public class CoupleHedgeStrategy : Strategy
 	/// <summary>
 	/// Allowed trading side.
 	/// </summary>
-	public SideMode SideToOpenOrders
+	public SideModes SideToOpenOrders
 	{
 		get => _sideToOpenOrders.Value;
 		set => _sideToOpenOrders.Value = value;
@@ -430,7 +430,7 @@ public class CoupleHedgeStrategy : Strategy
 	{
 		base.OnStarted(time);
 
-		if (TypeOperation == Oper.CloseImmediatelyAllOrders)
+		if (TypeOperation == Operations.CloseImmediatelyAllOrders)
 		{
 			CloseAllPairs(time);
 			Stop();
@@ -499,12 +499,12 @@ public class CoupleHedgeStrategy : Strategy
 
 	private void TryOpenInitialOrder(ICandleMessage candle, PairState pair, decimal trend, decimal atr)
 	{
-		if (TypeOperation == Oper.StandByMode)
+		if (TypeOperation == Operations.StandByMode)
 		return;
 
 		var deviation = atr > 0m ? (candle.ClosePrice - trend) / atr : 0m;
-		var desireLong = deviation >= SignalThreshold && (SideToOpenOrders == SideMode.TradePlusAndMinus || SideToOpenOrders == SideMode.TradeOnlyPlus);
-		var desireShort = deviation <= -SignalThreshold && (SideToOpenOrders == SideMode.TradePlusAndMinus || SideToOpenOrders == SideMode.TradeOnlyMinus);
+		var desireLong = deviation >= SignalThreshold && (SideToOpenOrders == SideModes.TradePlusAndMinus || SideToOpenOrders == SideModes.TradeOnlyPlus);
+		var desireShort = deviation <= -SignalThreshold && (SideToOpenOrders == SideModes.TradePlusAndMinus || SideToOpenOrders == SideModes.TradeOnlyMinus);
 
 		if (!desireLong && !desireShort)
 		return;
@@ -529,7 +529,7 @@ public class CoupleHedgeStrategy : Strategy
 
 	private void HandleScaling(PairState pair, decimal profit, decimal absVolume, decimal atr)
 	{
-		if (OpenOrdersInLoss == StepMode.NotOpenInLoss)
+		if (OpenOrdersInLoss == StepModes.NotOpenInLoss)
 		return;
 
 		var lotLoss = absVolume > 0m ? -profit / absVolume : 0m;
@@ -570,14 +570,14 @@ public class CoupleHedgeStrategy : Strategy
 		var targetPerLot = TargetCloseProfit * GetLotMultiplier(absVolume);
 		var profitReached = profit >= targetPerLot;
 
-		if (TypeCloseInProfit == CloseProfitMode.BasketOrders)
+		if (TypeCloseInProfit == CloseProfitModes.BasketOrders)
 		{
 			HandleBasketProfitExit();
 			pair.ProfitDelayCounter = 0;
 			return;
 		}
 
-		if (TypeCloseInProfit == CloseProfitMode.HybridMode)
+		if (TypeCloseInProfit == CloseProfitModes.HybridMode)
 		{
 			HandleBasketProfitExit();
 		}
@@ -596,7 +596,7 @@ public class CoupleHedgeStrategy : Strategy
 
 		ClosePair(pair);
 
-		if (TypeOperation == Oper.CloseInProfitAndStop)
+		if (TypeOperation == Operations.CloseInProfitAndStop)
 		{
 			Stop();
 		}
@@ -631,7 +631,7 @@ public class CoupleHedgeStrategy : Strategy
 
 		CloseAllPairs(CurrentTime);
 
-		if (TypeOperation == Oper.CloseInProfitAndStop)
+		if (TypeOperation == Operations.CloseInProfitAndStop)
 		{
 			Stop();
 		}
@@ -662,13 +662,13 @@ public class CoupleHedgeStrategy : Strategy
 
 		switch (TypeCloseInLoss)
 		{
-			case CloseLossMode.NotCloseInLoss:
+			case CloseLossModes.NotCloseInLoss:
 			pair.LossDelayCounter = 0;
 			return;
-			case CloseLossMode.WholeTicket:
+			case CloseLossModes.WholeTicket:
 			ClosePair(pair);
 			break;
-			case CloseLossMode.OnlyFirstOrder:
+			case CloseLossModes.OnlyFirstOrder:
 			var baseVolume = pair.BaseVolume;
 			if (baseVolume <= 0m)
 			return;
@@ -733,15 +733,15 @@ public class CoupleHedgeStrategy : Strategy
 
 	private bool IsTradingAllowedForNewOrders()
 	{
-		return TypeOperation == Oper.NormalOperation || TypeOperation == Oper.CloseInProfitAndStop;
+		return TypeOperation == Operations.NormalOperation || TypeOperation == Operations.CloseInProfitAndStop;
 	}
 
 	private decimal CalculateStepThreshold(int levelIndex, decimal atr)
 	{
 		var baseThreshold = OpenOrdersInLoss switch
 		{
-			StepMode.OpenWithAutoStep => atr * StepOpenNextOrders,
-			StepMode.OpenWithManualStep => StepOpenNextOrders,
+			StepModes.OpenWithAutoStep => atr * StepOpenNextOrders,
+			StepModes.OpenWithManualStep => StepOpenNextOrders,
 			_ => 0m
 		};
 
@@ -750,9 +750,9 @@ public class CoupleHedgeStrategy : Strategy
 
 		var multiplier = StepOrdersProgress switch
 		{
-			StepProgression.StaticalStep => 1m,
-			StepProgression.GeometricalStep => 1m + levelIndex,
-			StepProgression.ExponentialStep => (decimal)Math.Pow(2, levelIndex),
+			StepProgressions.StaticalStep => 1m,
+			StepProgressions.GeometricalStep => 1m + levelIndex,
+			StepProgressions.ExponentialStep => (decimal)Math.Pow(2, levelIndex),
 			_ => 1m
 		};
 
@@ -767,9 +767,9 @@ public class CoupleHedgeStrategy : Strategy
 
 		var multiplier = LotOrdersProgress switch
 		{
-			LotProgression.StaticalLot => 1m,
-			LotProgression.GeometricalLot => 1m + levelIndex,
-			LotProgression.ExponentialLot => (decimal)Math.Pow(2, levelIndex),
+			LotProgressions.StaticalLot => 1m,
+			LotProgressions.GeometricalLot => 1m + levelIndex,
+			LotProgressions.ExponentialLot => (decimal)Math.Pow(2, levelIndex),
 			_ => 1m
 		};
 

--- a/API/3358_VR_Smart_Grid_Lite/CS/VrSmartGridLiteStrategy.cs
+++ b/API/3358_VR_Smart_Grid_Lite/CS/VrSmartGridLiteStrategy.cs
@@ -21,7 +21,7 @@ public class VrSmartGridLiteStrategy : Strategy
 	private readonly StrategyParam<int> _takeProfitPips;
 	private readonly StrategyParam<decimal> _startVolume;
 	private readonly StrategyParam<decimal> _maximalVolume;
-	private readonly StrategyParam<CloseModeOption> _closeMode;
+	private readonly StrategyParam<CloseModeOptions> _closeMode;
 	private readonly StrategyParam<int> _orderStepPips;
 	private readonly StrategyParam<int> _minimalProfitPips;
 	private readonly StrategyParam<int> _slippagePips;
@@ -34,7 +34,7 @@ public class VrSmartGridLiteStrategy : Strategy
 	/// <summary>
 	/// Defines how the grid closes positions.
 	/// </summary>
-	public enum CloseModeOption
+	public enum CloseModeOptions
 	{
 		/// <summary>
 		/// Close opposite extremes at a weighted average price.
@@ -77,7 +77,7 @@ public class VrSmartGridLiteStrategy : Strategy
 	/// <summary>
 	/// Closing mode for managing grid exits.
 	/// </summary>
-	public CloseModeOption CloseMode
+	public CloseModeOptions CloseMode
 	{
 		get => _closeMode.Value;
 		set => _closeMode.Value = value;
@@ -136,7 +136,7 @@ public class VrSmartGridLiteStrategy : Strategy
 			.SetGreaterThanZero()
 			.SetDisplay("Maximal Volume", "Upper limit for any single order", "Trading");
 
-		_closeMode = Param(nameof(CloseMode), CloseModeOption.Average)
+		_closeMode = Param(nameof(CloseMode), CloseModeOptions.Average)
 			.SetDisplay("Close Mode", "How the grid exits positions", "Exit");
 
 		_orderStepPips = Param(nameof(OrderStepPips), 390)
@@ -241,7 +241,7 @@ public class VrSmartGridLiteStrategy : Strategy
 	/// </summary>
 	private void ProcessCloseLogic(ICandleMessage candle, decimal minimalProfitDistance, SideStatistics buyStats, SideStatistics sellStats)
 	{
-		if (CloseMode == CloseModeOption.Average)
+		if (CloseMode == CloseModeOptions.Average)
 		{
 			if (buyStats.Count >= 2 && buyStats.MinEntry != null && buyStats.MaxEntry != null)
 			{
@@ -275,7 +275,7 @@ public class VrSmartGridLiteStrategy : Strategy
 				}
 			}
 		}
-		else if (CloseMode == CloseModeOption.PartClose)
+		else if (CloseMode == CloseModeOptions.PartClose)
 		{
 			if (!TryPrepareOrderVolume(StartVolume, out var startVolume))
 				return;

--- a/API/3359_VR_Smart_Grid_Lite_Averaging/CS/VrSmartGridLiteAveragingStrategy.cs
+++ b/API/3359_VR_Smart_Grid_Lite_Averaging/CS/VrSmartGridLiteAveragingStrategy.cs
@@ -21,7 +21,7 @@ public class VrSmartGridLiteAveragingStrategy : Strategy
 	private readonly StrategyParam<decimal> _takeProfitPips;
 	private readonly StrategyParam<decimal> _startVolume;
 	private readonly StrategyParam<decimal> _maxVolume;
-	private readonly StrategyParam<CloseMode> _closeMode;
+	private readonly StrategyParam<CloseModes> _closeMode;
 	private readonly StrategyParam<decimal> _orderStepPips;
 	private readonly StrategyParam<decimal> _minimalProfitPips;
 	private readonly StrategyParam<DataType> _candleType;
@@ -34,7 +34,7 @@ public class VrSmartGridLiteAveragingStrategy : Strategy
 	/// <summary>
 	/// Defines how the strategy exits grid positions.
 	/// </summary>
-	public enum CloseMode
+	public enum CloseModes
 	{
 		/// <summary>
 		/// Close the most extreme pair using the weighted average price.
@@ -66,7 +66,7 @@ public class VrSmartGridLiteAveragingStrategy : Strategy
 			.SetDisplay("Max Volume", "Maximum allowed trade volume per order", "Risk")
 			.SetCanOptimize(true);
 
-		_closeMode = Param(nameof(Mode), CloseMode.Average)
+		_closeMode = Param(nameof(Mode), CloseModes.Average)
 			.SetDisplay("Close Mode", "Averaging or partial close logic for managing the grid", "Risk Management");
 
 		_orderStepPips = Param(nameof(OrderStepPips), 390m)
@@ -113,7 +113,7 @@ public class VrSmartGridLiteAveragingStrategy : Strategy
 	/// <summary>
 	/// Exit logic applied when multiple grid orders are active.
 	/// </summary>
-	public CloseMode Mode
+	public CloseModes Mode
 	{
 		get => _closeMode.Value;
 		set => _closeMode.Value = value;
@@ -222,10 +222,10 @@ public class VrSmartGridLiteAveragingStrategy : Strategy
 	{
 		switch (Mode)
 		{
-			case CloseMode.Average:
+			case CloseModes.Average:
 				HandleAverageMode(candle);
 				break;
-			case CloseMode.PartialClose:
+			case CloseModes.PartialClose:
 				HandlePartialCloseMode(candle);
 				break;
 		}

--- a/API/3363_Timer_EA/CS/TimerEaStrategy.cs
+++ b/API/3363_Timer_EA/CS/TimerEaStrategy.cs
@@ -22,7 +22,7 @@ public class TimerEaStrategy : Strategy
 	/// <summary>
 	/// Entry order type used at the scheduled moment.
 	/// </summary>
-	public enum TimerOrderMode
+	public enum TimerOrderModes
 	{
 		/// <summary>Place market orders.</summary>
 		Market,
@@ -35,7 +35,7 @@ public class TimerEaStrategy : Strategy
 	/// <summary>
 	/// Position sizing logic that mimics the original MQL configuration.
 	/// </summary>
-	public enum LotSizingMode
+	public enum LotSizingModes
 	{
 		/// <summary>Use fixed volume defined by the user.</summary>
 		ManualLot,
@@ -43,7 +43,7 @@ public class TimerEaStrategy : Strategy
 		BalanceRisk
 	}
 
-	private readonly StrategyParam<TimerOrderMode> _orderMode;
+	private readonly StrategyParam<TimerOrderModes> _orderMode;
 	private readonly StrategyParam<bool> _openBuy;
 	private readonly StrategyParam<bool> _openSell;
 	private readonly StrategyParam<decimal> _takeProfitSteps;
@@ -55,7 +55,7 @@ public class TimerEaStrategy : Strategy
 	private readonly StrategyParam<decimal> _pendingDistanceSteps;
 	private readonly StrategyParam<int> _expirationMinutes;
 	private readonly StrategyParam<bool> _cancelPendingOnClose;
-	private readonly StrategyParam<LotSizingMode> _lotSizing;
+	private readonly StrategyParam<LotSizingModes> _lotSizing;
 	private readonly StrategyParam<decimal> _riskFactor;
 	private readonly StrategyParam<decimal> _manualVolume;
 	private readonly StrategyParam<DateTimeOffset> _openTime;
@@ -77,7 +77,7 @@ public class TimerEaStrategy : Strategy
 	/// </summary>
 	public TimerEaStrategy()
 	{
-		_orderMode = Param(nameof(OrderMode), TimerOrderMode.Market)
+		_orderMode = Param(nameof(OrderMode), TimerOrderModes.Market)
 			.SetDisplay("Order Mode", "Type of order submitted at the scheduled moment", "Entries");
 
 		_openBuy = Param(nameof(OpenBuy), false)
@@ -113,7 +113,7 @@ public class TimerEaStrategy : Strategy
 		_cancelPendingOnClose = Param(nameof(CancelPendingOnClose), true)
 			.SetDisplay("Cancel Pending", "Cancel pending orders when the close time is reached", "Exits");
 
-		_lotSizing = Param(nameof(LotSizing), LotSizingMode.ManualLot)
+		_lotSizing = Param(nameof(LotSizing), LotSizingModes.ManualLot)
 			.SetDisplay("Lot Sizing", "How to derive order volume", "Money Management");
 
 		_riskFactor = Param(nameof(RiskFactor), 1m)
@@ -137,7 +137,7 @@ public class TimerEaStrategy : Strategy
 	/// <summary>
 	/// Selected order placement mode.
 	/// </summary>
-	public TimerOrderMode OrderMode
+	public TimerOrderModes OrderMode
 	{
 		get => _orderMode.Value;
 		set => _orderMode.Value = value;
@@ -245,7 +245,7 @@ public class TimerEaStrategy : Strategy
 	/// <summary>
 	/// Position sizing logic selector.
 	/// </summary>
-	public LotSizingMode LotSizing
+	public LotSizingModes LotSizing
 	{
 		get => _lotSizing.Value;
 		set => _lotSizing.Value = value;
@@ -261,7 +261,7 @@ public class TimerEaStrategy : Strategy
 	}
 
 	/// <summary>
-	/// Fixed volume submitted when <see cref="LotSizingMode.ManualLot"/> is active.
+	/// Fixed volume submitted when <see cref="LotSizingModes.ManualLot"/> is active.
 	/// </summary>
 	public decimal ManualVolume
 	{
@@ -370,7 +370,7 @@ public class TimerEaStrategy : Strategy
 
 		switch (OrderMode)
 		{
-			case TimerOrderMode.Market:
+			case TimerOrderModes.Market:
 			{
 				if (OpenBuy)
 				{
@@ -387,7 +387,7 @@ public class TimerEaStrategy : Strategy
 				break;
 			}
 
-			case TimerOrderMode.PendingStop:
+			case TimerOrderModes.PendingStop:
 			{
 				if (OpenBuy && _buyPendingOrder == null)
 				{
@@ -416,7 +416,7 @@ public class TimerEaStrategy : Strategy
 				break;
 			}
 
-			case TimerOrderMode.PendingLimit:
+			case TimerOrderModes.PendingLimit:
 			{
 				if (OpenBuy && _buyPendingOrder == null)
 				{
@@ -553,8 +553,8 @@ public class TimerEaStrategy : Strategy
 	{
 		return LotSizing switch
 		{
-			LotSizingMode.ManualLot => Math.Max(0m, ManualVolume),
-			LotSizingMode.BalanceRisk => CalculateRiskVolume(),
+			LotSizingModes.ManualLot => Math.Max(0m, ManualVolume),
+			LotSizingModes.BalanceRisk => CalculateRiskVolume(),
 			_ => ManualVolume
 		};
 	}

--- a/API/3365_FXF_Safe_Trend_Scalp_V1/CS/FXFSafeTrendScalpV1Strategy.cs
+++ b/API/3365_FXF_Safe_Trend_Scalp_V1/CS/FXFSafeTrendScalpV1Strategy.cs
@@ -21,7 +21,7 @@ using StockSharp.Algo;
 /// </summary>
 public class FXFSafeTrendScalpV1Strategy : Strategy
 {
-private enum SignalDirection
+private enum SignalDirections
 {
 None,
 Buy,
@@ -49,7 +49,7 @@ private SimpleMovingAverage _fastMa;
 private SimpleMovingAverage _slowMa;
 private readonly List<ZigZagPivot> _highPivots = new();
 private readonly List<ZigZagPivot> _lowPivots = new();
-private SignalDirection _signal;
+private SignalDirections _signal;
 private int _barIndex;
 private decimal _pipSize;
 private int _searchDirection;
@@ -251,7 +251,7 @@ _fastMa = null;
 _slowMa = null;
 _highPivots.Clear();
 _lowPivots.Clear();
-_signal = SignalDirection.None;
+_signal = SignalDirections.None;
 _barIndex = -1;
 _pipSize = 0m;
 _searchDirection = 1;
@@ -324,24 +324,24 @@ var offset = GetPointsValue(TrendOffsetPoints);
 var highLine = GetTrendlineValue(_highPivots);
 var lowLine = GetTrendlineValue(_lowPivots);
 
-if (highLine.HasValue && _signal != SignalDirection.Sell)
+if (highLine.HasValue && _signal != SignalDirections.Sell)
 {
 var trigger = highLine.Value - offset;
 if (fastMaValue < slowMaValue && candle.ClosePrice >= trigger)
-_signal = SignalDirection.Sell;
+_signal = SignalDirections.Sell;
 }
 
-if (lowLine.HasValue && _signal != SignalDirection.Buy)
+if (lowLine.HasValue && _signal != SignalDirections.Buy)
 {
 var trigger = lowLine.Value + offset;
 if (fastMaValue > slowMaValue && candle.ClosePrice <= trigger)
-_signal = SignalDirection.Buy;
+_signal = SignalDirections.Buy;
 }
 }
 
 private void TryExecuteSignal(ICandleMessage candle)
 {
-if (_signal == SignalDirection.None)
+if (_signal == SignalDirections.None)
 return;
 
 if (!IsFormedAndOnlineAndAllowTrading())
@@ -368,9 +368,9 @@ var volume = AlignVolume(VolumePerTrade);
 if (volume <= 0m)
 return;
 
-var resultingPosition = _signal == SignalDirection.Buy ? Position + volume : Position - volume;
+var resultingPosition = _signal == SignalDirections.Buy ? Position + volume : Position - volume;
 
-if (_signal == SignalDirection.Buy)
+if (_signal == SignalDirections.Buy)
 BuyMarket(volume);
 else
 SellMarket(volume);

--- a/API/3369_Swap_Status/CS/SwapStatusStrategy.cs
+++ b/API/3369_Swap_Status/CS/SwapStatusStrategy.cs
@@ -21,7 +21,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class SwapStatusStrategy : Strategy
 {
-	private readonly StrategyParam<SwapPreset> _preset;
+	private readonly StrategyParam<SwapPresets> _preset;
 	private readonly StrategyParam<string> _customSymbols;
 
 	private readonly List<Security> _monitoredSecurities = new();
@@ -32,7 +32,7 @@ public class SwapStatusStrategy : Strategy
 	/// <summary>
 	/// Determines which predefined group of currency pairs should be monitored.
 	/// </summary>
-	public SwapPreset Preset
+	public SwapPresets Preset
 	{
 		get => _preset.Value;
 		set
@@ -60,7 +60,7 @@ public class SwapStatusStrategy : Strategy
 	/// </summary>
 	public SwapStatusStrategy()
 	{
-		_preset = Param(nameof(Preset), SwapPreset.PrimarySymbol)
+		_preset = Param(nameof(Preset), SwapPresets.PrimarySymbol)
 			.SetDisplay("Preset", "Predefined group of symbols to inspect", "General");
 
 		_customSymbols = Param(nameof(CustomSymbols), string.Empty)
@@ -166,7 +166,7 @@ public class SwapStatusStrategy : Strategy
 			_monitoredSecurities.Add(security);
 		}
 
-		if (Preset == SwapPreset.PrimarySymbol && Security != null)
+		if (Preset == SwapPresets.PrimarySymbol && Security != null)
 		{
 			// The original EA defaults to the current chart symbol, so include Strategy.Security.
 			AddSecurity(Security);
@@ -231,11 +231,11 @@ public class SwapStatusStrategy : Strategy
 		return "Zero";
 	}
 
-	private static IEnumerable<string> GetPresetSymbols(SwapPreset preset)
+	private static IEnumerable<string> GetPresetSymbols(SwapPresets preset)
 	{
 		return preset switch
 		{
-			SwapPreset.MajorPairs => new[]
+			SwapPresets.MajorPairs => new[]
 			{
 				"EURUSD",
 				"GBPUSD",
@@ -245,7 +245,7 @@ public class SwapStatusStrategy : Strategy
 				"USDCHF",
 				"USDJPY"
 			},
-			SwapPreset.MinorPairs => new[]
+			SwapPresets.MinorPairs => new[]
 			{
 				"EURGBP",
 				"EURJPY",
@@ -255,7 +255,7 @@ public class SwapStatusStrategy : Strategy
 				"AUDJPY",
 				"NZDJPY"
 			},
-			SwapPreset.ExoticPairs => new[]
+			SwapPresets.ExoticPairs => new[]
 			{
 				"EURTRY",
 				"EURZAR",
@@ -281,7 +281,7 @@ public class SwapStatusStrategy : Strategy
 /// <summary>
 /// Lists available symbol presets that mirror the MetaTrader scripts.
 /// </summary>
-public enum SwapPreset
+public enum SwapPresets
 {
 	/// <summary>
 	/// Only monitors the primary strategy security (matches Swap.mq4 behaviour).

--- a/API/3371_PricerEA/CS/PricerEaStrategy.cs
+++ b/API/3371_PricerEA/CS/PricerEaStrategy.cs
@@ -22,7 +22,7 @@ public class PricerEaStrategy : Strategy
 	/// <summary>
 	/// Volume selection mode.
 	/// </summary>
-	public enum LotSizingMode
+	public enum LotSizingModes
 	{
 		/// <summary>
 		/// Always use the manual volume parameter.
@@ -46,7 +46,7 @@ public class PricerEaStrategy : Strategy
 	private readonly StrategyParam<bool> _enableBreakEven;
 	private readonly StrategyParam<decimal> _breakEvenTriggerPoints;
 	private readonly StrategyParam<int> _pendingExpiryMinutes;
-	private readonly StrategyParam<LotSizingMode> _lotSizingMode;
+	private readonly StrategyParam<LotSizingModes> _lotSizingMode;
 	private readonly StrategyParam<decimal> _riskFactor;
 	private readonly StrategyParam<decimal> _manualVolume;
 
@@ -107,7 +107,7 @@ public class PricerEaStrategy : Strategy
 		_pendingExpiryMinutes = Param(nameof(PendingExpiryMinutes), 60)
 			.SetDisplay("Pending Expiry (minutes)", "Lifetime of the pending orders (0 keeps them alive)", "Pending Orders");
 
-		_lotSizingMode = Param(nameof(VolumeMode), LotSizingMode.Manual)
+		_lotSizingMode = Param(nameof(VolumeMode), LotSizingModes.Manual)
 			.SetDisplay("Lot Sizing Mode", "Choose between manual and automatic volume", "Risk");
 
 		_riskFactor = Param(nameof(RiskFactor), 1m)
@@ -221,7 +221,7 @@ public class PricerEaStrategy : Strategy
 	/// <summary>
 	/// Volume selection mode.
 	/// </summary>
-	public LotSizingMode VolumeMode
+	public LotSizingModes VolumeMode
 	{
 		get => _lotSizingMode.Value;
 		set => _lotSizingMode.Value = value;
@@ -237,7 +237,7 @@ public class PricerEaStrategy : Strategy
 	}
 
 	/// <summary>
-	/// Manual volume used when <see cref="VolumeMode"/> equals <see cref="LotSizingMode.Manual"/>.
+	/// Manual volume used when <see cref="VolumeMode"/> equals <see cref="LotSizingModes.Manual"/>.
 	/// </summary>
 	public decimal ManualVolume
 	{
@@ -679,7 +679,7 @@ public class PricerEaStrategy : Strategy
 
 	private decimal CalculateOrderVolume()
 	{
-		var volume = VolumeMode == LotSizingMode.Manual
+		var volume = VolumeMode == LotSizingModes.Manual
 			? ManualVolume
 			: CalculateAutomaticVolume();
 

--- a/API/3372_Basic_MA_Template/CS/BasicMaTemplateStrategy.cs
+++ b/API/3372_Basic_MA_Template/CS/BasicMaTemplateStrategy.cs
@@ -23,7 +23,7 @@ public class BasicMaTemplateStrategy : Strategy
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<int> _movingAveragePeriod;
 	private readonly StrategyParam<int> _movingAverageShift;
-	private readonly StrategyParam<MovingAverageMethod> _movingAverageMethod;
+	private readonly StrategyParam<MovingAverageMethods> _movingAverageMethod;
 	private readonly StrategyParam<decimal> _takeProfitPips;
 	private readonly StrategyParam<decimal> _stopLossPips;
 
@@ -63,7 +63,7 @@ public class BasicMaTemplateStrategy : Strategy
 	/// <summary>
 	/// Moving average calculation mode.
 	/// </summary>
-	public MovingAverageMethod MovingAverageMethod
+	public MovingAverageMethods MovingAverageMethods
 	{
 		get => _movingAverageMethod.Value;
 		set => _movingAverageMethod.Value = value;
@@ -104,7 +104,7 @@ public class BasicMaTemplateStrategy : Strategy
 		_movingAverageShift = Param(nameof(MovingAverageShift), 0)
 			.SetDisplay("MA Shift", "Forward shift applied to the moving average", "Indicator");
 
-		_movingAverageMethod = Param(nameof(MovingAverageMethod), MovingAverageMethod.Simple)
+		_movingAverageMethod = Param(nameof(MovingAverageMethods), MovingAverageMethods.Simple)
 			.SetDisplay("MA Method", "Moving average calculation mode", "Indicator");
 
 		_takeProfitPips = Param(nameof(TakeProfitPips), 38.5m)
@@ -139,7 +139,7 @@ public class BasicMaTemplateStrategy : Strategy
 	{
 		base.OnStarted(time);
 
-		var movingAverage = CreateMovingAverage(MovingAverageMethod, MovingAveragePeriod);
+		var movingAverage = CreateMovingAverage(MovingAverageMethods, MovingAveragePeriod);
 
 		var subscription = SubscribeCandles(CandleType);
 		subscription
@@ -237,14 +237,14 @@ public class BasicMaTemplateStrategy : Strategy
 		return step * multiplier;
 	}
 
-	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageMethod method, int period)
+	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageMethods method, int period)
 	{
 		return method switch
 		{
-			MovingAverageMethod.Simple => new SMA { Length = period },
-			MovingAverageMethod.Exponential => new EMA { Length = period },
-			MovingAverageMethod.Smoothed => new SMMA { Length = period },
-			MovingAverageMethod.LinearWeighted => new WMA { Length = period },
+			MovingAverageMethods.Simple => new SMA { Length = period },
+			MovingAverageMethods.Exponential => new EMA { Length = period },
+			MovingAverageMethods.Smoothed => new SMMA { Length = period },
+			MovingAverageMethods.LinearWeighted => new WMA { Length = period },
 			_ => new SMA { Length = period }
 		};
 	}
@@ -252,7 +252,7 @@ public class BasicMaTemplateStrategy : Strategy
 	/// <summary>
 	/// Available moving average methods corresponding to the original MQL inputs.
 	/// </summary>
-	public enum MovingAverageMethod
+	public enum MovingAverageMethods
 	{
 		/// <summary>
 		/// Simple moving average (MODE_SMA in MetaTrader).

--- a/API/3381_Multi_Currency_Template/CS/MultiCurrencyTemplateStrategy.cs
+++ b/API/3381_Multi_Currency_Template/CS/MultiCurrencyTemplateStrategy.cs
@@ -19,7 +19,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class MultiCurrencyTemplateStrategy : Strategy
 {
-	private readonly StrategyParam<OrderMethodType> _orderMethod;
+	private readonly StrategyParam<OrderMethodTypes> _orderMethod;
 	private readonly StrategyParam<decimal> _tradeVolume;
 	private readonly StrategyParam<int> _stopLossPips;
 	private readonly StrategyParam<int> _takeProfitPips;
@@ -47,7 +47,7 @@ public class MultiCurrencyTemplateStrategy : Strategy
 	/// <summary>
 	/// Supported order directions.
 	/// </summary>
-	public enum OrderMethodType
+	public enum OrderMethodTypes
 	{
 		/// <summary>
 		/// Allow both long and short signals.
@@ -70,7 +70,7 @@ public class MultiCurrencyTemplateStrategy : Strategy
 	/// </summary>
 	public MultiCurrencyTemplateStrategy()
 	{
-		_orderMethod = Param(nameof(OrderMethod), OrderMethodType.BuyAndSell)
+		_orderMethod = Param(nameof(OrderMethod), OrderMethodTypes.BuyAndSell)
 			.SetDisplay("Order Method", "Choose whether the strategy trades long, short or both directions.", "Trading")
 			.SetCanOptimize(true);
 
@@ -129,7 +129,7 @@ public class MultiCurrencyTemplateStrategy : Strategy
 	/// <summary>
 	/// Defines which direction the strategy may trade.
 	/// </summary>
-	public OrderMethodType OrderMethod
+	public OrderMethodTypes OrderMethod
 	{
 		get => _orderMethod.Value;
 		set => _orderMethod.Value = value;
@@ -292,9 +292,9 @@ public class MultiCurrencyTemplateStrategy : Strategy
 
 		var signal = fastEma > slowEma ? 1 : fastEma < slowEma ? -1 : 0;
 
-		if (signal > 0 && OrderMethod != OrderMethodType.SellOnly)
+		if (signal > 0 && OrderMethod != OrderMethodTypes.SellOnly)
 			TryEnterLong(candle);
-		else if (signal < 0 && OrderMethod != OrderMethodType.BuyOnly)
+		else if (signal < 0 && OrderMethod != OrderMethodTypes.BuyOnly)
 			TryEnterShort(candle);
 
 		if (EnableMartingale)
@@ -474,7 +474,7 @@ public class MultiCurrencyTemplateStrategy : Strategy
 
 		var price = candle.ClosePrice;
 
-		if (Position > 0m && OrderMethod != OrderMethodType.SellOnly)
+		if (Position > 0m && OrderMethod != OrderMethodTypes.SellOnly)
 		{
 			var reference = _longReferencePrice ?? PositionPrice ?? price;
 			if (price <= reference - step)
@@ -490,7 +490,7 @@ public class MultiCurrencyTemplateStrategy : Strategy
 				}
 			}
 		}
-		else if (Position < 0m && OrderMethod != OrderMethodType.BuyOnly)
+		else if (Position < 0m && OrderMethod != OrderMethodTypes.BuyOnly)
 		{
 			var reference = _shortReferencePrice ?? PositionPrice ?? price;
 			if (price >= reference + step)

--- a/API/3382_Basic_ATR_Stop_Take/CS/BasicAtrStopTakeStrategy.cs
+++ b/API/3382_Basic_ATR_Stop_Take/CS/BasicAtrStopTakeStrategy.cs
@@ -19,7 +19,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class BasicAtrStopTakeStrategy : Strategy
 {
-	private readonly StrategyParam<TradeDirection> _tradeDirection;
+	private readonly StrategyParam<TradeDirections> _tradeDirection;
 	private readonly StrategyParam<decimal> _tradeVolume;
 	private readonly StrategyParam<int> _atrPeriod;
 	private readonly StrategyParam<decimal> _stopLossFactor;
@@ -37,7 +37,7 @@ public class BasicAtrStopTakeStrategy : Strategy
 	/// <summary>
 	/// Trading direction copied from the original expert advisor.
 	/// </summary>
-	public enum TradeDirection
+	public enum TradeDirections
 	{
 		/// <summary>
 		/// Do not open new positions.
@@ -58,7 +58,7 @@ public class BasicAtrStopTakeStrategy : Strategy
 	/// <summary>
 	/// Selected market side for the ATR-protected trade.
 	/// </summary>
-	public TradeDirection Direction
+	public TradeDirections Direction
 	{
 		get => _tradeDirection.Value;
 		set => _tradeDirection.Value = value;
@@ -114,7 +114,7 @@ public class BasicAtrStopTakeStrategy : Strategy
 	/// </summary>
 	public BasicAtrStopTakeStrategy()
 	{
-		_tradeDirection = Param(nameof(Direction), TradeDirection.Buy)
+		_tradeDirection = Param(nameof(Direction), TradeDirections.Buy)
 			.SetDisplay("Trade Direction", "Market side used for the ATR trade", "Trading");
 
 		_tradeVolume = Param(nameof(TradeVolume), 1m)
@@ -231,7 +231,7 @@ public class BasicAtrStopTakeStrategy : Strategy
 		{
 			ResetTradeLevels();
 
-			if (Direction == TradeDirection.None)
+			if (Direction == TradeDirections.None)
 				return;
 
 			if (atrValue <= 0m)
@@ -243,7 +243,7 @@ public class BasicAtrStopTakeStrategy : Strategy
 
 			switch (Direction)
 			{
-				case TradeDirection.Buy:
+				case TradeDirections.Buy:
 				{
 					BuyMarket(volume);
 					_entryPrice = candle.ClosePrice;
@@ -252,7 +252,7 @@ public class BasicAtrStopTakeStrategy : Strategy
 					break;
 				}
 
-				case TradeDirection.Sell:
+				case TradeDirections.Sell:
 				{
 					SellMarket(volume);
 					_entryPrice = candle.ClosePrice;

--- a/API/3386_Manual_Trading_Lightweight_Utility/CS/ManualTradingLightweightUtilityStrategy.cs
+++ b/API/3386_Manual_Trading_Lightweight_Utility/CS/ManualTradingLightweightUtilityStrategy.cs
@@ -19,8 +19,8 @@ namespace StockSharp.Samples.Strategies;
 public class ManualTradingLightweightUtilityStrategy : Strategy
 {
 private readonly StrategyParam<DataType> _candleType;
-private readonly StrategyParam<ManualOrderMode> _buyOrderMode;
-private readonly StrategyParam<ManualOrderMode> _sellOrderMode;
+private readonly StrategyParam<ManualOrderModes> _buyOrderMode;
+private readonly StrategyParam<ManualOrderModes> _sellOrderMode;
 private readonly StrategyParam<bool> _buyAutomaticPrice;
 private readonly StrategyParam<bool> _sellAutomaticPrice;
 private readonly StrategyParam<decimal> _buyManualPrice;
@@ -50,7 +50,7 @@ private bool _pointWarningIssued;
 /// <summary>
 /// Describes the execution mode of the manual order.
 /// </summary>
-public enum ManualOrderMode
+public enum ManualOrderModes
 {
 /// <summary>
 /// Send a market order immediately.
@@ -76,10 +76,10 @@ public ManualTradingLightweightUtilityStrategy()
 _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(1).TimeFrame())
 .SetDisplay("Candle Type", "Market data series used to evaluate offsets and protective levels.", "Market Data");
 
-_buyOrderMode = Param(nameof(BuyOrderMode), ManualOrderMode.MarketExecution)
+_buyOrderMode = Param(nameof(BuyOrderMode), ManualOrderModes.MarketExecution)
 .SetDisplay("Buy Mode", "Execution mode for buy requests.", "Manual Controls");
 
-_sellOrderMode = Param(nameof(SellOrderMode), ManualOrderMode.MarketExecution)
+_sellOrderMode = Param(nameof(SellOrderMode), ManualOrderModes.MarketExecution)
 .SetDisplay("Sell Mode", "Execution mode for sell requests.", "Manual Controls");
 
 _buyAutomaticPrice = Param(nameof(UseAutomaticBuyPrice), true)
@@ -163,7 +163,7 @@ set => _candleType.Value = value;
 /// <summary>
 /// Execution mode for buy requests.
 /// </summary>
-public ManualOrderMode BuyOrderMode
+public ManualOrderModes BuyOrderMode
 {
 get => _buyOrderMode.Value;
 set => _buyOrderMode.Value = value;
@@ -172,7 +172,7 @@ set => _buyOrderMode.Value = value;
 /// <summary>
 /// Execution mode for sell requests.
 /// </summary>
-public ManualOrderMode SellOrderMode
+public ManualOrderModes SellOrderMode
 {
 get => _sellOrderMode.Value;
 set => _sellOrderMode.Value = value;
@@ -401,13 +401,13 @@ return;
 
 switch (BuyOrderMode)
 {
-case ManualOrderMode.MarketExecution:
+case ManualOrderModes.MarketExecution:
 BuyMarket(volume);
 LogInfo($"BUY market order submitted. Volume={volume}, Comment={OrderComment}.");
 CompleteBuyRequest();
 break;
 
-case ManualOrderMode.PendingLimit:
+case ManualOrderModes.PendingLimit:
 {
 var price = ResolveBuyPrice(candle, true);
 if (price <= 0m)
@@ -423,7 +423,7 @@ CompleteBuyRequest();
 break;
 }
 
-case ManualOrderMode.PendingStop:
+case ManualOrderModes.PendingStop:
 {
 var price = ResolveBuyPrice(candle, false);
 if (price <= 0m)
@@ -456,13 +456,13 @@ return;
 
 switch (SellOrderMode)
 {
-case ManualOrderMode.MarketExecution:
+case ManualOrderModes.MarketExecution:
 SellMarket(volume);
 LogInfo($"SELL market order submitted. Volume={volume}, Comment={OrderComment}.");
 CompleteSellRequest();
 break;
 
-case ManualOrderMode.PendingLimit:
+case ManualOrderModes.PendingLimit:
 {
 var price = ResolveSellPrice(candle, true);
 if (price <= 0m)
@@ -478,7 +478,7 @@ CompleteSellRequest();
 break;
 }
 
-case ManualOrderMode.PendingStop:
+case ManualOrderModes.PendingStop:
 {
 var price = ResolveSellPrice(candle, false);
 if (price <= 0m)

--- a/API/3387_Manual_Trading_Lightweight_Utility_Panel/CS/ManualTradingLightweightUtilityPanelStrategy.cs
+++ b/API/3387_Manual_Trading_Lightweight_Utility_Panel/CS/ManualTradingLightweightUtilityPanelStrategy.cs
@@ -13,14 +13,14 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-public enum ManualTradingOrderType
+public enum ManualTradingOrderTypes
 {
 	MarketExecution,
 	PendingLimit,
 	PendingStop
 }
 
-public enum ManualPriceMode
+public enum ManualPriceModes
 {
 	Market,
 	Manual
@@ -43,10 +43,10 @@ public class ManualTradingLightweightUtilityPanelStrategy : Strategy
 
 	private readonly StrategyParam<decimal> _sellVolume;
 	private readonly StrategyParam<decimal> _buyVolume;
-	private readonly StrategyParam<ManualTradingOrderType> _sellOrderType;
-	private readonly StrategyParam<ManualTradingOrderType> _buyOrderType;
-	private readonly StrategyParam<ManualPriceMode> _sellPriceMode;
-	private readonly StrategyParam<ManualPriceMode> _buyPriceMode;
+	private readonly StrategyParam<ManualTradingOrderTypes> _sellOrderType;
+	private readonly StrategyParam<ManualTradingOrderTypes> _buyOrderType;
+	private readonly StrategyParam<ManualPriceModes> _sellPriceMode;
+	private readonly StrategyParam<ManualPriceModes> _buyPriceMode;
 	private readonly StrategyParam<decimal> _sellManualPrice;
 	private readonly StrategyParam<decimal> _buyManualPrice;
 	private readonly StrategyParam<bool> _sendSellOrder;
@@ -107,17 +107,17 @@ public class ManualTradingLightweightUtilityPanelStrategy : Strategy
 			.SetDisplay("Buy Volume", "Volume used for buy orders when Lot Control is enabled.", "Buy")
 			.SetCanOptimize(false);
 
-		_sellOrderType = Param(nameof(SellOrderType), ManualTradingOrderType.MarketExecution)
+		_sellOrderType = Param(nameof(SellOrderType), ManualTradingOrderTypes.MarketExecution)
 			.SetDisplay("Sell Order Type", "Order type used when submitting sell orders.", "Sell");
 
-		_buyOrderType = Param(nameof(BuyOrderType), ManualTradingOrderType.MarketExecution)
+		_buyOrderType = Param(nameof(BuyOrderType), ManualTradingOrderTypes.MarketExecution)
 			.SetDisplay("Buy Order Type", "Order type used when submitting buy orders.", "Buy");
 
-		_sellPriceMode = Param(nameof(SellPriceMode), ManualPriceMode.Market)
+		_sellPriceMode = Param(nameof(SellPriceMode), ManualPriceModes.Market)
 			.SetDisplay("Sell Price Mode", "Select automatic or manual price handling for sell orders.", "Sell")
 			.SetCanOptimize(false);
 
-		_buyPriceMode = Param(nameof(BuyPriceMode), ManualPriceMode.Market)
+		_buyPriceMode = Param(nameof(BuyPriceMode), ManualPriceModes.Market)
 			.SetDisplay("Buy Price Mode", "Select automatic or manual price handling for buy orders.", "Buy")
 			.SetCanOptimize(false);
 
@@ -204,25 +204,25 @@ public class ManualTradingLightweightUtilityPanelStrategy : Strategy
 		set => _buyVolume.Value = value;
 	}
 
-	public ManualTradingOrderType SellOrderType
+	public ManualTradingOrderTypes SellOrderType
 	{
 		get => _sellOrderType.Value;
 		set => _sellOrderType.Value = value;
 	}
 
-	public ManualTradingOrderType BuyOrderType
+	public ManualTradingOrderTypes BuyOrderType
 	{
 		get => _buyOrderType.Value;
 		set => _buyOrderType.Value = value;
 	}
 
-	public ManualPriceMode SellPriceMode
+	public ManualPriceModes SellPriceMode
 	{
 		get => _sellPriceMode.Value;
 		set => _sellPriceMode.Value = value;
 	}
 
-	public ManualPriceMode BuyPriceMode
+	public ManualPriceModes BuyPriceMode
 	{
 		get => _buyPriceMode.Value;
 		set => _buyPriceMode.Value = value;
@@ -324,12 +324,12 @@ public class ManualTradingLightweightUtilityPanelStrategy : Strategy
 		UpdateAutoPrice(Sides.Buy, BuyOrderType, BuyPriceMode, value => BuyManualPrice = value);
 	}
 
-	private void UpdateAutoPrice(Sides side, ManualTradingOrderType orderType, ManualPriceMode mode, Action<decimal> setter)
+	private void UpdateAutoPrice(Sides side, ManualTradingOrderTypes orderType, ManualPriceModes mode, Action<decimal> setter)
 	{
-		if (mode == ManualPriceMode.Manual)
+		if (mode == ManualPriceModes.Manual)
 			return;
 
-		if (orderType == ManualTradingOrderType.MarketExecution)
+		if (orderType == ManualTradingOrderTypes.MarketExecution)
 		{
 			setter(0m);
 			return;
@@ -386,7 +386,7 @@ public class ManualTradingLightweightUtilityPanelStrategy : Strategy
 		}
 	}
 
-	private void SendOrder(Sides side, ManualTradingOrderType orderType, ManualPriceMode priceMode, decimal manualPrice, decimal volume)
+	private void SendOrder(Sides side, ManualTradingOrderTypes orderType, ManualPriceModes priceMode, decimal manualPrice, decimal volume)
 	{
 		if (volume <= 0m)
 		{
@@ -405,10 +405,10 @@ public class ManualTradingLightweightUtilityPanelStrategy : Strategy
 
 		switch (orderType)
 		{
-			case ManualTradingOrderType.MarketExecution:
+			case ManualTradingOrderTypes.MarketExecution:
 				SubmitMarketOrder(side, adjustedVolume);
 				break;
-			case ManualTradingOrderType.PendingLimit:
+			case ManualTradingOrderTypes.PendingLimit:
 				if (orderPrice == null)
 				{
 					LogWarning($"{side} limit order skipped because price is unavailable.");
@@ -417,7 +417,7 @@ public class ManualTradingLightweightUtilityPanelStrategy : Strategy
 
 				SubmitLimitOrder(side, adjustedVolume, orderPrice.Value);
 				break;
-			case ManualTradingOrderType.PendingStop:
+			case ManualTradingOrderTypes.PendingStop:
 				if (orderPrice == null)
 				{
 					LogWarning($"{side} stop order skipped because price is unavailable.");
@@ -467,15 +467,15 @@ public class ManualTradingLightweightUtilityPanelStrategy : Strategy
 			SellStop(volume, normalizedPrice);
 	}
 
-	private decimal? ResolveOrderPrice(Sides side, ManualTradingOrderType orderType, ManualPriceMode mode, decimal manualPrice)
+	private decimal? ResolveOrderPrice(Sides side, ManualTradingOrderTypes orderType, ManualPriceModes mode, decimal manualPrice)
 	{
-		if (orderType == ManualTradingOrderType.MarketExecution)
+		if (orderType == ManualTradingOrderTypes.MarketExecution)
 			return null;
 
-		if (mode == ManualPriceMode.Manual && manualPrice > 0m)
+		if (mode == ManualPriceModes.Manual && manualPrice > 0m)
 			return manualPrice;
 
-		if (mode == ManualPriceMode.Manual)
+		if (mode == ManualPriceModes.Manual)
 		{
 			var fallback = ComputeManualFallbackPrice(side, orderType);
 			if (fallback != null)
@@ -485,7 +485,7 @@ public class ManualTradingLightweightUtilityPanelStrategy : Strategy
 		return ComputeAutoPrice(side, orderType);
 	}
 
-	private decimal? ComputeManualFallbackPrice(Sides side, ManualTradingOrderType orderType)
+	private decimal? ComputeManualFallbackPrice(Sides side, ManualTradingOrderTypes orderType)
 	{
 		var reference = side == Sides.Sell ? _lastBid ?? _lastTrade : _lastAsk ?? _lastTrade;
 		if (reference == null)
@@ -493,7 +493,7 @@ public class ManualTradingLightweightUtilityPanelStrategy : Strategy
 
 		var offset = GetPriceOffset(PriceStepPoints);
 		if (offset <= 0m)
-			offset = GetPriceOffset(orderType == ManualTradingOrderType.PendingLimit ? LimitOrderPoints : StopOrderPoints);
+			offset = GetPriceOffset(orderType == ManualTradingOrderTypes.PendingLimit ? LimitOrderPoints : StopOrderPoints);
 
 		if (offset <= 0m)
 			return reference;
@@ -502,13 +502,13 @@ public class ManualTradingLightweightUtilityPanelStrategy : Strategy
 		return reference.Value + direction * offset;
 	}
 
-	private decimal? ComputeAutoPrice(Sides side, ManualTradingOrderType orderType)
+	private decimal? ComputeAutoPrice(Sides side, ManualTradingOrderTypes orderType)
 	{
 		var reference = side == Sides.Sell ? _lastBid ?? _lastTrade : _lastAsk ?? _lastTrade;
 		if (reference == null)
 			return null;
 
-		var offset = orderType == ManualTradingOrderType.PendingLimit
+		var offset = orderType == ManualTradingOrderTypes.PendingLimit
 			? GetPriceOffset(LimitOrderPoints)
 			: GetPriceOffset(StopOrderPoints);
 
@@ -516,9 +516,9 @@ public class ManualTradingLightweightUtilityPanelStrategy : Strategy
 		return reference.Value + direction * offset;
 	}
 
-	private static decimal GetPriceDirection(Sides side, ManualTradingOrderType orderType)
+	private static decimal GetPriceDirection(Sides side, ManualTradingOrderTypes orderType)
 	{
-		return (side == Sides.Sell ? 1m : -1m) * (orderType == ManualTradingOrderType.PendingLimit ? 1m : -1m);
+		return (side == Sides.Sell ? 1m : -1m) * (orderType == ManualTradingOrderTypes.PendingLimit ? 1m : -1m);
 	}
 
 	private decimal ResolveVolume(bool isBuy)

--- a/API/3390_Ring_System_EA/CS/RingSystemEaStrategy.cs
+++ b/API/3390_Ring_System_EA/CS/RingSystemEaStrategy.cs
@@ -18,26 +18,26 @@ namespace StockSharp.Samples.Strategies;
 
 public class RingSystemEaStrategy : Strategy
 {
-	private readonly StrategyParam<Oper> _operationParam;
+	private readonly StrategyParam<Operations> _operationParam;
 	private readonly StrategyParam<int> _timerParam;
 	private readonly StrategyParam<string> _currenciesParam;
 	private readonly StrategyParam<string> _skipGroupsParam;
-	private readonly StrategyParam<Side> _sideParam;
-	private readonly StrategyParam<StepMode> _lossModeParam;
+	private readonly StrategyParam<Sides> _sideParam;
+	private readonly StrategyParam<StepModes> _lossModeParam;
 	private readonly StrategyParam<decimal> _stepParam;
-	private readonly StrategyParam<StepProgression> _stepProgressParam;
+	private readonly StrategyParam<StepProgressions> _stepProgressParam;
 	private readonly StrategyParam<int> _minutesParam;
 	private readonly StrategyParam<int> _maxGroupsParam;
-	private readonly StrategyParam<CloseProfitMode> _closeProfitParam;
+	private readonly StrategyParam<CloseProfitModes> _closeProfitParam;
 	private readonly StrategyParam<decimal> _targetProfitParam;
 	private readonly StrategyParam<int> _delayProfitParam;
-	private readonly StrategyParam<CloseLossMode> _closeLossParam;
+	private readonly StrategyParam<CloseLossModes> _closeLossParam;
 	private readonly StrategyParam<decimal> _targetLossParam;
 	private readonly StrategyParam<int> _delayLossParam;
 	private readonly StrategyParam<bool> _autoLotParam;
 	private readonly StrategyParam<decimal> _riskParam;
 	private readonly StrategyParam<decimal> _manualLotParam;
-	private readonly StrategyParam<LotProgression> _lotProgressParam;
+	private readonly StrategyParam<LotProgressions> _lotProgressParam;
 	private readonly StrategyParam<bool> _fairLotParam;
 	private readonly StrategyParam<decimal> _maxLotParam;
 	private readonly StrategyParam<bool> _controlSessionParam;
@@ -65,7 +65,7 @@ public class RingSystemEaStrategy : Strategy
 
 	public RingSystemEaStrategy()
 	{
-		_operationParam = Param(nameof(TypeOfOperation), Oper.NormalOperation)
+		_operationParam = Param(nameof(TypeOfOperation), Operations.NormalOperation)
 			.SetDisplay("Operation Mode", "Defines how the basket operates", "Core")
 			.SetDescription("Matches the four MT4 modes: standby, trading, close on profit, or emergency close.");
 
@@ -79,17 +79,17 @@ public class RingSystemEaStrategy : Strategy
 		_skipGroupsParam = Param(nameof(NoOfGroupToSkip), "57,58,59,60")
 			.SetDisplay("Skip Groups", "Comma separated group numbers to disable", "Universe");
 
-		_sideParam = Param(nameof(SideOpenOrders), Side.OpenPlusAndMinus)
+		_sideParam = Param(nameof(SideOpenOrders), Sides.OpenPlusAndMinus)
 			.SetDisplay("Allowed Sides", "Choose whether plus, minus or both baskets trade", "Core");
 
-		_lossModeParam = Param(nameof(OpenOrdersInLoss), StepMode.OpenWithManualStep)
+		_lossModeParam = Param(nameof(OpenOrdersInLoss), StepModes.OpenWithManualStep)
 			.SetDisplay("Loss Mode", "Controls re-entry when basket is in loss", "Trading");
 
 		_stepParam = Param(nameof(StepOpenNextOrders), 200m)
 			.SetDisplay("Next Step", "Loss level that triggers additional orders", "Trading")
 			.SetGreaterThanZero();
 
-		_stepProgressParam = Param(nameof(StepOrdersProgress), StepProgression.StaticalStep)
+		_stepProgressParam = Param(nameof(StepOrdersProgress), StepProgressions.StaticalStep)
 			.SetDisplay("Step Progression", "How loss thresholds scale with new orders", "Trading");
 
 		_minutesParam = Param(nameof(MinutesForNextOrder), 60)
@@ -100,7 +100,7 @@ public class RingSystemEaStrategy : Strategy
 			.SetDisplay("Max Groups", "Simultaneous groups allowed (0 = unlimited)", "Trading")
 			.SetGreaterThanOrEqualTo(0);
 
-		_closeProfitParam = Param(nameof(TypeCloseInProfit), CloseProfitMode.SingleTicket)
+		_closeProfitParam = Param(nameof(TypeCloseInProfit), CloseProfitModes.SingleTicket)
 			.SetDisplay("Profit Close", "Scope of profit based exits", "Risk");
 
 		_targetProfitParam = Param(nameof(TargetCloseProfit), 200m)
@@ -111,7 +111,7 @@ public class RingSystemEaStrategy : Strategy
 			.SetDisplay("Profit Delay", "Number of evaluations before closing", "Risk")
 			.SetGreaterThanOrEqualTo(1);
 
-		_closeLossParam = Param(nameof(TypeCloseInLoss), CloseLossMode.NotCloseInLoss)
+		_closeLossParam = Param(nameof(TypeCloseInLoss), CloseLossModes.NotCloseInLoss)
 			.SetDisplay("Loss Close", "How losses are handled", "Risk");
 
 		_targetLossParam = Param(nameof(TargetCloseLoss), 1000m)
@@ -133,7 +133,7 @@ public class RingSystemEaStrategy : Strategy
 			.SetDisplay("Manual Lot", "Base lot when auto sizing is disabled", "Money")
 			.SetGreaterThanZero();
 
-		_lotProgressParam = Param(nameof(LotOrdersProgress), LotProgression.StaticalLot)
+		_lotProgressParam = Param(nameof(LotOrdersProgress), LotProgressions.StaticalLot)
 			.SetDisplay("Lot Progression", "Scaling rule for successive orders", "Money");
 
 		_fairLotParam = Param(nameof(UseFairLotSize), false)
@@ -189,7 +189,7 @@ public class RingSystemEaStrategy : Strategy
 			.SetDisplay("Candle Type", "Primary timeframe for calculations", "Data");
 	}
 
-	public Oper TypeOfOperation
+	public Operations TypeOfOperation
 	{
 		get => _operationParam.Value;
 		set => _operationParam.Value = value;
@@ -213,13 +213,13 @@ public class RingSystemEaStrategy : Strategy
 		set => _skipGroupsParam.Value = value;
 	}
 
-	public Side SideOpenOrders
+	public Sides SideOpenOrders
 	{
 		get => _sideParam.Value;
 		set => _sideParam.Value = value;
 	}
 
-	public StepMode OpenOrdersInLoss
+	public StepModes OpenOrdersInLoss
 	{
 		get => _lossModeParam.Value;
 		set => _lossModeParam.Value = value;
@@ -231,7 +231,7 @@ public class RingSystemEaStrategy : Strategy
 		set => _stepParam.Value = value;
 	}
 
-	public StepProgression StepOrdersProgress
+	public StepProgressions StepOrdersProgress
 	{
 		get => _stepProgressParam.Value;
 		set => _stepProgressParam.Value = value;
@@ -249,7 +249,7 @@ public class RingSystemEaStrategy : Strategy
 		set => _maxGroupsParam.Value = value;
 	}
 
-	public CloseProfitMode TypeCloseInProfit
+	public CloseProfitModes TypeCloseInProfit
 	{
 		get => _closeProfitParam.Value;
 		set => _closeProfitParam.Value = value;
@@ -267,7 +267,7 @@ public class RingSystemEaStrategy : Strategy
 		set => _delayProfitParam.Value = value;
 	}
 
-	public CloseLossMode TypeCloseInLoss
+	public CloseLossModes TypeCloseInLoss
 	{
 		get => _closeLossParam.Value;
 		set => _closeLossParam.Value = value;
@@ -303,7 +303,7 @@ public class RingSystemEaStrategy : Strategy
 		set => _manualLotParam.Value = value;
 	}
 
-	public LotProgression LotOrdersProgress
+	public LotProgressions LotOrdersProgress
 	{
 		get => _lotProgressParam.Value;
 		set => _lotProgressParam.Value = value;
@@ -554,7 +554,7 @@ public class RingSystemEaStrategy : Strategy
 
 		UpdateProfits(group);
 
-		if (TypeOfOperation == Oper.CloseImmediatelyAllOrders)
+		if (TypeOfOperation == Operations.CloseImmediatelyAllOrders)
 		{
 			CloseGroup(group);
 			return;
@@ -567,7 +567,7 @@ public class RingSystemEaStrategy : Strategy
 		if (!IsSessionAllowed(time))
 			return;
 
-		if (TypeCloseInProfit == CloseProfitMode.BasketTicket)
+		if (TypeCloseInProfit == CloseProfitModes.BasketTicket)
 		{
 			HandleBasketClose(group);
 		}
@@ -577,31 +577,31 @@ public class RingSystemEaStrategy : Strategy
 			HandleSideClose(group, false);
 		}
 
-		if (TypeCloseInProfit == CloseProfitMode.PairByPair)
+		if (TypeCloseInProfit == CloseProfitModes.PairByPair)
 		{
 			HandlePairClose(group, true);
 			HandlePairClose(group, false);
 		}
 
-		if (TypeCloseInLoss != CloseLossMode.NotCloseInLoss)
+		if (TypeCloseInLoss != CloseLossModes.NotCloseInLoss)
 		{
 			HandleLossExit(group, true);
 			HandleLossExit(group, false);
 		}
 
-		if (TypeOfOperation == Oper.CloseInProfitAndStop)
+		if (TypeOfOperation == Operations.CloseInProfitAndStop)
 			return;
 
-		if (TypeOfOperation == Oper.StandByMode)
+		if (TypeOfOperation == Operations.StandByMode)
 			return;
 
 		if (MaximumGroups > 0 && ActiveGroupCount() >= MaximumGroups && !group.IsActive)
 			return;
 
-		if (SideOpenOrders == Side.OpenOnlyPlus || SideOpenOrders == Side.OpenPlusAndMinus)
+		if (SideOpenOrders == Sides.OpenOnlyPlus || SideOpenOrders == Sides.OpenPlusAndMinus)
 			HandleOpen(group, true, time);
 
-		if (SideOpenOrders == Side.OpenOnlyMinus || SideOpenOrders == Side.OpenPlusAndMinus)
+		if (SideOpenOrders == Sides.OpenOnlyMinus || SideOpenOrders == Sides.OpenPlusAndMinus)
 			HandleOpen(group, false, time);
 	}
 
@@ -627,7 +627,7 @@ public class RingSystemEaStrategy : Strategy
 			group.Minus.ProfitDelay = 0;
 		}
 
-		if (TypeCloseInLoss == CloseLossMode.WholeTicket && profit <= -TargetCloseLoss)
+		if (TypeCloseInLoss == CloseLossModes.WholeTicket && profit <= -TargetCloseLoss)
 		{
 			if (++group.Plus.LossDelay >= DelayCloseLoss && ++group.Minus.LossDelay >= DelayCloseLoss)
 			{
@@ -646,7 +646,7 @@ public class RingSystemEaStrategy : Strategy
 		var side = isPlus ? group.Plus : group.Minus;
 		var profit = side.Profit;
 
-		if (profit >= TargetCloseProfit && TypeCloseInProfit == CloseProfitMode.SingleTicket)
+		if (profit >= TargetCloseProfit && TypeCloseInProfit == CloseProfitModes.SingleTicket)
 		{
 			if (++side.ProfitDelay >= DelayCloseProfit)
 			{
@@ -658,7 +658,7 @@ public class RingSystemEaStrategy : Strategy
 			side.ProfitDelay = 0;
 		}
 
-		if (profit <= -TargetCloseLoss && TypeCloseInLoss == CloseLossMode.WholeTicket)
+		if (profit <= -TargetCloseLoss && TypeCloseInLoss == CloseLossModes.WholeTicket)
 		{
 			if (++side.LossDelay >= DelayCloseLoss)
 			{
@@ -692,7 +692,7 @@ public class RingSystemEaStrategy : Strategy
 	private void HandleLossExit(GroupState group, bool isPlus)
 	{
 		var side = isPlus ? group.Plus : group.Minus;
-		if (TypeCloseInLoss == CloseLossMode.PartialTicket && side.Profit <= -TargetCloseLoss)
+		if (TypeCloseInLoss == CloseLossModes.PartialTicket && side.Profit <= -TargetCloseLoss)
 		{
 			if (++side.LossDelay >= DelayCloseLoss)
 			{
@@ -712,7 +712,7 @@ public class RingSystemEaStrategy : Strategy
 			return;
 		}
 
-		if (OpenOrdersInLoss == StepMode.NotOpenInLoss)
+		if (OpenOrdersInLoss == StepModes.NotOpenInLoss)
 			return;
 
 		var threshold = GetNextThreshold(side.Orders);
@@ -908,10 +908,10 @@ public class RingSystemEaStrategy : Strategy
 	{
 		return LotOrdersProgress switch
 		{
-			LotProgression.StaticalLot => 1m,
-			LotProgression.GeometricalLot => (decimal)Math.Pow(2, orderIndex),
-			LotProgression.ExponentialLot => (decimal)Math.Pow(3, orderIndex),
-			LotProgression.DecreasesLot => 1m / Math.Max(1, orderIndex + 1),
+			LotProgressions.StaticalLot => 1m,
+			LotProgressions.GeometricalLot => (decimal)Math.Pow(2, orderIndex),
+			LotProgressions.ExponentialLot => (decimal)Math.Pow(3, orderIndex),
+			LotProgressions.DecreasesLot => 1m / Math.Max(1, orderIndex + 1),
 			_ => 1m
 		};
 	}
@@ -920,9 +920,9 @@ public class RingSystemEaStrategy : Strategy
 	{
 		var multiplier = StepOrdersProgress switch
 		{
-			StepProgression.StaticalStep => 1m,
-			StepProgression.GeometricalStep => orderIndex + 1m,
-			StepProgression.ExponentialStep => (decimal)Math.Pow(2, orderIndex),
+			StepProgressions.StaticalStep => 1m,
+			StepProgressions.GeometricalStep => orderIndex + 1m,
+			StepProgressions.ExponentialStep => (decimal)Math.Pow(2, orderIndex),
 			_ => 1m
 		};
 
@@ -1234,7 +1234,7 @@ public class RingSystemEaStrategy : Strategy
 		}
 	}
 
-	public enum Oper
+	public enum Operations
 	{
 		StandByMode,
 		NormalOperation,
@@ -1242,42 +1242,42 @@ public class RingSystemEaStrategy : Strategy
 		CloseImmediatelyAllOrders
 	}
 
-	public enum Side
+	public enum Sides
 	{
 		OpenOnlyPlus,
 		OpenOnlyMinus,
 		OpenPlusAndMinus
 	}
 
-	public enum StepMode
+	public enum StepModes
 	{
 		NotOpenInLoss,
 		OpenWithManualStep,
 		OpenWithAutoStep
 	}
 
-	public enum StepProgression
+	public enum StepProgressions
 	{
 		StaticalStep,
 		GeometricalStep,
 		ExponentialStep
 	}
 
-	public enum CloseProfitMode
+	public enum CloseProfitModes
 	{
 		SingleTicket,
 		BasketTicket,
 		PairByPair
 	}
 
-	public enum CloseLossMode
+	public enum CloseLossModes
 	{
 		WholeTicket,
 		PartialTicket,
 		NotCloseInLoss
 	}
 
-	public enum LotProgression
+	public enum LotProgressions
 	{
 		StaticalLot,
 		GeometricalLot,

--- a/API/3391_Couple_Hedge_Basket/CS/CoupleHedgeBasketStrategy.cs
+++ b/API/3391_Couple_Hedge_Basket/CS/CoupleHedgeBasketStrategy.cs
@@ -23,22 +23,22 @@ public class CoupleHedgeBasketStrategy : Strategy
 	private readonly GroupSlot[] _groups;
 	private readonly StrategyParam<int> _groupCount;
 
-	private readonly StrategyParam<OperationMode> _operationMode;
-	private readonly StrategyParam<SideSelection> _sideSelection;
-	private readonly StrategyParam<StepMode> _stepMode;
-	private readonly StrategyParam<StepProgression> _stepProgression;
+	private readonly StrategyParam<OperationModes> _operationMode;
+	private readonly StrategyParam<SideSelections> _sideSelection;
+	private readonly StrategyParam<StepModes> _stepMode;
+	private readonly StrategyParam<StepProgressions> _stepProgression;
 	private readonly StrategyParam<int> _minutesBetweenOrders;
 	private readonly StrategyParam<int> _maximumGroups;
-	private readonly StrategyParam<CloseProfitMode> _closeProfitMode;
+	private readonly StrategyParam<CloseProfitModes> _closeProfitMode;
 	private readonly StrategyParam<decimal> _targetCloseProfit;
 	private readonly StrategyParam<int> _delayCloseProfit;
-	private readonly StrategyParam<CloseLossMode> _closeLossMode;
+	private readonly StrategyParam<CloseLossModes> _closeLossMode;
 	private readonly StrategyParam<decimal> _targetCloseLoss;
 	private readonly StrategyParam<int> _delayCloseLoss;
 	private readonly StrategyParam<bool> _autoLot;
 	private readonly StrategyParam<decimal> _riskFactor;
 	private readonly StrategyParam<decimal> _manualLotSize;
-	private readonly StrategyParam<LotProgression> _lotProgression;
+	private readonly StrategyParam<LotProgressions> _lotProgression;
 	private readonly StrategyParam<decimal> _lotProgressionFactor;
 	private readonly StrategyParam<decimal> _stepProgressionFactor;
 	private readonly StrategyParam<bool> _useFairLotSize;
@@ -57,7 +57,7 @@ public class CoupleHedgeBasketStrategy : Strategy
 	/// <summary>
 	/// Mode that controls how the strategy should behave.
 	/// </summary>
-	public OperationMode OperationMode
+	public OperationModes OperationModes
 	{
 		get => _operationMode.Value;
 		set => _operationMode.Value = value;
@@ -66,7 +66,7 @@ public class CoupleHedgeBasketStrategy : Strategy
 	/// <summary>
 	/// Selects which sides of the hedge should be traded.
 	/// </summary>
-	public SideSelection SideSelection
+	public SideSelections SideSelections
 	{
 		get => _sideSelection.Value;
 		set => _sideSelection.Value = value;
@@ -75,7 +75,7 @@ public class CoupleHedgeBasketStrategy : Strategy
 	/// <summary>
 	/// Defines how new entries in loss should be opened.
 	/// </summary>
-	public StepMode StepMode
+	public StepModes StepModes
 	{
 		get => _stepMode.Value;
 		set => _stepMode.Value = value;
@@ -84,7 +84,7 @@ public class CoupleHedgeBasketStrategy : Strategy
 	/// <summary>
 	/// Pattern used to extend the entry step when averaging down.
 	/// </summary>
-	public StepProgression StepProgression
+	public StepProgressions StepProgressions
 	{
 		get => _stepProgression.Value;
 		set => _stepProgression.Value = value;
@@ -117,7 +117,7 @@ public class CoupleHedgeBasketStrategy : Strategy
 	/// <summary>
 	/// Determines the closing behaviour when the basket is profitable.
 	/// </summary>
-	public CloseProfitMode CloseProfitMode
+	public CloseProfitModes CloseProfitModes
 	{
 		get => _closeProfitMode.Value;
 		set => _closeProfitMode.Value = value;
@@ -144,7 +144,7 @@ public class CoupleHedgeBasketStrategy : Strategy
 	/// <summary>
 	/// Determines how to close the basket when it is losing.
 	/// </summary>
-	public CloseLossMode CloseLossMode
+	public CloseLossModes CloseLossModes
 	{
 		get => _closeLossMode.Value;
 		set => _closeLossMode.Value = value;
@@ -198,7 +198,7 @@ public class CoupleHedgeBasketStrategy : Strategy
 	/// <summary>
 	/// Progression applied to volumes when scaling into a basket.
 	/// </summary>
-	public LotProgression LotProgression
+	public LotProgressions LotProgressions
 	{
 		get => _lotProgression.Value;
 		set => _lotProgression.Value = value;
@@ -335,16 +335,16 @@ public class CoupleHedgeBasketStrategy : Strategy
 	/// </summary>
 	public CoupleHedgeBasketStrategy()
 	{
-		_operationMode = Param(nameof(OperationMode), OperationMode.NormalOperation)
+		_operationMode = Param(nameof(OperationModes), OperationModes.NormalOperation)
 		.SetDisplay("Operation Mode", "Select how the robot behaves", "General");
 
-		_sideSelection = Param(nameof(SideSelection), SideSelection.OpenPlusAndMinus)
+		_sideSelection = Param(nameof(SideSelections), SideSelections.OpenPlusAndMinus)
 		.SetDisplay("Side Selection", "Choose which sides should be traded", "General");
 
-		_stepMode = Param(nameof(StepMode), StepMode.OpenWithManualStep)
+		_stepMode = Param(nameof(StepModes), StepModes.OpenWithManualStep)
 		.SetDisplay("Step Mode", "How new baskets are opened", "Risk Management");
 
-		_stepProgression = Param(nameof(StepProgression), StepProgression.Geometrical)
+		_stepProgression = Param(nameof(StepProgressions), StepProgressions.Geometrical)
 		.SetDisplay("Step Progression", "How the step grows when adding baskets", "Risk Management");
 
 		_minutesBetweenOrders = Param(nameof(MinutesBetweenOrders), 5)
@@ -355,7 +355,7 @@ public class CoupleHedgeBasketStrategy : Strategy
 		.SetNotNegative()
 		.SetDisplay("Maximum Groups", "Limit the number of simultaneously trading groups", "General");
 
-		_closeProfitMode = Param(nameof(CloseProfitMode), CloseProfitMode.BothSides)
+		_closeProfitMode = Param(nameof(CloseProfitModes), CloseProfitModes.BothSides)
 		.SetDisplay("Close Profit Mode", "How baskets are closed when profitable", "Exits");
 
 		_targetCloseProfit = Param(nameof(TargetCloseProfit), 100m)
@@ -367,7 +367,7 @@ public class CoupleHedgeBasketStrategy : Strategy
 		.SetNotNegative()
 		.SetDisplay("Profit Delay", "Seconds to wait before closing in profit", "Exits");
 
-		_closeLossMode = Param(nameof(CloseLossMode), CloseLossMode.NotCloseInLoss)
+		_closeLossMode = Param(nameof(CloseLossModes), CloseLossModes.NotCloseInLoss)
 		.SetDisplay("Close Loss Mode", "How baskets are closed when losing", "Exits");
 
 		_targetCloseLoss = Param(nameof(TargetCloseLoss), 1000m)
@@ -391,7 +391,7 @@ public class CoupleHedgeBasketStrategy : Strategy
 		.SetDisplay("Manual Lot", "Fixed volume when auto lot is disabled", "Position Sizing")
 		.SetCanOptimize(true);
 
-		_lotProgression = Param(nameof(LotProgression), LotProgression.Geometrical)
+		_lotProgression = Param(nameof(LotProgressions), LotProgressions.Geometrical)
 		.SetDisplay("Lot Progression", "How volume grows for additional baskets", "Position Sizing");
 
 		_lotProgressionFactor = Param(nameof(ProgressionFactor), 1.5m)
@@ -537,16 +537,16 @@ public class CoupleHedgeBasketStrategy : Strategy
 		if (!IsTradingAllowed(now))
 		return;
 
-		var operation = OperationMode;
+		var operation = OperationModes;
 
-		if (operation == OperationMode.StandBy)
+		if (operation == OperationModes.StandBy)
 		return;
 
 		var plusVolume = slot.GetPositionVolume(slot.PlusSecurity, Portfolio, this);
 		var minusVolume = slot.GetPositionVolume(slot.MinusSecurity, Portfolio, this);
 		var hasOpenPositions = plusVolume != 0m || minusVolume != 0m;
 
-		if (operation == OperationMode.CloseImmediatelyAllOrders)
+		if (operation == OperationModes.CloseImmediatelyAllOrders)
 		{
 			// Emergency flatten request from the parameter set.
 			if (hasOpenPositions)
@@ -554,7 +554,7 @@ public class CoupleHedgeBasketStrategy : Strategy
 			return;
 		}
 
-		if (operation == OperationMode.CloseInProfitAndStop && !hasOpenPositions && slot.HasCompletedCycle)
+		if (operation == OperationModes.CloseInProfitAndStop && !hasOpenPositions && slot.HasCompletedCycle)
 		return;
 
 		var groupProfit = GetGroupProfit(slot);
@@ -573,7 +573,7 @@ public class CoupleHedgeBasketStrategy : Strategy
 			return;
 		}
 
-		if (operation == OperationMode.CloseInProfitAndStop)
+		if (operation == OperationModes.CloseInProfitAndStop)
 		return;
 
 		// Abort if the infrastructure is not ready (for example during reconnects).
@@ -584,7 +584,7 @@ public class CoupleHedgeBasketStrategy : Strategy
 		if (!CanOpenMoreBaskets(slot, now))
 		return;
 
-		var stepTrigger = slot.GetNextOpenTrigger(StepMode, StepOpenNext, StepProgression, StepProgressionFactor);
+		var stepTrigger = slot.GetNextOpenTrigger(StepModes, StepOpenNext, StepProgressions, StepProgressionFactor);
 
 		if (!ShouldAverage(groupProfit, stepTrigger, hasOpenPositions))
 		return;
@@ -603,7 +603,7 @@ public class CoupleHedgeBasketStrategy : Strategy
 
 	private bool ShouldAverage(decimal groupProfit, decimal trigger, bool hasOpenPositions)
 	{
-		if (StepMode == StepMode.NotOpenInLoss && hasOpenPositions)
+		if (StepModes == StepModes.NotOpenInLoss && hasOpenPositions)
 		return false;
 
 		if (!hasOpenPositions)
@@ -633,7 +633,7 @@ public class CoupleHedgeBasketStrategy : Strategy
 		var plus = slot.PlusSecurity!;
 		var minus = slot.MinusSecurity!;
 
-		var side = SideSelection;
+		var side = SideSelections;
 
 		var plusVolume = lot;
 		var minusVolume = lot;
@@ -661,7 +661,7 @@ public class CoupleHedgeBasketStrategy : Strategy
 
 		switch (side)
 		{
-			case SideSelection.OpenPlusAndMinus:
+			case SideSelections.OpenPlusAndMinus:
 			if (plusVolume > 0m)
 			BuyMarket(plusVolume, security: plus);
 
@@ -669,18 +669,18 @@ public class CoupleHedgeBasketStrategy : Strategy
 			SellMarket(minusVolume, security: minus);
 			break;
 
-			case SideSelection.OpenOnlyPlus:
+			case SideSelections.OpenOnlyPlus:
 			if (plusVolume > 0m)
 			BuyMarket(plusVolume, security: plus);
 			break;
 
-			case SideSelection.OpenOnlyMinus:
+			case SideSelections.OpenOnlyMinus:
 			if (minusVolume > 0m)
 			SellMarket(minusVolume, security: minus);
 			break;
 		}
 
-		slot.RegisterOpen(time, StepMode, StepProgression, StepProgressionFactor, StepOpenNext);
+		slot.RegisterOpen(time, StepModes, StepProgressions, StepProgressionFactor, StepOpenNext);
 	}
 
 	private void CloseGroup(GroupSlot slot, decimal plusVolume, decimal minusVolume)
@@ -727,7 +727,7 @@ public class CoupleHedgeBasketStrategy : Strategy
 			lot = ManualLotSize;
 		}
 
-		var multiplier = slot.GetLotMultiplier(LotProgression, ProgressionFactor);
+		var multiplier = slot.GetLotMultiplier(LotProgressions, ProgressionFactor);
 
 		lot *= multiplier;
 
@@ -739,22 +739,22 @@ public class CoupleHedgeBasketStrategy : Strategy
 		if (TargetCloseProfit <= 0m)
 		return false;
 
-		return CloseProfitMode switch
+		return CloseProfitModes switch
 		{
-			CloseProfitMode.SideBySide => slot.EvaluateSideClose(TargetCloseProfit, plusProfit, minusProfit, DelayCloseProfit, now, true),
+			CloseProfitModes.SideBySide => slot.EvaluateSideClose(TargetCloseProfit, plusProfit, minusProfit, DelayCloseProfit, now, true),
 			_ => slot.EvaluateBasketClose(TargetCloseProfit, groupProfit, DelayCloseProfit, now, true),
 		};
 	}
 
 	private bool ShouldCloseInLoss(GroupSlot slot, decimal groupProfit, decimal plusProfit, decimal minusProfit, DateTimeOffset now)
 	{
-		if (TargetCloseLoss <= 0m || CloseLossMode == CloseLossMode.NotCloseInLoss)
+		if (TargetCloseLoss <= 0m || CloseLossModes == CloseLossModes.NotCloseInLoss)
 		return false;
 
-		return CloseLossMode switch
+		return CloseLossModes switch
 		{
-			CloseLossMode.WholeSide => slot.EvaluateSideClose(TargetCloseLoss, plusProfit, minusProfit, DelayCloseLoss, now, false),
-			CloseLossMode.PartialSide => slot.EvaluateBasketClose(TargetCloseLoss, groupProfit, DelayCloseLoss, now, false),
+			CloseLossModes.WholeSide => slot.EvaluateSideClose(TargetCloseLoss, plusProfit, minusProfit, DelayCloseLoss, now, false),
+			CloseLossModes.PartialSide => slot.EvaluateBasketClose(TargetCloseLoss, groupProfit, DelayCloseLoss, now, false),
 			_ => false,
 		};
 	}
@@ -1038,19 +1038,19 @@ public class CoupleHedgeBasketStrategy : Strategy
 			return step > 0m ? step : 1m;
 		}
 
-		public decimal GetLotMultiplier(LotProgression mode, decimal factor)
+		public decimal GetLotMultiplier(LotProgressions mode, decimal factor)
 		{
 			return mode switch
 			{
-				LotProgression.StaticalLot => 1m,
-				LotProgression.GeometricalLot => (decimal)Math.Pow((double)factor, BasketNumber),
-				LotProgression.ExponentialLot => (decimal)Math.Exp(BasketNumber * Math.Log((double)Math.Max(factor, 1.0001m))),
-				LotProgression.DecreasesLot => 1m / (decimal)Math.Pow((double)factor, BasketNumber),
+				LotProgressions.StaticalLot => 1m,
+				LotProgressions.GeometricalLot => (decimal)Math.Pow((double)factor, BasketNumber),
+				LotProgressions.ExponentialLot => (decimal)Math.Exp(BasketNumber * Math.Log((double)Math.Max(factor, 1.0001m))),
+				LotProgressions.DecreasesLot => 1m / (decimal)Math.Pow((double)factor, BasketNumber),
 				_ => 1m,
 			};
 		}
 
-		public decimal GetNextOpenTrigger(StepMode mode, decimal initial, StepProgression progression, decimal factor)
+		public decimal GetNextOpenTrigger(StepModes mode, decimal initial, StepProgressions progression, decimal factor)
 		{
 			if (BasketNumber == 0 || _nextTrigger == 0m)
 			{
@@ -1061,16 +1061,16 @@ public class CoupleHedgeBasketStrategy : Strategy
 			return _nextTrigger;
 		}
 
-		private decimal CalculateBaseStep(StepMode mode, decimal initial)
+		private decimal CalculateBaseStep(StepModes mode, decimal initial)
 		{
 			return mode switch
 			{
-				StepMode.OpenWithAutoStep => _rangeAverage > 0m ? Math.Max(initial, _rangeAverage) : initial,
+				StepModes.OpenWithAutoStep => _rangeAverage > 0m ? Math.Max(initial, _rangeAverage) : initial,
 				_ => initial,
 			};
 		}
 
-		public void RegisterOpen(DateTimeOffset time, StepMode mode, StepProgression progression, decimal factor, decimal initial)
+		public void RegisterOpen(DateTimeOffset time, StepModes mode, StepProgressions progression, decimal factor, decimal initial)
 		{
 			LastOpenTime = time;
 			BasketNumber++;
@@ -1082,9 +1082,9 @@ public class CoupleHedgeBasketStrategy : Strategy
 
 			var multiplier = progression switch
 			{
-				StepProgression.StaticalStep => 1m,
-				StepProgression.GeometricalStep => (decimal)Math.Pow((double)factor, BasketNumber),
-				StepProgression.ExponentialStep => (decimal)Math.Exp(BasketNumber * Math.Log((double)Math.Max(factor, 1.0001m))),
+				StepProgressions.StaticalStep => 1m,
+				StepProgressions.GeometricalStep => (decimal)Math.Pow((double)factor, BasketNumber),
+				StepProgressions.ExponentialStep => (decimal)Math.Exp(BasketNumber * Math.Log((double)Math.Max(factor, 1.0001m))),
 				_ => 1m,
 			};
 
@@ -1183,7 +1183,7 @@ public class CoupleHedgeBasketStrategy : Strategy
 	/// <summary>
 	/// Trading modes available for the strategy.
 	/// </summary>
-	public enum OperationMode
+	public enum OperationModes
 	{
 		StandBy,
 		NormalOperation,
@@ -1194,7 +1194,7 @@ public class CoupleHedgeBasketStrategy : Strategy
 	/// <summary>
 	/// Which sides of the hedge should be traded.
 	/// </summary>
-	public enum SideSelection
+	public enum SideSelections
 	{
 		OpenOnlyPlus,
 		OpenOnlyMinus,
@@ -1204,7 +1204,7 @@ public class CoupleHedgeBasketStrategy : Strategy
 	/// <summary>
 	/// Defines how new baskets should be opened when the current basket is losing.
 	/// </summary>
-	public enum StepMode
+	public enum StepModes
 	{
 		NotOpenInLoss,
 		OpenWithManualStep,
@@ -1214,7 +1214,7 @@ public class CoupleHedgeBasketStrategy : Strategy
 	/// <summary>
 	/// Progression rules used to grow the step.
 	/// </summary>
-	public enum StepProgression
+	public enum StepProgressions
 	{
 		StaticalStep,
 		GeometricalStep,
@@ -1224,7 +1224,7 @@ public class CoupleHedgeBasketStrategy : Strategy
 	/// <summary>
 	/// Closing behaviour for profitable baskets.
 	/// </summary>
-	public enum CloseProfitMode
+	public enum CloseProfitModes
 	{
 		SideBySide,
 		BothSides,
@@ -1236,7 +1236,7 @@ public class CoupleHedgeBasketStrategy : Strategy
 	/// <summary>
 	/// Closing behaviour for losing baskets.
 	/// </summary>
-	public enum CloseLossMode
+	public enum CloseLossModes
 	{
 		WholeSide,
 		PartialSide,
@@ -1246,7 +1246,7 @@ public class CoupleHedgeBasketStrategy : Strategy
 	/// <summary>
 	/// Lot progression rules when scaling into a basket.
 	/// </summary>
-	public enum LotProgression
+	public enum LotProgressions
 	{
 		StaticalLot,
 		GeometricalLot,

--- a/API/3394_Virtual_Profit_Close/CS/VirtualProfitCloseStrategy.cs
+++ b/API/3394_Virtual_Profit_Close/CS/VirtualProfitCloseStrategy.cs
@@ -18,7 +18,7 @@ using StockSharp.Messages;
 /// </summary>
 public class VirtualProfitCloseStrategy : Strategy
 {
-	private enum DemoDirection
+	private enum DemoDirections
 	{
 		Sell,
 		Buy
@@ -29,7 +29,7 @@ public class VirtualProfitCloseStrategy : Strategy
 	private readonly StrategyParam<decimal> _trailingOffsetPips;
 	private readonly StrategyParam<decimal> _trailingActivationPips;
 	private readonly StrategyParam<bool> _enableDemoMode;
-	private readonly StrategyParam<DemoDirection> _demoDirection;
+	private readonly StrategyParam<DemoDirections> _demoDirection;
 	private readonly StrategyParam<decimal> _demoVolume;
 	private readonly StrategyParam<decimal> _demoStopPips;
 
@@ -71,7 +71,7 @@ public class VirtualProfitCloseStrategy : Strategy
 		_enableDemoMode = Param(nameof(EnableDemoMode), false)
 			.SetDisplay("Demo Mode", "Automatically open showcase positions", "Testing");
 
-		_demoDirection = Param(nameof(DemoOrderDirection), DemoDirection.Sell)
+		_demoDirection = Param(nameof(DemoOrderDirection), DemoDirections.Sell)
 			.SetDisplay("Demo Direction", "Order side used in demo mode", "Testing");
 
 		_demoVolume = Param(nameof(DemoOrderVolume), 1m)
@@ -131,7 +131,7 @@ public class VirtualProfitCloseStrategy : Strategy
 	/// <summary>
 	/// Direction used for demo orders.
 	/// </summary>
-	public DemoDirection DemoOrderDirection
+	public DemoDirections DemoOrderDirection
 	{
 		get => _demoDirection.Value;
 		set => _demoDirection.Value = value;
@@ -329,13 +329,13 @@ public class VirtualProfitCloseStrategy : Strategy
 
 		switch (DemoOrderDirection)
 		{
-			case DemoDirection.Buy:
+			case DemoDirections.Buy:
 			{
 			BuyMarket(volume);
 			ApplyDemoStop(true);
 			break;
 			}
-			case DemoDirection.Sell:
+			case DemoDirections.Sell:
 			{
 			SellMarket(volume);
 			ApplyDemoStop(false);

--- a/API/3397_Currency_Strength_EA/CS/CurrencyStrengthEaStrategy.cs
+++ b/API/3397_Currency_Strength_EA/CS/CurrencyStrengthEaStrategy.cs
@@ -31,14 +31,14 @@ public class CurrencyStrengthEaStrategy : Strategy
 	private readonly StrategyParam<decimal> _upperLimit;
 	private readonly StrategyParam<decimal> _lowerLimit;
 	private readonly StrategyParam<int> _atrPeriod;
-	private readonly StrategyParam<StepMode> _stopMode;
+	private readonly StrategyParam<StepModes> _stopMode;
 	private readonly StrategyParam<decimal> _stopLossFactor;
 	private readonly StrategyParam<decimal> _takeProfitFactor;
 	private readonly StrategyParam<decimal> _trailingStop;
 	private readonly StrategyParam<decimal> _trailingStep;
 	private readonly StrategyParam<string> _startTime;
 	private readonly StrategyParam<string> _endTime;
-	private readonly StrategyParam<TimeModes> _timeMode;
+	private readonly StrategyParam<TimeModeses> _timeMode;
 	private readonly StrategyParam<string> _baseCurrency;
 	private readonly StrategyParam<string> _quoteCurrency;
 
@@ -92,7 +92,7 @@ public class CurrencyStrengthEaStrategy : Strategy
 		.SetGreaterThanZero()
 		.SetDisplay("ATR Period", "ATR lookback used for stop and target", "Risk Management");
 
-		_stopMode = Param(nameof(StopMode), StepMode.InAtr)
+		_stopMode = Param(nameof(StopMode), StepModes.InAtr)
 		.SetDisplay("Stop Mode", "Select whether stops are based on ATR or absolute points", "Risk Management");
 
 		_stopLossFactor = Param(nameof(StopLossFactor), 0m)
@@ -113,7 +113,7 @@ public class CurrencyStrengthEaStrategy : Strategy
 		_endTime = Param(nameof(EndTime), "16:00")
 		.SetDisplay("End Time", "Trading session end (HH:mm)", "Session");
 
-		_timeMode = Param(nameof(TimeMode), TimeModes.Server)
+		_timeMode = Param(nameof(TimeMode), TimeModeses.Server)
 		.SetDisplay("Time Mode", "Select which clock is used for the session filter", "Session");
 
 		_baseCurrency = Param(nameof(BaseCurrency), "EUR")
@@ -207,7 +207,7 @@ public class CurrencyStrengthEaStrategy : Strategy
 	/// <summary>
 	/// Defines whether stop distances are in ATR units or raw points.
 	/// </summary>
-	public StepMode StopMode
+	public StepModes StopMode
 	{
 		get => _stopMode.Value;
 		set => _stopMode.Value = value;
@@ -270,7 +270,7 @@ public class CurrencyStrengthEaStrategy : Strategy
 	/// <summary>
 	/// Selects which clock is used for the session filter.
 	/// </summary>
-	public TimeModes TimeMode
+	public TimeModeses TimeMode
 	{
 		get => _timeMode.Value;
 		set => _timeMode.Value = value;
@@ -525,8 +525,8 @@ public class CurrencyStrengthEaStrategy : Strategy
 
 		return StopMode switch
 		{
-			StepMode.InAtr => _currentAtr is decimal atr ? atr * StopLossFactor : 0m,
-			StepMode.InPips => Security?.PriceStep is decimal step ? step * StopLossFactor : 0m,
+			StepModes.InAtr => _currentAtr is decimal atr ? atr * StopLossFactor : 0m,
+			StepModes.InPips => Security?.PriceStep is decimal step ? step * StopLossFactor : 0m,
 			_ => 0m,
 		};
 	}
@@ -538,8 +538,8 @@ public class CurrencyStrengthEaStrategy : Strategy
 
 		return StopMode switch
 		{
-			StepMode.InAtr => _currentAtr is decimal atr ? atr * TakeProfitFactor : 0m,
-			StepMode.InPips => Security?.PriceStep is decimal step ? step * TakeProfitFactor : 0m,
+			StepModes.InAtr => _currentAtr is decimal atr ? atr * TakeProfitFactor : 0m,
+			StepModes.InPips => Security?.PriceStep is decimal step ? step * TakeProfitFactor : 0m,
 			_ => 0m,
 		};
 	}
@@ -617,9 +617,9 @@ public class CurrencyStrengthEaStrategy : Strategy
 
 		var reference = TimeMode switch
 		{
-			TimeModes.Server => time,
-			TimeModes.Gmt => time.ToUniversalTime(),
-			TimeModes.Local => time.ToLocalTime(),
+			TimeModeses.Server => time,
+			TimeModeses.Gmt => time.ToUniversalTime(),
+			TimeModeses.Local => time.ToLocalTime(),
 			_ => time,
 		};
 
@@ -710,7 +710,7 @@ public class CurrencyStrengthEaStrategy : Strategy
 	/// <summary>
 	/// Session clock modes.
 	/// </summary>
-	public enum TimeModes
+	public enum TimeModeses
 	{
 		Server,
 		Gmt,
@@ -720,7 +720,7 @@ public class CurrencyStrengthEaStrategy : Strategy
 	/// <summary>
 	/// Distance mode for protective orders.
 	/// </summary>
-	public enum StepMode
+	public enum StepModes
 	{
 		InAtr,
 		InPips,

--- a/API/3399_Basket_Close/CS/BasketCloseStrategy.cs
+++ b/API/3399_Basket_Close/CS/BasketCloseStrategy.cs
@@ -13,13 +13,13 @@ using StockSharp.Algo.Strategies;
 using StockSharp.BusinessEntities;
 using StockSharp.Messages;
 
-public enum BasketCloseLossMode
+public enum BasketCloseLossModes
 {
 	Percentage,
 	Currency,
 }
 
-public enum BasketCloseProfitMode
+public enum BasketCloseProfitModes
 {
 	Percentage,
 	Currency,
@@ -27,10 +27,10 @@ public enum BasketCloseProfitMode
 
 public class BasketCloseStrategy : Strategy
 {
-	private readonly StrategyParam<BasketCloseLossMode> _lossMode;
+	private readonly StrategyParam<BasketCloseLossModes> _lossMode;
 	private readonly StrategyParam<decimal> _lossPercentage;
 	private readonly StrategyParam<decimal> _lossCurrency;
-	private readonly StrategyParam<BasketCloseProfitMode> _profitMode;
+	private readonly StrategyParam<BasketCloseProfitModes> _profitMode;
 	private readonly StrategyParam<decimal> _profitPercentage;
 	private readonly StrategyParam<decimal> _profitCurrency;
 	private readonly StrategyParam<DataType> _candleType;
@@ -44,7 +44,7 @@ public class BasketCloseStrategy : Strategy
 
 	public BasketCloseStrategy()
 	{
-		_lossMode = Param(nameof(LossMode), BasketCloseLossMode.Percentage)
+		_lossMode = Param(nameof(LossMode), BasketCloseLossModes.Percentage)
 			.SetDisplay("Loss Mode", "Determines whether the loss threshold is evaluated in percent or currency.", "General");
 
 		_lossPercentage = Param(nameof(LossPercentage), 1m)
@@ -55,7 +55,7 @@ public class BasketCloseStrategy : Strategy
 			.SetGreaterThanZero()
 			.SetDisplay("Loss Currency", "Close all positions once floating loss reaches this amount.", "Risk");
 
-		_profitMode = Param(nameof(ProfitMode), BasketCloseProfitMode.Percentage)
+		_profitMode = Param(nameof(ProfitMode), BasketCloseProfitModes.Percentage)
 			.SetDisplay("Profit Mode", "Determines whether the profit target is evaluated in percent or currency.", "General");
 
 		_profitPercentage = Param(nameof(ProfitPercentage), 1m)
@@ -77,7 +77,7 @@ public class BasketCloseStrategy : Strategy
 			.SetDisplay("Test Order Volume", "Default size for the optional test order.", "Testing");
 	}
 
-	public BasketCloseLossMode LossMode
+	public BasketCloseLossModes LossMode
 	{
 		get => _lossMode.Value;
 		set => _lossMode.Value = value;
@@ -95,7 +95,7 @@ public class BasketCloseStrategy : Strategy
 		set => _lossCurrency.Value = value;
 	}
 
-	public BasketCloseProfitMode ProfitMode
+	public BasketCloseProfitModes ProfitMode
 	{
 		get => _profitMode.Value;
 		set => _profitMode.Value = value;
@@ -229,8 +229,8 @@ public class BasketCloseStrategy : Strategy
 	{
 		return LossMode switch
 		{
-			BasketCloseLossMode.Percentage => percentage <= -LossPercentage,
-			BasketCloseLossMode.Currency => totalProfit <= -LossCurrency,
+			BasketCloseLossModes.Percentage => percentage <= -LossPercentage,
+			BasketCloseLossModes.Currency => totalProfit <= -LossCurrency,
 			_ => false,
 		};
 	}
@@ -239,8 +239,8 @@ public class BasketCloseStrategy : Strategy
 	{
 		return ProfitMode switch
 		{
-			BasketCloseProfitMode.Percentage => percentage >= ProfitPercentage,
-			BasketCloseProfitMode.Currency => totalProfit >= ProfitCurrency,
+			BasketCloseProfitModes.Percentage => percentage >= ProfitPercentage,
+			BasketCloseProfitModes.Currency => totalProfit >= ProfitCurrency,
 			_ => false,
 		};
 	}

--- a/API/3401_My_TS15/CS/MyTs15Strategy.cs
+++ b/API/3401_My_TS15/CS/MyTs15Strategy.cs
@@ -20,7 +20,7 @@ public class MyTs15Strategy : Strategy
 {
 	private readonly StrategyParam<int> _maPeriod;
 	private readonly StrategyParam<int> _maShift;
-	private readonly StrategyParam<MovingAverageMethod> _maMethod;
+	private readonly StrategyParam<MovingAverageMethods> _maMethod;
 	private readonly StrategyParam<CandlePrice> _maPrice;
 	private readonly StrategyParam<int> _maBarsTrail;
 	private readonly StrategyParam<decimal> _trailBehindMaPoints;
@@ -50,7 +50,7 @@ public class MyTs15Strategy : Strategy
 		.SetDisplay("MA Shift", "Additional bar shift applied when requesting MA values.", "Moving Average")
 		.SetNotNegative();
 
-		_maMethod = Param(nameof(MaMethod), MovingAverageMethod.LinearWeighted)
+		_maMethod = Param(nameof(MaMethod), MovingAverageMethods.LinearWeighted)
 		.SetDisplay("MA Method", "Moving average smoothing method.", "Moving Average");
 
 		_maPrice = Param(nameof(MaPrice), CandlePrice.Weighted)
@@ -92,7 +92,7 @@ public class MyTs15Strategy : Strategy
 
 	public int MaPeriod { get => _maPeriod.Value; set => _maPeriod.Value = value; }
 	public int MaShift { get => _maShift.Value; set => _maShift.Value = value; }
-	public MovingAverageMethod MaMethod { get => _maMethod.Value; set => _maMethod.Value = value; }
+	public MovingAverageMethods MaMethod { get => _maMethod.Value; set => _maMethod.Value = value; }
 	public CandlePrice MaPrice { get => _maPrice.Value; set => _maPrice.Value = value; }
 	public int MaBarsTrail { get => _maBarsTrail.Value; set => _maBarsTrail.Value = value; }
 	public decimal TrailBehindMaPoints { get => _trailBehindMaPoints.Value; set => _trailBehindMaPoints.Value = value; }
@@ -385,14 +385,14 @@ public class MyTs15Strategy : Strategy
 		};
 	}
 
-	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageMethod method, int length, CandlePrice price)
+	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageMethods method, int length, CandlePrice price)
 	{
 		LengthIndicator<decimal> indicator = method switch
 		{
-			MovingAverageMethod.Simple => new SimpleMovingAverage(),
-			MovingAverageMethod.Exponential => new ExponentialMovingAverage(),
-			MovingAverageMethod.Smoothed => new SmoothedMovingAverage(),
-			MovingAverageMethod.LinearWeighted => new WeightedMovingAverage(),
+			MovingAverageMethods.Simple => new SimpleMovingAverage(),
+			MovingAverageMethods.Exponential => new ExponentialMovingAverage(),
+			MovingAverageMethods.Smoothed => new SmoothedMovingAverage(),
+			MovingAverageMethods.LinearWeighted => new WeightedMovingAverage(),
 			_ => new SimpleMovingAverage(),
 		};
 
@@ -420,7 +420,7 @@ public class MyTs15Strategy : Strategy
 	/// <summary>
 	/// Moving average smoothing methods supported by the strategy.
 	/// </summary>
-	public enum MovingAverageMethod
+	public enum MovingAverageMethods
 	{
 		/// <summary>
 		/// Simple moving average.

--- a/API/3409_Potential_Entries/CS/PotentialEntriesStrategy.cs
+++ b/API/3409_Potential_Entries/CS/PotentialEntriesStrategy.cs
@@ -19,7 +19,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class PotentialEntriesStrategy : Strategy
 {
-	private readonly StrategyParam<PatternMode> _patternMode;
+	private readonly StrategyParam<PatternModes> _patternMode;
 	private readonly StrategyParam<decimal> _tradeVolume;
 	private readonly StrategyParam<DataType> _candleType;
 
@@ -30,7 +30,7 @@ public class PotentialEntriesStrategy : Strategy
 	/// <summary>
 	/// Pattern direction to evaluate.
 	/// </summary>
-	public PatternMode PatternSide
+	public PatternModes PatternSide
 	{
 		get => _patternMode.Value;
 		set => _patternMode.Value = value;
@@ -59,7 +59,7 @@ public class PotentialEntriesStrategy : Strategy
 	/// </summary>
 	public PotentialEntriesStrategy()
 	{
-		_patternMode = Param(nameof(PatternSide), PatternMode.Bullish)
+		_patternMode = Param(nameof(PatternSide), PatternModes.Bullish)
 		.SetDisplay("Pattern Side", "Candlestick direction to scan", "General")
 		.SetCanOptimize(true);
 
@@ -122,7 +122,7 @@ public class PotentialEntriesStrategy : Strategy
 
 		if (_previousCandle is CandleSnapshot previous)
 		{
-			if (PatternSide == PatternMode.Bullish)
+			if (PatternSide == PatternModes.Bullish)
 			{
 				if (IsBullishHammer(current, previous))
 				{
@@ -137,7 +137,7 @@ public class PotentialEntriesStrategy : Strategy
 					EnterLong(current, previous);
 				}
 			}
-			else if (PatternSide == PatternMode.Bearish)
+			else if (PatternSide == PatternModes.Bearish)
 			{
 				if (IsBearishShootingStar(current, previous))
 				{
@@ -305,7 +305,7 @@ public class PotentialEntriesStrategy : Strategy
 	/// <summary>
 	/// Directional mode for candlestick patterns.
 	/// </summary>
-	public enum PatternMode
+	public enum PatternModes
 	{
 		/// <summary>
 		/// Evaluate bullish reversal and momentum signals only.

--- a/API/3412_Range_Breakout_Weekly/CS/RangeBreakoutWeeklyStrategy.cs
+++ b/API/3412_Range_Breakout_Weekly/CS/RangeBreakoutWeeklyStrategy.cs
@@ -30,14 +30,14 @@ public class RangeBreakoutWeeklyStrategy : Strategy
 	private readonly StrategyParam<DataType> _hourCandleType;
 	private readonly StrategyParam<DataType> _atrCandleType;
 
-	private enum BreakoutPhase
+	private enum BreakoutPhases
 	{
 		Standby,
 		Setup,
 		Trade,
 	}
 
-	private BreakoutPhase _phase;
+	private BreakoutPhases _phase;
 	private DayOfWeek _effectiveTradingDay;
 	private AverageTrueRange _atrIndicator = null!;
 	private decimal? _atrValue;
@@ -207,7 +207,7 @@ public class RangeBreakoutWeeklyStrategy : Strategy
 	{
 		base.OnReseted();
 
-		_phase = BreakoutPhase.Standby;
+		_phase = BreakoutPhases.Standby;
 		_effectiveTradingDay = DayOfWeek.Monday;
 		_atrIndicator = null!;
 		_atrValue = null;
@@ -306,7 +306,7 @@ public class RangeBreakoutWeeklyStrategy : Strategy
 		if (candle.State != CandleStates.Finished)
 			return;
 
-		if (_phase != BreakoutPhase.Standby)
+		if (_phase != BreakoutPhases.Standby)
 			return;
 
 		if (candle.OpenTime.DayOfWeek != _effectiveTradingDay)
@@ -344,7 +344,7 @@ public class RangeBreakoutWeeklyStrategy : Strategy
 
 	private void TryEnterPosition()
 	{
-		if (_phase != BreakoutPhase.Setup)
+		if (_phase != BreakoutPhases.Setup)
 			return;
 
 		if (_entryOrderPending)
@@ -366,7 +366,7 @@ public class RangeBreakoutWeeklyStrategy : Strategy
 			_entryDirection = Sides.Buy;
 			_entryVolume = volume;
 			_entryOrderPending = true;
-			_phase = BreakoutPhase.Trade;
+			_phase = BreakoutPhases.Trade;
 			return;
 		}
 
@@ -376,13 +376,13 @@ public class RangeBreakoutWeeklyStrategy : Strategy
 			_entryDirection = Sides.Sell;
 			_entryVolume = volume;
 			_entryOrderPending = true;
-			_phase = BreakoutPhase.Trade;
+			_phase = BreakoutPhases.Trade;
 		}
 	}
 
 	private void ManageActivePosition()
 	{
-		if (_phase != BreakoutPhase.Trade)
+		if (_phase != BreakoutPhases.Trade)
 			return;
 
 		if (_exitOrderPending)
@@ -462,7 +462,7 @@ public class RangeBreakoutWeeklyStrategy : Strategy
 		_lowerStop = NormalizeAbsolute(lowerStop + lossOffset);
 
 		_setupPrepared = true;
-		_phase = BreakoutPhase.Setup;
+		_phase = BreakoutPhases.Setup;
 		_entryDirection = null;
 		_entryVolume = 0m;
 		_pendingExitIsLoss = false;
@@ -531,7 +531,7 @@ public class RangeBreakoutWeeklyStrategy : Strategy
 
 	private void ResetExecutionState()
 	{
-		_phase = BreakoutPhase.Standby;
+		_phase = BreakoutPhases.Standby;
 		_setupPrepared = false;
 		_centerPrice = null;
 		_upperTrigger = null;

--- a/API/3418_Galender/CS/GalenderStrategy.cs
+++ b/API/3418_Galender/CS/GalenderStrategy.cs
@@ -23,7 +23,7 @@ public class GalenderStrategy : Strategy
 	private readonly StrategyParam<DateTimeOffset> _dateTo;
 	private readonly StrategyParam<string> _currencyFilter;
 	private readonly StrategyParam<string> _keywordFilter;
-	private readonly StrategyParam<CalendarImportanceFilter> _importanceFilter;
+	private readonly StrategyParam<CalendarImportanceFilters> _importanceFilter;
 
 	private readonly List<CalendarEntry> _entries = new();
 
@@ -44,7 +44,7 @@ public class GalenderStrategy : Strategy
 		_keywordFilter = Param(nameof(KeywordFilter), "interest")
 			.SetDisplay("Keyword Filter", "Keyword that must exist in the news text", "Filters");
 
-		_importanceFilter = Param(nameof(ImportanceFilter), CalendarImportanceFilter.All)
+		_importanceFilter = Param(nameof(ImportanceFilter), CalendarImportanceFilters.All)
 			.SetDisplay("Importance", "Economic importance requirement", "Filters");
 	}
 
@@ -87,7 +87,7 @@ public class GalenderStrategy : Strategy
 	/// <summary>
 	/// Importance level that must be present in the news text.
 	/// </summary>
-	public CalendarImportanceFilter ImportanceFilter
+	public CalendarImportanceFilters ImportanceFilter
 	{
 		get => _importanceFilter.Value;
 		set => _importanceFilter.Value = value;
@@ -219,7 +219,7 @@ public class GalenderStrategy : Strategy
 	private bool MatchesImportance(string text)
 	{
 		var importance = ImportanceFilter;
-		if (importance == CalendarImportanceFilter.All)
+		if (importance == CalendarImportanceFilters.All)
 		{
 			return true;
 		}
@@ -228,10 +228,10 @@ public class GalenderStrategy : Strategy
 
 		return importance switch
 		{
-			CalendarImportanceFilter.None => ContainsWord(upperText, "NONE"),
-			CalendarImportanceFilter.Low => ContainsWord(upperText, "LOW"),
-			CalendarImportanceFilter.Moderate => ContainsWord(upperText, "MODERATE") || ContainsWord(upperText, "MEDIUM"),
-			CalendarImportanceFilter.High => ContainsWord(upperText, "HIGH"),
+			CalendarImportanceFilters.None => ContainsWord(upperText, "NONE"),
+			CalendarImportanceFilters.Low => ContainsWord(upperText, "LOW"),
+			CalendarImportanceFilters.Moderate => ContainsWord(upperText, "MODERATE") || ContainsWord(upperText, "MEDIUM"),
+			CalendarImportanceFilters.High => ContainsWord(upperText, "HIGH"),
 			_ => true
 		};
 	}
@@ -353,7 +353,7 @@ public class GalenderStrategy : Strategy
 	/// <summary>
 	/// Enumeration of supported importance filters.
 	/// </summary>
-	public enum CalendarImportanceFilter
+	public enum CalendarImportanceFilters
 	{
 		/// <summary>
 		/// No importance filter (matches only events tagged with "none").

--- a/API/3424_RangeBreakout2/CS/RangeBreakout2Strategy.cs
+++ b/API/3424_RangeBreakout2/CS/RangeBreakout2Strategy.cs
@@ -21,28 +21,28 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class RangeBreakout2Strategy : Strategy
 {
-	private enum PeriodicityMode
+	private enum PeriodicityModes
 	{
 		Weekly,
 		Daily,
 		NonStop,
 	}
 
-	private enum RangeCalculationMode
+	private enum RangeCalculationModes
 	{
 		Atr,
 		Percent,
 		Fixed,
 	}
 
-	private enum TradeModeOption
+	private enum TradeModeOptions
 	{
 		Stop,
 		Limit,
 		Random,
 	}
 
-	private enum LotManagementMode
+	private enum LotManagementModes
 	{
 		Constant,
 		Linear,
@@ -50,26 +50,26 @@ public class RangeBreakout2Strategy : Strategy
 		Fibonacci,
 	}
 
-	private enum StrategyPhase
+	private enum StrategyPhases
 	{
 		StandBy,
 		Setup,
 		Trade,
 	}
 
-	private readonly StrategyParam<PeriodicityMode> _periodicity;
+	private readonly StrategyParam<PeriodicityModes> _periodicity;
 	private readonly StrategyParam<DayOfWeek> _dayOfWeek;
 	private readonly StrategyParam<int> _hour;
-	private readonly StrategyParam<RangeCalculationMode> _rangeMode;
+	private readonly StrategyParam<RangeCalculationModes> _rangeMode;
 	private readonly StrategyParam<decimal> _atrPercentage;
 	private readonly StrategyParam<decimal> _pricePercentage;
 	private readonly StrategyParam<int> _fixedRangePoints;
 	private readonly StrategyParam<int> _atrLength;
-	private readonly StrategyParam<TradeModeOption> _tradeMode;
+	private readonly StrategyParam<TradeModeOptions> _tradeMode;
 	private readonly StrategyParam<decimal> _rangePercentage;
 	private readonly StrategyParam<decimal> _takeProfitPercentage;
 	private readonly StrategyParam<decimal> _stopLossPercentage;
-	private readonly StrategyParam<LotManagementMode> _lotMode;
+	private readonly StrategyParam<LotManagementModes> _lotMode;
 	private readonly StrategyParam<decimal> _marginPercentage;
 	private readonly StrategyParam<decimal> _lotMultiplier;
 	private readonly StrategyParam<decimal> _rangeMultiplier;
@@ -80,7 +80,7 @@ public class RangeBreakout2Strategy : Strategy
 	private decimal _atrValue;
 	private decimal? _lastAsk;
 	private decimal? _lastBid;
-	private StrategyPhase _phase = StrategyPhase.StandBy;
+	private StrategyPhases _phase = StrategyPhases.StandBy;
 	private decimal _setupRange;
 	private decimal _setupCenter;
 	private decimal _setupHigh;
@@ -100,7 +100,7 @@ public class RangeBreakout2Strategy : Strategy
 	/// </summary>
 	public RangeBreakout2Strategy()
 	{
-		_periodicity = Param(nameof(Periodicity), PeriodicityMode.Weekly)
+		_periodicity = Param(nameof(Periodicity), PeriodicityModes.Weekly)
 			.SetDisplay("Periodicity", "Schedule of the range preparation", "Schedule")
 			.SetCanOptimize(true);
 
@@ -113,7 +113,7 @@ public class RangeBreakout2Strategy : Strategy
 			.SetOptimize(0, 23, 1)
 			.SetCanOptimize(true);
 
-		_rangeMode = Param(nameof(RangeMode), RangeCalculationMode.Atr)
+		_rangeMode = Param(nameof(RangeMode), RangeCalculationModes.Atr)
 			.SetDisplay("Range Mode", "Method used to calculate the raw range", "Range")
 			.SetCanOptimize(true);
 
@@ -137,7 +137,7 @@ public class RangeBreakout2Strategy : Strategy
 			.SetDisplay("ATR Length", "Number of candles used for ATR calculation", "Range")
 			.SetCanOptimize(true);
 
-		_tradeMode = Param(nameof(TradeMode), TradeModeOption.Stop)
+		_tradeMode = Param(nameof(TradeMode), TradeModeOptions.Stop)
 			.SetDisplay("Trade Mode", "Order type used on range breakout", "Trading")
 			.SetCanOptimize(true);
 
@@ -156,7 +156,7 @@ public class RangeBreakout2Strategy : Strategy
 			.SetDisplay("Stop-Loss Percentage", "Percentage of the range used for stop-loss", "Trading")
 			.SetCanOptimize(true);
 
-		_lotMode = Param(nameof(LotMode), LotManagementMode.Martingale)
+		_lotMode = Param(nameof(LotMode), LotManagementModes.Martingale)
 			.SetDisplay("Lot Mode", "Money management scheme", "Risk")
 			.SetCanOptimize(true);
 
@@ -185,7 +185,7 @@ public class RangeBreakout2Strategy : Strategy
 	/// <summary>
 	/// Range preparation schedule.
 	/// </summary>
-	public PeriodicityMode Periodicity
+	public PeriodicityModes Periodicity
 	{
 		get => _periodicity.Value;
 		set => _periodicity.Value = value;
@@ -212,7 +212,7 @@ public class RangeBreakout2Strategy : Strategy
 	/// <summary>
 	/// Range calculation method.
 	/// </summary>
-	public RangeCalculationMode RangeMode
+	public RangeCalculationModes RangeMode
 	{
 		get => _rangeMode.Value;
 		set => _rangeMode.Value = value;
@@ -257,7 +257,7 @@ public class RangeBreakout2Strategy : Strategy
 	/// <summary>
 	/// Trading mode (stop, limit or random).
 	/// </summary>
-	public TradeModeOption TradeMode
+	public TradeModeOptions TradeMode
 	{
 		get => _tradeMode.Value;
 		set => _tradeMode.Value = value;
@@ -293,7 +293,7 @@ public class RangeBreakout2Strategy : Strategy
 	/// <summary>
 	/// Money management scheme.
 	/// </summary>
-	public LotManagementMode LotMode
+	public LotManagementModes LotMode
 	{
 		get => _lotMode.Value;
 		set => _lotMode.Value = value;
@@ -352,7 +352,7 @@ public class RangeBreakout2Strategy : Strategy
 
 		yield return (Security, SignalCandleType);
 
-		if (RangeMode == RangeCalculationMode.Atr)
+		if (RangeMode == RangeCalculationModes.Atr)
 			yield return (Security, AtrCandleType);
 	}
 
@@ -365,7 +365,7 @@ public class RangeBreakout2Strategy : Strategy
 		_atrValue = 0m;
 		_lastAsk = null;
 		_lastBid = null;
-		_phase = StrategyPhase.StandBy;
+		_phase = StrategyPhases.StandBy;
 		_setupRange = 0m;
 		_setupCenter = 0m;
 		_setupHigh = 0m;
@@ -397,7 +397,7 @@ public class RangeBreakout2Strategy : Strategy
 			.WhenNew(ProcessSignalCandle)
 			.Start();
 
-		if (RangeMode == RangeCalculationMode.Atr)
+		if (RangeMode == RangeCalculationModes.Atr)
 		{
 			_atrIndicator = new AverageTrueRange { Length = AtrLength };
 
@@ -420,7 +420,7 @@ public class RangeBreakout2Strategy : Strategy
 		if (!IsFormedAndOnlineAndAllowTrading())
 			return;
 
-		if (_phase == StrategyPhase.StandBy && ShouldStartSetup(candle.CloseTime))
+		if (_phase == StrategyPhases.StandBy && ShouldStartSetup(candle.CloseTime))
 			TryPrepareSetup();
 	}
 
@@ -442,7 +442,7 @@ public class RangeBreakout2Strategy : Strategy
 		if (bestAsk != null)
 			_lastAsk = bestAsk;
 
-		if (_phase == StrategyPhase.Setup)
+		if (_phase == StrategyPhases.Setup)
 			TryExecuteEntries();
 	}
 
@@ -454,9 +454,9 @@ public class RangeBreakout2Strategy : Strategy
 
 		return Periodicity switch
 		{
-			PeriodicityMode.Weekly => time.DayOfWeek == DayOfWeekSetting && time.Hour == triggerHour,
-			PeriodicityMode.Daily => time.Hour == triggerHour,
-			PeriodicityMode.NonStop => true,
+			PeriodicityModes.Weekly => time.DayOfWeek == DayOfWeekSetting && time.Hour == triggerHour,
+			PeriodicityModes.Daily => time.Hour == triggerHour,
+			PeriodicityModes.NonStop => true,
 			_ => false,
 		};
 	}
@@ -477,16 +477,16 @@ public class RangeBreakout2Strategy : Strategy
 		_setupHigh = _setupCenter + offset;
 		_setupLow = _setupCenter - offset;
 
-		_phase = StrategyPhase.Setup;
+		_phase = StrategyPhases.Setup;
 	}
 
 	private decimal CalculateRawRange(decimal referencePrice)
 	{
 		return RangeMode switch
 		{
-			RangeCalculationMode.Atr => CalculateAtrRange(referencePrice),
-			RangeCalculationMode.Percent => referencePrice * PricePercentage / 100m,
-			RangeCalculationMode.Fixed => (Security?.PriceStep ?? 0m) * FixedRangePoints,
+			RangeCalculationModes.Atr => CalculateAtrRange(referencePrice),
+			RangeCalculationModes.Percent => referencePrice * PricePercentage / 100m,
+			RangeCalculationModes.Fixed => (Security?.PriceStep ?? 0m) * FixedRangePoints,
 			_ => 0m,
 		};
 	}
@@ -507,7 +507,7 @@ public class RangeBreakout2Strategy : Strategy
 		if (_lastAsk == null || _lastBid == null)
 			return;
 
-		if (_phase != StrategyPhase.Setup)
+		if (_phase != StrategyPhases.Setup)
 			return;
 
 		var ask = _lastAsk.Value;
@@ -539,7 +539,7 @@ public class RangeBreakout2Strategy : Strategy
 
 		if (isUpper)
 		{
-			if (mode == TradeModeOption.Stop)
+			if (mode == TradeModeOptions.Stop)
 			{
 				referencePrice = ask;
 				order = BuyMarket(volume);
@@ -552,7 +552,7 @@ public class RangeBreakout2Strategy : Strategy
 		}
 		else
 		{
-			if (mode == TradeModeOption.Stop)
+			if (mode == TradeModeOptions.Stop)
 			{
 				referencePrice = bid;
 				order = SellMarket(volume);
@@ -571,25 +571,25 @@ public class RangeBreakout2Strategy : Strategy
 		}
 
 		ApplyProtections(order.Side, referencePrice, volume);
-		_phase = StrategyPhase.Trade;
+		_phase = StrategyPhases.Trade;
 	}
 
-	private TradeModeOption ResolveTradeMode()
+	private TradeModeOptions ResolveTradeMode()
 	{
-		if (TradeMode != TradeModeOption.Random)
+		if (TradeMode != TradeModeOptions.Random)
 			return TradeMode;
 
-		return _random.Next(2) == 0 ? TradeModeOption.Stop : TradeModeOption.Limit;
+		return _random.Next(2) == 0 ? TradeModeOptions.Stop : TradeModeOptions.Limit;
 	}
 
 	private decimal PrepareTradeVolume()
 	{
 		return LotMode switch
 		{
-			LotManagementMode.Constant => RecalculateBaseVolume(),
-			LotManagementMode.Linear => PrepareLinearVolume(),
-			LotManagementMode.Martingale => PrepareMartingaleVolume(),
-			LotManagementMode.Fibonacci => PrepareFibonacciVolume(),
+			LotManagementModes.Constant => RecalculateBaseVolume(),
+			LotManagementModes.Linear => PrepareLinearVolume(),
+			LotManagementModes.Martingale => PrepareMartingaleVolume(),
+			LotManagementModes.Fibonacci => PrepareFibonacciVolume(),
 			_ => RecalculateBaseVolume(),
 		};
 	}
@@ -762,7 +762,7 @@ public class RangeBreakout2Strategy : Strategy
 
 	private void ResetToStandBy()
 	{
-		_phase = StrategyPhase.StandBy;
+		_phase = StrategyPhases.StandBy;
 		_setupRange = 0m;
 		_setupCenter = 0m;
 		_setupHigh = 0m;

--- a/API/3442_Specific_Day_Time/CS/SpecificDayTimeStrategy.cs
+++ b/API/3442_Specific_Day_Time/CS/SpecificDayTimeStrategy.cs
@@ -20,14 +20,14 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class SpecificDayTimeStrategy : Strategy
 {
-	private enum OrderMode
+	private enum OrderModes
 	{
 		Market,
 		Stop,
 		Limit,
 	}
 
-	private enum LotSizingMode
+	private enum LotSizingModes
 	{
 		Manual,
 		Automatic,
@@ -48,7 +48,7 @@ public class SpecificDayTimeStrategy : Strategy
 
 	private readonly StrategyParam<DateTimeOffset> _openTime;
 	private readonly StrategyParam<DateTimeOffset> _closeTime;
-	private readonly StrategyParam<OrderMode> _orderMode;
+	private readonly StrategyParam<OrderModes> _orderMode;
 	private readonly StrategyParam<bool> _openBuy;
 	private readonly StrategyParam<bool> _openSell;
 	private readonly StrategyParam<decimal> _takeProfitPoints;
@@ -59,7 +59,7 @@ public class SpecificDayTimeStrategy : Strategy
 	private readonly StrategyParam<decimal> _breakEvenAfterPoints;
 	private readonly StrategyParam<decimal> _orderDistancePoints;
 	private readonly StrategyParam<int> _pendingExpireMinutes;
-	private readonly StrategyParam<LotSizingMode> _lotSizing;
+	private readonly StrategyParam<LotSizingModes> _lotSizing;
 	private readonly StrategyParam<decimal> _riskFactor;
 	private readonly StrategyParam<decimal> _manualVolume;
 	private readonly StrategyParam<bool> _closeOwn;
@@ -93,7 +93,7 @@ public class SpecificDayTimeStrategy : Strategy
 		_closeTime = Param(nameof(CloseTime), new DateTimeOffset(new DateTime(2021, 11, 29, 12, 0, 0, DateTimeKind.Utc)))
 		.SetDisplay("Close Time", "Day and time to close orders.", "Scheduling");
 
-		_orderMode = Param(nameof(OrderPlacement), OrderMode.Market)
+		_orderMode = Param(nameof(OrderPlacement), OrderModes.Market)
 		.SetDisplay("Order Mode", "Type of orders to place.", "Trading");
 
 		_openBuy = Param(nameof(OpenBuyOrders), false)
@@ -132,7 +132,7 @@ public class SpecificDayTimeStrategy : Strategy
 		.SetDisplay("Pending Expiry", "Minutes until pending orders expire (0 keeps them).", "Trading")
 		.SetNotNegative();
 
-		_lotSizing = Param(nameof(LotSizing), LotSizingMode.Manual)
+		_lotSizing = Param(nameof(LotSizing), LotSizingModes.Manual)
 		.SetDisplay("Lot Sizing", "Manual size or automatic risk factor.", "Risk");
 
 		_riskFactor = Param(nameof(RiskFactor), 1m)
@@ -174,7 +174,7 @@ public class SpecificDayTimeStrategy : Strategy
 	/// <summary>
 	/// Order placement mode.
 	/// </summary>
-	public OrderMode OrderPlacement
+	public OrderModes OrderPlacement
 	{
 		get => _orderMode.Value;
 		set => _orderMode.Value = value;
@@ -273,7 +273,7 @@ public class SpecificDayTimeStrategy : Strategy
 	/// <summary>
 	/// Selects between manual or automatic lot sizing.
 	/// </summary>
-	public LotSizingMode LotSizing
+	public LotSizingModes LotSizing
 	{
 		get => _lotSizing.Value;
 		set => _lotSizing.Value = value;
@@ -412,13 +412,13 @@ public class SpecificDayTimeStrategy : Strategy
 
 		switch (OrderPlacement)
 		{
-			case OrderMode.Market:
+			case OrderModes.Market:
 			OpenMarketOrders(volume);
 			break;
-			case OrderMode.Stop:
+			case OrderModes.Stop:
 			OpenPendingOrders(volume, true);
 			break;
-			case OrderMode.Limit:
+			case OrderModes.Limit:
 			OpenPendingOrders(volume, false);
 			break;
 		}
@@ -753,7 +753,7 @@ public class SpecificDayTimeStrategy : Strategy
 
 	private decimal CalculateVolume()
 	{
-		if (LotSizing == LotSizingMode.Manual)
+		if (LotSizing == LotSizingModes.Manual)
 		return ManualVolume;
 
 		var portfolioValue = Portfolio?.CurrentValue ?? Portfolio?.BeginValue ?? 0m;

--- a/API/3451_Basic_Martingale_EA_3/CS/BasicMartingaleEa3Strategy.cs
+++ b/API/3451_Basic_Martingale_EA_3/CS/BasicMartingaleEa3Strategy.cs
@@ -19,14 +19,14 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class BasicMartingaleEa3Strategy : Strategy
 {
-	private enum AveragingMode
+	private enum AveragingModes
 	{
 		AverageDown,
 		AverageUp,
 		None,
 	}
 
-	private enum MartinMode
+	private enum MartinModes
 	{
 		Multiply,
 		Increment,
@@ -50,8 +50,8 @@ public class BasicMartingaleEa3Strategy : Strategy
 	private readonly StrategyParam<int> _atrPeriod;
 	private readonly StrategyParam<decimal> _gridMultiplier;
 	private readonly StrategyParam<int> _maxAverageOrders;
-	private readonly StrategyParam<AveragingMode> _averagingMode;
-	private readonly StrategyParam<MartinMode> _martinMode;
+	private readonly StrategyParam<AveragingModes> _averagingMode;
+	private readonly StrategyParam<MartinModes> _martinMode;
 	private readonly StrategyParam<decimal> _lotMultiplier;
 	private readonly StrategyParam<decimal> _lotIncrement;
 	private readonly StrategyParam<bool> _tradeAtNewBar;
@@ -125,10 +125,10 @@ public class BasicMartingaleEa3Strategy : Strategy
 			.SetGreaterThanZero()
 			.SetDisplay("Max Average Orders", "Maximum additional entries per side", "Money Management");
 
-		_averagingMode = Param(nameof(Averaging), AveragingMode.AverageDown)
+		_averagingMode = Param(nameof(Averaging), AveragingModes.AverageDown)
 			.SetDisplay("Averaging Mode", "Choose averaging direction", "Money Management");
 
-		_martinMode = Param(nameof(Martin), MartinMode.Multiply)
+		_martinMode = Param(nameof(Martin), MartinModes.Multiply)
 			.SetDisplay("Martingale Mode", "Volume growth scheme", "Money Management");
 
 		_lotMultiplier = Param(nameof(LotMultiplier), 1.5m)
@@ -257,7 +257,7 @@ public class BasicMartingaleEa3Strategy : Strategy
 	/// <summary>
 	/// Averaging mode defining when additional trades are allowed.
 	/// </summary>
-	public AveragingMode Averaging
+	public AveragingModes Averaging
 	{
 		get => _averagingMode.Value;
 		set => _averagingMode.Value = value;
@@ -266,14 +266,14 @@ public class BasicMartingaleEa3Strategy : Strategy
 	/// <summary>
 	/// Martingale mode controlling the next order size.
 	/// </summary>
-	public MartinMode Martin
+	public MartinModes Martin
 	{
 		get => _martinMode.Value;
 		set => _martinMode.Value = value;
 	}
 
 	/// <summary>
-	/// Multiplication factor when martingale mode is <see cref="MartinMode.Multiply"/>.
+	/// Multiplication factor when martingale mode is <see cref="MartinModes.Multiply"/>.
 	/// </summary>
 	public decimal LotMultiplier
 	{
@@ -282,7 +282,7 @@ public class BasicMartingaleEa3Strategy : Strategy
 	}
 
 	/// <summary>
-	/// Increment added when martingale mode is <see cref="MartinMode.Increment"/>.
+	/// Increment added when martingale mode is <see cref="MartinModes.Increment"/>.
 	/// </summary>
 	public decimal LotIncrement
 	{
@@ -490,7 +490,7 @@ public class BasicMartingaleEa3Strategy : Strategy
 
 		var atrDistance = GridMultiplier * _lastAtr;
 
-		if (Averaging == AveragingMode.AverageDown)
+		if (Averaging == AveragingModes.AverageDown)
 		{
 			if (price <= lowestPrice - atrDistance)
 			{
@@ -499,7 +499,7 @@ public class BasicMartingaleEa3Strategy : Strategy
 				_lastBuyVolume = nextVolume;
 			}
 		}
-		else if (Averaging == AveragingMode.AverageUp)
+		else if (Averaging == AveragingModes.AverageUp)
 		{
 			if (price >= highestPrice + atrDistance)
 			{
@@ -548,7 +548,7 @@ public class BasicMartingaleEa3Strategy : Strategy
 
 		var atrDistance = GridMultiplier * _lastAtr;
 
-		if (Averaging == AveragingMode.AverageDown)
+		if (Averaging == AveragingModes.AverageDown)
 		{
 			if (price >= highestPrice + atrDistance)
 			{
@@ -557,7 +557,7 @@ public class BasicMartingaleEa3Strategy : Strategy
 				_lastSellVolume = nextVolume;
 			}
 		}
-		else if (Averaging == AveragingMode.AverageUp)
+		else if (Averaging == AveragingModes.AverageUp)
 		{
 			if (price <= lowestPrice - atrDistance)
 			{
@@ -657,10 +657,10 @@ public class BasicMartingaleEa3Strategy : Strategy
 		decimal nextVolume = referenceVolume;
 		switch (Martin)
 		{
-			case MartinMode.Multiply:
+			case MartinModes.Multiply:
 				nextVolume = referenceVolume * LotMultiplier;
 				break;
-			case MartinMode.Increment:
+			case MartinModes.Increment:
 				nextVolume = referenceVolume + LotIncrement;
 				break;
 		}

--- a/API/3454_Fibonacci_Potential_Entries_Retracement/CS/FibonacciPotentialEntriesRetracementStrategy.cs
+++ b/API/3454_Fibonacci_Potential_Entries_Retracement/CS/FibonacciPotentialEntriesRetracementStrategy.cs
@@ -26,7 +26,7 @@ public class FibonacciPotentialEntriesRetracementStrategy : Strategy
 	private readonly StrategyParam<decimal> _p100Level;
 	private readonly StrategyParam<decimal> _targetLevel;
 	private readonly StrategyParam<decimal> _riskPercent;
-	private readonly StrategyParam<MarketBiasType> _marketBias;
+	private readonly StrategyParam<MarketBiasTypes> _marketBias;
 
 	private decimal? _bestAsk;
 	private decimal? _bestBid;
@@ -54,7 +54,7 @@ public class FibonacciPotentialEntriesRetracementStrategy : Strategy
 	/// <summary>
 	/// Defines the direction bias of the strategy.
 	/// </summary>
-	public enum MarketBiasType
+	public enum MarketBiasTypes
 	{
 		Bull = 1,
 		Bear = 2,
@@ -117,7 +117,7 @@ public class FibonacciPotentialEntriesRetracementStrategy : Strategy
 	/// <summary>
 	/// Selected market bias (long or short campaign).
 	/// </summary>
-	public MarketBiasType MarketBias
+	public MarketBiasTypes MarketBias
 	{
 		get => _marketBias.Value;
 		set => _marketBias.Value = value;
@@ -148,7 +148,7 @@ public class FibonacciPotentialEntriesRetracementStrategy : Strategy
 			.SetDisplay("Risk Percent", "Total risk percentage allocated to both entries.", "Risk")
 			.SetGreaterOrEqual(FirstTradeRiskPercent);
 
-		_marketBias = Param(nameof(MarketBias), MarketBiasType.Bull)
+		_marketBias = Param(nameof(MarketBias), MarketBiasTypes.Bull)
 			.SetDisplay("Market Bias", "Long (Bull) or short (Bear) execution mode.", "General");
 	}
 
@@ -237,19 +237,19 @@ public class FibonacciPotentialEntriesRetracementStrategy : Strategy
 		var spread = Math.Max(0m, ask - bid);
 		var riskSecondTrade = Math.Max(0m, RiskPercent - FirstTradeRiskPercent);
 
-		var firstStop = MarketBias == MarketBiasType.Bull
+		var firstStop = MarketBias == MarketBiasTypes.Bull
 			? P61Level - 3m * spread
 			: P61Level + 3m * spread;
 
 		var midpoint = (P61Level + P100Level) / 2m;
-		var secondStop = MarketBias == MarketBiasType.Bull
+		var secondStop = MarketBias == MarketBiasTypes.Bull
 			? midpoint - 3m * spread
 			: midpoint + 3m * spread;
 
 		if (firstStop <= 0m || secondStop <= 0m)
 			return;
 
-		if (MarketBias == MarketBiasType.Bull)
+		if (MarketBias == MarketBiasTypes.Bull)
 		{
 			if (firstStop >= P50Level || secondStop >= P61Level)
 				return;
@@ -269,7 +269,7 @@ public class FibonacciPotentialEntriesRetracementStrategy : Strategy
 		if (firstVolume > 0m)
 		{
 			_firstInitialStop = firstStop;
-			_firstEntryOrder = MarketBias == MarketBiasType.Bull
+			_firstEntryOrder = MarketBias == MarketBiasTypes.Bull
 				? BuyLimit(price: P50Level, volume: firstVolume)
 				: SellLimit(price: P50Level, volume: firstVolume);
 		}
@@ -277,7 +277,7 @@ public class FibonacciPotentialEntriesRetracementStrategy : Strategy
 		if (secondVolume > 0m)
 		{
 			_secondInitialStop = secondStop;
-			_secondEntryOrder = MarketBias == MarketBiasType.Bull
+			_secondEntryOrder = MarketBias == MarketBiasTypes.Bull
 				? BuyLimit(price: P61Level, volume: secondVolume)
 				: SellLimit(price: P61Level, volume: secondVolume);
 		}
@@ -316,7 +316,7 @@ public class FibonacciPotentialEntriesRetracementStrategy : Strategy
 		if (maxClosable <= 0m)
 			return;
 
-		partialOrder = MarketBias == MarketBiasType.Bull
+		partialOrder = MarketBias == MarketBiasTypes.Bull
 			? SellMarket(maxClosable)
 			: BuyMarket(maxClosable);
 
@@ -483,7 +483,7 @@ public class FibonacciPotentialEntriesRetracementStrategy : Strategy
 		if (stopOrder != null)
 			CancelOrder(stopOrder);
 
-		stopOrder = MarketBias == MarketBiasType.Bull
+		stopOrder = MarketBias == MarketBiasTypes.Bull
 			? SellStop(cappedVolume, price)
 			: BuyStop(cappedVolume, price);
 

--- a/API/3458_Smart_Forex_System/CS/SmartForexSystemStrategy.cs
+++ b/API/3458_Smart_Forex_System/CS/SmartForexSystemStrategy.cs
@@ -19,7 +19,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class SmartForexSystemStrategy : Strategy
 {
-	private readonly StrategyParam<StartMode> _mode;
+	private readonly StrategyParam<StartModes> _mode;
 	private readonly StrategyParam<decimal> _percentThreshold;
 	private readonly StrategyParam<decimal> _startVolume;
 	private readonly StrategyParam<decimal> _maxVolume;
@@ -42,7 +42,7 @@ public class SmartForexSystemStrategy : Strategy
 	/// </summary>
 	public SmartForexSystemStrategy()
 	{
-		_mode = Param(nameof(Mode), StartMode.LongAndShort)
+		_mode = Param(nameof(Mode), StartModes.LongAndShort)
 			.SetDisplay("Trading Mode", "Directional filter for opening baskets", "Trading")
 			.SetCanOptimize(true);
 
@@ -107,7 +107,7 @@ public class SmartForexSystemStrategy : Strategy
 	/// <summary>
 	/// Determines which market directions the strategy is allowed to trade.
 	/// </summary>
-	public StartMode Mode
+	public StartModes Mode
 	{
 		get => _mode.Value;
 		set => _mode.Value = value;
@@ -234,15 +234,15 @@ public class SmartForexSystemStrategy : Strategy
 
 		ManageOpenBaskets(candle.ClosePrice, point);
 
-		if (Mode != StartMode.Off)
+		if (Mode != StartModes.Off)
 		{
 			var signal = DetermineSignal(candle);
 
-			if (signal == TradeDirection.Buy && AllowsLongs() && _buyEntries.Count == 0)
+			if (signal == TradeDirections.Buy && AllowsLongs() && _buyEntries.Count == 0)
 			{
 				OpenBuy(candle.ClosePrice, StartVolume);
 			}
-			else if (signal == TradeDirection.Sell && AllowsShorts() && _sellEntries.Count == 0)
+			else if (signal == TradeDirections.Sell && AllowsShorts() && _sellEntries.Count == 0)
 			{
 				OpenSell(candle.ClosePrice, StartVolume);
 			}
@@ -255,22 +255,22 @@ public class SmartForexSystemStrategy : Strategy
 		_referenceClose = candle.ClosePrice;
 	}
 
-	private TradeDirection DetermineSignal(ICandleMessage candle)
+	private TradeDirections DetermineSignal(ICandleMessage candle)
 	{
 		if (_previousCandle == null || _referenceClose == null || _referenceClose.Value == 0m)
-			return TradeDirection.None;
+			return TradeDirections.None;
 
 		var previousOpen = _previousCandle.OpenPrice;
 		var previousClose = _previousCandle.ClosePrice;
 		var force = (candle.ClosePrice - _referenceClose.Value) / _referenceClose.Value * 10000m;
 
 		if (previousClose < previousOpen && force <= -PercentThreshold)
-			return TradeDirection.Buy;
+			return TradeDirections.Buy;
 
 		if (previousClose > previousOpen && force >= PercentThreshold)
-			return TradeDirection.Sell;
+			return TradeDirections.Sell;
 
-		return TradeDirection.None;
+		return TradeDirections.None;
 	}
 
 	private void ManageOpenBaskets(decimal price, decimal point)
@@ -469,18 +469,18 @@ public class SmartForexSystemStrategy : Strategy
 
 	private bool AllowsLongs()
 	{
-		return Mode == StartMode.LongOnly || Mode == StartMode.LongAndShort;
+		return Mode == StartModes.LongOnly || Mode == StartModes.LongAndShort;
 	}
 
 	private bool AllowsShorts()
 	{
-		return Mode == StartMode.ShortOnly || Mode == StartMode.LongAndShort;
+		return Mode == StartModes.ShortOnly || Mode == StartModes.LongAndShort;
 	}
 
 	/// <summary>
 	/// Directional trading modes supported by the strategy.
 	/// </summary>
-	public enum StartMode
+	public enum StartModes
 	{
 		ShortOnly = 1,
 		LongOnly = 2,
@@ -488,7 +488,7 @@ public class SmartForexSystemStrategy : Strategy
 		Off = 4,
 	}
 
-	private enum TradeDirection
+	private enum TradeDirections
 	{
 		None,
 		Buy,

--- a/API/3463_TugbaGold/CS/TugbaGoldStrategy.cs
+++ b/API/3463_TugbaGold/CS/TugbaGoldStrategy.cs
@@ -22,7 +22,7 @@ public class TugbaGoldStrategy : Strategy
 	private readonly StrategyParam<decimal> _takeProfitPips;
 	private readonly StrategyParam<decimal> _startVolume;
 	private readonly StrategyParam<decimal> _maxVolume;
-	private readonly StrategyParam<CloseOrderMode> _closeMode;
+	private readonly StrategyParam<CloseOrderModes> _closeMode;
 	private readonly StrategyParam<decimal> _pointOrderStepPips;
 	private readonly StrategyParam<decimal> _minimalProfitPips;
 	private readonly StrategyParam<DataType> _candleType;
@@ -63,7 +63,7 @@ public class TugbaGoldStrategy : Strategy
 	/// <summary>
 	/// Averaging exit mode.
 	/// </summary>
-	public CloseOrderMode CloseMode
+	public CloseOrderModes CloseMode
 	{
 		get => _closeMode.Value;
 		set => _closeMode.Value = value;
@@ -113,7 +113,7 @@ public class TugbaGoldStrategy : Strategy
 			.SetDisplay("Max Volume", "Upper cap for order volume (0 disables)", "Trading")
 			.SetGreaterThanOrEqualZero();
 
-		_closeMode = Param(nameof(CloseMode), CloseOrderMode.Average)
+		_closeMode = Param(nameof(CloseMode), CloseOrderModes.Average)
 			.SetDisplay("Close Mode", "Averaging exit logic", "Trading");
 
 		_pointOrderStepPips = Param(nameof(PointOrderStepPips), 390m)
@@ -215,7 +215,7 @@ public class TugbaGoldStrategy : Strategy
 			}
 		}
 
-		if (CloseMode == CloseOrderMode.Average)
+		if (CloseMode == CloseOrderModes.Average)
 		{
 			if (buyTarget is decimal bt && buyCount >= 2 && bid >= bt)
 			{
@@ -362,7 +362,7 @@ public class TugbaGoldStrategy : Strategy
 		if (denominator <= 0m)
 			return null;
 
-		if (CloseMode == CloseOrderMode.Average)
+		if (CloseMode == CloseOrderModes.Average)
 		{
 			return (maxEntry.Price * maxEntry.Volume + minEntry.Price * minEntry.Volume) / denominator + minimalProfit;
 		}
@@ -381,7 +381,7 @@ public class TugbaGoldStrategy : Strategy
 		if (denominator <= 0m)
 			return null;
 
-		if (CloseMode == CloseOrderMode.Average)
+		if (CloseMode == CloseOrderModes.Average)
 		{
 			return (maxEntry.Price * maxEntry.Volume + minEntry.Price * minEntry.Volume) / denominator - minimalProfit;
 		}
@@ -593,7 +593,7 @@ public class TugbaGoldStrategy : Strategy
 	/// <summary>
 	/// Exit mode for averaging positions.
 	/// </summary>
-	public enum CloseOrderMode
+	public enum CloseOrderModes
 	{
 		Average,
 		Partial,

--- a/API/3466_Ronz_Auto_SLTP/CS/RonzAutoSltpStrategy.cs
+++ b/API/3466_Ronz_Auto_SLTP/CS/RonzAutoSltpStrategy.cs
@@ -37,7 +37,7 @@ public class RonzAutoSltpStrategy : Strategy
 	private readonly StrategyParam<bool> _enableLockProfit;
 	private readonly StrategyParam<int> _lockProfitAfterPips;
 	private readonly StrategyParam<int> _profitLockPips;
-	private readonly StrategyParam<TrailingMode> _trailingMode;
+	private readonly StrategyParam<TrailingModes> _trailingMode;
 	private readonly StrategyParam<int> _trailingStopPips;
 	private readonly StrategyParam<int> _trailingStepPips;
 	private readonly StrategyParam<bool> _enableAlerts;
@@ -81,7 +81,7 @@ public class RonzAutoSltpStrategy : Strategy
 		.SetDisplay("Locked Profit (pips)", "Profit preserved once the lock is active.", "Trailing")
 		.SetCanOptimize(true);
 
-		_trailingMode = Param(nameof(TrailingStopMode), TrailingMode.Classic)
+		_trailingMode = Param(nameof(TrailingStopMode), TrailingModes.Classic)
 		.SetDisplay("Trailing Mode", "Style of the trailing stop used after the lock threshold.", "Trailing");
 
 		_trailingStopPips = Param(nameof(TrailingStopPips), 50)
@@ -164,7 +164,7 @@ public class RonzAutoSltpStrategy : Strategy
 	/// <summary>
 	/// Trailing stop style.
 	/// </summary>
-	public TrailingMode TrailingStopMode
+	public TrailingModes TrailingStopMode
 	{
 		get => _trailingMode.Value;
 		set => _trailingMode.Value = value;
@@ -624,12 +624,12 @@ public class RonzAutoSltpStrategy : Strategy
 		decimal candidate;
 		switch (TrailingStopMode)
 		{
-			case TrailingMode.None:
+			case TrailingModes.None:
 			return null;
-			case TrailingMode.Classic:
+			case TrailingModes.Classic:
 			candidate = isLong ? currentPrice - distance : currentPrice + distance;
 			break;
-			case TrailingMode.StepDistance:
+			case TrailingModes.StepDistance:
 			{
 				var adjusted = distance - stepDistance;
 				if (adjusted <= 0m)
@@ -637,7 +637,7 @@ public class RonzAutoSltpStrategy : Strategy
 				candidate = isLong ? currentPrice - adjusted : currentPrice + adjusted;
 				break;
 			}
-			case TrailingMode.StepByStep:
+			case TrailingModes.StepByStep:
 			{
 				if (stepDistance <= 0m)
 				return null;
@@ -716,7 +716,7 @@ public class RonzAutoSltpStrategy : Strategy
 	/// <summary>
 	/// Trailing stop options that match the MetaTrader implementation.
 	/// </summary>
-	public enum TrailingMode
+	public enum TrailingModes
 	{
 		None,
 		Classic,

--- a/API/3469_TradingPanel_Batch/CS/TradingPanelBatchStrategy.cs
+++ b/API/3469_TradingPanel_Batch/CS/TradingPanelBatchStrategy.cs
@@ -23,7 +23,7 @@ public class TradingPanelBatchStrategy : Strategy
 	/// <summary>
 	/// Direction requested for the next batch of orders.
 	/// </summary>
-	public enum TradeDirection
+	public enum TradeDirections
 	{
 		/// <summary>
 		/// Do not execute any trades.
@@ -45,7 +45,7 @@ public class TradingPanelBatchStrategy : Strategy
 	private readonly StrategyParam<decimal> _stopLossPips;
 	private readonly StrategyParam<decimal> _takeProfitPips;
 	private readonly StrategyParam<decimal> _orderVolume;
-	private readonly StrategyParam<TradeDirection> _direction;
+	private readonly StrategyParam<TradeDirections> _direction;
 	private readonly StrategyParam<DataType> _candleType;
 
 	private decimal _pipSize;
@@ -88,9 +88,9 @@ public class TradingPanelBatchStrategy : Strategy
 
 	/// <summary>
 	/// Trade direction to be executed on the next completed candle.
-	/// Automatically returns to <see cref="TradeDirection.None"/> after execution.
+	/// Automatically returns to <see cref="TradeDirections.None"/> after execution.
 	/// </summary>
-	public TradeDirection Direction
+	public TradeDirections Direction
 	{
 		get => _direction.Value;
 		set => _direction.Value = value;
@@ -132,7 +132,7 @@ public class TradingPanelBatchStrategy : Strategy
 		.SetGreaterThanZero()
 		.SetDisplay("Order Volume", "Volume of a single market order", "Execution");
 
-		_direction = Param(nameof(Direction), TradeDirection.None)
+		_direction = Param(nameof(Direction), TradeDirections.None)
 		.SetDisplay("Direction", "Trade direction for the next execution", "Execution");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(1).TimeFrame())
@@ -190,14 +190,14 @@ public class TradingPanelBatchStrategy : Strategy
 	private void ExecuteBatch(decimal referencePrice)
 	{
 		var direction = Direction;
-		if (direction == TradeDirection.None)
+		if (direction == TradeDirections.None)
 		return;
 
 		var volume = OrderVolume;
 		if (volume <= 0m)
 		{
 			LogWarning("Order volume must be positive to send trades.");
-			Direction = TradeDirection.None;
+			Direction = TradeDirections.None;
 			return;
 		}
 
@@ -205,7 +205,7 @@ public class TradingPanelBatchStrategy : Strategy
 		if (count <= 0)
 		{
 			LogWarning("Number of orders must be positive to send trades.");
-			Direction = TradeDirection.None;
+			Direction = TradeDirections.None;
 			return;
 		}
 
@@ -213,10 +213,10 @@ public class TradingPanelBatchStrategy : Strategy
 		{
 			switch (direction)
 			{
-			case TradeDirection.Buy:
+			case TradeDirections.Buy:
 				BuyMarket(volume);
 				break;
-			case TradeDirection.Sell:
+			case TradeDirections.Sell:
 				SellMarket(volume);
 				break;
 			}
@@ -224,7 +224,7 @@ public class TradingPanelBatchStrategy : Strategy
 
 		LogInfo($"Executed {count} {direction} market order(s) at reference price {referencePrice:F5} with volume {volume}.");
 
-		Direction = TradeDirection.None;
+		Direction = TradeDirections.None;
 	}
 
 	private decimal ConvertPipsToPrice(decimal pips)

--- a/API/3473_AutoTrading_Scheduler/CS/AutoTradingSchedulerStrategy.cs
+++ b/API/3473_AutoTrading_Scheduler/CS/AutoTradingSchedulerStrategy.cs
@@ -23,7 +23,7 @@ namespace StockSharp.Samples.Strategies;
 public class AutoTradingSchedulerStrategy : Strategy
 {
 	private readonly StrategyParam<bool> _schedulerEnabled;
-	private readonly StrategyParam<TimeReference> _referenceClock;
+	private readonly StrategyParam<TimeReferences> _referenceClock;
 	private readonly StrategyParam<bool> _closePositions;
 	private readonly StrategyParam<string> _mondaySchedule;
 	private readonly StrategyParam<string> _tuesdaySchedule;
@@ -50,7 +50,7 @@ public class AutoTradingSchedulerStrategy : Strategy
 	/// <summary>
 	/// Selects whether local or exchange/server time should be used.
 	/// </summary>
-	public TimeReference ReferenceClock
+	public TimeReferences ReferenceClock
 	{
 		get => _referenceClock.Value;
 		set => _referenceClock.Value = value;
@@ -141,7 +141,7 @@ public class AutoTradingSchedulerStrategy : Strategy
 		_schedulerEnabled = Param(nameof(SchedulerEnabled), false)
 		.SetDisplay("Scheduler Enabled", "Turns the timetable module on or off", "General");
 
-		_referenceClock = Param(nameof(ReferenceClock), TimeReference.Local)
+		_referenceClock = Param(nameof(ReferenceClock), TimeReferences.Local)
 		.SetDisplay("Reference Clock", "Pick Local or Exchange time base", "General");
 
 		_closePositions = Param(nameof(ClosePositionsBeforeDisable), true)
@@ -348,7 +348,7 @@ public class AutoTradingSchedulerStrategy : Strategy
 
 	private DateTimeOffset GetReferenceTime()
 	{
-		var now = ReferenceClock == TimeReference.Local ? DateTimeOffset.Now : CurrentTime;
+		var now = ReferenceClock == TimeReferences.Local ? DateTimeOffset.Now : CurrentTime;
 		if (now == default)
 			now = DateTimeOffset.Now;
 		return now;
@@ -374,7 +374,7 @@ public class AutoTradingSchedulerStrategy : Strategy
 	/// <summary>
 	/// Type of time base used by the scheduler.
 	/// </summary>
-	public enum TimeReference
+	public enum TimeReferences
 	{
 		/// <summary>
 		/// Use the local machine time.

--- a/API/3476_Averaging_By_Signal/CS/AveragingBySignalStrategy.cs
+++ b/API/3476_Averaging_By_Signal/CS/AveragingBySignalStrategy.cs
@@ -23,7 +23,7 @@ public class AveragingBySignalStrategy : Strategy
 /// <summary>
 /// Position sizing mode that mirrors the MQL LotType input.
 /// </summary>
-public enum LotSizingMode
+public enum LotSizingModes
 {
 /// <summary>
 /// Always use the base volume for every order.
@@ -39,7 +39,7 @@ Multiplier,
 /// <summary>
 /// Moving average calculation method used by the expert advisor.
 /// </summary>
-public enum MovingAverageMethod
+public enum MovingAverageMethods
 {
 /// <summary>
 /// Simple moving average (arithmetic mean).
@@ -64,12 +64,12 @@ LinearWeighted,
 
 private readonly StrategyParam<DataType> _candleType;
 private readonly StrategyParam<decimal> _initialVolume;
-private readonly StrategyParam<LotSizingMode> _lotSizing;
+private readonly StrategyParam<LotSizingModes> _lotSizing;
 private readonly StrategyParam<decimal> _multiplier;
 private readonly StrategyParam<int> _fastPeriod;
-private readonly StrategyParam<MovingAverageMethod> _fastMethod;
+private readonly StrategyParam<MovingAverageMethods> _fastMethod;
 private readonly StrategyParam<int> _slowPeriod;
-private readonly StrategyParam<MovingAverageMethod> _slowMethod;
+private readonly StrategyParam<MovingAverageMethods> _slowMethod;
 private readonly StrategyParam<int> _takeProfitPips;
 private readonly StrategyParam<bool> _averagingBySignal;
 private readonly StrategyParam<decimal> _layerDistancePips;
@@ -116,7 +116,7 @@ _initialVolume = Param(nameof(InitialVolume), 0.1m)
 .SetGreaterThanZero()
 .SetCanOptimize(true);
 
-_lotSizing = Param(nameof(LotSizing), LotSizingMode.Multiplier)
+_lotSizing = Param(nameof(LotSizing), LotSizingModes.Multiplier)
 .SetDisplay("Lot Sizing", "Choose between fixed or multiplier-based sizing.", "Money Management");
 
 _multiplier = Param(nameof(Multiplier), 2m)
@@ -129,7 +129,7 @@ _fastPeriod = Param(nameof(FastPeriod), 28)
 .SetGreaterThanZero()
 .SetCanOptimize(true);
 
-_fastMethod = Param(nameof(FastMethod), MovingAverageMethod.LinearWeighted)
+_fastMethod = Param(nameof(FastMethod), MovingAverageMethods.LinearWeighted)
 .SetDisplay("Fast Method", "Moving average method for the fast line.", "Indicators");
 
 _slowPeriod = Param(nameof(SlowPeriod), 50)
@@ -137,7 +137,7 @@ _slowPeriod = Param(nameof(SlowPeriod), 50)
 .SetGreaterThanZero()
 .SetCanOptimize(true);
 
-_slowMethod = Param(nameof(SlowMethod), MovingAverageMethod.Smoothed)
+_slowMethod = Param(nameof(SlowMethod), MovingAverageMethods.Smoothed)
 .SetDisplay("Slow Method", "Moving average method for the slow line.", "Indicators");
 
 _takeProfitPips = Param(nameof(TakeProfitPips), 15)
@@ -193,14 +193,14 @@ set => _initialVolume.Value = value;
 /// <summary>
 /// Sizing logic used when calculating volumes for averaging layers.
 /// </summary>
-public LotSizingMode LotSizing
+public LotSizingModes LotSizing
 {
 get => _lotSizing.Value;
 set => _lotSizing.Value = value;
 }
 
 /// <summary>
-/// Multiplier applied when <see cref="LotSizingMode.Multiplier"/> is selected.
+/// Multiplier applied when <see cref="LotSizingModes.Multiplier"/> is selected.
 /// </summary>
 public decimal Multiplier
 {
@@ -220,7 +220,7 @@ set => _fastPeriod.Value = value;
 /// <summary>
 /// Moving average method for the fast line.
 /// </summary>
-public MovingAverageMethod FastMethod
+public MovingAverageMethods FastMethod
 {
 get => _fastMethod.Value;
 set => _fastMethod.Value = value;
@@ -238,7 +238,7 @@ set => _slowPeriod.Value = value;
 /// <summary>
 /// Moving average method for the slow line.
 /// </summary>
-public MovingAverageMethod SlowMethod
+public MovingAverageMethods SlowMethod
 {
 get => _slowMethod.Value;
 set => _slowMethod.Value = value;
@@ -571,7 +571,7 @@ private decimal CalculateOrderVolume(int layerIndex)
 {
 var volume = InitialVolume;
 
-if (LotSizing == LotSizingMode.Multiplier)
+if (LotSizing == LotSizingModes.Multiplier)
 {
 for (var i = 0; i < layerIndex; i++)
 volume *= Multiplier;
@@ -604,14 +604,14 @@ volume = maxVolume.Value;
 return volume;
 }
 
-private IIndicator CreateMovingAverage(MovingAverageMethod method, int length)
+private IIndicator CreateMovingAverage(MovingAverageMethods method, int length)
 {
 return method switch
 {
-MovingAverageMethod.Simple => new SimpleMovingAverage { Length = length },
-MovingAverageMethod.Exponential => new ExponentialMovingAverage { Length = length },
-MovingAverageMethod.Smoothed => new SmoothedMovingAverage { Length = length },
-MovingAverageMethod.LinearWeighted => new WeightedMovingAverage { Length = length },
+MovingAverageMethods.Simple => new SimpleMovingAverage { Length = length },
+MovingAverageMethods.Exponential => new ExponentialMovingAverage { Length = length },
+MovingAverageMethods.Smoothed => new SmoothedMovingAverage { Length = length },
+MovingAverageMethods.LinearWeighted => new WeightedMovingAverage { Length = length },
 _ => new SimpleMovingAverage { Length = length },
 };
 }

--- a/API/3485_ValidateMe/CS/ValidateMeStrategy.cs
+++ b/API/3485_ValidateMe/CS/ValidateMeStrategy.cs
@@ -24,7 +24,7 @@ public class ValidateMeStrategy : Strategy
 	private readonly StrategyParam<int> _orderTakePips;
 	private readonly StrategyParam<int> _orderStopPips;
 	private readonly StrategyParam<decimal> _lots;
-	private readonly StrategyParam<TradeDirection> _direction;
+	private readonly StrategyParam<TradeDirections> _direction;
 
 	private decimal _pipSize;
 
@@ -62,7 +62,7 @@ public class ValidateMeStrategy : Strategy
 	/// <summary>
 	/// Trade direction to execute when no open position exists.
 	/// </summary>
-	public TradeDirection Direction
+	public TradeDirections Direction
 	{
 		get => _direction.Value;
 		set => _direction.Value = value;
@@ -71,7 +71,7 @@ public class ValidateMeStrategy : Strategy
 	/// <summary>
 	/// Available trade directions.
 	/// </summary>
-	public enum TradeDirection
+	public enum TradeDirections
 	{
 		Buy,
 		Sell,
@@ -94,7 +94,7 @@ public class ValidateMeStrategy : Strategy
 			.SetGreaterThanZero()
 			.SetDisplay("Lots", "Order volume in lots", "General");
 
-		_direction = Param(nameof(Direction), TradeDirection.Buy)
+		_direction = Param(nameof(Direction), TradeDirections.Buy)
 			.SetDisplay("Direction", "Trade direction when signals align", "General");
 	}
 
@@ -150,7 +150,7 @@ public class ValidateMeStrategy : Strategy
 
 		var volume = Lots;
 
-		if (Direction == TradeDirection.Buy)
+		if (Direction == TradeDirections.Buy)
 		{
 			BuyMarket(volume);
 		}

--- a/API/3486_AverageCandleCross/CS/AverageCandleCrossStrategy.cs
+++ b/API/3486_AverageCandleCross/CS/AverageCandleCrossStrategy.cs
@@ -22,28 +22,28 @@ namespace StockSharp.Samples.Strategies;
 public class AverageCandleCrossStrategy : Strategy
 {
 	private readonly StrategyParam<int> _firstTrendFastPeriod;
-	private readonly StrategyParam<MaMethodOption> _firstTrendFastMethod;
+	private readonly StrategyParam<MaMethodOptions> _firstTrendFastMethod;
 	private readonly StrategyParam<int> _firstTrendSlowPeriod;
-	private readonly StrategyParam<MaMethodOption> _firstTrendSlowMethod;
+	private readonly StrategyParam<MaMethodOptions> _firstTrendSlowMethod;
 	private readonly StrategyParam<int> _secondTrendFastPeriod;
-	private readonly StrategyParam<MaMethodOption> _secondTrendFastMethod;
+	private readonly StrategyParam<MaMethodOptions> _secondTrendFastMethod;
 	private readonly StrategyParam<int> _secondTrendSlowPeriod;
-	private readonly StrategyParam<MaMethodOption> _secondTrendSlowMethod;
+	private readonly StrategyParam<MaMethodOptions> _secondTrendSlowMethod;
 	private readonly StrategyParam<int> _bullCrossPeriod;
-	private readonly StrategyParam<MaMethodOption> _bullCrossMethod;
+	private readonly StrategyParam<MaMethodOptions> _bullCrossMethod;
 	private readonly StrategyParam<decimal> _buyVolume;
 	private readonly StrategyParam<decimal> _buyStopLossPips;
 	private readonly StrategyParam<decimal> _buyTakeProfitPercent;
 	private readonly StrategyParam<int> _firstTrendBearFastPeriod;
-	private readonly StrategyParam<MaMethodOption> _firstTrendBearFastMethod;
+	private readonly StrategyParam<MaMethodOptions> _firstTrendBearFastMethod;
 	private readonly StrategyParam<int> _firstTrendBearSlowPeriod;
-	private readonly StrategyParam<MaMethodOption> _firstTrendBearSlowMethod;
+	private readonly StrategyParam<MaMethodOptions> _firstTrendBearSlowMethod;
 	private readonly StrategyParam<int> _secondTrendBearFastPeriod;
-	private readonly StrategyParam<MaMethodOption> _secondTrendBearFastMethod;
+	private readonly StrategyParam<MaMethodOptions> _secondTrendBearFastMethod;
 	private readonly StrategyParam<int> _secondTrendBearSlowPeriod;
-	private readonly StrategyParam<MaMethodOption> _secondTrendBearSlowMethod;
+	private readonly StrategyParam<MaMethodOptions> _secondTrendBearSlowMethod;
 	private readonly StrategyParam<int> _bearCrossPeriod;
-	private readonly StrategyParam<MaMethodOption> _bearCrossMethod;
+	private readonly StrategyParam<MaMethodOptions> _bearCrossMethod;
 	private readonly StrategyParam<decimal> _sellVolume;
 	private readonly StrategyParam<decimal> _sellStopLossPips;
 	private readonly StrategyParam<decimal> _sellTakeProfitPercent;
@@ -99,7 +99,7 @@ public class AverageCandleCrossStrategy : Strategy
 		.SetDisplay("First Trend Fast Period", "Period of the fast trend filter moving average (buy side)", "Buy Filters")
 		.SetCanOptimize(true);
 
-		_firstTrendFastMethod = Param(nameof(FirstTrendFastMethod), MaMethodOption.Simple)
+		_firstTrendFastMethod = Param(nameof(FirstTrendFastMethod), MaMethodOptions.Simple)
 		.SetDisplay("First Trend Fast Method", "Smoothing method for the fast trend filter (buy side)", "Buy Filters")
 		.SetCanOptimize(true);
 
@@ -108,7 +108,7 @@ public class AverageCandleCrossStrategy : Strategy
 		.SetDisplay("First Trend Slow Period", "Period of the slow trend filter moving average (buy side)", "Buy Filters")
 		.SetCanOptimize(true);
 
-		_firstTrendSlowMethod = Param(nameof(FirstTrendSlowMethod), MaMethodOption.Simple)
+		_firstTrendSlowMethod = Param(nameof(FirstTrendSlowMethod), MaMethodOptions.Simple)
 		.SetDisplay("First Trend Slow Method", "Smoothing method for the slow trend filter (buy side)", "Buy Filters")
 		.SetCanOptimize(true);
 
@@ -117,7 +117,7 @@ public class AverageCandleCrossStrategy : Strategy
 		.SetDisplay("Second Trend Fast Period", "Period of the secondary fast trend filter (buy side)", "Buy Filters")
 		.SetCanOptimize(true);
 
-		_secondTrendFastMethod = Param(nameof(SecondTrendFastMethod), MaMethodOption.Simple)
+		_secondTrendFastMethod = Param(nameof(SecondTrendFastMethod), MaMethodOptions.Simple)
 		.SetDisplay("Second Trend Fast Method", "Smoothing method for the secondary fast trend filter (buy side)", "Buy Filters")
 		.SetCanOptimize(true);
 
@@ -126,7 +126,7 @@ public class AverageCandleCrossStrategy : Strategy
 		.SetDisplay("Second Trend Slow Period", "Period of the secondary slow trend filter (buy side)", "Buy Filters")
 		.SetCanOptimize(true);
 
-		_secondTrendSlowMethod = Param(nameof(SecondTrendSlowMethod), MaMethodOption.Simple)
+		_secondTrendSlowMethod = Param(nameof(SecondTrendSlowMethod), MaMethodOptions.Simple)
 		.SetDisplay("Second Trend Slow Method", "Smoothing method for the secondary slow trend filter (buy side)", "Buy Filters")
 		.SetCanOptimize(true);
 
@@ -135,7 +135,7 @@ public class AverageCandleCrossStrategy : Strategy
 		.SetDisplay("Bull Cross Period", "Period of the moving average used for bullish candle cross detection", "Buy Filters")
 		.SetCanOptimize(true);
 
-		_bullCrossMethod = Param(nameof(BullCrossMethod), MaMethodOption.Simple)
+		_bullCrossMethod = Param(nameof(BullCrossMethod), MaMethodOptions.Simple)
 		.SetDisplay("Bull Cross Method", "Smoothing method for the candle cross moving average (buy side)", "Buy Filters")
 		.SetCanOptimize(true);
 
@@ -156,7 +156,7 @@ public class AverageCandleCrossStrategy : Strategy
 		.SetDisplay("First Trend Fast Period (Sell)", "Period of the fast trend filter moving average (sell side)", "Sell Filters")
 		.SetCanOptimize(true);
 
-		_firstTrendBearFastMethod = Param(nameof(FirstTrendBearFastMethod), MaMethodOption.Simple)
+		_firstTrendBearFastMethod = Param(nameof(FirstTrendBearFastMethod), MaMethodOptions.Simple)
 		.SetDisplay("First Trend Fast Method (Sell)", "Smoothing method for the fast trend filter (sell side)", "Sell Filters")
 		.SetCanOptimize(true);
 
@@ -165,7 +165,7 @@ public class AverageCandleCrossStrategy : Strategy
 		.SetDisplay("First Trend Slow Period (Sell)", "Period of the slow trend filter moving average (sell side)", "Sell Filters")
 		.SetCanOptimize(true);
 
-		_firstTrendBearSlowMethod = Param(nameof(FirstTrendBearSlowMethod), MaMethodOption.Simple)
+		_firstTrendBearSlowMethod = Param(nameof(FirstTrendBearSlowMethod), MaMethodOptions.Simple)
 		.SetDisplay("First Trend Slow Method (Sell)", "Smoothing method for the slow trend filter (sell side)", "Sell Filters")
 		.SetCanOptimize(true);
 
@@ -174,7 +174,7 @@ public class AverageCandleCrossStrategy : Strategy
 		.SetDisplay("Second Trend Fast Period (Sell)", "Period of the secondary fast trend filter (sell side)", "Sell Filters")
 		.SetCanOptimize(true);
 
-		_secondTrendBearFastMethod = Param(nameof(SecondTrendBearFastMethod), MaMethodOption.Simple)
+		_secondTrendBearFastMethod = Param(nameof(SecondTrendBearFastMethod), MaMethodOptions.Simple)
 		.SetDisplay("Second Trend Fast Method (Sell)", "Smoothing method for the secondary fast trend filter (sell side)", "Sell Filters")
 		.SetCanOptimize(true);
 
@@ -183,7 +183,7 @@ public class AverageCandleCrossStrategy : Strategy
 		.SetDisplay("Second Trend Slow Period (Sell)", "Period of the secondary slow trend filter (sell side)", "Sell Filters")
 		.SetCanOptimize(true);
 
-		_secondTrendBearSlowMethod = Param(nameof(SecondTrendBearSlowMethod), MaMethodOption.Simple)
+		_secondTrendBearSlowMethod = Param(nameof(SecondTrendBearSlowMethod), MaMethodOptions.Simple)
 		.SetDisplay("Second Trend Slow Method (Sell)", "Smoothing method for the secondary slow trend filter (sell side)", "Sell Filters")
 		.SetCanOptimize(true);
 
@@ -192,7 +192,7 @@ public class AverageCandleCrossStrategy : Strategy
 		.SetDisplay("Bear Cross Period", "Period of the moving average used for bearish candle cross detection", "Sell Filters")
 		.SetCanOptimize(true);
 
-		_bearCrossMethod = Param(nameof(BearCrossMethod), MaMethodOption.Simple)
+		_bearCrossMethod = Param(nameof(BearCrossMethod), MaMethodOptions.Simple)
 		.SetDisplay("Bear Cross Method", "Smoothing method for the candle cross moving average (sell side)", "Sell Filters")
 		.SetCanOptimize(true);
 
@@ -224,7 +224,7 @@ public class AverageCandleCrossStrategy : Strategy
 	/// <summary>
 	/// Moving average method of the first trend fast filter for the long setup.
 	/// </summary>
-	public MaMethodOption FirstTrendFastMethod { get => _firstTrendFastMethod.Value; set => _firstTrendFastMethod.Value = value; }
+	public MaMethodOptions FirstTrendFastMethod { get => _firstTrendFastMethod.Value; set => _firstTrendFastMethod.Value = value; }
 
 	/// <summary>
 	/// Slow period of the first trend filter for the long setup.
@@ -234,7 +234,7 @@ public class AverageCandleCrossStrategy : Strategy
 	/// <summary>
 	/// Moving average method of the first trend slow filter for the long setup.
 	/// </summary>
-	public MaMethodOption FirstTrendSlowMethod { get => _firstTrendSlowMethod.Value; set => _firstTrendSlowMethod.Value = value; }
+	public MaMethodOptions FirstTrendSlowMethod { get => _firstTrendSlowMethod.Value; set => _firstTrendSlowMethod.Value = value; }
 
 	/// <summary>
 	/// Fast period of the second trend filter for the long setup.
@@ -244,7 +244,7 @@ public class AverageCandleCrossStrategy : Strategy
 	/// <summary>
 	/// Moving average method of the second trend fast filter for the long setup.
 	/// </summary>
-	public MaMethodOption SecondTrendFastMethod { get => _secondTrendFastMethod.Value; set => _secondTrendFastMethod.Value = value; }
+	public MaMethodOptions SecondTrendFastMethod { get => _secondTrendFastMethod.Value; set => _secondTrendFastMethod.Value = value; }
 
 	/// <summary>
 	/// Slow period of the second trend filter for the long setup.
@@ -254,7 +254,7 @@ public class AverageCandleCrossStrategy : Strategy
 	/// <summary>
 	/// Moving average method of the second trend slow filter for the long setup.
 	/// </summary>
-	public MaMethodOption SecondTrendSlowMethod { get => _secondTrendSlowMethod.Value; set => _secondTrendSlowMethod.Value = value; }
+	public MaMethodOptions SecondTrendSlowMethod { get => _secondTrendSlowMethod.Value; set => _secondTrendSlowMethod.Value = value; }
 
 	/// <summary>
 	/// Period of the moving average that participates in the bullish candle cross check.
@@ -264,7 +264,7 @@ public class AverageCandleCrossStrategy : Strategy
 	/// <summary>
 	/// Moving average method used in the bullish candle cross check.
 	/// </summary>
-	public MaMethodOption BullCrossMethod { get => _bullCrossMethod.Value; set => _bullCrossMethod.Value = value; }
+	public MaMethodOptions BullCrossMethod { get => _bullCrossMethod.Value; set => _bullCrossMethod.Value = value; }
 
 	/// <summary>
 	/// Volume of a single long trade.
@@ -289,7 +289,7 @@ public class AverageCandleCrossStrategy : Strategy
 	/// <summary>
 	/// Moving average method of the first trend fast filter for the short setup.
 	/// </summary>
-	public MaMethodOption FirstTrendBearFastMethod { get => _firstTrendBearFastMethod.Value; set => _firstTrendBearFastMethod.Value = value; }
+	public MaMethodOptions FirstTrendBearFastMethod { get => _firstTrendBearFastMethod.Value; set => _firstTrendBearFastMethod.Value = value; }
 
 	/// <summary>
 	/// Slow period of the first trend filter for the short setup.
@@ -299,7 +299,7 @@ public class AverageCandleCrossStrategy : Strategy
 	/// <summary>
 	/// Moving average method of the first trend slow filter for the short setup.
 	/// </summary>
-	public MaMethodOption FirstTrendBearSlowMethod { get => _firstTrendBearSlowMethod.Value; set => _firstTrendBearSlowMethod.Value = value; }
+	public MaMethodOptions FirstTrendBearSlowMethod { get => _firstTrendBearSlowMethod.Value; set => _firstTrendBearSlowMethod.Value = value; }
 
 	/// <summary>
 	/// Fast period of the second trend filter for the short setup.
@@ -309,7 +309,7 @@ public class AverageCandleCrossStrategy : Strategy
 	/// <summary>
 	/// Moving average method of the second trend fast filter for the short setup.
 	/// </summary>
-	public MaMethodOption SecondTrendBearFastMethod { get => _secondTrendBearFastMethod.Value; set => _secondTrendBearFastMethod.Value = value; }
+	public MaMethodOptions SecondTrendBearFastMethod { get => _secondTrendBearFastMethod.Value; set => _secondTrendBearFastMethod.Value = value; }
 
 	/// <summary>
 	/// Slow period of the second trend filter for the short setup.
@@ -319,7 +319,7 @@ public class AverageCandleCrossStrategy : Strategy
 	/// <summary>
 	/// Moving average method of the second trend slow filter for the short setup.
 	/// </summary>
-	public MaMethodOption SecondTrendBearSlowMethod { get => _secondTrendBearSlowMethod.Value; set => _secondTrendBearSlowMethod.Value = value; }
+	public MaMethodOptions SecondTrendBearSlowMethod { get => _secondTrendBearSlowMethod.Value; set => _secondTrendBearSlowMethod.Value = value; }
 
 	/// <summary>
 	/// Period of the moving average that participates in the bearish candle cross check.
@@ -329,7 +329,7 @@ public class AverageCandleCrossStrategy : Strategy
 	/// <summary>
 	/// Moving average method used in the bearish candle cross check.
 	/// </summary>
-	public MaMethodOption BearCrossMethod { get => _bearCrossMethod.Value; set => _bearCrossMethod.Value = value; }
+	public MaMethodOptions BearCrossMethod { get => _bearCrossMethod.Value; set => _bearCrossMethod.Value = value; }
 
 	/// <summary>
 	/// Volume of a single short trade.
@@ -642,14 +642,14 @@ public class AverageCandleCrossStrategy : Strategy
 		CancelProtection(ref _takeProfitOrder);
 	}
 
-	private static LengthIndicator<decimal> CreateMovingAverage(MaMethodOption method, int period)
+	private static LengthIndicator<decimal> CreateMovingAverage(MaMethodOptions method, int period)
 	{
 		return method switch
 		{
-			MaMethodOption.Simple => new SimpleMovingAverage { Length = period },
-			MaMethodOption.Exponential => new ExponentialMovingAverage { Length = period },
-			MaMethodOption.Smoothed => new SmoothedMovingAverage { Length = period },
-			MaMethodOption.LinearWeighted => new WeightedMovingAverage { Length = period },
+			MaMethodOptions.Simple => new SimpleMovingAverage { Length = period },
+			MaMethodOptions.Exponential => new ExponentialMovingAverage { Length = period },
+			MaMethodOptions.Smoothed => new SmoothedMovingAverage { Length = period },
+			MaMethodOptions.LinearWeighted => new WeightedMovingAverage { Length = period },
 			_ => new SimpleMovingAverage { Length = period }
 		};
 	}
@@ -657,7 +657,7 @@ public class AverageCandleCrossStrategy : Strategy
 	/// <summary>
 	/// Moving average smoothing methods supported by the strategy.
 	/// </summary>
-	public enum MaMethodOption
+	public enum MaMethodOptions
 	{
 		/// <summary>
 		/// Simple moving average.

--- a/API/3489_Buy_Sell_On_Your_Price/CS/BuySellOnYourPriceStrategy.cs
+++ b/API/3489_Buy_Sell_On_Your_Price/CS/BuySellOnYourPriceStrategy.cs
@@ -23,12 +23,12 @@ public class BuySellOnYourPriceStrategy : Strategy
 	private readonly StrategyParam<decimal> _entryPrice;
 	private readonly StrategyParam<decimal> _stopLossPrice;
 	private readonly StrategyParam<decimal> _takeProfitPrice;
-	private readonly StrategyParam<OrderMode> _orderMode;
+	private readonly StrategyParam<OrderModes> _orderMode;
 
 	/// <summary>
 	/// Type of order to execute when the strategy starts.
 	/// </summary>
-	public enum OrderMode
+	public enum OrderModes
 	{
 		/// <summary>
 		/// Do not send any order.
@@ -105,7 +105,7 @@ public class BuySellOnYourPriceStrategy : Strategy
 	/// <summary>
 	/// Selected order mode.
 	/// </summary>
-	public OrderMode Mode
+	public OrderModes Mode
 	{
 		get => _orderMode.Value;
 		set => _orderMode.Value = value;
@@ -129,7 +129,7 @@ public class BuySellOnYourPriceStrategy : Strategy
 		_takeProfitPrice = Param(nameof(TakeProfitPrice), 0m)
 			.SetDisplay("Take Profit Price", "Absolute take-profit level", "Risk Management");
 
-		_orderMode = Param(nameof(Mode), OrderMode.None)
+		_orderMode = Param(nameof(Mode), OrderModes.None)
 			.SetDisplay("Order Mode", "Type of order to submit", "General");
 	}
 
@@ -145,7 +145,7 @@ public class BuySellOnYourPriceStrategy : Strategy
 		base.OnStarted(time);
 
 		var mode = Mode;
-		if (mode == OrderMode.None)
+		if (mode == OrderModes.None)
 		{
 			LogInfo("Order mode is set to None. No orders will be sent.");
 			return;
@@ -170,7 +170,7 @@ public class BuySellOnYourPriceStrategy : Strategy
 			return;
 		}
 
-		var isBuy = mode is OrderMode.Buy or OrderMode.BuyLimit or OrderMode.BuyStop;
+		var isBuy = mode is OrderModes.Buy or OrderModes.BuyLimit or OrderModes.BuyStop;
 		var entryPrice = ResolveEntryPrice(mode, isBuy);
 
 		if (!ValidateEntryPrice(mode, entryPrice))
@@ -182,32 +182,32 @@ public class BuySellOnYourPriceStrategy : Strategy
 
 		switch (mode)
 		{
-			case OrderMode.Buy:
+			case OrderModes.Buy:
 				BuyMarket(volume);
 				LogInfo($"Market buy order sent. Volume={volume}.");
 				break;
 
-			case OrderMode.Sell:
+			case OrderModes.Sell:
 				SellMarket(volume);
 				LogInfo($"Market sell order sent. Volume={volume}.");
 				break;
 
-			case OrderMode.BuyLimit:
+			case OrderModes.BuyLimit:
 				BuyLimit(volume, entryPrice);
 				LogInfo($"Buy limit order placed at {entryPrice}. Volume={volume}.");
 				break;
 
-			case OrderMode.SellLimit:
+			case OrderModes.SellLimit:
 				SellLimit(volume, entryPrice);
 				LogInfo($"Sell limit order placed at {entryPrice}. Volume={volume}.");
 				break;
 
-			case OrderMode.BuyStop:
+			case OrderModes.BuyStop:
 				BuyStop(volume, entryPrice);
 				LogInfo($"Buy stop order placed at {entryPrice}. Volume={volume}.");
 				break;
 
-			case OrderMode.SellStop:
+			case OrderModes.SellStop:
 				SellStop(volume, entryPrice);
 				LogInfo($"Sell stop order placed at {entryPrice}. Volume={volume}.");
 				break;
@@ -225,9 +225,9 @@ public class BuySellOnYourPriceStrategy : Strategy
 		return false;
 	}
 
-	private decimal ResolveEntryPrice(OrderMode mode, bool isBuy)
+	private decimal ResolveEntryPrice(OrderModes mode, bool isBuy)
 	{
-		if (mode == OrderMode.Buy || mode == OrderMode.Sell)
+		if (mode == OrderModes.Buy || mode == OrderModes.Sell)
 		{
 			var bestBid = Security.BestBid?.Price ?? 0m;
 			var bestAsk = Security.BestAsk?.Price ?? 0m;
@@ -248,9 +248,9 @@ public class BuySellOnYourPriceStrategy : Strategy
 		return EntryPrice;
 	}
 
-	private bool ValidateEntryPrice(OrderMode mode, decimal entryPrice)
+	private bool ValidateEntryPrice(OrderModes mode, decimal entryPrice)
 	{
-		if (mode == OrderMode.Buy || mode == OrderMode.Sell)
+		if (mode == OrderModes.Buy || mode == OrderModes.Sell)
 		{
 			if (entryPrice <= 0m)
 			{

--- a/API/3490_Commission_Calculator/CS/CommissionCalculatorStrategy.cs
+++ b/API/3490_Commission_Calculator/CS/CommissionCalculatorStrategy.cs
@@ -24,7 +24,7 @@ public class CommissionCalculatorStrategy : Strategy
 	private readonly StrategyParam<decimal> _stopLossPrice;
 	private readonly StrategyParam<decimal> _takeProfitPrice;
 	private readonly StrategyParam<decimal> _commissionRate;
-	private readonly StrategyParam<OrderMode> _orderMode;
+	private readonly StrategyParam<OrderModes> _orderMode;
 
 	private decimal _totalFee;
 	private decimal _lastFee;
@@ -34,7 +34,7 @@ public class CommissionCalculatorStrategy : Strategy
 	/// <summary>
 	/// Available order execution modes.
 	/// </summary>
-	public enum OrderMode
+	public enum OrderModes
 	{
 		/// <summary>
 		/// Do not send any order.
@@ -120,7 +120,7 @@ public class CommissionCalculatorStrategy : Strategy
 	/// <summary>
 	/// Selected order execution mode.
 	/// </summary>
-	public OrderMode Mode
+	public OrderModes Mode
 	{
 		get => _orderMode.Value;
 		set => _orderMode.Value = value;
@@ -148,7 +148,7 @@ public class CommissionCalculatorStrategy : Strategy
 			.SetGreaterThanZero()
 			.SetDisplay("Commission Rate %", "Commission rate applied to each executed trade", "General");
 
-		_orderMode = Param(nameof(Mode), OrderMode.None)
+		_orderMode = Param(nameof(Mode), OrderModes.None)
 			.SetDisplay("Order Mode", "Type of order that should be placed", "Trading");
 	}
 
@@ -249,7 +249,7 @@ public class CommissionCalculatorStrategy : Strategy
 
 		var volume = Volume;
 
-		if (Mode == OrderMode.None || volume <= 0m)
+		if (Mode == OrderModes.None || volume <= 0m)
 		{
 			LogInfo("Order mode is set to None or volume is zero. No order will be sent.");
 			return;
@@ -257,12 +257,12 @@ public class CommissionCalculatorStrategy : Strategy
 
 		Order order = Mode switch
 		{
-			OrderMode.MarketBuy => BuyMarket(volume),
-			OrderMode.MarketSell => SellMarket(volume),
-			OrderMode.BuyLimit => EntryPrice > 0m ? BuyLimit(EntryPrice, volume) : null,
-			OrderMode.SellLimit => EntryPrice > 0m ? SellLimit(EntryPrice, volume) : null,
-			OrderMode.BuyStop => EntryPrice > 0m ? BuyStop(EntryPrice, volume) : null,
-			OrderMode.SellStop => EntryPrice > 0m ? SellStop(EntryPrice, volume) : null,
+			OrderModes.MarketBuy => BuyMarket(volume),
+			OrderModes.MarketSell => SellMarket(volume),
+			OrderModes.BuyLimit => EntryPrice > 0m ? BuyLimit(EntryPrice, volume) : null,
+			OrderModes.SellLimit => EntryPrice > 0m ? SellLimit(EntryPrice, volume) : null,
+			OrderModes.BuyStop => EntryPrice > 0m ? BuyStop(EntryPrice, volume) : null,
+			OrderModes.SellStop => EntryPrice > 0m ? SellStop(EntryPrice, volume) : null,
 			_ => null,
 		};
 

--- a/API/3492_Simple_Engulfing/CS/SimpleEngulfingStrategy.cs
+++ b/API/3492_Simple_Engulfing/CS/SimpleEngulfingStrategy.cs
@@ -26,7 +26,7 @@ public class SimpleEngulfingStrategy : Strategy
 	private readonly StrategyParam<decimal> _takeProfitPips;
 	private readonly StrategyParam<decimal> _minBodyPips;
 	private readonly StrategyParam<decimal> _maxBodyPips;
-	private readonly StrategyParam<EngulfingTradeDirection> _direction;
+	private readonly StrategyParam<EngulfingTradeDirections> _direction;
 
 	private decimal _pipSize;
 	private CandleSnapshot? _previousCandle;
@@ -59,7 +59,7 @@ public class SimpleEngulfingStrategy : Strategy
 			.SetNotNegative()
 			.SetDisplay("Max Body (pips)", "Maximum candle body size accepted by the pattern. Set to zero to disable the filter.", "Pattern");
 
-		_direction = Param(nameof(Direction), EngulfingTradeDirection.BuyOnly)
+		_direction = Param(nameof(Direction), EngulfingTradeDirections.BuyOnly)
 			.SetDisplay("Direction", "Defines which side of the original MetaTrader robots should be executed.", "Trading");
 	}
 
@@ -120,7 +120,7 @@ public class SimpleEngulfingStrategy : Strategy
 	/// <summary>
 	/// Defines whether the strategy trades buy setups, sell setups, or both.
 	/// </summary>
-	public EngulfingTradeDirection Direction
+	public EngulfingTradeDirections Direction
 	{
 		get => _direction.Value;
 		set => _direction.Value = value;
@@ -252,9 +252,9 @@ public class SimpleEngulfingStrategy : Strategy
 	{
 		return Direction switch
 		{
-			EngulfingTradeDirection.BuyOnly => side == Sides.Buy,
-			EngulfingTradeDirection.SellOnly => side == Sides.Sell,
-			EngulfingTradeDirection.Both => true,
+			EngulfingTradeDirections.BuyOnly => side == Sides.Buy,
+			EngulfingTradeDirections.SellOnly => side == Sides.Sell,
+			EngulfingTradeDirections.Both => true,
 			_ => false
 		};
 	}
@@ -282,7 +282,7 @@ public class SimpleEngulfingStrategy : Strategy
 	/// <summary>
 	/// Specifies which signals of the MetaTrader robots should be executed.
 	/// </summary>
-	public enum EngulfingTradeDirection
+	public enum EngulfingTradeDirections
 	{
 		BuyOnly,
 		SellOnly,

--- a/API/3498_Heiken_Ashi_Engulf/CS/HeikenAshiEngulfStrategy.cs
+++ b/API/3498_Heiken_Ashi_Engulf/CS/HeikenAshiEngulfStrategy.cs
@@ -19,16 +19,16 @@ namespace StockSharp.Samples.Strategies;
 public class HeikenAshiEngulfStrategy : Strategy
 {
 	private readonly StrategyParam<DataType> _candleType;
-	private readonly StrategyParam<TradeDirectionOption> _directionParam;
+	private readonly StrategyParam<TradeDirectionOptions> _directionParam;
 	private readonly StrategyParam<decimal> _buyVolume;
 	private readonly StrategyParam<decimal> _buyStopLossPips;
 	private readonly StrategyParam<decimal> _buyTakeProfitPips;
 	private readonly StrategyParam<int> _buyBaselinePeriod;
-	private readonly StrategyParam<MaMethod> _buyBaselineMethod;
+	private readonly StrategyParam<MaMethods> _buyBaselineMethod;
 	private readonly StrategyParam<int> _buyFastPeriod;
-	private readonly StrategyParam<MaMethod> _buyFastMethod;
+	private readonly StrategyParam<MaMethods> _buyFastMethod;
 	private readonly StrategyParam<int> _buySlowPeriod;
-	private readonly StrategyParam<MaMethod> _buySlowMethod;
+	private readonly StrategyParam<MaMethods> _buySlowMethod;
 	private readonly StrategyParam<int> _buyPrimaryRsiPeriod;
 	private readonly StrategyParam<int> _buyPrimaryShift;
 	private readonly StrategyParam<int> _buyPrimaryWindow;
@@ -45,11 +45,11 @@ public class HeikenAshiEngulfStrategy : Strategy
 	private readonly StrategyParam<decimal> _sellStopLossPips;
 	private readonly StrategyParam<decimal> _sellTakeProfitPips;
 	private readonly StrategyParam<int> _sellBaselinePeriod;
-	private readonly StrategyParam<MaMethod> _sellBaselineMethod;
+	private readonly StrategyParam<MaMethods> _sellBaselineMethod;
 	private readonly StrategyParam<int> _sellFastPeriod;
-	private readonly StrategyParam<MaMethod> _sellFastMethod;
+	private readonly StrategyParam<MaMethods> _sellFastMethod;
 	private readonly StrategyParam<int> _sellSlowPeriod;
-	private readonly StrategyParam<MaMethod> _sellSlowMethod;
+	private readonly StrategyParam<MaMethods> _sellSlowMethod;
 	private readonly StrategyParam<int> _sellPrimaryRsiPeriod;
 	private readonly StrategyParam<int> _sellPrimaryShift;
 	private readonly StrategyParam<int> _sellPrimaryWindow;
@@ -100,7 +100,7 @@ public class HeikenAshiEngulfStrategy : Strategy
 		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(1).TimeFrame())
 		.SetDisplay("Candle Type", "Timeframe used for all indicators and signal calculations.", "Data");
 
-		_directionParam = Param(nameof(Direction), TradeDirectionOption.Both)
+		_directionParam = Param(nameof(Direction), TradeDirectionOptions.Both)
 		.SetDisplay("Trade Direction", "Which side of the engulfing setup should be executed.", "Trading");
 
 		_buyVolume = Param(nameof(BuyVolume), 0.01m)
@@ -119,21 +119,21 @@ public class HeikenAshiEngulfStrategy : Strategy
 		.SetGreaterThanZero()
 		.SetDisplay("Buy Baseline MA Period", "Length of the moving average compared with the bullish Heiken Ashi candle.", "Filters");
 
-		_buyBaselineMethod = Param(nameof(BuyBaselineMethod), MaMethod.Exponential)
+		_buyBaselineMethod = Param(nameof(BuyBaselineMethod), MaMethods.Exponential)
 		.SetDisplay("Buy Baseline MA Method", "Type of moving average used against the Heiken Ashi candle.", "Filters");
 
 		_buyFastPeriod = Param(nameof(BuyFastPeriod), 20)
 		.SetGreaterThanZero()
 		.SetDisplay("Buy Fast MA Period", "Length of the fast trend filter moving average.", "Filters");
 
-		_buyFastMethod = Param(nameof(BuyFastMethod), MaMethod.Exponential)
+		_buyFastMethod = Param(nameof(BuyFastMethod), MaMethods.Exponential)
 		.SetDisplay("Buy Fast MA Method", "Moving average method for the fast trend filter.", "Filters");
 
 		_buySlowPeriod = Param(nameof(BuySlowPeriod), 30)
 		.SetGreaterThanZero()
 		.SetDisplay("Buy Slow MA Period", "Length of the slow trend filter moving average.", "Filters");
 
-		_buySlowMethod = Param(nameof(BuySlowMethod), MaMethod.Exponential)
+		_buySlowMethod = Param(nameof(BuySlowMethod), MaMethods.Exponential)
 		.SetDisplay("Buy Slow MA Method", "Moving average method for the slow trend filter.", "Filters");
 
 		_buyPrimaryRsiPeriod = Param(nameof(BuyPrimaryRsiPeriod), 14)
@@ -196,21 +196,21 @@ public class HeikenAshiEngulfStrategy : Strategy
 		.SetGreaterThanZero()
 		.SetDisplay("Sell Baseline MA Period", "Length of the moving average compared with the bearish Heiken Ashi candle.", "Filters");
 
-		_sellBaselineMethod = Param(nameof(SellBaselineMethod), MaMethod.Exponential)
+		_sellBaselineMethod = Param(nameof(SellBaselineMethod), MaMethods.Exponential)
 		.SetDisplay("Sell Baseline MA Method", "Type of moving average used against the bearish Heiken Ashi candle.", "Filters");
 
 		_sellFastPeriod = Param(nameof(SellFastPeriod), 20)
 		.SetGreaterThanZero()
 		.SetDisplay("Sell Fast MA Period", "Length of the fast trend filter moving average for shorts.", "Filters");
 
-		_sellFastMethod = Param(nameof(SellFastMethod), MaMethod.Exponential)
+		_sellFastMethod = Param(nameof(SellFastMethod), MaMethods.Exponential)
 		.SetDisplay("Sell Fast MA Method", "Moving average method for the fast bearish trend filter.", "Filters");
 
 		_sellSlowPeriod = Param(nameof(SellSlowPeriod), 30)
 		.SetGreaterThanZero()
 		.SetDisplay("Sell Slow MA Period", "Length of the slow trend filter moving average for shorts.", "Filters");
 
-		_sellSlowMethod = Param(nameof(SellSlowMethod), MaMethod.Exponential)
+		_sellSlowMethod = Param(nameof(SellSlowMethod), MaMethods.Exponential)
 		.SetDisplay("Sell Slow MA Method", "Moving average method for the slow bearish trend filter.", "Filters");
 
 		_sellPrimaryRsiPeriod = Param(nameof(SellPrimaryRsiPeriod), 14)
@@ -276,7 +276,7 @@ public class HeikenAshiEngulfStrategy : Strategy
 	/// <summary>
 	/// Direction handled by the strategy.
 	/// </summary>
-	public TradeDirectionOption Direction
+	public TradeDirectionOptions Direction
 	{
 		get => _directionParam.Value;
 		set => _directionParam.Value = value;
@@ -445,10 +445,10 @@ public class HeikenAshiEngulfStrategy : Strategy
 		if (!IsFormedAndOnlineAndAllowTrading())
 		return;
 
-		if (Direction != TradeDirectionOption.SellOnly && TryEnterLong(candle))
+		if (Direction != TradeDirectionOptions.SellOnly && TryEnterLong(candle))
 		return;
 
-		if (Direction != TradeDirectionOption.BuyOnly)
+		if (Direction != TradeDirectionOptions.BuyOnly)
 		TryEnterShort(candle);
 	}
 
@@ -723,24 +723,24 @@ public class HeikenAshiEngulfStrategy : Strategy
 		return step * multiplier;
 	}
 
-	private static LengthIndicator<decimal> CreateMovingAverage(MaMethod method, int period)
+	private static LengthIndicator<decimal> CreateMovingAverage(MaMethods method, int period)
 	{
 		return method switch
 		{
-			MaMethod.Simple => new SimpleMovingAverage { Length = period, CandlePrice = CandlePrice.Close },
-			MaMethod.Exponential => new ExponentialMovingAverage { Length = period, CandlePrice = CandlePrice.Close },
-			MaMethod.Smoothed => new SmoothedMovingAverage { Length = period, CandlePrice = CandlePrice.Close },
-			MaMethod.LinearWeighted => new WeightedMovingAverage { Length = period, CandlePrice = CandlePrice.Close },
+			MaMethods.Simple => new SimpleMovingAverage { Length = period, CandlePrice = CandlePrice.Close },
+			MaMethods.Exponential => new ExponentialMovingAverage { Length = period, CandlePrice = CandlePrice.Close },
+			MaMethods.Smoothed => new SmoothedMovingAverage { Length = period, CandlePrice = CandlePrice.Close },
+			MaMethods.LinearWeighted => new WeightedMovingAverage { Length = period, CandlePrice = CandlePrice.Close },
 			_ => new ExponentialMovingAverage { Length = period, CandlePrice = CandlePrice.Close }
 		};
 	}
 
 	private int BuyBaselinePeriod => _buyBaselinePeriod.Value;
-	private MaMethod BuyBaselineMethod => _buyBaselineMethod.Value;
+	private MaMethods BuyBaselineMethod => _buyBaselineMethod.Value;
 	private int BuyFastPeriod => _buyFastPeriod.Value;
-	private MaMethod BuyFastMethod => _buyFastMethod.Value;
+	private MaMethods BuyFastMethod => _buyFastMethod.Value;
 	private int BuySlowPeriod => _buySlowPeriod.Value;
-	private MaMethod BuySlowMethod => _buySlowMethod.Value;
+	private MaMethods BuySlowMethod => _buySlowMethod.Value;
 	private int BuyPrimaryRsiPeriod => _buyPrimaryRsiPeriod.Value;
 	private int BuyPrimaryShift => _buyPrimaryShift.Value;
 	private int BuyPrimaryWindow => _buyPrimaryWindow.Value;
@@ -754,11 +754,11 @@ public class HeikenAshiEngulfStrategy : Strategy
 	private decimal BuySecondaryUpper => _buySecondaryUpper.Value;
 	private decimal BuySecondaryLower => _buySecondaryLower.Value;
 	private int SellBaselinePeriod => _sellBaselinePeriod.Value;
-	private MaMethod SellBaselineMethod => _sellBaselineMethod.Value;
+	private MaMethods SellBaselineMethod => _sellBaselineMethod.Value;
 	private int SellFastPeriod => _sellFastPeriod.Value;
-	private MaMethod SellFastMethod => _sellFastMethod.Value;
+	private MaMethods SellFastMethod => _sellFastMethod.Value;
 	private int SellSlowPeriod => _sellSlowPeriod.Value;
-	private MaMethod SellSlowMethod => _sellSlowMethod.Value;
+	private MaMethods SellSlowMethod => _sellSlowMethod.Value;
 	private int SellPrimaryRsiPeriod => _sellPrimaryRsiPeriod.Value;
 	private int SellPrimaryShift => _sellPrimaryShift.Value;
 	private int SellPrimaryWindow => _sellPrimaryWindow.Value;
@@ -812,7 +812,7 @@ public class HeikenAshiEngulfStrategy : Strategy
 	/// <summary>
 	/// Moving average methods supported by MetaTrader.
 	/// </summary>
-	public enum MaMethod
+	public enum MaMethods
 	{
 		Simple,
 		Exponential,
@@ -823,7 +823,7 @@ public class HeikenAshiEngulfStrategy : Strategy
 	/// <summary>
 	/// Trade direction options.
 	/// </summary>
-	public enum TradeDirectionOption
+	public enum TradeDirectionOptions
 	{
 		BuyOnly,
 		SellOnly,

--- a/API/3499_Alligator_Candle_Cross/CS/AlligatorCandleCrossStrategy.cs
+++ b/API/3499_Alligator_Candle_Cross/CS/AlligatorCandleCrossStrategy.cs
@@ -30,7 +30,7 @@ public class AlligatorCandleCrossStrategy : Strategy
 	private readonly StrategyParam<int> _lipsPeriod;
 	private readonly StrategyParam<int> _lipsShift;
 	private readonly StrategyParam<DataType> _candleType;
-	private readonly StrategyParam<AlligatorCrossMode> _entryMode;
+	private readonly StrategyParam<AlligatorCrossModes> _entryMode;
 
 	private SmoothedMovingAverage _jaw = null!;
 	private SmoothedMovingAverage _teeth = null!;
@@ -143,7 +143,7 @@ public class AlligatorCandleCrossStrategy : Strategy
 	/// <summary>
 	/// Directional bias for the candle cross signals.
 	/// </summary>
-	public AlligatorCrossMode EntryMode
+	public AlligatorCrossModes EntryMode
 	{
 		get => _entryMode.Value;
 		set => _entryMode.Value = value;
@@ -193,7 +193,7 @@ public class AlligatorCandleCrossStrategy : Strategy
 		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(1).TimeFrame())
 		.SetDisplay("Candle Type", "Time frame used for candle subscription", "General");
 
-		_entryMode = Param(nameof(EntryMode), AlligatorCrossMode.Both)
+		_entryMode = Param(nameof(EntryMode), AlligatorCrossModes.Both)
 		.SetDisplay("Entry Mode", "Directional bias for cross signals", "Trading");
 	}
 
@@ -337,8 +337,8 @@ public class AlligatorCandleCrossStrategy : Strategy
 
 		if (Position == 0 && IsFormedAndOnlineAndAllowTrading() && _previousClose is decimal prevClose)
 		{
-			var allowLong = EntryMode is AlligatorCrossMode.Both or AlligatorCrossMode.LongOnly;
-			var allowShort = EntryMode is AlligatorCrossMode.Both or AlligatorCrossMode.ShortOnly;
+			var allowLong = EntryMode is AlligatorCrossModes.Both or AlligatorCrossModes.LongOnly;
+			var allowShort = EntryMode is AlligatorCrossModes.Both or AlligatorCrossModes.ShortOnly;
 
 			var alligatorUpperPrev = Math.Max(jawPrevious, Math.Max(teethPrevious, lipsPrevious));
 			var alligatorLowerPrev = Math.Min(jawPrevious, Math.Min(teethPrevious, lipsPrevious));
@@ -474,7 +474,7 @@ public class AlligatorCandleCrossStrategy : Strategy
 /// <summary>
 /// Selects the trade direction for the Alligator candle cross logic.
 /// </summary>
-public enum AlligatorCrossMode
+public enum AlligatorCrossModes
 {
 	/// <summary>
 	/// Enable both long and short entries.

--- a/API/3500_Zone_Recovery_Hedge/CS/ZoneRecoveryHedgeStrategy.cs
+++ b/API/3500_Zone_Recovery_Hedge/CS/ZoneRecoveryHedgeStrategy.cs
@@ -22,7 +22,7 @@ public class ZoneRecoveryHedgeStrategy : Strategy
 {
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<DataType> _atrCandleType;
-	private readonly StrategyParam<ZoneRecoveryMode> _mode;
+	private readonly StrategyParam<ZoneRecoveryModes> _mode;
 	private readonly StrategyParam<int> _rsiPeriod;
 	private readonly StrategyParam<decimal> _overboughtLevel;
 	private readonly StrategyParam<decimal> _oversoldLevel;
@@ -87,7 +87,7 @@ public class ZoneRecoveryHedgeStrategy : Strategy
 		_atrCandleType = Param(nameof(AtrCandleType), TimeSpan.FromDays(1).TimeFrame())
 		.SetDisplay("ATR Candle", "Timeframe used for ATR based sizing", "General");
 
-		_mode = Param(nameof(Mode), ZoneRecoveryMode.RsiMultiTimeframe)
+		_mode = Param(nameof(Mode), ZoneRecoveryModes.RsiMultiTimeframe)
 		.SetDisplay("Mode", "Manual mode disables automatic entries", "Signals");
 
 		_rsiPeriod = Param(nameof(RsiPeriod), 14)
@@ -229,7 +229,7 @@ public class ZoneRecoveryHedgeStrategy : Strategy
 	/// <summary>
 	/// Strategy operating mode.
 	/// </summary>
-	public ZoneRecoveryMode Mode
+	public ZoneRecoveryModes Mode
 	{
 		get => _mode.Value;
 		set => _mode.Value = value;
@@ -393,7 +393,7 @@ public class ZoneRecoveryHedgeStrategy : Strategy
 	/// </summary>
 	public void StartManualMarketCycle(bool isBuy)
 	{
-		if (Mode != ZoneRecoveryMode.Manual)
+		if (Mode != ZoneRecoveryModes.Manual)
 		{
 			LogInfo("Manual cycle ignored because the mode is not Manual.");
 			return;
@@ -417,7 +417,7 @@ public class ZoneRecoveryHedgeStrategy : Strategy
 	/// </summary>
 	public void StartManualPendingCycle(bool isBuy)
 	{
-		if (Mode != ZoneRecoveryMode.Manual)
+		if (Mode != ZoneRecoveryModes.Manual)
 		{
 			LogInfo("Manual cycle ignored because the mode is not Manual.");
 			return;
@@ -500,7 +500,7 @@ public class ZoneRecoveryHedgeStrategy : Strategy
 			return;
 		}
 
-		if (Mode != ZoneRecoveryMode.RsiMultiTimeframe)
+		if (Mode != ZoneRecoveryModes.RsiMultiTimeframe)
 		return;
 
 		var barShift = _tradeOnBarOpen.Value ? 1 : 0;
@@ -1033,7 +1033,7 @@ public class ZoneRecoveryHedgeStrategy : Strategy
 /// <summary>
 /// Available operating modes for the zone recovery hedge strategy.
 /// </summary>
-public enum ZoneRecoveryMode
+public enum ZoneRecoveryModes
 {
 	/// <summary>
 	/// Manual entries only. Use helper methods to start cycles.

--- a/API/3507_Sample_Detect_Economic_Calendar/CS/SampleDetectEconomicCalendarStrategy.cs
+++ b/API/3507_Sample_Detect_Economic_Calendar/CS/SampleDetectEconomicCalendarStrategy.cs
@@ -376,7 +376,7 @@ public class SampleDetectEconomicCalendarStrategy : Strategy
 		if (!evt.Currency.EqualsIgnoreCase(BaseCurrency))
 		return;
 
-		if (evt.Importance != NewsImportance.High)
+		if (evt.Importance != NewsImportances.High)
 		return;
 
 		if (BuyDistancePoints <= 0 || SellDistancePoints <= 0)
@@ -613,33 +613,33 @@ public class SampleDetectEconomicCalendarStrategy : Strategy
 		return false;
 	}
 
-	private static bool TryParseImportance(string value, out NewsImportance importance)
+	private static bool TryParseImportance(string value, out NewsImportances importance)
 	{
 		if (value.EqualsIgnoreCase("high"))
 		{
-			importance = NewsImportance.High;
+			importance = NewsImportances.High;
 			return true;
 		}
 
 		if (value.EqualsIgnoreCase("medium"))
 		{
-			importance = NewsImportance.Medium;
+			importance = NewsImportances.Medium;
 			return true;
 		}
 
 		if (value.EqualsIgnoreCase("low"))
 		{
-			importance = NewsImportance.Low;
+			importance = NewsImportances.Low;
 			return true;
 		}
 
 		if (value.EqualsIgnoreCase("nfp") || value.EqualsIgnoreCase("non-farm"))
 		{
-			importance = NewsImportance.Nfp;
+			importance = NewsImportances.Nfp;
 			return true;
 		}
 
-		importance = NewsImportance.Low;
+		importance = NewsImportances.Low;
 		return false;
 	}
 
@@ -647,7 +647,7 @@ public class SampleDetectEconomicCalendarStrategy : Strategy
 	{
 		public DateTimeOffset Time { get; init; }
 		public string Currency { get; init; } = string.Empty;
-		public NewsImportance Importance { get; init; }
+		public NewsImportances Importance { get; init; }
 		public string Title { get; init; } = string.Empty;
 		public bool OrdersPlaced { get; set; }
 		public bool Completed { get; set; }
@@ -656,7 +656,7 @@ public class SampleDetectEconomicCalendarStrategy : Strategy
 		public Order SellOrder { get; set; }
 	}
 
-	private enum NewsImportance
+	private enum NewsImportances
 	{
 		Low,
 		Medium,

--- a/API/3522_iCHO_Trend_CCIDualOnMA_Filter/CS/iCHO_Trend_CCIDualOnMA_FilterStrategy.cs
+++ b/API/3522_iCHO_Trend_CCIDualOnMA_Filter/CS/iCHO_Trend_CCIDualOnMA_FilterStrategy.cs
@@ -21,17 +21,17 @@ public class iCHO_Trend_CCIDualOnMA_FilterStrategy : Strategy
 {
 	private readonly StrategyParam<int> _fastChaikinLength;
 	private readonly StrategyParam<int> _slowChaikinLength;
-	private readonly StrategyParam<MovingAverageMethod> _chaikinMethod;
+	private readonly StrategyParam<MovingAverageMethods> _chaikinMethod;
 	private readonly StrategyParam<int> _fastCciLength;
 	private readonly StrategyParam<int> _slowCciLength;
 	private readonly StrategyParam<int> _maLength;
-	private readonly StrategyParam<MovingAverageMethod> _maMethod;
-	private readonly StrategyParam<AppliedPrice> _maPrice;
+	private readonly StrategyParam<MovingAverageMethods> _maMethod;
+	private readonly StrategyParam<AppliedPrices> _maPrice;
 	private readonly StrategyParam<bool> _useClosedBar;
 	private readonly StrategyParam<bool> _reverseSignals;
 	private readonly StrategyParam<bool> _closeOpposite;
 	private readonly StrategyParam<bool> _onlyOnePosition;
-	private readonly StrategyParam<TradeModeOption> _tradeMode;
+	private readonly StrategyParam<TradeModeOptions> _tradeMode;
 	private readonly StrategyParam<bool> _useTimeFilter;
 	private readonly StrategyParam<int> _startHour;
 	private readonly StrategyParam<int> _startMinute;
@@ -65,7 +65,7 @@ public class iCHO_Trend_CCIDualOnMA_FilterStrategy : Strategy
 		.SetGreaterThanZero()
 		.SetDisplay("Chaikin Slow", "Slow EMA length", "Chaikin");
 
-		_chaikinMethod = Param(nameof(ChaikinMethod), MovingAverageMethod.Exponential)
+		_chaikinMethod = Param(nameof(ChaikinMethod), MovingAverageMethods.Exponential)
 		.SetDisplay("Chaikin MA", "Averaging method", "Chaikin");
 
 		_fastCciLength = Param(nameof(FastCciLength), 14)
@@ -80,10 +80,10 @@ public class iCHO_Trend_CCIDualOnMA_FilterStrategy : Strategy
 		.SetGreaterThanZero()
 		.SetDisplay("MA Length", "MA length for price preprocessing", "Filter");
 
-		_maMethod = Param(nameof(MaMethod), MovingAverageMethod.Simple)
+		_maMethod = Param(nameof(MaMethod), MovingAverageMethods.Simple)
 		.SetDisplay("MA Method", "MA method for price preprocessing", "Filter");
 
-		_maPrice = Param(nameof(MaPrice), AppliedPrice.Close)
+		_maPrice = Param(nameof(MaPrice), AppliedPrices.Close)
 		.SetDisplay("MA Price", "Price type sent into MA", "Filter");
 
 		_useClosedBar = Param(nameof(UseClosedBar), true)
@@ -98,7 +98,7 @@ public class iCHO_Trend_CCIDualOnMA_FilterStrategy : Strategy
 		_onlyOnePosition = Param(nameof(OnlyOnePosition), false)
 		.SetDisplay("Only One", "Allow only one open position", "Risk");
 
-		_tradeMode = Param(nameof(TradeMode), TradeModeOption.BuyAndSell)
+		_tradeMode = Param(nameof(TradeMode), TradeModeOptions.BuyAndSell)
 		.SetDisplay("Trade Mode", "Allowed trade direction", "Signals");
 
 		_useTimeFilter = Param(nameof(UseTimeFilter), true)
@@ -141,7 +141,7 @@ public class iCHO_Trend_CCIDualOnMA_FilterStrategy : Strategy
 	/// <summary>
 	/// Moving average method used inside the Chaikin oscillator.
 	/// </summary>
-	public MovingAverageMethod ChaikinMethod
+	public MovingAverageMethods ChaikinMethod
 	{
 		get => _chaikinMethod.Value;
 		set => _chaikinMethod.Value = value;
@@ -177,7 +177,7 @@ public class iCHO_Trend_CCIDualOnMA_FilterStrategy : Strategy
 	/// <summary>
 	/// Moving average method for preprocessing price.
 	/// </summary>
-	public MovingAverageMethod MaMethod
+	public MovingAverageMethods MaMethod
 	{
 		get => _maMethod.Value;
 		set => _maMethod.Value = value;
@@ -186,7 +186,7 @@ public class iCHO_Trend_CCIDualOnMA_FilterStrategy : Strategy
 	/// <summary>
 	/// Price type passed into the preprocessing MA.
 	/// </summary>
-	public AppliedPrice MaPrice
+	public AppliedPrices MaPrice
 	{
 		get => _maPrice.Value;
 		set => _maPrice.Value = value;
@@ -231,7 +231,7 @@ public class iCHO_Trend_CCIDualOnMA_FilterStrategy : Strategy
 	/// <summary>
 	/// Trade mode restriction.
 	/// </summary>
-	public TradeModeOption TradeMode
+	public TradeModeOptions TradeMode
 	{
 		get => _tradeMode.Value;
 		set => _tradeMode.Value = value;
@@ -409,20 +409,20 @@ public class iCHO_Trend_CCIDualOnMA_FilterStrategy : Strategy
 			if (zeroCrossUp)
 			{
 				closeShort = true;
-				if (TradeMode != TradeModeOption.SellOnly)
+				if (TradeMode != TradeModeOptions.SellOnly)
 				wantLong = true;
 			}
 
 			if (zeroCrossDown)
 			{
 				closeLong = true;
-				if (TradeMode != TradeModeOption.BuyOnly)
+				if (TradeMode != TradeModeOptions.BuyOnly)
 				wantShort = true;
 			}
 
 			if (choPositive && cciBullCross)
 			{
-				if (TradeMode != TradeModeOption.SellOnly)
+				if (TradeMode != TradeModeOptions.SellOnly)
 				wantLong = true;
 				else
 				closeShort = true;
@@ -430,7 +430,7 @@ public class iCHO_Trend_CCIDualOnMA_FilterStrategy : Strategy
 
 			if (choNegative && cciBearCross)
 			{
-				if (TradeMode != TradeModeOption.BuyOnly)
+				if (TradeMode != TradeModeOptions.BuyOnly)
 				wantShort = true;
 				else
 				closeLong = true;
@@ -441,20 +441,20 @@ public class iCHO_Trend_CCIDualOnMA_FilterStrategy : Strategy
 			if (zeroCrossUp)
 			{
 				closeLong = true;
-				if (TradeMode != TradeModeOption.BuyOnly)
+				if (TradeMode != TradeModeOptions.BuyOnly)
 				wantShort = true;
 			}
 
 			if (zeroCrossDown)
 			{
 				closeShort = true;
-				if (TradeMode != TradeModeOption.SellOnly)
+				if (TradeMode != TradeModeOptions.SellOnly)
 				wantLong = true;
 			}
 
 			if (choPositive && cciBullCross)
 			{
-				if (TradeMode != TradeModeOption.BuyOnly)
+				if (TradeMode != TradeModeOptions.BuyOnly)
 				wantShort = true;
 				else
 				closeLong = true;
@@ -462,7 +462,7 @@ public class iCHO_Trend_CCIDualOnMA_FilterStrategy : Strategy
 
 			if (choNegative && cciBearCross)
 			{
-				if (TradeMode != TradeModeOption.SellOnly)
+				if (TradeMode != TradeModeOptions.SellOnly)
 				wantLong = true;
 				else
 				closeShort = true;
@@ -540,17 +540,17 @@ public class iCHO_Trend_CCIDualOnMA_FilterStrategy : Strategy
 		_prevSlowCci = slowCci;
 	}
 
-	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPrice price)
+	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPrices price)
 	{
 		return price switch
 		{
-			AppliedPrice.Close => candle.ClosePrice,
-			AppliedPrice.Open => candle.OpenPrice,
-			AppliedPrice.High => candle.HighPrice,
-			AppliedPrice.Low => candle.LowPrice,
-			AppliedPrice.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-			AppliedPrice.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-			AppliedPrice.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice * 2m) / 4m,
+			AppliedPrices.Close => candle.ClosePrice,
+			AppliedPrices.Open => candle.OpenPrice,
+			AppliedPrices.High => candle.HighPrice,
+			AppliedPrices.Low => candle.LowPrice,
+			AppliedPrices.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+			AppliedPrices.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+			AppliedPrices.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice * 2m) / 4m,
 			_ => candle.ClosePrice,
 		};
 	}
@@ -571,14 +571,14 @@ public class iCHO_Trend_CCIDualOnMA_FilterStrategy : Strategy
 		: current >= start || current < end;
 	}
 
-	private static IIndicator CreateMovingAverage(MovingAverageMethod method, int length)
+	private static IIndicator CreateMovingAverage(MovingAverageMethods method, int length)
 	{
 		IIndicator indicator = method switch
 		{
-			MovingAverageMethod.Simple => new SimpleMovingAverage { Length = length },
-			MovingAverageMethod.Exponential => new ExponentialMovingAverage { Length = length },
-			MovingAverageMethod.Smoothed => new SmoothedMovingAverage { Length = length },
-			MovingAverageMethod.LinearWeighted => new WeightedMovingAverage { Length = length },
+			MovingAverageMethods.Simple => new SimpleMovingAverage { Length = length },
+			MovingAverageMethods.Exponential => new ExponentialMovingAverage { Length = length },
+			MovingAverageMethods.Smoothed => new SmoothedMovingAverage { Length = length },
+			MovingAverageMethods.LinearWeighted => new WeightedMovingAverage { Length = length },
 			_ => new SimpleMovingAverage { Length = length },
 		};
 
@@ -588,7 +588,7 @@ public class iCHO_Trend_CCIDualOnMA_FilterStrategy : Strategy
 	/// <summary>
 	/// Available moving average methods.
 	/// </summary>
-	public enum MovingAverageMethod
+	public enum MovingAverageMethods
 	{
 		Simple,
 		Exponential,
@@ -599,7 +599,7 @@ public class iCHO_Trend_CCIDualOnMA_FilterStrategy : Strategy
 	/// <summary>
 	/// Price source used for preprocessing moving average.
 	/// </summary>
-	public enum AppliedPrice
+	public enum AppliedPrices
 	{
 		Close,
 		Open,
@@ -613,7 +613,7 @@ public class iCHO_Trend_CCIDualOnMA_FilterStrategy : Strategy
 	/// <summary>
 	/// Trade direction restriction.
 	/// </summary>
-	public enum TradeModeOption
+	public enum TradeModeOptions
 	{
 		BuyOnly,
 		SellOnly,

--- a/API/3523_Trailing_Only_Close_All_Button/CS/TrailingOnlyCloseAllButtonStrategy.cs
+++ b/API/3523_Trailing_Only_Close_All_Button/CS/TrailingOnlyCloseAllButtonStrategy.cs
@@ -23,9 +23,9 @@ public class TrailingOnlyCloseAllButtonStrategy : Strategy
 	private readonly StrategyParam<decimal> _takeProfitPips;
 	private readonly StrategyParam<decimal> _trailingStopPips;
 	private readonly StrategyParam<decimal> _trailingStepPips;
-	private readonly StrategyParam<CloseMode> _closeMode;
-	private readonly StrategyParam<CloseSymbol> _closeSymbol;
-	private readonly StrategyParam<CloseProfitFilter> _closeProfitFilter;
+	private readonly StrategyParam<CloseModes> _closeMode;
+	private readonly StrategyParam<CloseSymbols> _closeSymbol;
+	private readonly StrategyParam<CloseProfitFilters> _closeProfitFilter;
 	private readonly StrategyParam<bool> _closeAll;
 
 	private decimal? _longStop;
@@ -39,7 +39,7 @@ public class TrailingOnlyCloseAllButtonStrategy : Strategy
 	/// <summary>
 	/// Defines what should be closed when the manual button is triggered.
 	/// </summary>
-	public enum CloseMode
+	public enum CloseModes
 	{
 		Positions,
 		All,
@@ -49,7 +49,7 @@ public class TrailingOnlyCloseAllButtonStrategy : Strategy
 	/// <summary>
 	/// Defines whether the manual closing routine targets only the current symbol or all tracked instruments.
 	/// </summary>
-	public enum CloseSymbol
+	public enum CloseSymbols
 	{
 		Chart,
 		All,
@@ -58,7 +58,7 @@ public class TrailingOnlyCloseAllButtonStrategy : Strategy
 	/// <summary>
 	/// Profit filter applied before closing positions.
 	/// </summary>
-	public enum CloseProfitFilter
+	public enum CloseProfitFilters
 	{
 		All,
 		ProfitOnly,
@@ -104,7 +104,7 @@ public class TrailingOnlyCloseAllButtonStrategy : Strategy
 	/// <summary>
 	/// Manual close mode for the button.
 	/// </summary>
-	public CloseMode ManualCloseMode
+	public CloseModes ManualCloseMode
 	{
 		get => _closeMode.Value;
 		set => _closeMode.Value = value;
@@ -113,7 +113,7 @@ public class TrailingOnlyCloseAllButtonStrategy : Strategy
 	/// <summary>
 	/// Manual close symbol scope for the button.
 	/// </summary>
-	public CloseSymbol ManualCloseSymbol
+	public CloseSymbols ManualCloseSymbol
 	{
 		get => _closeSymbol.Value;
 		set => _closeSymbol.Value = value;
@@ -122,7 +122,7 @@ public class TrailingOnlyCloseAllButtonStrategy : Strategy
 	/// <summary>
 	/// Manual close profit filter for the button.
 	/// </summary>
-	public CloseProfitFilter ManualCloseProfitFilter
+	public CloseProfitFilters ManualCloseProfitFilter
 	{
 		get => _closeProfitFilter.Value;
 		set => _closeProfitFilter.Value = value;
@@ -174,15 +174,15 @@ public class TrailingOnlyCloseAllButtonStrategy : Strategy
 			.SetNotNegative()
 			.SetDisplay("Trailing Step", "Additional profit in MetaTrader pips before moving the stop", "Risk");
 
-		_closeMode = Param(nameof(ManualCloseMode), CloseMode.Positions)
+		_closeMode = Param(nameof(ManualCloseMode), CloseModes.Positions)
 			.SetDisplay("Close Mode", "Objects affected by the manual close", "Manual")
 			.SetCanOptimize(false);
 
-		_closeSymbol = Param(nameof(ManualCloseSymbol), CloseSymbol.Chart)
+		_closeSymbol = Param(nameof(ManualCloseSymbol), CloseSymbols.Chart)
 			.SetDisplay("Symbol Scope", "Whether to close only the main symbol or all", "Manual")
 			.SetCanOptimize(false);
 
-		_closeProfitFilter = Param(nameof(ManualCloseProfitFilter), CloseProfitFilter.ProfitOnly)
+		_closeProfitFilter = Param(nameof(ManualCloseProfitFilter), CloseProfitFilters.ProfitOnly)
 			.SetDisplay("Profit Filter", "Filter positions by floating PnL before closing", "Manual")
 			.SetCanOptimize(false);
 
@@ -436,12 +436,12 @@ public class TrailingOnlyCloseAllButtonStrategy : Strategy
 
 	private void ExecuteManualClose()
 	{
-		if (ManualCloseMode != CloseMode.Orders)
+		if (ManualCloseMode != CloseModes.Orders)
 		{
 			ClosePositionsByFilter();
 		}
 
-		if (ManualCloseMode != CloseMode.Positions)
+		if (ManualCloseMode != CloseModes.Positions)
 		{
 			CancelOrdersByFilter();
 		}
@@ -491,7 +491,7 @@ public class TrailingOnlyCloseAllButtonStrategy : Strategy
 			return false;
 		}
 
-		if (ManualCloseSymbol == CloseSymbol.Chart && Security != null && !Equals(position.Security, Security))
+		if (ManualCloseSymbol == CloseSymbols.Chart && Security != null && !Equals(position.Security, Security))
 		{
 			return false;
 		}
@@ -500,11 +500,11 @@ public class TrailingOnlyCloseAllButtonStrategy : Strategy
 
 		switch (ManualCloseProfitFilter)
 		{
-			case CloseProfitFilter.ProfitOnly when pnl <= 0m:
+			case CloseProfitFilters.ProfitOnly when pnl <= 0m:
 			{
 				return false;
 			}
-			case CloseProfitFilter.LossOnly when pnl >= 0m:
+			case CloseProfitFilters.LossOnly when pnl >= 0m:
 			{
 				return false;
 			}
@@ -536,7 +536,7 @@ public class TrailingOnlyCloseAllButtonStrategy : Strategy
 			return false;
 		}
 
-		if (ManualCloseSymbol == CloseSymbol.Chart && Security != null && !Equals(order.Security, Security))
+		if (ManualCloseSymbol == CloseSymbols.Chart && Security != null && !Equals(order.Security, Security))
 		{
 			return false;
 		}

--- a/API/3525_Close_All_Control/CS/CloseAllControlStrategy.cs
+++ b/API/3525_Close_All_Control/CS/CloseAllControlStrategy.cs
@@ -20,7 +20,7 @@ using System.Reflection;
 /// Strategy that replicates the MetaTrader "CloseAll" utility for managing existing orders.
 /// The strategy performs the configured bulk close action immediately when it starts.
 /// </summary>
-public enum CloseAllMode
+public enum CloseAllModes
 {
 	/// <summary>
 	/// Close all open positions that match the comment filter.
@@ -84,7 +84,7 @@ public enum CloseAllMode
 public class CloseAllControlStrategy : Strategy
 {
 	private readonly StrategyParam<string> _orderComment;
-	private readonly StrategyParam<CloseAllMode> _mode;
+	private readonly StrategyParam<CloseAllModes> _mode;
 	private readonly StrategyParam<string> _currencyId;
 	private readonly StrategyParam<long> _magicOrTicket;
 
@@ -101,7 +101,7 @@ public class CloseAllControlStrategy : Strategy
 	/// <summary>
 	/// Gets or sets which close scenario must be executed when the strategy starts.
 	/// </summary>
-	public CloseAllMode Mode
+	public CloseAllModes Mode
 	{
 		get => _mode.Value;
 		set => _mode.Value = value;
@@ -133,7 +133,7 @@ public class CloseAllControlStrategy : Strategy
 		_orderComment = Param(nameof(OrderComment), "Bonnitta EA")
 			.SetDisplay("Order Comment", "Substring that must be present in the order comment to be processed.", "Filters");
 
-		_mode = Param(nameof(Mode), CloseAllMode.CloseAll)
+		_mode = Param(nameof(Mode), CloseAllModes.CloseAll)
 			.SetDisplay("Mode", "Bulk close scenario executed once the strategy starts.", "Execution");
 
 		_currencyId = Param(nameof(CurrencyId), string.Empty)
@@ -164,25 +164,25 @@ public class CloseAllControlStrategy : Strategy
 
 		switch (mode)
 		{
-			case CloseAllMode.CloseAll:
-			case CloseAllMode.CloseBuy:
-			case CloseAllMode.CloseSell:
-			case CloseAllMode.CloseCurrency:
-			case CloseAllMode.CloseMagic:
-			case CloseAllMode.CloseTicket:
-			case CloseAllMode.CloseAllAndPending:
-			case CloseAllMode.CloseAllAndPendingByMagic:
+			case CloseAllModes.CloseAll:
+			case CloseAllModes.CloseBuy:
+			case CloseAllModes.CloseSell:
+			case CloseAllModes.CloseCurrency:
+			case CloseAllModes.CloseMagic:
+			case CloseAllModes.CloseTicket:
+			case CloseAllModes.CloseAllAndPending:
+			case CloseAllModes.CloseAllAndPendingByMagic:
 				ClosePositions();
 				break;
 		}
 
 		switch (mode)
 		{
-			case CloseAllMode.ClosePending:
-			case CloseAllMode.ClosePendingByMagic:
-			case CloseAllMode.ClosePendingByMagicCurrency:
-			case CloseAllMode.CloseAllAndPending:
-			case CloseAllMode.CloseAllAndPendingByMagic:
+			case CloseAllModes.ClosePending:
+			case CloseAllModes.ClosePendingByMagic:
+			case CloseAllModes.ClosePendingByMagicCurrency:
+			case CloseAllModes.CloseAllAndPending:
+			case CloseAllModes.CloseAllAndPendingByMagic:
 				CancelPendingOrders();
 				break;
 		}
@@ -243,24 +243,24 @@ public class CloseAllControlStrategy : Strategy
 
 		switch (mode)
 		{
-			case CloseAllMode.CloseAll:
-			case CloseAllMode.CloseAllAndPending:
+			case CloseAllModes.CloseAll:
+			case CloseAllModes.CloseAllAndPending:
 			return true;
 
-			case CloseAllMode.CloseBuy:
+			case CloseAllModes.CloseBuy:
 			return position.CurrentValue > 0m;
 
-			case CloseAllMode.CloseSell:
+			case CloseAllModes.CloseSell:
 			return position.CurrentValue < 0m;
 
-			case CloseAllMode.CloseCurrency:
+			case CloseAllModes.CloseCurrency:
 			return MatchesCurrency(position.Security, true);
 
-			case CloseAllMode.CloseMagic:
-			case CloseAllMode.CloseAllAndPendingByMagic:
+			case CloseAllModes.CloseMagic:
+			case CloseAllModes.CloseAllAndPendingByMagic:
 			return MatchesMagicOrTicket(position);
 
-			case CloseAllMode.CloseTicket:
+			case CloseAllModes.CloseTicket:
 			return MatchesTicket(position);
 
 			default:
@@ -277,15 +277,15 @@ public class CloseAllControlStrategy : Strategy
 
 		switch (mode)
 		{
-			case CloseAllMode.ClosePending:
-			case CloseAllMode.CloseAllAndPending:
+			case CloseAllModes.ClosePending:
+			case CloseAllModes.CloseAllAndPending:
 			return true;
 
-			case CloseAllMode.ClosePendingByMagic:
-			case CloseAllMode.CloseAllAndPendingByMagic:
+			case CloseAllModes.ClosePendingByMagic:
+			case CloseAllModes.CloseAllAndPendingByMagic:
 			return MatchesMagicOrTicket(order);
 
-			case CloseAllMode.ClosePendingByMagicCurrency:
+			case CloseAllModes.ClosePendingByMagicCurrency:
 			return MatchesMagicOrTicket(order) && MatchesCurrency(order.Security, true);
 
 			default:

--- a/API/3526_Close_All_MT5/CS/CloseAllMt5Strategy.cs
+++ b/API/3526_Close_All_MT5/CS/CloseAllMt5Strategy.cs
@@ -25,10 +25,10 @@ using System.Reflection;
 /// </summary>
 public class CloseAllMt5Strategy : Strategy
 {
-	private readonly StrategyParam<PositionSelection> _positionSelection;
-	private readonly StrategyParam<ProfitMeasure> _profitMeasure;
+	private readonly StrategyParam<PositionSelections> _positionSelection;
+	private readonly StrategyParam<ProfitMeasures> _profitMeasure;
 	private readonly StrategyParam<decimal> _profitThreshold;
-	private readonly StrategyParam<CloseRequestMode> _closeMode;
+	private readonly StrategyParam<CloseRequestModes> _closeMode;
 	private readonly StrategyParam<string> _commentFilter;
 	private readonly StrategyParam<string> _currencyFilter;
 	private readonly StrategyParam<long> _magicNumber;
@@ -42,7 +42,7 @@ public class CloseAllMt5Strategy : Strategy
 	/// <summary>
 	/// Determines which position sides participate in the automatic profit checks.
 	/// </summary>
-	public PositionSelection PositionFilter
+	public PositionSelections PositionFilter
 	{
 		get => _positionSelection.Value;
 		set => _positionSelection.Value = value;
@@ -51,7 +51,7 @@ public class CloseAllMt5Strategy : Strategy
 	/// <summary>
 	/// Measurement unit used for the floating profit comparison.
 	/// </summary>
-	public ProfitMeasure ProfitMode
+	public ProfitMeasures ProfitMode
 	{
 		get => _profitMeasure.Value;
 		set => _profitMeasure.Value = value;
@@ -70,7 +70,7 @@ public class CloseAllMt5Strategy : Strategy
 	/// <summary>
 	/// Manual closing behaviour that emulates the button from the MQL version.
 	/// </summary>
-	public CloseRequestMode CloseMode
+	public CloseRequestModes CloseMode
 	{
 		get => _closeMode.Value;
 		set => _closeMode.Value = value;
@@ -86,7 +86,7 @@ public class CloseAllMt5Strategy : Strategy
 	}
 
 	/// <summary>
-	/// Symbol identifier applied when <see cref="CloseMode"/> equals <see cref="CloseRequestMode.CloseCurrency"/>.
+	/// Symbol identifier applied when <see cref="CloseMode"/> equals <see cref="CloseRequestModes.CloseCurrency"/>.
 	/// Leave empty to use the current strategy security.
 	/// </summary>
 	public string CurrencyFilter
@@ -96,7 +96,7 @@ public class CloseAllMt5Strategy : Strategy
 	}
 
 	/// <summary>
-	/// Strategy identifier (Magic number) used by <see cref="CloseRequestMode.CloseMagic"/>.
+	/// Strategy identifier (Magic number) used by <see cref="CloseRequestModes.CloseMagic"/>.
 	/// </summary>
 	public long MagicNumber
 	{
@@ -105,7 +105,7 @@ public class CloseAllMt5Strategy : Strategy
 	}
 
 	/// <summary>
-	/// Specific position identifier targeted by <see cref="CloseRequestMode.CloseTicket"/>.
+	/// Specific position identifier targeted by <see cref="CloseRequestModes.CloseTicket"/>.
 	/// </summary>
 	public long TicketNumber
 	{
@@ -150,10 +150,10 @@ public class CloseAllMt5Strategy : Strategy
 	/// </summary>
 	public CloseAllMt5Strategy()
 	{
-		_positionSelection = Param(nameof(PositionFilter), PositionSelection.Buy)
+		_positionSelection = Param(nameof(PositionFilter), PositionSelections.Buy)
 			.SetDisplay("Position Filter", "Positions included in automatic profit checks", "General");
 
-		_profitMeasure = Param(nameof(ProfitMode), ProfitMeasure.Money)
+		_profitMeasure = Param(nameof(ProfitMode), ProfitMeasures.Money)
 			.SetDisplay("Profit Mode", "Unit used to measure floating profit", "General");
 
 		_profitThreshold = Param(nameof(ProfitThreshold), 3m)
@@ -161,7 +161,7 @@ public class CloseAllMt5Strategy : Strategy
 			.SetCanOptimize(true)
 			.SetOptimize(-20m, 20m, 1m);
 
-		_closeMode = Param(nameof(CloseMode), CloseRequestMode.CloseAll)
+		_closeMode = Param(nameof(CloseMode), CloseRequestModes.CloseAll)
 			.SetDisplay("Close Mode", "Manual close behaviour", "Controls");
 
 		_commentFilter = Param(nameof(CommentFilter), "Bonnitta EA")
@@ -294,8 +294,8 @@ public class CloseAllMt5Strategy : Strategy
 
 		return PositionFilter switch
 		{
-			PositionSelection.Buy => volume > 0m,
-			PositionSelection.Sell => volume < 0m,
+			PositionSelections.Buy => volume > 0m,
+			PositionSelections.Sell => volume < 0m,
 			_ => volume != 0m,
 		};
 	}
@@ -354,7 +354,7 @@ public class CloseAllMt5Strategy : Strategy
 
 		switch (ProfitMode)
 		{
-			case ProfitMeasure.Money:
+			case ProfitMeasures.Money:
 			{
 				var pnl = position.PnL;
 				if (pnl.HasValue)
@@ -376,7 +376,7 @@ public class CloseAllMt5Strategy : Strategy
 				return true;
 			}
 
-			case ProfitMeasure.Points:
+			case ProfitMeasures.Points:
 			{
 				var step = security.PriceStep ?? 0m;
 				if (step <= 0m)
@@ -386,7 +386,7 @@ public class CloseAllMt5Strategy : Strategy
 				return true;
 			}
 
-			case ProfitMeasure.Pips:
+			case ProfitMeasures.Pips:
 			{
 				var pipSize = GetPipSize(security);
 				if (pipSize <= 0m)
@@ -453,7 +453,7 @@ public class CloseAllMt5Strategy : Strategy
 			ClosePosition(position);
 		}
 
-		if (CloseMode == CloseRequestMode.CloseAllAndPending)
+		if (CloseMode == CloseRequestModes.CloseAllAndPending)
 		{
 			var securities = positions
 			.Select(p => p.Security)
@@ -473,17 +473,17 @@ public class CloseAllMt5Strategy : Strategy
 
 		switch (CloseMode)
 		{
-			case CloseRequestMode.CloseAll:
-			case CloseRequestMode.CloseAllAndPending:
+			case CloseRequestModes.CloseAll:
+			case CloseRequestModes.CloseAllAndPending:
 				return true;
 
-			case CloseRequestMode.CloseBuy:
+			case CloseRequestModes.CloseBuy:
 				return volume > 0m;
 
-			case CloseRequestMode.CloseSell:
+			case CloseRequestModes.CloseSell:
 				return volume < 0m;
 
-			case CloseRequestMode.CloseCurrency:
+			case CloseRequestModes.CloseCurrency:
 			{
 				var filter = CurrencyFilter;
 				if (filter.IsEmptyOrWhiteSpace())
@@ -496,7 +496,7 @@ public class CloseAllMt5Strategy : Strategy
 				return symbol != null && symbol.EqualsIgnoreCase(filter);
 			}
 
-			case CloseRequestMode.CloseMagic:
+			case CloseRequestModes.CloseMagic:
 			{
 				if (MagicNumber == 0L)
 					return false;
@@ -509,7 +509,7 @@ public class CloseAllMt5Strategy : Strategy
 				return strategyId.EqualsIgnoreCase(magic);
 			}
 
-			case CloseRequestMode.CloseTicket:
+			case CloseRequestModes.CloseTicket:
 			{
 				if (TicketNumber == 0L)
 					return false;
@@ -559,7 +559,7 @@ public class CloseAllMt5Strategy : Strategy
 	/// <summary>
 	/// Position side filter from the MQL version.
 	/// </summary>
-	public enum PositionSelection
+	public enum PositionSelections
 	{
 		/// <summary>Process only long positions.</summary>
 		Buy = 0,
@@ -572,7 +572,7 @@ public class CloseAllMt5Strategy : Strategy
 	/// <summary>
 	/// Profit evaluation unit.
 	/// </summary>
-	public enum ProfitMeasure
+	public enum ProfitMeasures
 	{
 		/// <summary>Use monetary profit reported by the portfolio.</summary>
 		Money = 0,
@@ -585,7 +585,7 @@ public class CloseAllMt5Strategy : Strategy
 	/// <summary>
 	/// Manual closing mode emulating the button from the original script.
 	/// </summary>
-	public enum CloseRequestMode
+	public enum CloseRequestModes
 	{
 		/// <summary>Close every matching position.</summary>
 		CloseAll = 0,

--- a/API/3527_TurnGrid/CS/TurnGridStrategy.cs
+++ b/API/3527_TurnGrid/CS/TurnGridStrategy.cs
@@ -18,7 +18,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class TurnGridStrategy : Strategy
 {
-	private enum TradeDirection
+	private enum TradeDirections
 	{
 		Buy,
 		Sell,
@@ -338,7 +338,7 @@ public class TurnGridStrategy : Strategy
 		if (_buyCount + _sellCount >= GridShares)
 			return;
 
-		var volume = CalculateVolume(TradeDirection.Buy);
+		var volume = CalculateVolume(TradeDirections.Buy);
 		if (volume <= 0m)
 			return;
 
@@ -362,7 +362,7 @@ public class TurnGridStrategy : Strategy
 		if (_buyCount + _sellCount >= GridShares)
 			return;
 
-		var volume = CalculateVolume(TradeDirection.Sell);
+		var volume = CalculateVolume(TradeDirections.Sell);
 		if (volume <= 0m)
 			return;
 
@@ -378,7 +378,7 @@ public class TurnGridStrategy : Strategy
 		_sellCount++;
 	}
 
-	private decimal CalculateVolume(TradeDirection direction)
+	private decimal CalculateVolume(TradeDirections direction)
 	{
 		if (_lastPrice <= 0m)
 			return 0m;
@@ -390,10 +390,10 @@ public class TurnGridStrategy : Strategy
 		decimal money;
 		switch (direction)
 		{
-			case TradeDirection.Buy:
+			case TradeDirections.Buy:
 				money = firstMoney + _buyCount * _openMoneyIncrement;
 				break;
-			case TradeDirection.Sell:
+			case TradeDirections.Sell:
 				money = firstMoney + _sellCount * _openMoneyIncrement;
 				break;
 			default:

--- a/API/3528_MA_Grid/CS/MaGridStrategy.cs
+++ b/API/3528_MA_Grid/CS/MaGridStrategy.cs
@@ -28,7 +28,7 @@ public class MaGridStrategy : Strategy
 	private readonly StrategyParam<decimal> _orderVolume;
 	private readonly StrategyParam<DataType> _candleType;
 
-	private readonly Dictionary<Order, OrderIntent> _orderIntents = new();
+	private readonly Dictionary<Order, OrderIntents> _orderIntents = new();
 
 	private ExponentialMovingAverage _ema;
 	private int _effectiveGridAmount;
@@ -39,7 +39,7 @@ public class MaGridStrategy : Strategy
 	private decimal _longExposure;
 	private decimal _shortExposure;
 
-	private enum OrderIntent
+	private enum OrderIntents
 	{
 		OpenLong,
 		OpenShort,
@@ -186,16 +186,16 @@ public class MaGridStrategy : Strategy
 
 		switch (intent)
 		{
-		case OrderIntent.OpenLong:
+		case OrderIntents.OpenLong:
 		_longExposure += volume;
 		break;
-		case OrderIntent.OpenShort:
+		case OrderIntents.OpenShort:
 		_shortExposure += volume;
 		break;
-		case OrderIntent.CloseLong:
+		case OrderIntents.CloseLong:
 		_longExposure = Math.Max(0m, _longExposure - volume);
 		break;
-		case OrderIntent.CloseShort:
+		case OrderIntents.CloseShort:
 		_shortExposure = Math.Max(0m, _shortExposure - volume);
 		break;
 		}
@@ -321,7 +321,7 @@ public class MaGridStrategy : Strategy
 		if (OrderVolume <= 0m)
 		return;
 
-		RegisterOrder(BuyMarket(OrderVolume), OrderIntent.OpenLong);
+		RegisterOrder(BuyMarket(OrderVolume), OrderIntents.OpenLong);
 	}
 
 	private void OpenShortExposure()
@@ -329,7 +329,7 @@ public class MaGridStrategy : Strategy
 		if (OrderVolume <= 0m)
 		return;
 
-		RegisterOrder(SellMarket(OrderVolume), OrderIntent.OpenShort);
+		RegisterOrder(SellMarket(OrderVolume), OrderIntents.OpenShort);
 	}
 
 	private void CloseLongExposure()
@@ -341,7 +341,7 @@ public class MaGridStrategy : Strategy
 		if (volume <= VolumeTolerance)
 		return;
 
-		RegisterOrder(SellMarket(volume), OrderIntent.CloseLong);
+		RegisterOrder(SellMarket(volume), OrderIntents.CloseLong);
 	}
 
 	private void CloseShortExposure()
@@ -353,10 +353,10 @@ public class MaGridStrategy : Strategy
 		if (volume <= VolumeTolerance)
 		return;
 
-		RegisterOrder(BuyMarket(volume), OrderIntent.CloseShort);
+		RegisterOrder(BuyMarket(volume), OrderIntents.CloseShort);
 	}
 
-	private void RegisterOrder(Order order, OrderIntent intent)
+	private void RegisterOrder(Order order, OrderIntents intent)
 	{
 		if (order == null)
 		return;

--- a/API/3529_Bull_Row_Breakout/CS/BullRowBreakoutStrategy.cs
+++ b/API/3529_Bull_Row_Breakout/CS/BullRowBreakoutStrategy.cs
@@ -31,11 +31,11 @@ public class BullRowBreakoutStrategy : Strategy
 	private readonly StrategyParam<decimal> _takeProfitPercent;
 	private readonly StrategyParam<int> _bearRowSize;
 	private readonly StrategyParam<decimal> _bearMinBody;
-	private readonly StrategyParam<RowSequenceMode> _bearRowMode;
+	private readonly StrategyParam<RowSequenceModes> _bearRowMode;
 	private readonly StrategyParam<int> _bearShift;
 	private readonly StrategyParam<int> _bullRowSize;
 	private readonly StrategyParam<decimal> _bullMinBody;
-	private readonly StrategyParam<RowSequenceMode> _bullRowMode;
+	private readonly StrategyParam<RowSequenceModes> _bullRowMode;
 	private readonly StrategyParam<int> _bullShift;
 	private readonly StrategyParam<int> _breakoutLookback;
 	private readonly StrategyParam<int> _stochasticKPeriod;
@@ -70,7 +70,7 @@ public class BullRowBreakoutStrategy : Strategy
 		.SetDisplay("Bear min body", "Minimum bearish candle body (price steps)", "Pattern")
 		.SetCanOptimize(true);
 
-		_bearRowMode = Param(nameof(BearRowMode), RowSequenceMode.Normal)
+		_bearRowMode = Param(nameof(BearRowMode), RowSequenceModes.Normal)
 		.SetDisplay("Bear row mode", "Body size progression for bearish row", "Pattern")
 		.SetCanOptimize(true);
 
@@ -86,7 +86,7 @@ public class BullRowBreakoutStrategy : Strategy
 		.SetDisplay("Bull min body", "Minimum bullish candle body (price steps)", "Pattern")
 		.SetCanOptimize(true);
 
-		_bullRowMode = Param(nameof(BullRowMode), RowSequenceMode.Normal)
+		_bullRowMode = Param(nameof(BullRowMode), RowSequenceModes.Normal)
 		.SetDisplay("Bull row mode", "Body size progression for bullish row", "Pattern")
 		.SetCanOptimize(true);
 
@@ -171,7 +171,7 @@ public class BullRowBreakoutStrategy : Strategy
 	/// <summary>
 	/// Bearish row body progression requirement.
 	/// </summary>
-	public RowSequenceMode BearRowMode
+	public RowSequenceModes BearRowMode
 	{
 		get => _bearRowMode.Value;
 		set => _bearRowMode.Value = value;
@@ -207,7 +207,7 @@ public class BullRowBreakoutStrategy : Strategy
 	/// <summary>
 	/// Bullish row body progression requirement.
 	/// </summary>
-	public RowSequenceMode BullRowMode
+	public RowSequenceModes BullRowMode
 	{
 		get => _bullRowMode.Value;
 		set => _bullRowMode.Value = value;
@@ -421,7 +421,7 @@ public class BullRowBreakoutStrategy : Strategy
 
 	private bool HasBullRow() => HasRow(BullRowSize, BullMinBody, BullRowMode, BullShift, isBullish: true);
 
-	private bool HasRow(int size, decimal minBody, RowSequenceMode mode, int shift, bool isBullish)
+	private bool HasRow(int size, decimal minBody, RowSequenceModes mode, int shift, bool isBullish)
 	{
 		if (size <= 0 || shift <= 0)
 		return false;
@@ -448,10 +448,10 @@ public class BullRowBreakoutStrategy : Strategy
 			if (body < minBodyValue)
 			return false;
 
-			if (mode == RowSequenceMode.Bigger && previousBody > 0m && body <= previousBody)
+			if (mode == RowSequenceModes.Bigger && previousBody > 0m && body <= previousBody)
 			return false;
 
-			if (mode == RowSequenceMode.Smaller && previousBody > 0m && body >= previousBody)
+			if (mode == RowSequenceModes.Smaller && previousBody > 0m && body >= previousBody)
 			return false;
 
 			previousBody = body;
@@ -518,7 +518,7 @@ public class BullRowBreakoutStrategy : Strategy
 /// <summary>
 /// Defines how candle bodies must evolve inside a row.
 /// </summary>
-public enum RowSequenceMode
+public enum RowSequenceModes
 {
 	/// <summary>
 	/// Only direction and minimum body size are checked.

--- a/API/3530_RsiMaOnRsiFillingStep/CS/RsiMaOnRsiFillingStepStrategy.cs
+++ b/API/3530_RsiMaOnRsiFillingStep/CS/RsiMaOnRsiFillingStepStrategy.cs
@@ -22,7 +22,7 @@ public class RsiMaOnRsiFillingStepStrategy : Strategy
 	/// <summary>
 	/// Trade direction selection.
 	/// </summary>
-	public enum TradeMode
+	public enum TradeModes
 	{
 		/// <summary>
 		/// Only long trades are allowed.
@@ -46,7 +46,7 @@ public class RsiMaOnRsiFillingStepStrategy : Strategy
 	private readonly StrategyParam<MovingAverageTypes> _maType;
 	private readonly StrategyParam<decimal> _middleLevel;
 	private readonly StrategyParam<bool> _reverseSignals;
-	private readonly StrategyParam<TradeMode> _tradeMode;
+	private readonly StrategyParam<TradeModes> _tradeMode;
 	private readonly StrategyParam<bool> _closeOppositePositions;
 	private readonly StrategyParam<bool> _onlyOnePosition;
 	private readonly StrategyParam<bool> _useTimeWindow;
@@ -90,7 +90,7 @@ public class RsiMaOnRsiFillingStepStrategy : Strategy
 		_reverseSignals = Param(nameof(ReverseSignals), false)
 		.SetDisplay("Reverse Signals", "Swap buy and sell conditions.", "Signals");
 
-		_tradeMode = Param(nameof(Mode), TradeMode.Both)
+		_tradeMode = Param(nameof(Mode), TradeModes.Both)
 		.SetDisplay("Trade Mode", "Restrict trading direction.", "Signals");
 
 		_closeOppositePositions = Param(nameof(CloseOppositePositions), false)
@@ -166,7 +166,7 @@ public class RsiMaOnRsiFillingStepStrategy : Strategy
 	/// <summary>
 	/// Trade direction restriction.
 	/// </summary>
-	public TradeMode Mode
+	public TradeModes Mode
 	{
 		get => _tradeMode.Value;
 		set => _tradeMode.Value = value;
@@ -308,11 +308,11 @@ public class RsiMaOnRsiFillingStepStrategy : Strategy
 
 		if (crossUp && belowMiddle)
 		{
-			signalTriggered = TryExecuteSignal(TradeDirection.Long, candle, rsiValue, signalValue);
+			signalTriggered = TryExecuteSignal(TradeDirections.Long, candle, rsiValue, signalValue);
 		}
 		else if (crossDown && aboveMiddle)
 		{
-			signalTriggered = TryExecuteSignal(TradeDirection.Short, candle, rsiValue, signalValue);
+			signalTriggered = TryExecuteSignal(TradeDirections.Short, candle, rsiValue, signalValue);
 		}
 
 		if (signalTriggered)
@@ -324,17 +324,17 @@ public class RsiMaOnRsiFillingStepStrategy : Strategy
 		_previousSignal = signalValue;
 	}
 
-	private bool TryExecuteSignal(TradeDirection direction, ICandleMessage candle, decimal rsiValue, decimal signalValue)
+	private bool TryExecuteSignal(TradeDirections direction, ICandleMessage candle, decimal rsiValue, decimal signalValue)
 	{
 		if (ReverseSignals)
 		{
-			direction = direction == TradeDirection.Long ? TradeDirection.Short : TradeDirection.Long;
+			direction = direction == TradeDirections.Long ? TradeDirections.Short : TradeDirections.Long;
 		}
 
 		switch (direction)
 		{
-		case TradeDirection.Long:
-			if (Mode == TradeMode.SellOnly)
+		case TradeDirections.Long:
+			if (Mode == TradeModes.SellOnly)
 			return false;
 
 			if (!EnsureCapacityForNewPosition(isLong: true))
@@ -344,8 +344,8 @@ public class RsiMaOnRsiFillingStepStrategy : Strategy
 			LogInfo($"Buy signal: RSI {rsiValue:F2} crossed above MA {signalValue:F2} below middle level {MiddleLevel:F2}.");
 			return true;
 
-		case TradeDirection.Short:
-			if (Mode == TradeMode.BuyOnly)
+		case TradeDirections.Short:
+			if (Mode == TradeModes.BuyOnly)
 			return false;
 
 			if (!EnsureCapacityForNewPosition(isLong: false))
@@ -401,7 +401,7 @@ public class RsiMaOnRsiFillingStepStrategy : Strategy
 		return current >= start || current < end;
 	}
 
-	private enum TradeDirection
+	private enum TradeDirections
 	{
 		Long,
 		Short,

--- a/API/3531_RsiMaOnRsiDual/CS/RsiMaOnRsiDualStrategy.cs
+++ b/API/3531_RsiMaOnRsiDual/CS/RsiMaOnRsiDualStrategy.cs
@@ -22,7 +22,7 @@ public class RsiMaOnRsiDualStrategy : Strategy
 	private readonly StrategyParam<int> _fastRsiPeriod;
 	private readonly StrategyParam<int> _slowRsiPeriod;
 	private readonly StrategyParam<int> _maPeriod;
-	private readonly StrategyParam<AppliedPriceType> _appliedPrice;
+	private readonly StrategyParam<AppliedPriceTypes> _appliedPrice;
 	private readonly StrategyParam<decimal> _neutralLevel;
 	private readonly StrategyParam<bool> _allowLong;
 	private readonly StrategyParam<bool> _allowShort;
@@ -71,7 +71,7 @@ public class RsiMaOnRsiDualStrategy : Strategy
 			.SetCanOptimize(true)
 			.SetOptimize(2, 30, 1);
 
-		_appliedPrice = Param(nameof(AppliedPrice), AppliedPriceType.Close)
+		_appliedPrice = Param(nameof(AppliedPrice), AppliedPriceTypes.Close)
 			.SetDisplay("Applied price", "Price source used to build RSI values.", "Indicators");
 
 		_neutralLevel = Param(nameof(NeutralLevel), 50m)
@@ -128,7 +128,7 @@ public class RsiMaOnRsiDualStrategy : Strategy
 		set => _maPeriod.Value = value;
 	}
 
-	public AppliedPriceType AppliedPrice
+	public AppliedPriceTypes AppliedPrice
 	{
 		get => _appliedPrice.Value;
 		set => _appliedPrice.Value = value;
@@ -432,23 +432,23 @@ public class RsiMaOnRsiDualStrategy : Strategy
 		return t >= start || t < end;
 	}
 
-	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPriceType priceType)
+	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPriceTypes priceType)
 	{
 		return priceType switch
 		{
-			AppliedPriceType.Close => candle.ClosePrice,
-			AppliedPriceType.Open => candle.OpenPrice,
-			AppliedPriceType.High => candle.HighPrice,
-			AppliedPriceType.Low => candle.LowPrice,
-			AppliedPriceType.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-			AppliedPriceType.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-			AppliedPriceType.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
-			AppliedPriceType.Average => (candle.OpenPrice + candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 4m,
+			AppliedPriceTypes.Close => candle.ClosePrice,
+			AppliedPriceTypes.Open => candle.OpenPrice,
+			AppliedPriceTypes.High => candle.HighPrice,
+			AppliedPriceTypes.Low => candle.LowPrice,
+			AppliedPriceTypes.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+			AppliedPriceTypes.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+			AppliedPriceTypes.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
+			AppliedPriceTypes.Average => (candle.OpenPrice + candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 4m,
 			_ => candle.ClosePrice,
 		};
 	}
 
-	public enum AppliedPriceType
+	public enum AppliedPriceTypes
 	{
 		Close,
 		Open,

--- a/API/3532_Two_MA_Other_TimeFrame_Correct_Intersection/CS/TwoMAOtherTimeFrameCorrectIntersectionStrategy.cs
+++ b/API/3532_Two_MA_Other_TimeFrame_Correct_Intersection/CS/TwoMAOtherTimeFrameCorrectIntersectionStrategy.cs
@@ -25,11 +25,11 @@ private readonly StrategyParam<DataType> _fastTimeFrame;
 private readonly StrategyParam<DataType> _slowTimeFrame;
 private readonly StrategyParam<int> _fastLength;
 private readonly StrategyParam<int> _fastShift;
-private readonly StrategyParam<MovingAverageKind> _fastMethod;
+private readonly StrategyParam<MovingAverageKinds> _fastMethod;
 private readonly StrategyParam<CandlePrice> _fastAppliedPrice;
 private readonly StrategyParam<int> _slowLength;
 private readonly StrategyParam<int> _slowShift;
-private readonly StrategyParam<MovingAverageKind> _slowMethod;
+private readonly StrategyParam<MovingAverageKinds> _slowMethod;
 private readonly StrategyParam<CandlePrice> _slowAppliedPrice;
 
 private readonly Queue<decimal> _fastShiftBuffer = new();
@@ -68,7 +68,7 @@ _fastShift = Param(nameof(FastShift), 0)
 .SetDisplay("Fast MA Shift", "Horizontal shift applied to the fast moving average", "Indicators")
 .SetNotNegative();
 
-_fastMethod = Param(nameof(FastMethod), MovingAverageKind.Simple)
+_fastMethod = Param(nameof(FastMethod), MovingAverageKinds.Simple)
 .SetDisplay("Fast MA Method", "Smoothing method for the fast moving average", "Indicators");
 
 _fastAppliedPrice = Param(nameof(FastAppliedPrice), CandlePrice.Close)
@@ -82,7 +82,7 @@ _slowShift = Param(nameof(SlowShift), 0)
 .SetDisplay("Slow MA Shift", "Horizontal shift applied to the slow moving average", "Indicators")
 .SetNotNegative();
 
-_slowMethod = Param(nameof(SlowMethod), MovingAverageKind.Simple)
+_slowMethod = Param(nameof(SlowMethod), MovingAverageKinds.Simple)
 .SetDisplay("Slow MA Method", "Smoothing method for the slow moving average", "Indicators");
 
 _slowAppliedPrice = Param(nameof(SlowAppliedPrice), CandlePrice.Close)
@@ -164,7 +164,7 @@ set => _slowShift.Value = value;
 /// <summary>
 /// Smoothing method used for the fast moving average.
 /// </summary>
-public MovingAverageKind FastMethod
+public MovingAverageKinds FastMethod
 {
 get => _fastMethod.Value;
 set => _fastMethod.Value = value;
@@ -173,7 +173,7 @@ set => _fastMethod.Value = value;
 /// <summary>
 /// Smoothing method used for the slow moving average.
 /// </summary>
-public MovingAverageKind SlowMethod
+public MovingAverageKinds SlowMethod
 {
 get => _slowMethod.Value;
 set => _slowMethod.Value = value;
@@ -361,14 +361,14 @@ buffer.Dequeue();
 return shiftedValue;
 }
 
-private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageKind kind, int length, CandlePrice price)
+private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageKinds kind, int length, CandlePrice price)
 {
 return kind switch
 {
-MovingAverageKind.Simple => new SimpleMovingAverage { Length = length, CandlePrice = price },
-MovingAverageKind.Exponential => new ExponentialMovingAverage { Length = length, CandlePrice = price },
-MovingAverageKind.Smoothed => new SmoothedMovingAverage { Length = length, CandlePrice = price },
-MovingAverageKind.LinearWeighted => new WeightedMovingAverage { Length = length, CandlePrice = price },
+MovingAverageKinds.Simple => new SimpleMovingAverage { Length = length, CandlePrice = price },
+MovingAverageKinds.Exponential => new ExponentialMovingAverage { Length = length, CandlePrice = price },
+MovingAverageKinds.Smoothed => new SmoothedMovingAverage { Length = length, CandlePrice = price },
+MovingAverageKinds.LinearWeighted => new WeightedMovingAverage { Length = length, CandlePrice = price },
 _ => new SimpleMovingAverage { Length = length, CandlePrice = price }
 };
 }
@@ -377,7 +377,7 @@ _ => new SimpleMovingAverage { Length = length, CandlePrice = price }
 /// Moving average types supported by the strategy.
 /// Matches the available options in the original MQL5 expert advisor.
 /// </summary>
-public enum MovingAverageKind
+public enum MovingAverageKinds
 {
 Simple,
 Exponential,

--- a/API/3533_CHO_Smoothed_EA/CS/ChoSmoothedEaStrategy.cs
+++ b/API/3533_CHO_Smoothed_EA/CS/ChoSmoothedEaStrategy.cs
@@ -25,7 +25,7 @@ public class ChoSmoothedEaStrategy : Strategy
 	private readonly StrategyParam<int> _maPeriod;
 	private readonly StrategyParam<MovingAverageTypes> _maType;
 	private readonly StrategyParam<bool> _useZeroLevel;
-	private readonly StrategyParam<ChoTradeMode> _tradeMode;
+	private readonly StrategyParam<ChoTradeModes> _tradeMode;
 	private readonly StrategyParam<bool> _reverseSignals;
 	private readonly StrategyParam<bool> _closeOpposite;
 	private readonly StrategyParam<bool> _onlyOnePosition;
@@ -101,7 +101,7 @@ public class ChoSmoothedEaStrategy : Strategy
 	/// <summary>
 	/// Allowed trade direction.
 	/// </summary>
-	public ChoTradeMode TradeMode
+	public ChoTradeModes TradeMode
 	{
 		get => _tradeMode.Value;
 		set => _tradeMode.Value = value;
@@ -229,7 +229,7 @@ public class ChoSmoothedEaStrategy : Strategy
 		_useZeroLevel = Param(nameof(UseZeroLevel), true)
 			.SetDisplay("Use Zero Level", "Require oscillator to be below/above zero", "Filters");
 
-		_tradeMode = Param(nameof(TradeMode), ChoTradeMode.BuyAndSell)
+		_tradeMode = Param(nameof(TradeMode), ChoTradeModes.BuyAndSell)
 			.SetDisplay("Trade Mode", "Allowed direction of trades", "Risk");
 
 		_reverseSignals = Param(nameof(ReverseSignals), false)
@@ -353,7 +353,7 @@ public class ChoSmoothedEaStrategy : Strategy
 			return;
 		}
 
-		if (buySignal && TradeMode != ChoTradeMode.SellOnly)
+		if (buySignal && TradeMode != ChoTradeModes.SellOnly)
 		{
 			if (Position < 0)
 			{
@@ -377,7 +377,7 @@ public class ChoSmoothedEaStrategy : Strategy
 				SetupRiskLevels(candle.ClosePrice, true);
 			}
 		}
-		else if (sellSignal && TradeMode != ChoTradeMode.BuyOnly)
+		else if (sellSignal && TradeMode != ChoTradeModes.BuyOnly)
 		{
 			if (Position > 0)
 			{
@@ -526,7 +526,7 @@ public class ChoSmoothedEaStrategy : Strategy
 	/// <summary>
 	/// Trade mode selection.
 	/// </summary>
-	public enum ChoTradeMode
+	public enum ChoTradeModes
 	{
 		/// <summary>
 		/// Allow both long and short trades.

--- a/API/3538_MA_on_Momentum_Min_Profit/CS/MaOnMomentumMinProfitStrategy.cs
+++ b/API/3538_MA_on_Momentum_Min_Profit/CS/MaOnMomentumMinProfitStrategy.cs
@@ -21,7 +21,7 @@ public class MaOnMomentumMinProfitStrategy : Strategy
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<int> _momentumPeriod;
 	private readonly StrategyParam<int> _momentumMaPeriod;
-	private readonly StrategyParam<MomentumMovingAverageType> _momentumMaType;
+	private readonly StrategyParam<MomentumMovingAverageTypes> _momentumMaType;
 	private readonly StrategyParam<bool> _reverseSignals;
 	private readonly StrategyParam<bool> _closeOpposite;
 	private readonly StrategyParam<bool> _onlyOnePosition;
@@ -66,7 +66,7 @@ public class MaOnMomentumMinProfitStrategy : Strategy
 	/// <summary>
 	/// Moving average calculation mode applied to momentum.
 	/// </summary>
-	public MomentumMovingAverageType MomentumMovingAverageType
+	public MomentumMovingAverageTypes MomentumMovingAverageTypes
 	{
 		get => _momentumMaType.Value;
 		set => _momentumMaType.Value = value;
@@ -155,7 +155,7 @@ public class MaOnMomentumMinProfitStrategy : Strategy
 			.SetCanOptimize(true)
 			.SetOptimize(3, 30, 3);
 
-		_momentumMaType = Param(nameof(MomentumMovingAverageType), MomentumMovingAverageType.Smoothed)
+		_momentumMaType = Param(nameof(MomentumMovingAverageTypes), MomentumMovingAverageTypes.Smoothed)
 			.SetDisplay("MA Type", "Moving-average algorithm applied to momentum", "Momentum");
 
 		_reverseSignals = Param(nameof(ReverseSignals), false)
@@ -208,7 +208,7 @@ public class MaOnMomentumMinProfitStrategy : Strategy
 			Length = MomentumPeriod
 		};
 
-		_momentumAverage = CreateMovingAverage(MomentumMovingAverageType, MomentumMovingAveragePeriod);
+		_momentumAverage = CreateMovingAverage(MomentumMovingAverageTypes, MomentumMovingAveragePeriod);
 
 		var subscription = SubscribeCandles(CandleType);
 		subscription
@@ -361,14 +361,14 @@ public class MaOnMomentumMinProfitStrategy : Strategy
 		}
 	}
 
-	private static LengthIndicator<decimal> CreateMovingAverage(MomentumMovingAverageType type, int length)
+	private static LengthIndicator<decimal> CreateMovingAverage(MomentumMovingAverageTypes type, int length)
 	{
 		return type switch
 		{
-			MomentumMovingAverageType.Simple => new SimpleMovingAverage { Length = length },
-			MomentumMovingAverageType.Exponential => new ExponentialMovingAverage { Length = length },
-			MomentumMovingAverageType.Smoothed => new SmoothedMovingAverage { Length = length },
-			MomentumMovingAverageType.Weighted => new WeightedMovingAverage { Length = length },
+			MomentumMovingAverageTypes.Simple => new SimpleMovingAverage { Length = length },
+			MomentumMovingAverageTypes.Exponential => new ExponentialMovingAverage { Length = length },
+			MomentumMovingAverageTypes.Smoothed => new SmoothedMovingAverage { Length = length },
+			MomentumMovingAverageTypes.Weighted => new WeightedMovingAverage { Length = length },
 			_ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
 		};
 	}
@@ -376,7 +376,7 @@ public class MaOnMomentumMinProfitStrategy : Strategy
 	/// <summary>
 	/// Moving-average calculation modes available for momentum smoothing.
 	/// </summary>
-	public enum MomentumMovingAverageType
+	public enum MomentumMovingAverageTypes
 	{
 		Simple,
 		Exponential,

--- a/API/3541_Trailing_Activate/CS/TrailingActivateStrategy.cs
+++ b/API/3541_Trailing_Activate/CS/TrailingActivateStrategy.cs
@@ -13,7 +13,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-public enum TrailingActivateMode
+public enum TrailingActivateModes
 {
 	EveryTick,
 	NewBar,
@@ -26,7 +26,7 @@ public enum TrailingActivateMode
 public class TrailingActivateStrategy : Strategy
 {
 	private readonly StrategyParam<DataType> _candleType;
-	private readonly StrategyParam<TrailingActivateMode> _trailingMode;
+	private readonly StrategyParam<TrailingActivateModes> _trailingMode;
 	private readonly StrategyParam<decimal> _trailingActivatePoints;
 	private readonly StrategyParam<decimal> _trailingStopPoints;
 	private readonly StrategyParam<decimal> _trailingStepPoints;
@@ -49,7 +49,7 @@ public class TrailingActivateStrategy : Strategy
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
 			.SetDisplay("Candle Type", "Timeframe used when trailing on new bars", "General");
 
-		_trailingMode = Param(nameof(TrailingMode), TrailingActivateMode.NewBar)
+		_trailingMode = Param(nameof(TrailingMode), TrailingActivateModes.NewBar)
 			.SetDisplay("Trailing Mode", "Choose between per-tick or per-bar trailing updates", "General");
 
 		_trailingActivatePoints = Param(nameof(TrailingActivatePoints), 70m)
@@ -77,7 +77,7 @@ public class TrailingActivateStrategy : Strategy
 	/// <summary>
 	/// Defines whether the trailing stop reacts to every tick or to finished candles only.
 	/// </summary>
-	public TrailingActivateMode TrailingMode
+	public TrailingActivateModes TrailingMode
 	{
 		get => _trailingMode.Value;
 		set => _trailingMode.Value = value;
@@ -146,7 +146,7 @@ public class TrailingActivateStrategy : Strategy
 		if (!IsFormedAndOnlineAndAllowTrading())
 			return;
 
-		if (TrailingMode != TrailingActivateMode.NewBar)
+		if (TrailingMode != TrailingActivateModes.NewBar)
 			return;
 
 		if (candle.State != CandleStates.Finished)
@@ -169,7 +169,7 @@ public class TrailingActivateStrategy : Strategy
 		if (!IsFormedAndOnlineAndAllowTrading())
 			return;
 
-		if (TrailingMode != TrailingActivateMode.EveryTick)
+		if (TrailingMode != TrailingActivateModes.EveryTick)
 			return;
 
 		UpdateOffsets();

--- a/API/3542_Trailing_Activate_Close_All/CS/TrailingActivateCloseAllStrategy.cs
+++ b/API/3542_Trailing_Activate_Close_All/CS/TrailingActivateCloseAllStrategy.cs
@@ -19,7 +19,7 @@ using StockSharp.Algo;
 /// <summary>
 /// Defines how often the trailing logic is evaluated.
 /// </summary>
-public enum TrailingMode
+public enum TrailingModes
 {
 	/// <summary>
 	/// Recalculate protection on every tick.
@@ -48,7 +48,7 @@ public class TrailingActivateCloseAllStrategy : Strategy
 	?? TryGetField("FreezeDistance");
 
 	private readonly StrategyParam<DataType> _candleType;
-	private readonly StrategyParam<TrailingMode> _trailingMode;
+	private readonly StrategyParam<TrailingModes> _trailingMode;
 	private readonly StrategyParam<decimal> _stopLossPoints;
 	private readonly StrategyParam<decimal> _takeProfitPoints;
 	private readonly StrategyParam<decimal> _trailingActivatePoints;
@@ -81,7 +81,7 @@ public class TrailingActivateCloseAllStrategy : Strategy
 	/// <summary>
 	/// Frequency of trailing calculations.
 	/// </summary>
-	public TrailingMode TrailingMode
+	public TrailingModes TrailingModes
 	{
 		get => _trailingMode.Value;
 		set => _trailingMode.Value = value;
@@ -167,7 +167,7 @@ public class TrailingActivateCloseAllStrategy : Strategy
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(1).TimeFrame())
 		.SetDisplay("Candle Type", "Timeframe for bar-based trailing.", "General");
 
-		_trailingMode = Param(nameof(TrailingMode), TrailingMode.NewBar)
+		_trailingMode = Param(nameof(TrailingModes), TrailingModes.NewBar)
 		.SetDisplay("Trailing Mode", "Frequency of trailing calculations.", "General");
 
 		_stopLossPoints = Param(nameof(StopLossPoints), 150m)
@@ -213,7 +213,7 @@ public class TrailingActivateCloseAllStrategy : Strategy
 	{
 		yield return (Security, DataType.Level1);
 
-		if (TrailingMode == TrailingMode.NewBar)
+		if (TrailingModes == TrailingModes.NewBar)
 		{
 			yield return (Security, CandleType);
 		}
@@ -266,7 +266,7 @@ public class TrailingActivateCloseAllStrategy : Strategy
 		.Bind(ProcessLevel1)
 		.Start();
 
-		if (TrailingMode == TrailingMode.NewBar)
+		if (TrailingModes == TrailingModes.NewBar)
 		{
 			var subscription = SubscribeCandles(CandleType);
 			subscription.Bind(ProcessCandle).Start();
@@ -324,7 +324,7 @@ public class TrailingActivateCloseAllStrategy : Strategy
 		if (FreezeLevelField is Level1Fields freezeField && message.Changes.TryGetValue(freezeField, out var freezeValue))
 		_freezeLevel = ToDecimal(freezeValue);
 
-		if (TrailingMode == TrailingMode.EveryTick)
+		if (TrailingModes == TrailingModes.EveryTick)
 		UpdateProtectionAndTrailing();
 	}
 

--- a/API/3547_AutoRisk/CS/AutoRiskStrategy.cs
+++ b/API/3547_AutoRisk/CS/AutoRiskStrategy.cs
@@ -20,7 +20,7 @@ namespace StockSharp.Samples.Strategies;
 public class AutoRiskStrategy : Strategy
 {
 	private readonly StrategyParam<decimal> _riskFactor;
-	private readonly StrategyParam<AutoRiskCalculationMode> _calculationMode;
+	private readonly StrategyParam<AutoRiskCalculationModes> _calculationMode;
 	private readonly StrategyParam<bool> _roundUp;
 	private readonly StrategyParam<DataType> _candleType;
 
@@ -37,7 +37,7 @@ public class AutoRiskStrategy : Strategy
 			.SetDisplay("Risk % on daily ATR")
 			.SetCanOptimize(true);
 
-		_calculationMode = Param(nameof(CalculationMode), AutoRiskCalculationMode.Balance)
+		_calculationMode = Param(nameof(CalculationMode), AutoRiskCalculationModes.Balance)
 			.SetDisplay("Account metric used in the lot size formula");
 
 		_roundUp = Param(nameof(RoundUp), true)
@@ -59,7 +59,7 @@ public class AutoRiskStrategy : Strategy
 	/// <summary>
 	/// Determines which portfolio metric is used for the calculation.
 	/// </summary>
-	public AutoRiskCalculationMode CalculationMode
+	public AutoRiskCalculationModes CalculationMode
 	{
 		get => _calculationMode.Value;
 		set => _calculationMode.Value = value;
@@ -135,7 +135,7 @@ public class AutoRiskStrategy : Strategy
 
 		var equity = portfolio.CurrentValue ?? portfolio.BeginValue ?? 0m;
 		var balance = portfolio.BeginValue ?? portfolio.CurrentValue ?? 0m;
-		var basis = CalculationMode == AutoRiskCalculationMode.Balance ? balance : equity;
+		var basis = CalculationMode == AutoRiskCalculationModes.Balance ? balance : equity;
 
 		if (basis <= 0m)
 			return;
@@ -207,7 +207,7 @@ public class AutoRiskStrategy : Strategy
 /// <summary>
 /// Available account metrics for the AutoRisk sizing logic.
 /// </summary>
-public enum AutoRiskCalculationMode
+public enum AutoRiskCalculationModes
 {
 	/// <summary>
 	/// Uses portfolio equity (current value) for the calculation.

--- a/API/3548_Rsi_Dual_Cloud/CS/RsiDualCloudStrategy.cs
+++ b/API/3548_Rsi_Dual_Cloud/CS/RsiDualCloudStrategy.cs
@@ -32,7 +32,7 @@ private readonly StrategyParam<bool> _useLeavingSignal;
 private readonly StrategyParam<bool> _useCrossingSignal;
 private readonly StrategyParam<bool> _useClosedCandles;
 private readonly StrategyParam<bool> _reverseSignals;
-private readonly StrategyParam<TradeModeOption> _tradeMode;
+private readonly StrategyParam<TradeModeOptions> _tradeMode;
 
 private RelativeStrengthIndex _fastRsi = null!;
 private RelativeStrengthIndex _slowRsi = null!;
@@ -45,7 +45,7 @@ private bool _isInitialized;
 /// <summary>
 /// Defines how the strategy may open positions.
 /// </summary>
-public enum TradeModeOption
+public enum TradeModeOptions
 {
 Both,
 LongOnly,
@@ -163,7 +163,7 @@ set => _reverseSignals.Value = value;
 /// <summary>
 /// Defines the allowed trade direction.
 /// </summary>
-public TradeModeOption TradeMode
+public TradeModeOptions TradeMode
 {
 get => _tradeMode.Value;
 set => _tradeMode.Value = value;
@@ -221,7 +221,7 @@ _useClosedCandles = Param(nameof(UseClosedCandles), true)
 _reverseSignals = Param(nameof(ReverseSignals), false)
 .SetDisplay("Reverse", "Invert the signal direction", "Trading");
 
-_tradeMode = Param(nameof(TradeMode), TradeModeOption.Both)
+_tradeMode = Param(nameof(TradeMode), TradeModeOptions.Both)
 .SetDisplay("Trade Mode", "Allowed trade direction", "Trading");
 }
 
@@ -362,7 +362,7 @@ return false;
 private void HandleLongEntry()
 {
 // Respect trade mode restrictions.
-if (TradeMode == TradeModeOption.ShortOnly)
+if (TradeMode == TradeModeOptions.ShortOnly)
 return;
 
 // Close a short position before opening a long one.
@@ -376,7 +376,7 @@ BuyMarket(OrderVolume);
 private void HandleShortEntry()
 {
 // Respect trade mode restrictions.
-if (TradeMode == TradeModeOption.LongOnly)
+if (TradeMode == TradeModeOptions.LongOnly)
 return;
 
 // Close a long position before opening a short one.

--- a/API/3551_DeMarker_Pending/CS/DeMarkerPendingStrategy.cs
+++ b/API/3551_DeMarker_Pending/CS/DeMarkerPendingStrategy.cs
@@ -23,7 +23,7 @@ public class DeMarkerPendingStrategy : Strategy
 	/// <summary>
 	/// Type of pending order created after a signal.
 	/// </summary>
-	public enum PendingMode
+	public enum PendingModes
 	{
 		/// <summary>
 		/// Place stop orders beyond the current market price.
@@ -40,7 +40,7 @@ public class DeMarkerPendingStrategy : Strategy
 	private readonly StrategyParam<decimal> _takeProfitPoints;
 	private readonly StrategyParam<decimal> _pendingIndentPoints;
 	private readonly StrategyParam<int> _pendingExpirationMinutes;
-	private readonly StrategyParam<PendingMode> _pendingMode;
+	private readonly StrategyParam<PendingModes> _pendingMode;
 	private readonly StrategyParam<bool> _singlePendingOnly;
 	private readonly StrategyParam<bool> _replacePreviousPending;
 	private readonly StrategyParam<int> _demarkerPeriod;
@@ -82,7 +82,7 @@ public class DeMarkerPendingStrategy : Strategy
 		.SetDisplay("Pending Expiration", "Lifetime of pending orders in minutes (0 disables expiration).", "Trading")
 		.SetCanOptimize(true);
 
-		_pendingMode = Param(nameof(Mode), PendingMode.Stop)
+		_pendingMode = Param(nameof(Mode), PendingModes.Stop)
 		.SetDisplay("Pending Mode", "Choose stop or limit pending orders.", "Trading");
 
 		_singlePendingOnly = Param(nameof(SinglePendingOnly), false)
@@ -157,7 +157,7 @@ public class DeMarkerPendingStrategy : Strategy
 	/// <summary>
 	/// Pending order mode (stop or limit).
 	/// </summary>
-	public PendingMode Mode
+	public PendingModes Mode
 	{
 		get => _pendingMode.Value;
 		set => _pendingMode.Value = value;
@@ -338,9 +338,9 @@ public class DeMarkerPendingStrategy : Strategy
 
 		decimal price;
 		if (direction == Sides.Buy)
-			price = Mode == PendingMode.Stop ? referencePrice + indent : referencePrice - indent;
+			price = Mode == PendingModes.Stop ? referencePrice + indent : referencePrice - indent;
 		else
-			price = Mode == PendingMode.Stop ? referencePrice - indent : referencePrice + indent;
+			price = Mode == PendingModes.Stop ? referencePrice - indent : referencePrice + indent;
 
 		price = RoundPrice(price);
 		if (price <= 0m)
@@ -359,10 +359,10 @@ public class DeMarkerPendingStrategy : Strategy
 			takeProfit = direction == Sides.Buy ? price + takeDistance : price - takeDistance;
 
 		Order order = direction == Sides.Buy
-		? (Mode == PendingMode.Stop
+		? (Mode == PendingModes.Stop
 		? BuyStop(Volume, price, stopLoss: stopLoss, takeProfit: takeProfit)
 		: BuyLimit(Volume, price, stopLoss: stopLoss, takeProfit: takeProfit))
-		: (Mode == PendingMode.Stop
+		: (Mode == PendingModes.Stop
 		? SellStop(Volume, price, stopLoss: stopLoss, takeProfit: takeProfit)
 		: SellLimit(Volume, price, stopLoss: stopLoss, takeProfit: takeProfit));
 

--- a/API/3553_OsMA_Four_Colors_Arrow/CS/OsMaFourColorsArrowStrategy.cs
+++ b/API/3553_OsMA_Four_Colors_Arrow/CS/OsMaFourColorsArrowStrategy.cs
@@ -22,7 +22,7 @@ public class OsMaFourColorsArrowStrategy : Strategy
 	/// <summary>
 	/// Trade direction restriction that mirrors the original expert inputs.
 	/// </summary>
-	public enum TradeDirectionMode
+	public enum TradeDirectionModes
 	{
 		/// <summary>Allow only long positions.</summary>
 		LongOnly,
@@ -47,7 +47,7 @@ public class OsMaFourColorsArrowStrategy : Strategy
 	private readonly StrategyParam<int> _trailingStepPips;
 	private readonly StrategyParam<int> _maxPositions;
 	private readonly StrategyParam<bool> _reverseSignals;
-	private readonly StrategyParam<TradeDirectionMode> _tradeMode;
+	private readonly StrategyParam<TradeDirectionModes> _tradeMode;
 	private readonly StrategyParam<bool> _closeOpposite;
 	private readonly StrategyParam<bool> _onlyOnePosition;
 	private readonly StrategyParam<bool> _useTimeControl;
@@ -110,7 +110,7 @@ public class OsMaFourColorsArrowStrategy : Strategy
 		_reverseSignals = Param(nameof(ReverseSignals), false)
 		.SetDisplay("Reverse Signals", "Invert buy and sell logic", "Trading");
 
-		_tradeMode = Param(nameof(DirectionMode), TradeDirectionMode.Both)
+		_tradeMode = Param(nameof(DirectionMode), TradeDirectionModes.Both)
 		.SetDisplay("Trade Mode", "Allow longs, shorts, or both", "Trading");
 
 		_closeOpposite = Param(nameof(CloseOppositePositions), false)
@@ -256,7 +256,7 @@ public class OsMaFourColorsArrowStrategy : Strategy
 	/// <summary>
 	/// Allowed trade direction.
 	/// </summary>
-	public TradeDirectionMode DirectionMode
+	public TradeDirectionModes DirectionMode
 	{
 		get => _tradeMode.Value;
 		set => _tradeMode.Value = value;
@@ -456,7 +456,7 @@ LongMa = { Length = SlowPeriod }
 
 	private void TryEnterLong()
 	{
-		if (DirectionMode == TradeDirectionMode.ShortOnly)
+		if (DirectionMode == TradeDirectionModes.ShortOnly)
 			return;
 
 		if (TradeVolume <= 0m)
@@ -485,7 +485,7 @@ LongMa = { Length = SlowPeriod }
 
 	private void TryEnterShort()
 	{
-		if (DirectionMode == TradeDirectionMode.LongOnly)
+		if (DirectionMode == TradeDirectionModes.LongOnly)
 			return;
 
 		if (TradeVolume <= 0m)

--- a/API/3554_iVIDyA_Simple/CS/IvidyaSimpleStrategy.cs
+++ b/API/3554_iVIDyA_Simple/CS/IvidyaSimpleStrategy.cs
@@ -24,7 +24,7 @@ public class IvidyaSimpleStrategy : Strategy
 	private readonly StrategyParam<int> _cmoPeriod;
 	private readonly StrategyParam<int> _emaPeriod;
 	private readonly StrategyParam<int> _maShift;
-	private readonly StrategyParam<AppliedPriceType> _appliedPrice;
+	private readonly StrategyParam<AppliedPriceTypes> _appliedPrice;
 	private readonly StrategyParam<DataType> _candleType;
 
 	private ChandeMomentumOscillator _cmo = null!;
@@ -63,7 +63,7 @@ public class IvidyaSimpleStrategy : Strategy
 	/// <summary>
 	/// Candle price used as input for the VIDYA calculation.
 	/// </summary>
-	public AppliedPriceType AppliedPrice { get => _appliedPrice.Value; set => _appliedPrice.Value = value; }
+	public AppliedPriceTypes AppliedPrice { get => _appliedPrice.Value; set => _appliedPrice.Value = value; }
 
 	/// <summary>
 	/// Candle type processed by the strategy.
@@ -102,7 +102,7 @@ public class IvidyaSimpleStrategy : Strategy
 			.SetNotNegative()
 			.SetCanOptimize(true);
 
-		_appliedPrice = Param(nameof(AppliedPrice), AppliedPriceType.Close)
+		_appliedPrice = Param(nameof(AppliedPrice), AppliedPriceTypes.Close)
 			.SetDisplay("Applied Price", "Price source for VIDYA", "Indicator")
 			.SetCanOptimize(true);
 
@@ -218,12 +218,12 @@ public class IvidyaSimpleStrategy : Strategy
 	{
 		return AppliedPrice switch
 		{
-			AppliedPriceType.Open => candle.OpenPrice,
-			AppliedPriceType.High => candle.HighPrice,
-			AppliedPriceType.Low => candle.LowPrice,
-			AppliedPriceType.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-			AppliedPriceType.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-			AppliedPriceType.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
+			AppliedPriceTypes.Open => candle.OpenPrice,
+			AppliedPriceTypes.High => candle.HighPrice,
+			AppliedPriceTypes.Low => candle.LowPrice,
+			AppliedPriceTypes.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+			AppliedPriceTypes.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+			AppliedPriceTypes.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
 			_ => candle.ClosePrice,
 		};
 	}
@@ -231,7 +231,7 @@ public class IvidyaSimpleStrategy : Strategy
 	/// <summary>
 	/// Price sources compatible with MetaTrader applied price options.
 	/// </summary>
-	public enum AppliedPriceType
+	public enum AppliedPriceTypes
 	{
 		Close,
 		Open,

--- a/API/3558_At_Random_Full/CS/AtRandomFullStrategy.cs
+++ b/API/3558_At_Random_Full/CS/AtRandomFullStrategy.cs
@@ -36,7 +36,7 @@ public class AtRandomFullStrategy : Strategy
 	private readonly StrategyParam<bool> _useTimeControl;
 	private readonly StrategyParam<TimeSpan> _sessionStart;
 	private readonly StrategyParam<TimeSpan> _sessionEnd;
-	private readonly StrategyParam<TradeMode> _tradeMode;
+	private readonly StrategyParam<TradeModes> _tradeMode;
 	private readonly StrategyParam<int> _randomSeed;
 
 	private Random _random;
@@ -57,7 +57,7 @@ public class AtRandomFullStrategy : Strategy
 	/// <summary>
 	/// Defines which side of the market is allowed to trade.
 	/// </summary>
-	public enum TradeMode
+	public enum TradeModes
 	{
 		/// <summary>
 		/// Long and short positions are permitted.
@@ -213,7 +213,7 @@ public class AtRandomFullStrategy : Strategy
 	/// <summary>
 	/// Allowed trade direction.
 	/// </summary>
-	public TradeMode Mode
+	public TradeModes Mode
 	{
 		get => _tradeMode.Value;
 		set => _tradeMode.Value = value;
@@ -296,7 +296,7 @@ public class AtRandomFullStrategy : Strategy
 		_sessionEnd = Param(nameof(SessionEnd), new TimeSpan(15, 2, 0))
 			.SetDisplay("Session End", "Trading window end time", "Timing");
 
-		_tradeMode = Param(nameof(Mode), TradeMode.Both)
+		_tradeMode = Param(nameof(Mode), TradeModes.Both)
 			.SetDisplay("Trade Mode", "Allowed trade direction", "Execution");
 
 		_randomSeed = Param(nameof(RandomSeed), 0)
@@ -429,9 +429,9 @@ public class AtRandomFullStrategy : Strategy
 	{
 		return Mode switch
 		{
-			TradeMode.Both => true,
-			TradeMode.BuyOnly => side == Sides.Buy,
-			TradeMode.SellOnly => side == Sides.Sell,
+			TradeModes.Both => true,
+			TradeModes.BuyOnly => side == Sides.Buy,
+			TradeModes.SellOnly => side == Sides.Sell,
 			_ => true
 		};
 	}

--- a/API/3559_Two_Pending_Orders_2/CS/TwoPendingOrders2Strategy.cs
+++ b/API/3559_Two_Pending_Orders_2/CS/TwoPendingOrders2Strategy.cs
@@ -28,8 +28,8 @@ public class TwoPendingOrders2Strategy : Strategy
 	private readonly StrategyParam<decimal> _trailingActivatePoints;
 	private readonly StrategyParam<decimal> _trailingStopPoints;
 	private readonly StrategyParam<decimal> _trailingStepPoints;
-	private readonly StrategyParam<TradeMode> _tradeMode;
-	private readonly StrategyParam<PendingOrderMode> _pendingType;
+	private readonly StrategyParam<TradeModes> _tradeMode;
+	private readonly StrategyParam<PendingOrderModes> _pendingType;
 	private readonly StrategyParam<int> _pendingExpirationMinutes;
 	private readonly StrategyParam<decimal> _pendingIndentPoints;
 	private readonly StrategyParam<decimal> _pendingMaxSpreadPoints;
@@ -80,10 +80,10 @@ public class TwoPendingOrders2Strategy : Strategy
 		.SetDisplay("Trailing Step (points)", "Minimum increment to move the trailing stop.", "Trailing")
 		.SetCanOptimize(true);
 
-		_tradeMode = Param(nameof(TradeMode), TradeMode.BuySell)
+		_tradeMode = Param(nameof(TradeModes), TradeModes.BuySell)
 		.SetDisplay("Trade Mode", "Allowed trade direction for new pending orders.", "General");
 
-		_pendingType = Param(nameof(PendingType), PendingOrderMode.Stop)
+		_pendingType = Param(nameof(PendingType), PendingOrderModes.Stop)
 		.SetDisplay("Pending Type", "Choose between stop or limit pending orders.", "General");
 
 		_pendingExpirationMinutes = Param(nameof(PendingExpirationMinutes), 600)
@@ -176,7 +176,7 @@ public class TwoPendingOrders2Strategy : Strategy
 	/// <summary>
 	/// Trade direction allowed for fresh pending orders.
 	/// </summary>
-	public TradeMode TradeMode
+	public TradeModes TradeModes
 	{
 		get => _tradeMode.Value;
 		set => _tradeMode.Value = value;
@@ -185,7 +185,7 @@ public class TwoPendingOrders2Strategy : Strategy
 	/// <summary>
 	/// Defines whether stop or limit orders are used.
 	/// </summary>
-	public PendingOrderMode PendingType
+	public PendingOrderModes PendingType
 	{
 		get => _pendingType.Value;
 		set => _pendingType.Value = value;
@@ -493,14 +493,14 @@ public class TwoPendingOrders2Strategy : Strategy
 
 		if (IsDirectionAllowed(Sides.Buy))
 		{
-			var price = PendingType == PendingOrderMode.Stop ? ask + indent : bid - indent;
+			var price = PendingType == PendingOrderModes.Stop ? ask + indent : bid - indent;
 			if (ReverseLevels)
-			price = PendingType == PendingOrderMode.Stop ? bid - indent : ask + indent;
+			price = PendingType == PendingOrderModes.Stop ? bid - indent : ask + indent;
 
 			price = NormalizePrice(price);
 			if (IsFarFromPositions(price))
 			{
-				if (PendingType == PendingOrderMode.Stop)
+				if (PendingType == PendingOrderModes.Stop)
 				BuyStop(price);
 				else
 				BuyLimit(price);
@@ -509,14 +509,14 @@ public class TwoPendingOrders2Strategy : Strategy
 
 		if (IsDirectionAllowed(Sides.Sell))
 		{
-			var price = PendingType == PendingOrderMode.Stop ? bid - indent : ask + indent;
+			var price = PendingType == PendingOrderModes.Stop ? bid - indent : ask + indent;
 			if (ReverseLevels)
-			price = PendingType == PendingOrderMode.Stop ? ask + indent : bid - indent;
+			price = PendingType == PendingOrderModes.Stop ? ask + indent : bid - indent;
 
 			price = NormalizePrice(price);
 			if (IsFarFromPositions(price))
 			{
-				if (PendingType == PendingOrderMode.Stop)
+				if (PendingType == PendingOrderModes.Stop)
 				SellStop(price);
 				else
 				SellLimit(price);
@@ -554,10 +554,10 @@ public class TwoPendingOrders2Strategy : Strategy
 
 	private bool IsDirectionAllowed(Sides side)
 	{
-		return TradeMode switch
+		return TradeModes switch
 		{
-			TradeMode.Buy => side == Sides.Buy,
-			TradeMode.Sell => side == Sides.Sell,
+			TradeModes.Buy => side == Sides.Buy,
+			TradeModes.Sell => side == Sides.Sell,
 			_ => true,
 		};
 	}
@@ -617,7 +617,7 @@ public class TwoPendingOrders2Strategy : Strategy
 	/// <summary>
 	/// Pending order type supported by the strategy.
 	/// </summary>
-	public enum PendingOrderMode
+	public enum PendingOrderModes
 	{
 		/// <summary>
 		/// Use stop orders placed away from the market.
@@ -633,7 +633,7 @@ public class TwoPendingOrders2Strategy : Strategy
 	/// <summary>
 	/// Trade direction restrictions.
 	/// </summary>
-	public enum TradeMode
+	public enum TradeModes
 	{
 		/// <summary>
 		/// Long trades only.

--- a/API/3561_MACD_Fixed_PSAR/CS/MacdFixedPsarStrategy.cs
+++ b/API/3561_MACD_Fixed_PSAR/CS/MacdFixedPsarStrategy.cs
@@ -22,7 +22,7 @@ public class MacdFixedPsarStrategy : Strategy
 {
 	private readonly StrategyParam<decimal> _takeProfitPips;
 	private readonly StrategyParam<decimal> _stopLossPips;
-	private readonly StrategyParam<TrailingMode> _trailingMode;
+	private readonly StrategyParam<TrailingModes> _trailingMode;
 	private readonly StrategyParam<decimal> _trailingStopPips;
 	private readonly StrategyParam<decimal> _psarStep;
 	private readonly StrategyParam<decimal> _psarMaximum;
@@ -61,7 +61,7 @@ public class MacdFixedPsarStrategy : Strategy
 	/// <summary>
 	/// Trailing modes matching the original expert advisor options.
 	/// </summary>
-	public enum TrailingMode
+	public enum TrailingModes
 	{
 		/// <summary>
 		/// Trailing is disabled and only the initial stop-loss is used.
@@ -101,14 +101,14 @@ public class MacdFixedPsarStrategy : Strategy
 	/// <summary>
 	/// Selected trailing stop mode.
 	/// </summary>
-	public TrailingMode TrailMode
+	public TrailingModes TrailMode
 	{
 		get => _trailingMode.Value;
 		set => _trailingMode.Value = value;
 	}
 
 	/// <summary>
-	/// Fixed trailing stop distance in pips (used when <see cref="TrailMode"/> equals <see cref="TrailingMode.Fixed"/>).
+	/// Fixed trailing stop distance in pips (used when <see cref="TrailMode"/> equals <see cref="TrailingModes.Fixed"/>).
 	/// </summary>
 	public decimal TrailingStopPips
 	{
@@ -184,7 +184,7 @@ public class MacdFixedPsarStrategy : Strategy
 		.SetCanOptimize(true)
 		.SetDisplay("Stop Loss (pips)", "Stop-loss distance expressed in pips", "Risk");
 
-		_trailingMode = Param(nameof(TrailMode), TrailingMode.FixedPsar)
+		_trailingMode = Param(nameof(TrailMode), TrailingModes.FixedPsar)
 		.SetDisplay("Trailing Mode", "Trailing logic: None, Fixed, or Fixed PSAR", "Risk");
 
 		_trailingStopPips = Param(nameof(TrailingStopPips), 30m)
@@ -495,14 +495,14 @@ public class MacdFixedPsarStrategy : Strategy
 
 		switch (TrailMode)
 		{
-			case TrailingMode.None:
+			case TrailingModes.None:
 			return;
 
-			case TrailingMode.Fixed:
+			case TrailingModes.Fixed:
 			UpdateLongFixedTrailing(candle);
 			break;
 
-			case TrailingMode.FixedPsar:
+			case TrailingModes.FixedPsar:
 			UpdateLongPsarTrailing(candle);
 			break;
 		}
@@ -515,14 +515,14 @@ public class MacdFixedPsarStrategy : Strategy
 
 		switch (TrailMode)
 		{
-			case TrailingMode.None:
+			case TrailingModes.None:
 			return;
 
-			case TrailingMode.Fixed:
+			case TrailingModes.Fixed:
 			UpdateShortFixedTrailing(candle);
 			break;
 
-			case TrailingMode.FixedPsar:
+			case TrailingModes.FixedPsar:
 			UpdateShortPsarTrailing(candle);
 			break;
 		}

--- a/API/3563_Simple_Order_Panel/CS/SimpleOrderPanelStrategy.cs
+++ b/API/3563_Simple_Order_Panel/CS/SimpleOrderPanelStrategy.cs
@@ -18,21 +18,21 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class SimpleOrderPanelStrategy : Strategy
 {
-	public enum RiskMode
+	public enum RiskModes
 	{
 		FixedVolume,
 		BalancePercent,
 	}
 
-	public enum StopTakeMode
+	public enum StopTakeModes
 	{
 		PriceLevels,
 		PointOffsets,
 	}
 
-	private readonly StrategyParam<RiskMode> _riskCalculationMode;
+	private readonly StrategyParam<RiskModes> _riskCalculationMode;
 	private readonly StrategyParam<decimal> _riskValue;
-	private readonly StrategyParam<StopTakeMode> _stopTakeMode;
+	private readonly StrategyParam<StopTakeModes> _stopTakeMode;
 	private readonly StrategyParam<decimal> _stopLossValue;
 	private readonly StrategyParam<decimal> _takeProfitValue;
 	private readonly StrategyParam<bool> _buyMarketRequest;
@@ -85,7 +85,7 @@ public class SimpleOrderPanelStrategy : Strategy
 	/// </summary>
 	public SimpleOrderPanelStrategy()
 	{
-		_riskCalculationMode = Param(nameof(RiskCalculation), RiskMode.FixedVolume)
+		_riskCalculationMode = Param(nameof(RiskCalculation), RiskModes.FixedVolume)
 		.SetDisplay("Risk Mode", "Choose between fixed lots or balance percentage sizing.", "Risk")
 		.SetCanOptimize(false);
 
@@ -94,7 +94,7 @@ public class SimpleOrderPanelStrategy : Strategy
 		.SetDisplay("Risk Value", "Lot size or balance percent depending on the selected mode.", "Risk")
 		.SetCanOptimize(false);
 
-		_stopTakeMode = Param(nameof(StopTakeCalculation), StopTakeMode.PointOffsets)
+		_stopTakeMode = Param(nameof(StopTakeCalculation), StopTakeModes.PointOffsets)
 		.SetDisplay("Stop/Take Mode", "Interpret stop-loss and take-profit values as absolute prices or MetaTrader points.", "Risk")
 		.SetCanOptimize(false);
 
@@ -173,7 +173,7 @@ public class SimpleOrderPanelStrategy : Strategy
 	/// <summary>
 	/// Determines whether the strategy sizes trades by fixed volume or balance percentage.
 	/// </summary>
-	public RiskMode RiskCalculation
+	public RiskModes RiskCalculation
 	{
 		get => _riskCalculationMode.Value;
 		set => _riskCalculationMode.Value = value;
@@ -191,7 +191,7 @@ public class SimpleOrderPanelStrategy : Strategy
 	/// <summary>
 	/// Defines how stop-loss and take-profit inputs are interpreted.
 	/// </summary>
-	public StopTakeMode StopTakeCalculation
+	public StopTakeModes StopTakeCalculation
 	{
 		get => _stopTakeMode.Value;
 		set => _stopTakeMode.Value = value;
@@ -737,7 +737,7 @@ public class SimpleOrderPanelStrategy : Strategy
 
 	private decimal CalculateVolume(Sides direction, decimal entryPrice)
 	{
-		var volume = RiskCalculation == RiskMode.FixedVolume
+		var volume = RiskCalculation == RiskModes.FixedVolume
 		? RiskValue
 		: CalculateRiskBasedVolume(direction, entryPrice);
 
@@ -785,7 +785,7 @@ public class SimpleOrderPanelStrategy : Strategy
 		if (StopLossValue <= 0m)
 		return 0m;
 
-		if (StopTakeCalculation == StopTakeMode.PriceLevels)
+		if (StopTakeCalculation == StopTakeModes.PriceLevels)
 		{
 			return Math.Abs(entryPrice - StopLossValue);
 		}
@@ -806,7 +806,7 @@ public class SimpleOrderPanelStrategy : Strategy
 		if (StopLossValue <= 0m)
 		return null;
 
-		if (StopTakeCalculation == StopTakeMode.PriceLevels)
+		if (StopTakeCalculation == StopTakeModes.PriceLevels)
 		return StopLossValue;
 
 		var distance = StopLossValue * (_pointSize > 0m ? _pointSize : CalculatePointSize());
@@ -822,7 +822,7 @@ public class SimpleOrderPanelStrategy : Strategy
 		if (TakeProfitValue <= 0m)
 		return null;
 
-		if (StopTakeCalculation == StopTakeMode.PriceLevels)
+		if (StopTakeCalculation == StopTakeModes.PriceLevels)
 		return TakeProfitValue;
 
 		var distance = TakeProfitValue * (_pointSize > 0m ? _pointSize : CalculatePointSize());

--- a/API/3565_News_Template_Universal/CS/NewsTemplateUniversalStrategy.cs
+++ b/API/3565_News_Template_Universal/CS/NewsTemplateUniversalStrategy.cs
@@ -347,46 +347,46 @@ public class NewsTemplateUniversalStrategy : Strategy
 		return text.IndexOf(filter.Trim().ToUpperInvariant(), StringComparison.Ordinal) >= 0;
 	}
 
-	private NewsImportance ParseImportance(NewsMessage news)
+	private NewsImportances ParseImportance(NewsMessage news)
 	{
 		var text = BuildNormalizedText(news);
 
 		if (text.IndexOf("***", StringComparison.Ordinal) >= 0)
-		return NewsImportance.High;
+		return NewsImportances.High;
 
 		if (text.IndexOf("**", StringComparison.Ordinal) >= 0)
-		return NewsImportance.Medium;
+		return NewsImportances.Medium;
 
 		if (text.Contains('*'))
-		return NewsImportance.Low;
+		return NewsImportances.Low;
 
 		if (text.IndexOf("HIGH", StringComparison.Ordinal) >= 0)
-		return NewsImportance.High;
+		return NewsImportances.High;
 
 		if (text.IndexOf("MEDIUM", StringComparison.Ordinal) >= 0 || text.IndexOf("MODERATE", StringComparison.Ordinal) >= 0)
-		return NewsImportance.Medium;
+		return NewsImportances.Medium;
 
 		if (text.IndexOf("LOW", StringComparison.Ordinal) >= 0)
-		return NewsImportance.Low;
+		return NewsImportances.Low;
 
-		return NewsImportance.Unknown;
+		return NewsImportances.Unknown;
 	}
 
-	private bool IsImportanceAccepted(NewsImportance importance)
+	private bool IsImportanceAccepted(NewsImportances importance)
 	{
 		return importance switch
 		{
-			NewsImportance.High => IncludeHigh,
-			NewsImportance.Medium => IncludeMedium,
-			NewsImportance.Low => IncludeLow,
-			NewsImportance.Unknown => IncludeHigh || IncludeMedium || IncludeLow,
+			NewsImportances.High => IncludeHigh,
+			NewsImportances.Medium => IncludeMedium,
+			NewsImportances.Low => IncludeLow,
+			NewsImportances.Unknown => IncludeHigh || IncludeMedium || IncludeLow,
 			_ => false,
 		};
 	}
 
-	private sealed record class NewsEvent(DateTimeOffset Time, NewsImportance Importance, string Headline);
+	private sealed record class NewsEvent(DateTimeOffset Time, NewsImportances Importance, string Headline);
 
-	private enum NewsImportance
+	private enum NewsImportances
 	{
 		Unknown = 0,
 		Low = 1,

--- a/API/3595_EAFrameworkLayout/CS/EAFrameworkLayoutStrategy.cs
+++ b/API/3595_EAFrameworkLayout/CS/EAFrameworkLayoutStrategy.cs
@@ -23,7 +23,7 @@ public class EAFrameworkLayoutStrategy : Strategy
 	private readonly StrategyParam<decimal> _tradeInitLots;
 	private readonly StrategyParam<int> _autoCloseAfterXH1;
 	private readonly StrategyParam<bool> _isReverse;
-	private readonly StrategyParam<DealDirectionAllow> _dealDirectionAllow;
+	private readonly StrategyParam<DealDirectionAllows> _dealDirectionAllow;
 	private readonly StrategyParam<double> _usTimeLeftBound;
 	private readonly StrategyParam<double> _usTimeRightBound;
 	private readonly StrategyParam<double> _nonUsTimeLeftBound;
@@ -43,7 +43,7 @@ public class EAFrameworkLayoutStrategy : Strategy
 	/// <summary>
 	/// Deal direction permissions.
 	/// </summary>
-	public enum DealDirectionAllow
+	public enum DealDirectionAllows
 	{
 		Both,
 		Up,
@@ -71,7 +71,7 @@ public class EAFrameworkLayoutStrategy : Strategy
 		_isReverse = Param(nameof(IsReverse), false)
 			.SetDisplay("Reverse", "Whether the strategy should attempt to reverse positions", "General");
 
-		_dealDirectionAllow = Param(nameof(DirectionAllow), DealDirectionAllow.Both)
+		_dealDirectionAllow = Param(nameof(DirectionAllow), DealDirectionAllows.Both)
 			.SetDisplay("Direction", "Allowed trade direction when managing positions", "General");
 
 		_usTimeLeftBound = Param(nameof(UsTimeLeftBound), 2.0)
@@ -129,7 +129,7 @@ public class EAFrameworkLayoutStrategy : Strategy
 	/// <summary>
 	/// Allowed trade direction when managing positions.
 	/// </summary>
-	public DealDirectionAllow DirectionAllow
+	public DealDirectionAllows DirectionAllow
 	{
 		get => _dealDirectionAllow.Value;
 		set => _dealDirectionAllow.Value = value;
@@ -293,9 +293,9 @@ public class EAFrameworkLayoutStrategy : Strategy
 	{
 		return DirectionAllow switch
 		{
-			DealDirectionAllow.Both => true,
-			DealDirectionAllow.Up => positionSign > 0,
-			DealDirectionAllow.Down => positionSign < 0,
+			DealDirectionAllows.Both => true,
+			DealDirectionAllows.Up => positionSign > 0,
+			DealDirectionAllows.Down => positionSign < 0,
 			_ => true,
 		};
 	}

--- a/API/3613_Fine_Clock/CS/FineClockStrategy.cs
+++ b/API/3613_Fine_Clock/CS/FineClockStrategy.cs
@@ -25,7 +25,7 @@ public class FineClockStrategy : Strategy
 	/// <summary>
 	/// Available clock formats.
 	/// </summary>
-	public enum ClockFormat
+	public enum ClockFormats
 	{
 		/// <summary>
 		/// Displays hours, minutes and seconds.
@@ -41,7 +41,7 @@ public class FineClockStrategy : Strategy
 	/// <summary>
 	/// Supported time sources for the clock.
 	/// </summary>
-	public enum ClockTimeSource
+	public enum ClockTimeSources
 	{
 		/// <summary>
 		/// Use the local computer time.
@@ -62,7 +62,7 @@ public class FineClockStrategy : Strategy
 	/// <summary>
 	/// Preferred placement of the clock label.
 	/// </summary>
-	public enum ClockCorner
+	public enum ClockCorners
 	{
 		/// <summary>
 		/// Upper left corner of the chart.
@@ -86,9 +86,9 @@ public class FineClockStrategy : Strategy
 	}
 
 	private readonly StrategyParam<DataType> _candleType;
-	private readonly StrategyParam<ClockFormat> _format;
-	private readonly StrategyParam<ClockTimeSource> _timeSource;
-	private readonly StrategyParam<ClockCorner> _corner;
+	private readonly StrategyParam<ClockFormats> _format;
+	private readonly StrategyParam<ClockTimeSources> _timeSource;
+	private readonly StrategyParam<ClockCorners> _corner;
 	private readonly StrategyParam<int> _horizontalOffset;
 	private readonly StrategyParam<int> _verticalOffset;
 	private readonly StrategyParam<int> _shadowOffset;
@@ -109,13 +109,13 @@ public class FineClockStrategy : Strategy
 		_candleType = Param(nameof(CandleType), TimeSpan.FromSeconds(1).TimeFrame())
 		.SetDisplay("Candle Type", "Data type used to feed the clock and draw candles", "General");
 
-		_format = Param(nameof(Format), ClockFormat.Seconds)
+		_format = Param(nameof(Format), ClockFormats.Seconds)
 		.SetDisplay("Format", "Clock output format", "Visualization");
 
-		_timeSource = Param(nameof(TimeSource), ClockTimeSource.Local)
+		_timeSource = Param(nameof(TimeSource), ClockTimeSources.Local)
 		.SetDisplay("Time Source", "Select between local, server or UTC time", "Visualization");
 
-		_corner = Param(nameof(Corner), ClockCorner.RightLower)
+		_corner = Param(nameof(Corner), ClockCorners.RightLower)
 		.SetDisplay("Corner", "Preferred placement of the text label", "Visualization");
 
 		_horizontalOffset = Param(nameof(HorizontalOffset), 0)
@@ -146,7 +146,7 @@ public class FineClockStrategy : Strategy
 	/// <summary>
 	/// Clock display format.
 	/// </summary>
-	public ClockFormat Format
+	public ClockFormats Format
 	{
 		get => _format.Value;
 		set => _format.Value = value;
@@ -155,7 +155,7 @@ public class FineClockStrategy : Strategy
 	/// <summary>
 	/// Selected time source for the clock.
 	/// </summary>
-	public ClockTimeSource TimeSource
+	public ClockTimeSources TimeSource
 	{
 		get => _timeSource.Value;
 		set => _timeSource.Value = value;
@@ -164,7 +164,7 @@ public class FineClockStrategy : Strategy
 	/// <summary>
 	/// Preferred chart corner used to position the clock.
 	/// </summary>
-	public ClockCorner Corner
+	public ClockCorners Corner
 	{
 		get => _corner.Value;
 		set => _corner.Value = value;
@@ -352,7 +352,7 @@ public class FineClockStrategy : Strategy
 		var timeUnit = GetTimeFrame();
 		if (timeUnit <= TimeSpan.Zero)
 		{
-			timeUnit = Format == ClockFormat.Seconds ? TimeSpan.FromSeconds(1) : TimeSpan.FromMinutes(1);
+			timeUnit = Format == ClockFormats.Seconds ? TimeSpan.FromSeconds(1) : TimeSpan.FromMinutes(1);
 		}
 
 		var priceStep = Security.PriceStep;
@@ -361,8 +361,8 @@ public class FineClockStrategy : Strategy
 			priceStep = Math.Abs(basePrice) > 0m ? Math.Abs(basePrice) * 0.001m : 1m;
 		}
 
-		var horizontalDirection = Corner is ClockCorner.RightUpper or ClockCorner.RightLower ? 1 : -1;
-		var verticalDirection = Corner is ClockCorner.LeftUpper or ClockCorner.RightUpper ? 1 : -1;
+		var horizontalDirection = Corner is ClockCorners.RightUpper or ClockCorners.RightLower ? 1 : -1;
+		var verticalDirection = Corner is ClockCorners.LeftUpper or ClockCorners.RightUpper ? 1 : -1;
 
 		var mainTime = baseTime + TimeSpan.FromTicks(timeUnit.Ticks * HorizontalOffset * horizontalDirection);
 		var mainPrice = basePrice + priceStep.Value * VerticalOffset * verticalDirection;
@@ -414,9 +414,9 @@ public class FineClockStrategy : Strategy
 
 		return TimeSource switch
 		{
-			ClockTimeSource.Local => now.ToLocalTime(),
-			ClockTimeSource.Server => now,
-			ClockTimeSource.Utc => now.ToUniversalTime(),
+			ClockTimeSources.Local => now.ToLocalTime(),
+			ClockTimeSources.Server => now,
+			ClockTimeSources.Utc => now.ToUniversalTime(),
 			_ => now,
 		};
 	}
@@ -425,14 +425,14 @@ public class FineClockStrategy : Strategy
 	{
 		return Format switch
 		{
-			ClockFormat.Minutes => time.ToString(" HH:mm "),
+			ClockFormats.Minutes => time.ToString(" HH:mm "),
 			_ => time.ToString(" HH:mm:ss "),
 		};
 	}
 
 	private TimeSpan GetTimerInterval()
 	{
-		return Format == ClockFormat.Seconds ? TimeSpan.FromSeconds(1) : TimeSpan.FromMinutes(1);
+		return Format == ClockFormats.Seconds ? TimeSpan.FromSeconds(1) : TimeSpan.FromMinutes(1);
 	}
 }
 

--- a/API/3615_Check_Open_Orders/CS/CheckOpenOrdersStrategy.cs
+++ b/API/3615_Check_Open_Orders/CS/CheckOpenOrdersStrategy.cs
@@ -16,7 +16,7 @@ using StockSharp.Messages;
 using System.Threading;
 using System.Threading.Tasks;
 
-public enum CheckOpenOrdersMode
+public enum CheckOpenOrdersModes
 {
 	CheckAllTypes = 0,
 	CheckOnlyBuy = 1,
@@ -33,7 +33,7 @@ public class CheckOpenOrdersStrategy : Strategy
 	private readonly StrategyParam<decimal> _takeProfitPoints;
 	private readonly StrategyParam<decimal> _slippagePoints;
 	private readonly StrategyParam<int> _waitTimeMilliseconds;
-	private readonly StrategyParam<CheckOpenOrdersMode> _mode;
+	private readonly StrategyParam<CheckOpenOrdersModes> _mode;
 
 	private CancellationTokenSource _ordersCts;
 	private string _modeDescription = string.Empty;
@@ -68,7 +68,7 @@ public class CheckOpenOrdersStrategy : Strategy
 		.SetGreaterThanZero()
 		.SetDisplay("Wait Time (ms)", "Delay in milliseconds between the sample orders.", "Execution");
 
-		_mode = Param(nameof(Mode), CheckOpenOrdersMode.CheckAllTypes)
+		_mode = Param(nameof(Mode), CheckOpenOrdersModes.CheckAllTypes)
 		.SetDisplay("Order Filter", "Type of market positions monitored by the status message.", "Monitoring");
 	}
 
@@ -128,7 +128,7 @@ public class CheckOpenOrdersStrategy : Strategy
 	/// <summary>
 	/// Type of open orders checked by the status report.
 	/// </summary>
-	public CheckOpenOrdersMode Mode
+	public CheckOpenOrdersModes Mode
 	{
 		get => _mode.Value;
 		set
@@ -246,15 +246,15 @@ public class CheckOpenOrdersStrategy : Strategy
 	{
 		_modeDescription = Mode switch
 		{
-			CheckOpenOrdersMode.CheckOnlyBuy => "Checking for buy market open orders only",
-			CheckOpenOrdersMode.CheckOnlySell => "Checking sell market open orders only",
+			CheckOpenOrdersModes.CheckOnlyBuy => "Checking for buy market open orders only",
+			CheckOpenOrdersModes.CheckOnlySell => "Checking sell market open orders only",
 			_ => "Checking all market open orders"
 		};
 
 		_orderTypesDescription = Mode switch
 		{
-			CheckOpenOrdersMode.CheckOnlyBuy => "buy",
-			CheckOpenOrdersMode.CheckOnlySell => "sell",
+			CheckOpenOrdersModes.CheckOnlyBuy => "buy",
+			CheckOpenOrdersModes.CheckOnlySell => "sell",
 			_ => "buy and sell"
 		};
 	}
@@ -278,8 +278,8 @@ public class CheckOpenOrdersStrategy : Strategy
 	{
 		return Mode switch
 		{
-			CheckOpenOrdersMode.CheckOnlyBuy => Position > 0m,
-			CheckOpenOrdersMode.CheckOnlySell => Position < 0m,
+			CheckOpenOrdersModes.CheckOnlyBuy => Position > 0m,
+			CheckOpenOrdersModes.CheckOnlySell => Position < 0m,
 			_ => Position != 0m,
 		};
 	}

--- a/API/3625_BandOsMa/CS/BandOsMaStrategy.cs
+++ b/API/3625_BandOsMa/CS/BandOsMaStrategy.cs
@@ -25,13 +25,13 @@ public class BandOsMaStrategy : Strategy
 	private readonly StrategyParam<int> _macdFastPeriod;
 	private readonly StrategyParam<int> _macdSlowPeriod;
 	private readonly StrategyParam<int> _macdSignalPeriod;
-	private readonly StrategyParam<IndicatorAppliedPrice> _priceType;
+	private readonly StrategyParam<IndicatorAppliedPrices> _priceType;
 	private readonly StrategyParam<int> _bollingerPeriod;
 	private readonly StrategyParam<int> _bollingerShift;
 	private readonly StrategyParam<decimal> _bollingerDeviation;
 	private readonly StrategyParam<int> _maPeriod;
 	private readonly StrategyParam<int> _maShift;
-	private readonly StrategyParam<MovingAverageMethod> _maMethod;
+	private readonly StrategyParam<MovingAverageMethods> _maMethod;
 
 	private MovingAverageConvergenceDivergenceSignal _macd;
 	private BollingerBands _bollinger;
@@ -107,7 +107,7 @@ public class BandOsMaStrategy : Strategy
 	/// <summary>
 	/// Applied price mapping that mirrors MetaTrader PRICE_* constants.
 	/// </summary>
-	public IndicatorAppliedPrice PriceType
+	public IndicatorAppliedPrices PriceType
 	{
 		get => _priceType.Value;
 		set => _priceType.Value = value;
@@ -161,7 +161,7 @@ public class BandOsMaStrategy : Strategy
 	/// <summary>
 	/// Moving average method matching the MetaTrader enumeration.
 	/// </summary>
-	public MovingAverageMethod MovingAverageMethod
+	public MovingAverageMethods MovingAverageMethods
 	{
 		get => _maMethod.Value;
 		set => _maMethod.Value = value;
@@ -200,7 +200,7 @@ public class BandOsMaStrategy : Strategy
 		.SetDisplay("MACD Signal", "Signal EMA length used inside MACD", "Indicators")
 		.SetCanOptimize(true);
 
-		_priceType = Param(nameof(PriceType), IndicatorAppliedPrice.Typical)
+		_priceType = Param(nameof(PriceType), IndicatorAppliedPrices.Typical)
 		.SetDisplay("Applied Price", "Price source forwarded to the MACD", "General")
 		.SetCanOptimize(true);
 
@@ -227,7 +227,7 @@ public class BandOsMaStrategy : Strategy
 		.SetDisplay("OsMA MA Shift", "Shift applied to the moving average buffer", "Indicators")
 		.SetCanOptimize(true);
 
-		_maMethod = Param(nameof(MovingAverageMethod), MovingAverageMethod.Simple)
+		_maMethod = Param(nameof(MovingAverageMethods), MovingAverageMethods.Simple)
 		.SetDisplay("OsMA MA Method", "Moving average method applied to the OsMA", "Indicators")
 		.SetCanOptimize(true);
 	}
@@ -283,7 +283,7 @@ public class BandOsMaStrategy : Strategy
 			Width = BollingerDeviation
 		};
 
-		_osmaAverage = CreateMovingAverage(MovingAverageMethod, MovingAveragePeriod);
+		_osmaAverage = CreateMovingAverage(MovingAverageMethods, MovingAveragePeriod);
 
 		var subscription = SubscribeCandles(CandleType);
 		subscription
@@ -547,27 +547,27 @@ private static bool TryGetRecentPair(List<decimal> history, int shift, out decim
 	return true;
 }
 
-private static decimal GetAppliedPrice(ICandleMessage candle, IndicatorAppliedPrice priceType)
+private static decimal GetAppliedPrice(ICandleMessage candle, IndicatorAppliedPrices priceType)
 {
 	return priceType switch
 	{
-		IndicatorAppliedPrice.Open => candle.OpenPrice,
-		IndicatorAppliedPrice.High => candle.HighPrice,
-		IndicatorAppliedPrice.Low => candle.LowPrice,
-		IndicatorAppliedPrice.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-		IndicatorAppliedPrice.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-		IndicatorAppliedPrice.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice + candle.ClosePrice) / 4m,
+		IndicatorAppliedPrices.Open => candle.OpenPrice,
+		IndicatorAppliedPrices.High => candle.HighPrice,
+		IndicatorAppliedPrices.Low => candle.LowPrice,
+		IndicatorAppliedPrices.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+		IndicatorAppliedPrices.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+		IndicatorAppliedPrices.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice + candle.ClosePrice) / 4m,
 		_ => candle.ClosePrice
 	};
 }
 
-private static IIndicator CreateMovingAverage(MovingAverageMethod method, int length)
+private static IIndicator CreateMovingAverage(MovingAverageMethods method, int length)
 {
 	return method switch
 	{
-		MovingAverageMethod.Exponential => new ExponentialMovingAverage { Length = length },
-		MovingAverageMethod.Smoothed => new SmoothedMovingAverage { Length = length },
-		MovingAverageMethod.LinearWeighted => new WeightedMovingAverage { Length = length },
+		MovingAverageMethods.Exponential => new ExponentialMovingAverage { Length = length },
+		MovingAverageMethods.Smoothed => new SmoothedMovingAverage { Length = length },
+		MovingAverageMethods.LinearWeighted => new WeightedMovingAverage { Length = length },
 		_ => new SimpleMovingAverage { Length = length }
 	};
 }
@@ -576,7 +576,7 @@ private static IIndicator CreateMovingAverage(MovingAverageMethod method, int le
 /// <summary>
 /// Enumeration mirroring the MetaTrader applied price options.
 /// </summary>
-public enum IndicatorAppliedPrice
+public enum IndicatorAppliedPrices
 {
 	Close,
 	Open,
@@ -590,7 +590,7 @@ public enum IndicatorAppliedPrice
 /// <summary>
 /// Moving average methods corresponding to MetaTrader's ENUM_MA_METHOD values.
 /// </summary>
-public enum MovingAverageMethod
+public enum MovingAverageMethods
 {
 	Simple,
 	Exponential,

--- a/API/3626_Band_OsMA_Custom/CS/BandOsMaCustomStrategy.cs
+++ b/API/3626_Band_OsMA_Custom/CS/BandOsMaCustomStrategy.cs
@@ -26,13 +26,13 @@ public class BandOsMaCustomStrategy : Strategy
 	private readonly StrategyParam<int> _fastOsmaPeriod;
 	private readonly StrategyParam<int> _slowOsmaPeriod;
 	private readonly StrategyParam<int> _signalPeriod;
-	private readonly StrategyParam<AppliedPriceType> _appliedPrice;
+	private readonly StrategyParam<AppliedPriceTypes> _appliedPrice;
 	private readonly StrategyParam<int> _bandsPeriod;
 	private readonly StrategyParam<int> _bandsShift;
 	private readonly StrategyParam<decimal> _bandsDeviation;
 	private readonly StrategyParam<int> _maPeriod;
 	private readonly StrategyParam<int> _maShift;
-	private readonly StrategyParam<MovingAverageMethod> _maMethod;
+	private readonly StrategyParam<MovingAverageMethods> _maMethod;
 	private readonly StrategyParam<decimal> _stopLossPoints;
 	private readonly StrategyParam<decimal> _orderVolume;
 
@@ -88,7 +88,7 @@ public class BandOsMaCustomStrategy : Strategy
 	/// <summary>
 	/// Applied price mapping that mirrors the MetaTrader PRICE_* constants.
 	/// </summary>
-	public AppliedPriceType AppliedPrice
+	public AppliedPriceTypes AppliedPrice
 	{
 		get => _appliedPrice.Value;
 		set => _appliedPrice.Value = value;
@@ -142,7 +142,7 @@ public class BandOsMaCustomStrategy : Strategy
 	/// <summary>
 	/// Moving average calculation method (SMA, EMA, SMMA, LWMA).
 	/// </summary>
-	public MovingAverageMethod MaMethod
+	public MovingAverageMethods MaMethod
 	{
 		get => _maMethod.Value;
 		set => _maMethod.Value = value;
@@ -189,7 +189,7 @@ public class BandOsMaCustomStrategy : Strategy
 		.SetDisplay("Signal", "Signal SMA period for the MACD histogram", "Indicators")
 		.SetCanOptimize(true);
 
-		_appliedPrice = Param(nameof(AppliedPrice), AppliedPriceType.Typical)
+		_appliedPrice = Param(nameof(AppliedPrice), AppliedPriceTypes.Typical)
 		.SetDisplay("Applied Price", "Which candle price feeds the OsMA", "Indicators")
 		.SetCanOptimize(true);
 
@@ -216,7 +216,7 @@ public class BandOsMaCustomStrategy : Strategy
 		.SetDisplay("MA Shift", "Bar shift applied to the exit moving average", "Indicators")
 		.SetCanOptimize(true);
 
-		_maMethod = Param(nameof(MaMethod), MovingAverageMethod.Simple)
+		_maMethod = Param(nameof(MaMethod), MovingAverageMethods.Simple)
 		.SetDisplay("MA Method", "Calculation method for the exit average", "Indicators")
 		.SetCanOptimize(true);
 
@@ -429,13 +429,13 @@ public class BandOsMaCustomStrategy : Strategy
 	{
 		return AppliedPrice switch
 		{
-			AppliedPriceType.Close => candle.ClosePrice,
-			AppliedPriceType.Open => candle.OpenPrice,
-			AppliedPriceType.High => candle.HighPrice,
-			AppliedPriceType.Low => candle.LowPrice,
-			AppliedPriceType.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-			AppliedPriceType.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-			AppliedPriceType.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice + candle.ClosePrice) / 4m,
+			AppliedPriceTypes.Close => candle.ClosePrice,
+			AppliedPriceTypes.Open => candle.OpenPrice,
+			AppliedPriceTypes.High => candle.HighPrice,
+			AppliedPriceTypes.Low => candle.LowPrice,
+			AppliedPriceTypes.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+			AppliedPriceTypes.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+			AppliedPriceTypes.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice + candle.ClosePrice) / 4m,
 			_ => candle.ClosePrice,
 		};
 	}
@@ -470,14 +470,14 @@ public class BandOsMaCustomStrategy : Strategy
 		return new Unit(distanceInPoints * _pointValue, UnitTypes.Absolute);
 	}
 
-	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageMethod method, int length)
+	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageMethods method, int length)
 	{
 		return method switch
 		{
-			MovingAverageMethod.Simple => new SimpleMovingAverage { Length = length },
-			MovingAverageMethod.Exponential => new ExponentialMovingAverage { Length = length },
-			MovingAverageMethod.Smoothed => new SmoothedMovingAverage { Length = length },
-			MovingAverageMethod.LinearWeighted => new LinearWeightedMovingAverage { Length = length },
+			MovingAverageMethods.Simple => new SimpleMovingAverage { Length = length },
+			MovingAverageMethods.Exponential => new ExponentialMovingAverage { Length = length },
+			MovingAverageMethods.Smoothed => new SmoothedMovingAverage { Length = length },
+			MovingAverageMethods.LinearWeighted => new LinearWeightedMovingAverage { Length = length },
 			_ => new SimpleMovingAverage { Length = length },
 		};
 	}
@@ -485,7 +485,7 @@ public class BandOsMaCustomStrategy : Strategy
 	/// <summary>
 	/// Enum that mirrors the MetaTrader MODE_* applied price constants.
 	/// </summary>
-	public enum AppliedPriceType
+	public enum AppliedPriceTypes
 	{
 		Close = 0,
 		Open = 1,
@@ -499,7 +499,7 @@ public class BandOsMaCustomStrategy : Strategy
 	/// <summary>
 	/// Enum that mirrors the MetaTrader moving average methods.
 	/// </summary>
-	public enum MovingAverageMethod
+	public enum MovingAverageMethods
 	{
 		Simple = 0,
 		Exponential = 1,

--- a/API/3629_Random_Trader_Bias/CS/RandomBiasTraderStrategy.cs
+++ b/API/3629_Random_Trader_Bias/CS/RandomBiasTraderStrategy.cs
@@ -21,7 +21,7 @@ public class RandomBiasTraderStrategy : Strategy
 {
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<decimal> _rewardRiskRatio;
-	private readonly StrategyParam<LossMode> _lossMode;
+	private readonly StrategyParam<LossModes> _lossMode;
 	private readonly StrategyParam<decimal> _lossAtrMultiplier;
 	private readonly StrategyParam<decimal> _lossPipDistance;
 	private readonly StrategyParam<decimal> _riskPercentPerTrade;
@@ -56,7 +56,7 @@ public class RandomBiasTraderStrategy : Strategy
 		.SetCanOptimize(true)
 		.SetOptimize(1m, 5m, 0.5m);
 
-		_lossMode = Param(nameof(LossType), LossMode.Pip)
+		_lossMode = Param(nameof(LossType), LossModes.Pip)
 		.SetDisplay("Stop Mode", "Select between fixed pip or ATR based stop calculation.", "Risk");
 
 		_lossAtrMultiplier = Param(nameof(LossAtrMultiplier), 5m)
@@ -111,14 +111,14 @@ public class RandomBiasTraderStrategy : Strategy
 	/// <summary>
 	/// Stop loss calculation mode.
 	/// </summary>
-	public LossMode LossType
+	public LossModes LossType
 	{
 		get => _lossMode.Value;
 		set => _lossMode.Value = value;
 	}
 
 	/// <summary>
-	/// ATR multiplier used when <see cref="LossType"/> equals <see cref="LossMode.Atr"/>.
+	/// ATR multiplier used when <see cref="LossType"/> equals <see cref="LossModes.Atr"/>.
 	/// </summary>
 	public decimal LossAtrMultiplier
 	{
@@ -260,7 +260,7 @@ public class RandomBiasTraderStrategy : Strategy
 
 	private decimal GetStopDistance(IIndicatorValue atrValue)
 	{
-		if (LossType == LossMode.Pip)
+		if (LossType == LossModes.Pip)
 		{
 			var pip = _pipSize;
 			if (pip <= 0m)
@@ -498,7 +498,7 @@ public class RandomBiasTraderStrategy : Strategy
 /// <summary>
 /// Stop loss calculation modes supported by <see cref="RandomBiasTraderStrategy"/>.
 /// </summary>
-public enum LossMode
+public enum LossModes
 {
 	/// <summary>
 	/// Calculate stop distance from the ATR(10) indicator.

--- a/API/3638_Donchian_Scalper/CS/DonchianScalperStrategy.cs
+++ b/API/3638_Donchian_Scalper/CS/DonchianScalperStrategy.cs
@@ -26,8 +26,8 @@ public class DonchianScalperStrategy : Strategy
 	private readonly StrategyParam<decimal> _stopLossPoints;
 	private readonly StrategyParam<decimal> _takeProfitPoints;
 	private readonly StrategyParam<DataType> _candleType;
-	private readonly StrategyParam<ProfitTargetMode> _profitTargetMode;
-	private readonly StrategyParam<TrailingProfitMode> _trailingMode;
+	private readonly StrategyParam<ProfitTargetModes> _profitTargetMode;
+	private readonly StrategyParam<TrailingProfitModes> _trailingMode;
 	private readonly StrategyParam<int> _cooldownBars;
 	private readonly StrategyParam<int> _atrPeriod;
 	private readonly StrategyParam<decimal> _atrMultiplier;
@@ -56,16 +56,16 @@ public class DonchianScalperStrategy : Strategy
 	/// <summary>
 	/// Determines how the strategy manages profitable positions.
 	/// </summary>
-	public enum ProfitTargetMode
+	public enum ProfitTargetModes
 	{
 		CloseAtProfit,
 		Trailing,
 	}
 
 	/// <summary>
-	/// Selects the trailing stop engine when <see cref="ProfitTargetMode.Trailing"/> is active.
+	/// Selects the trailing stop engine when <see cref="ProfitTargetModes.Trailing"/> is active.
 	/// </summary>
-	public enum TrailingProfitMode
+	public enum TrailingProfitModes
 	{
 		DonchianBoundary,
 		MovingAverage,
@@ -109,7 +109,7 @@ public class DonchianScalperStrategy : Strategy
 	}
 
 	/// <summary>
-	/// Profit target distance expressed in points. Only used when <see cref="ProfitTargetMode.CloseAtProfit"/> is selected.
+	/// Profit target distance expressed in points. Only used when <see cref="ProfitTargetModes.CloseAtProfit"/> is selected.
 	/// </summary>
 	public decimal TakeProfitPoints
 	{
@@ -129,16 +129,16 @@ public class DonchianScalperStrategy : Strategy
 	/// <summary>
 	/// Selected profit management style.
 	/// </summary>
-	public ProfitTargetMode ProfitMode
+	public ProfitTargetModes ProfitMode
 	{
 		get => _profitTargetMode.Value;
 		set => _profitTargetMode.Value = value;
 	}
 
 	/// <summary>
-	/// Selected trailing engine when profit mode is set to <see cref="ProfitTargetMode.Trailing"/>.
+	/// Selected trailing engine when profit mode is set to <see cref="ProfitTargetModes.Trailing"/>.
 	/// </summary>
-	public TrailingProfitMode TrailingMode
+	public TrailingProfitModes TrailingMode
 	{
 		get => _trailingMode.Value;
 		set => _trailingMode.Value = value;
@@ -154,7 +154,7 @@ public class DonchianScalperStrategy : Strategy
 	}
 
 	/// <summary>
-	/// ATR period used by the trailing stop when <see cref="TrailingProfitMode.AverageTrueRange"/> is active.
+	/// ATR period used by the trailing stop when <see cref="TrailingProfitModes.AverageTrueRange"/> is active.
 	/// </summary>
 	public int AtrPeriod
 	{
@@ -213,10 +213,10 @@ public class DonchianScalperStrategy : Strategy
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
 		.SetDisplay("Candle Type", "Primary timeframe used for calculations", "General");
 
-		_profitTargetMode = Param(nameof(ProfitMode), ProfitTargetMode.CloseAtProfit)
+		_profitTargetMode = Param(nameof(ProfitMode), ProfitTargetModes.CloseAtProfit)
 		.SetDisplay("Profit Mode", "Close at a fixed profit or trail a stop", "Risk");
 
-		_trailingMode = Param(nameof(TrailingMode), TrailingProfitMode.AverageTrueRange)
+		_trailingMode = Param(nameof(TrailingMode), TrailingProfitModes.AverageTrueRange)
 		.SetDisplay("Trailing Mode", "Trailing engine used when profit mode equals Trailing", "Risk");
 
 		_cooldownBars = Param(nameof(CooldownBars), 3)
@@ -476,7 +476,7 @@ public class DonchianScalperStrategy : Strategy
 			return;
 		}
 
-		if (ProfitMode == ProfitTargetMode.CloseAtProfit)
+		if (ProfitMode == ProfitTargetModes.CloseAtProfit)
 		{
 			var distance = TakeProfitPoints * _pointSize;
 			if (distance <= 0m)
@@ -541,9 +541,9 @@ public class DonchianScalperStrategy : Strategy
 		{
 			var target = TrailingMode switch
 			{
-				TrailingProfitMode.DonchianBoundary => CalculateLongStop(lower),
-				TrailingProfitMode.MovingAverage => AlignPrice(ema, false),
-				TrailingProfitMode.AverageTrueRange => AlignPrice(candle.ClosePrice - _lastAtr * AtrMultiplier, false),
+				TrailingProfitModes.DonchianBoundary => CalculateLongStop(lower),
+				TrailingProfitModes.MovingAverage => AlignPrice(ema, false),
+				TrailingProfitModes.AverageTrueRange => AlignPrice(candle.ClosePrice - _lastAtr * AtrMultiplier, false),
 				_ => null,
 			};
 
@@ -556,9 +556,9 @@ public class DonchianScalperStrategy : Strategy
 		{
 			var target = TrailingMode switch
 			{
-				TrailingProfitMode.DonchianBoundary => CalculateShortStop(upper),
-				TrailingProfitMode.MovingAverage => AlignPrice(ema, true),
-				TrailingProfitMode.AverageTrueRange => AlignPrice(candle.ClosePrice + _lastAtr * AtrMultiplier, true),
+				TrailingProfitModes.DonchianBoundary => CalculateShortStop(upper),
+				TrailingProfitModes.MovingAverage => AlignPrice(ema, true),
+				TrailingProfitModes.AverageTrueRange => AlignPrice(candle.ClosePrice + _lastAtr * AtrMultiplier, true),
 				_ => null,
 			};
 

--- a/API/3640_Mnist_Pattern_Classifier/CS/MnistPatternClassifierStrategy.cs
+++ b/API/3640_Mnist_Pattern_Classifier/CS/MnistPatternClassifierStrategy.cs
@@ -35,7 +35,7 @@ public class MnistPatternClassifierStrategy : Strategy
 	private int _lastClass = -1;
 	private decimal _lastConfidence;
 
-	private enum PatternBias
+	private enum PatternBiases
 	{
 		Neutral,
 		Bullish,
@@ -173,11 +173,11 @@ public class MnistPatternClassifierStrategy : Strategy
 		_previousClose = candle.ClosePrice;
 	}
 
-	private void ExecuteBias(PatternBias bias)
+	private void ExecuteBias(PatternBiases bias)
 	{
 		switch (bias)
 		{
-		case PatternBias.Bullish:
+		case PatternBiases.Bullish:
 			if (Position < 0)
 			BuyMarket(-Position);
 
@@ -188,7 +188,7 @@ public class MnistPatternClassifierStrategy : Strategy
 			}
 
 			break;
-		case PatternBias.Bearish:
+		case PatternBiases.Bearish:
 			if (Position > 0)
 			SellMarket(Position);
 
@@ -248,55 +248,55 @@ public class MnistPatternClassifierStrategy : Strategy
 
 		if (rangeStrength < stats.FlatThreshold)
 		{
-			return new PatternResult(0, Math.Max(confidence, 0.4m), PatternBias.Neutral);
+			return new PatternResult(0, Math.Max(confidence, 0.4m), PatternBiases.Neutral);
 		}
 
 		if (trendStrength >= stats.TrendThreshold)
 		{
 			if (rangePosition >= 0.75m && rangeStrength >= breakoutRange)
 			{
-				return new PatternResult(3, confidence, PatternBias.Bullish);
+				return new PatternResult(3, confidence, PatternBiases.Bullish);
 			}
 
 			if (momentum < 0m)
 			{
-				return new PatternResult(6, confidence * 0.8m, PatternBias.Bullish);
+				return new PatternResult(6, confidence * 0.8m, PatternBiases.Bullish);
 			}
 
-			return new PatternResult(1, confidence, PatternBias.Bullish);
+			return new PatternResult(1, confidence, PatternBiases.Bullish);
 		}
 
 		if (trendStrength <= -stats.TrendThreshold)
 		{
 			if (rangePosition <= 0.25m && rangeStrength >= breakoutRange)
 			{
-				return new PatternResult(4, confidence, PatternBias.Bearish);
+				return new PatternResult(4, confidence, PatternBiases.Bearish);
 			}
 
 			if (momentum > 0m)
 			{
-				return new PatternResult(7, confidence * 0.8m, PatternBias.Bearish);
+				return new PatternResult(7, confidence * 0.8m, PatternBiases.Bearish);
 			}
 
-			return new PatternResult(2, confidence, PatternBias.Bearish);
+			return new PatternResult(2, confidence, PatternBiases.Bearish);
 		}
 
 		if (rangeStrength >= breakoutRange)
 		{
-			return new PatternResult(5, confidence * 0.9m, PatternBias.Neutral);
+			return new PatternResult(5, confidence * 0.9m, PatternBiases.Neutral);
 		}
 
 		if (rangePosition <= 0.4m && rsi >= 55m)
 		{
-			return new PatternResult(8, confidence * 0.85m, PatternBias.Bullish);
+			return new PatternResult(8, confidence * 0.85m, PatternBiases.Bullish);
 		}
 
 		if (rangePosition >= 0.6m && rsi <= 45m)
 		{
-			return new PatternResult(9, confidence * 0.85m, PatternBias.Bearish);
+			return new PatternResult(9, confidence * 0.85m, PatternBiases.Bearish);
 		}
 
-		return new PatternResult(0, confidence * 0.7m, PatternBias.Neutral);
+		return new PatternResult(0, confidence * 0.7m, PatternBiases.Neutral);
 	}
 
 	private PatternStatistics CalculateStatistics(decimal currentClose, decimal rsiValue, decimal atrValue)
@@ -348,7 +348,7 @@ public class MnistPatternClassifierStrategy : Strategy
 
 	private readonly struct PatternResult
 	{
-		public PatternResult(int patternClass, decimal confidence, PatternBias bias)
+		public PatternResult(int patternClass, decimal confidence, PatternBiases bias)
 		{
 			PatternClass = patternClass;
 			Confidence = confidence;
@@ -359,7 +359,7 @@ public class MnistPatternClassifierStrategy : Strategy
 
 		public decimal Confidence { get; }
 
-		public PatternBias Bias { get; }
+		public PatternBiases Bias { get; }
 	}
 
 	private readonly struct PatternStatistics

--- a/API/3661_ClassicVirtualTrailing/CS/ClassicVirtualTrailingStrategy.cs
+++ b/API/3661_ClassicVirtualTrailing/CS/ClassicVirtualTrailingStrategy.cs
@@ -15,7 +15,7 @@ using System.Globalization;
 
 namespace StockSharp.Samples.Strategies;
 
-public enum TrailingManagementMode
+public enum TrailingManagementModes
 {
 	Classic,
 	Virtual
@@ -33,7 +33,7 @@ public class ClassicVirtualTrailingStrategy : Strategy
 	?? TryResolveField("StopPrice")
 	?? TryResolveField("StopDistance");
 
-	private readonly StrategyParam<TrailingManagementMode> _trailingMode;
+	private readonly StrategyParam<TrailingManagementModes> _trailingMode;
 	private readonly StrategyParam<decimal> _trailingStartPips;
 	private readonly StrategyParam<decimal> _trailingGapPips;
 
@@ -46,7 +46,7 @@ public class ClassicVirtualTrailingStrategy : Strategy
 	/// <summary>
 	/// Specifies whether classic or virtual trailing management is applied.
 	/// </summary>
-	public TrailingManagementMode TrailingMode
+	public TrailingManagementModes TrailingMode
 	{
 		get => _trailingMode.Value;
 		set => _trailingMode.Value = value;
@@ -75,7 +75,7 @@ public class ClassicVirtualTrailingStrategy : Strategy
 	/// </summary>
 	public ClassicVirtualTrailingStrategy()
 	{
-		_trailingMode = Param(nameof(TrailingMode), TrailingManagementMode.Virtual)
+		_trailingMode = Param(nameof(TrailingMode), TrailingManagementModes.Virtual)
 		.SetDisplay("Trailing Mode", "Classic updates stop orders, Virtual closes at the trail", "Risk Management");
 
 		_trailingStartPips = Param(nameof(TrailingStartPips), 30m)
@@ -185,7 +185,7 @@ public class ClassicVirtualTrailingStrategy : Strategy
 		var startDistance = Math.Max(0m, TrailingStartPips) * pipSize;
 		var gapDistance = Math.Max(0m, TrailingGapPips) * pipSize;
 
-		if (TrailingMode == TrailingManagementMode.Classic)
+		if (TrailingMode == TrailingManagementModes.Classic)
 		{
 			var minimalGap = GetMinimalClassicGap(pipSize);
 			if (gapDistance < minimalGap)
@@ -225,7 +225,7 @@ public class ClassicVirtualTrailingStrategy : Strategy
 		var startDistance = Math.Max(0m, TrailingStartPips) * pipSize;
 		var gapDistance = Math.Max(0m, TrailingGapPips) * pipSize;
 
-		if (TrailingMode == TrailingManagementMode.Classic)
+		if (TrailingMode == TrailingManagementModes.Classic)
 		{
 			var minimalGap = GetMinimalClassicGap(pipSize);
 			if (gapDistance < minimalGap)

--- a/API/3663_Trailing_Close_Manager/CS/TrailingCloseManagerStrategy.cs
+++ b/API/3663_Trailing_Close_Manager/CS/TrailingCloseManagerStrategy.cs
@@ -50,13 +50,13 @@ public class TrailingCloseManagerStrategy : Strategy
 
 	private sealed class CloseRequest
 	{
-		public CloseMode Mode { get; init; }
+		public CloseModes Mode { get; init; }
 		public int RemainingAttempts { get; set; }
 		public DateTimeOffset NextAttempt { get; set; }
 		public string Reason { get; set; } = string.Empty;
 	}
 
-	private enum CloseMode
+	private enum CloseModes
 	{
 		All,
 		Profitable,
@@ -284,19 +284,19 @@ public class TrailingCloseManagerStrategy : Strategy
 		if (CloseAllButton)
 		{
 			CloseAllButton = false;
-			EnqueueCloseRequest(CloseMode.All, "Manual close all requested", time);
+			EnqueueCloseRequest(CloseModes.All, "Manual close all requested", time);
 		}
 
 		if (CloseProfitableButton)
 		{
 			CloseProfitableButton = false;
-			EnqueueCloseRequest(CloseMode.Profitable, "Manual close of profitable positions requested", time);
+			EnqueueCloseRequest(CloseModes.Profitable, "Manual close of profitable positions requested", time);
 		}
 
 		if (CloseLosingButton)
 		{
 			CloseLosingButton = false;
-			EnqueueCloseRequest(CloseMode.Losing, "Manual close of losing positions requested", time);
+			EnqueueCloseRequest(CloseModes.Losing, "Manual close of losing positions requested", time);
 		}
 	}
 
@@ -306,12 +306,12 @@ public class TrailingCloseManagerStrategy : Strategy
 
 		if (CloseProfitThreshold > 0m && totalPnL >= CloseProfitThreshold)
 		{
-			EnqueueCloseRequest(CloseMode.All, $"Floating profit {totalPnL:0.##} reached the configured threshold {CloseProfitThreshold:0.##}", time);
+			EnqueueCloseRequest(CloseModes.All, $"Floating profit {totalPnL:0.##} reached the configured threshold {CloseProfitThreshold:0.##}", time);
 		}
 
 		if (CloseLossThreshold < 0m && totalPnL <= CloseLossThreshold)
 		{
-			EnqueueCloseRequest(CloseMode.All, $"Floating loss {totalPnL:0.##} reached the configured threshold {CloseLossThreshold:0.##}", time);
+			EnqueueCloseRequest(CloseModes.All, $"Floating loss {totalPnL:0.##} reached the configured threshold {CloseLossThreshold:0.##}", time);
 		}
 	}
 
@@ -358,7 +358,7 @@ public class TrailingCloseManagerStrategy : Strategy
 		}
 	}
 
-	private bool ExecuteClose(CloseMode mode)
+	private bool ExecuteClose(CloseModes mode)
 	{
 		var portfolio = Portfolio;
 		if (portfolio == null)
@@ -409,9 +409,9 @@ public class TrailingCloseManagerStrategy : Strategy
 
 			var shouldClose = mode switch
 			{
-			CloseMode.All => true,
-			CloseMode.Profitable => pnl > 0m,
-			CloseMode.Losing => pnl < 0m,
+			CloseModes.All => true,
+			CloseModes.Profitable => pnl > 0m,
+			CloseModes.Losing => pnl < 0m,
 			_ => false
 			};
 
@@ -578,7 +578,7 @@ public class TrailingCloseManagerStrategy : Strategy
 		}
 	}
 
-	private void EnqueueCloseRequest(CloseMode mode, string reason, DateTimeOffset time)
+	private void EnqueueCloseRequest(CloseModes mode, string reason, DateTimeOffset time)
 	{
 		var existing = _closeRequests.FirstOrDefault(r => r.Mode == mode);
 		if (existing != null)

--- a/API/3671_Grid_EA_Pro/CS/GridEaProStrategy.cs
+++ b/API/3671_Grid_EA_Pro/CS/GridEaProStrategy.cs
@@ -21,22 +21,22 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class GridEaProStrategy : Strategy
 {
-	public enum GridTradeMode
+	public enum GridTradeModes
 	{
 		Buy,
 		Sell,
 		Both,
 	}
 
-	public enum GridEntryMode
+	public enum GridEntryModes
 	{
 		Rsi,
 		FixedPoints,
 		Manual,
 	}
 
-	private readonly StrategyParam<GridTradeMode> _mode;
-	private readonly StrategyParam<GridEntryMode> _entryMode;
+	private readonly StrategyParam<GridTradeModes> _mode;
+	private readonly StrategyParam<GridEntryModes> _entryMode;
 	private readonly StrategyParam<int> _rsiPeriod;
 	private readonly StrategyParam<decimal> _rsiUpperLevel;
 	private readonly StrategyParam<decimal> _rsiLowerLevel;
@@ -95,7 +95,7 @@ public class GridEaProStrategy : Strategy
 	/// <summary>
 	/// Trade direction filter.
 	/// </summary>
-	public GridTradeMode Mode
+	public GridTradeModes Mode
 	{
 		get => _mode.Value;
 		set => _mode.Value = value;
@@ -104,7 +104,7 @@ public class GridEaProStrategy : Strategy
 	/// <summary>
 	/// Entry mode selection.
 	/// </summary>
-	public GridEntryMode EntryMode
+	public GridEntryModes EntryMode
 	{
 		get => _entryMode.Value;
 		set => _entryMode.Value = value;
@@ -331,10 +331,10 @@ public class GridEaProStrategy : Strategy
 	/// </summary>
 	public GridEaProStrategy()
 	{
-		_mode = Param(nameof(Mode), GridTradeMode.Both)
+		_mode = Param(nameof(Mode), GridTradeModes.Both)
 		.SetDisplay("Mode", "Allowed trade direction", "General");
 
-		_entryMode = Param(nameof(EntryMode), GridEntryMode.Rsi)
+		_entryMode = Param(nameof(EntryMode), GridEntryModes.Rsi)
 		.SetDisplay("Entry Mode", "Signal source", "General");
 
 		_rsiPeriod = Param(nameof(RsiPeriod), 10)
@@ -504,13 +504,13 @@ public class GridEaProStrategy : Strategy
 	{
 		switch (EntryMode)
 		{
-			case GridEntryMode.Rsi:
+			case GridEntryModes.Rsi:
 				HandleRsiEntries(candle, rsi);
 				break;
-			case GridEntryMode.FixedPoints:
+			case GridEntryModes.FixedPoints:
 				ScheduleBreakoutLevels(candle);
 				break;
-			case GridEntryMode.Manual:
+			case GridEntryModes.Manual:
 				break;
 		}
 	}
@@ -929,12 +929,12 @@ public class GridEaProStrategy : Strategy
 
 	private bool AllowLongEntries()
 	{
-		return Mode == GridTradeMode.Both || Mode == GridTradeMode.Buy;
+		return Mode == GridTradeModes.Both || Mode == GridTradeModes.Buy;
 	}
 
 	private bool AllowShortEntries()
 	{
-		return Mode == GridTradeMode.Both || Mode == GridTradeMode.Sell;
+		return Mode == GridTradeModes.Both || Mode == GridTradeModes.Sell;
 	}
 
 	private bool IsWithinTradingHours(DateTimeOffset time)

--- a/API/3685_EuroSurge_Simplified/CS/EuroSurgeSimplifiedStrategy.cs
+++ b/API/3685_EuroSurge_Simplified/CS/EuroSurgeSimplifiedStrategy.cs
@@ -13,7 +13,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-public enum TradeSizeType
+public enum TradeSizeTypes
 {
 	FixedSize,
 	BalancePercent,
@@ -27,7 +27,7 @@ public enum TradeSizeType
 /// </summary>
 public class EuroSurgeSimplifiedStrategy : Strategy
 {
-	private readonly StrategyParam<TradeSizeType> _tradeSizeType;
+	private readonly StrategyParam<TradeSizeTypes> _tradeSizeType;
 	private readonly StrategyParam<decimal> _fixedVolume;
 	private readonly StrategyParam<decimal> _tradeSizePercent;
 	private readonly StrategyParam<int> _takeProfitPoints;
@@ -64,7 +64,7 @@ public class EuroSurgeSimplifiedStrategy : Strategy
 	/// <summary>
 	/// Gets or sets the trade size calculation mode.
 	/// </summary>
-	public TradeSizeType TradeSizeType
+	public TradeSizeTypes TradeSizeTypes
 	{
 		get => _tradeSizeType.Value;
 		set => _tradeSizeType.Value = value;
@@ -282,12 +282,12 @@ public class EuroSurgeSimplifiedStrategy : Strategy
 	/// </summary>
 	public EuroSurgeSimplifiedStrategy()
 	{
-		_tradeSizeType = Param(nameof(TradeSizeType), TradeSizeType.FixedSize)
+		_tradeSizeType = Param(nameof(TradeSizeTypes), TradeSizeTypes.FixedSize)
 		.SetDisplay("Trade Size Mode", "How trading volume is calculated", "Money Management");
 
 		_fixedVolume = Param(nameof(FixedVolume), 1m)
 		.SetGreaterThanZero()
-		.SetDisplay("Fixed Volume", "Lot size used when TradeSizeType is FixedSize", "Money Management");
+		.SetDisplay("Fixed Volume", "Lot size used when TradeSizeTypes is FixedSize", "Money Management");
 
 		_tradeSizePercent = Param(nameof(TradeSizePercent), 1m)
 		.SetGreaterThanZero()
@@ -545,9 +545,9 @@ public class EuroSurgeSimplifiedStrategy : Strategy
 	{
 		var volume = FixedVolume;
 
-		switch (TradeSizeType)
+		switch (TradeSizeTypes)
 		{
-			case TradeSizeType.BalancePercent when Portfolio?.BeginValue is decimal balance && balance > 0m && referencePrice > 0m:
+			case TradeSizeTypes.BalancePercent when Portfolio?.BeginValue is decimal balance && balance > 0m && referencePrice > 0m:
 			{
 				var moneyToUse = balance * TradeSizePercent / 100m;
 				var estimatedVolume = moneyToUse / referencePrice;
@@ -556,7 +556,7 @@ public class EuroSurgeSimplifiedStrategy : Strategy
 				break;
 			}
 
-			case TradeSizeType.EquityPercent when Portfolio?.CurrentValue is decimal equity && equity > 0m && referencePrice > 0m:
+			case TradeSizeTypes.EquityPercent when Portfolio?.CurrentValue is decimal equity && equity > 0m && referencePrice > 0m:
 			{
 				var moneyToUse = equity * TradeSizePercent / 100m;
 				var estimatedVolume = moneyToUse / referencePrice;

--- a/API/3687_Smart_Trend_Follower/CS/SmartTrendFollowerStrategy.cs
+++ b/API/3687_Smart_Trend_Follower/CS/SmartTrendFollowerStrategy.cs
@@ -20,7 +20,7 @@ namespace StockSharp.Samples.Strategies;
 public class SmartTrendFollowerStrategy : Strategy
 {
 	private readonly StrategyParam<DataType> _candleType;
-	private readonly StrategyParam<SignalMode> _signalMode;
+	private readonly StrategyParam<SignalModes> _signalMode;
 	private readonly StrategyParam<decimal> _initialVolume;
 	private readonly StrategyParam<decimal> _multiplier;
 	private readonly StrategyParam<decimal> _layerDistancePips;
@@ -48,7 +48,7 @@ public class SmartTrendFollowerStrategy : Strategy
 	/// <summary>
 	/// Trading signal mode.
 	/// </summary>
-	public SignalMode SignalMode
+	public SignalModes SignalModes
 	{
 		get => _signalMode.Value;
 		set => _signalMode.Value = value;
@@ -158,7 +158,7 @@ public class SmartTrendFollowerStrategy : Strategy
 	/// </summary>
 	public SmartTrendFollowerStrategy()
 	{
-		_signalMode = Param(nameof(SignalMode), SignalMode.CrossMa)
+		_signalMode = Param(nameof(SignalModes), SignalModes.CrossMa)
 		.SetDisplay("Signal Mode", "Trading logic selection", "Signals");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(30).TimeFrame())
@@ -317,9 +317,9 @@ public class SmartTrendFollowerStrategy : Strategy
 
 	ManageExits(candle);
 
-	var signal = SignalDirection.None;
+	var signal = SignalDirections.None;
 
-	if (SignalMode == SignalMode.CrossMa)
+	if (SignalModes == SignalModes.CrossMa)
 	{
 	if (_prevFast.HasValue && _prevSlow.HasValue)
 	{
@@ -327,9 +327,9 @@ public class SmartTrendFollowerStrategy : Strategy
 	var crossSell = fast > slow && _prevSlow.Value > _prevFast.Value;
 
 	if (crossBuy)
-	signal = SignalDirection.Buy;
+	signal = SignalDirections.Buy;
 	else if (crossSell)
-	signal = SignalDirection.Sell;
+	signal = SignalDirections.Sell;
 	}
 	}
 	else if (_stochastic?.IsFormed == true && stochasticValue is StochasticOscillatorValue stoch && stoch.K is decimal kValue)
@@ -338,12 +338,12 @@ public class SmartTrendFollowerStrategy : Strategy
 	var bearish = candle.ClosePrice < candle.OpenPrice;
 
 	if (fast > slow && bullish && kValue <= 30m)
-	signal = SignalDirection.Buy;
+	signal = SignalDirections.Buy;
 	else if (fast < slow && bearish && kValue >= 70m)
-	signal = SignalDirection.Sell;
+	signal = SignalDirections.Sell;
 	}
 
-	if (signal != SignalDirection.None && IsFormedAndOnlineAndAllowTrading())
+	if (signal != SignalDirections.None && IsFormedAndOnlineAndAllowTrading())
 	{
 	ProcessSignal(signal, candle.ClosePrice);
 	}
@@ -352,11 +352,11 @@ public class SmartTrendFollowerStrategy : Strategy
 	_prevSlow = slow;
 	}
 
-	private void ProcessSignal(SignalDirection signal, decimal referencePrice)
+	private void ProcessSignal(SignalDirections signal, decimal referencePrice)
 	{
 	switch (signal)
 	{
-	case SignalDirection.Buy:
+	case SignalDirections.Buy:
 	{
 	var shortVolume = GetTotalVolume(_shortEntries);
 	if (shortVolume > 0m)
@@ -391,7 +391,7 @@ public class SmartTrendFollowerStrategy : Strategy
 
 	break;
 	}
-	case SignalDirection.Sell:
+	case SignalDirections.Sell:
 	{
 	var longVolume = GetTotalVolume(_longEntries);
 	if (longVolume > 0m)
@@ -599,7 +599,7 @@ public class SmartTrendFollowerStrategy : Strategy
 	return step;
 	}
 
-	private enum SignalDirection
+	private enum SignalDirections
 	{
 	None,
 	Buy,
@@ -609,7 +609,7 @@ public class SmartTrendFollowerStrategy : Strategy
 	/// <summary>
 	/// Signal selector for the strategy.
 	/// </summary>
-	public enum SignalMode
+	public enum SignalModes
 	{
 	/// <summary>
 	/// Use moving average crossovers in a contrarian fashion.

--- a/API/3690_Close_Agent/CS/CloseAgentStrategy.cs
+++ b/API/3690_Close_Agent/CS/CloseAgentStrategy.cs
@@ -19,7 +19,7 @@ namespace StockSharp.Samples.Strategies;
 /// <summary>
 /// Defines which positions should be processed by the strategy.
 /// </summary>
-public enum CloseAgentMode
+public enum CloseAgentModes
 {
 	/// <summary>
 	/// Only process positions opened manually or by other strategies.
@@ -40,7 +40,7 @@ public enum CloseAgentMode
 /// <summary>
 /// Defines how indicator data should be sampled for signal evaluation.
 /// </summary>
-public enum CloseAgentOperationMode
+public enum CloseAgentOperationModes
 {
 	/// <summary>
 	/// Evaluate signals using the latest forming candle values.
@@ -59,9 +59,9 @@ public enum CloseAgentOperationMode
 /// </summary>
 public class CloseAgentStrategy : Strategy
 {
-	private readonly StrategyParam<CloseAgentMode> _closeMode;
+	private readonly StrategyParam<CloseAgentModes> _closeMode;
 	private readonly StrategyParam<DataType> _candleType;
-	private readonly StrategyParam<CloseAgentOperationMode> _operationMode;
+	private readonly StrategyParam<CloseAgentOperationModes> _operationMode;
 	private readonly StrategyParam<decimal> _closeAllTarget;
 	private readonly StrategyParam<bool> _enableAlerts;
 	private readonly StrategyParam<int> _rsiLength;
@@ -79,7 +79,7 @@ public class CloseAgentStrategy : Strategy
 	/// <summary>
 	/// Determines which positions should be handled by the strategy.
 	/// </summary>
-	public CloseAgentMode CloseMode
+	public CloseAgentModes CloseMode
 	{
 		get => _closeMode.Value;
 		set => _closeMode.Value = value;
@@ -97,7 +97,7 @@ public class CloseAgentStrategy : Strategy
 	/// <summary>
 	/// Chooses whether signals rely on live or closed candle data.
 	/// </summary>
-	public CloseAgentOperationMode OperationMode
+	public CloseAgentOperationModes OperationMode
 	{
 		get => _operationMode.Value;
 		set => _operationMode.Value = value;
@@ -162,13 +162,13 @@ public class CloseAgentStrategy : Strategy
 	/// </summary>
 	public CloseAgentStrategy()
 	{
-		_closeMode = Param(nameof(CloseMode), CloseAgentMode.Both)
+		_closeMode = Param(nameof(CloseMode), CloseAgentModes.Both)
 		.SetDisplay("Close Mode", "Choose which positions are eligible for closing", "General");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
 		.SetDisplay("Candle Type", "Timeframe used for indicators", "General");
 
-		_operationMode = Param(nameof(OperationMode), CloseAgentOperationMode.LiveBar)
+		_operationMode = Param(nameof(OperationMode), CloseAgentOperationModes.LiveBar)
 		.SetDisplay("Operation Mode", "Use forming candles or closed candles for signals", "Signals");
 
 		_closeAllTarget = Param(nameof(CloseAllTarget), 0m)
@@ -262,7 +262,7 @@ public class CloseAgentStrategy : Strategy
 		if (_rsi is null || _bands is null)
 			return;
 
-		if (OperationMode == CloseAgentOperationMode.NewBar && candle.State != CandleStates.Finished)
+		if (OperationMode == CloseAgentOperationModes.NewBar && candle.State != CandleStates.Finished)
 			return;
 
 		if (!_rsi.IsFormed || !_bands.IsFormed)
@@ -270,7 +270,7 @@ public class CloseAgentStrategy : Strategy
 
 		_history.Enqueue((candle.CloseTime, candle.ClosePrice, rsiValue, upper, lower));
 
-		var shift = OperationMode == CloseAgentOperationMode.NewBar ? 1 : 0;
+		var shift = OperationMode == CloseAgentOperationModes.NewBar ? 1 : 0;
 		var maxItems = Math.Max(shift + 2, 3);
 		while (_history.Count > maxItems)
 			_history.Dequeue();
@@ -374,14 +374,14 @@ public class CloseAgentStrategy : Strategy
 	{
 		switch (CloseMode)
 		{
-			case CloseAgentMode.Both:
+			case CloseAgentModes.Both:
 				return true;
-			case CloseAgentMode.Auto:
+			case CloseAgentModes.Auto:
 			{
 				var strategyId = TryGetStrategyId(position);
 				return !strategyId.IsEmpty() && strategyId.EqualsIgnoreCase(Id);
 			}
-			case CloseAgentMode.Manual:
+			case CloseAgentModes.Manual:
 			{
 				var strategyId = TryGetStrategyId(position);
 				return strategyId.IsEmpty() || !strategyId.EqualsIgnoreCase(Id);

--- a/API/3697_Symbol_Swap/CS/SymbolSwapStrategy.cs
+++ b/API/3697_Symbol_Swap/CS/SymbolSwapStrategy.cs
@@ -24,7 +24,7 @@ public class SymbolSwapStrategy : Strategy
 {
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<string> _watchedSecurityId;
-	private readonly StrategyParam<PanelOutputMode> _outputMode;
+	private readonly StrategyParam<PanelOutputModes> _outputMode;
 
 	private ISubscription _candleSubscription;
 	private ISubscription _level1Subscription;
@@ -47,7 +47,7 @@ public class SymbolSwapStrategy : Strategy
 	/// <summary>
 	/// Defines how the status panel is rendered.
 	/// </summary>
-	public enum PanelOutputMode
+	public enum PanelOutputModes
 	{
 		/// <summary>
 		/// Write updates to the strategy log like MetaTrader's Comment window.
@@ -71,7 +71,7 @@ public class SymbolSwapStrategy : Strategy
 		_watchedSecurityId = Param(nameof(WatchedSecurityId), string.Empty)
 		.SetDisplay("Watched security id", "Optional identifier resolved through the SecurityProvider to override Strategy.Security.", "General");
 
-		_outputMode = Param(nameof(OutputMode), PanelOutputMode.Chart)
+		_outputMode = Param(nameof(OutputMode), PanelOutputModes.Chart)
 		.SetDisplay("Output mode", "Controls whether the panel is drawn on the chart or written to the log.", "Visualization");
 	}
 
@@ -96,7 +96,7 @@ public class SymbolSwapStrategy : Strategy
 	/// <summary>
 	/// Controls the rendering destination of the information block.
 	/// </summary>
-	public PanelOutputMode OutputMode
+	public PanelOutputModes OutputMode
 	{
 		get => _outputMode.Value;
 		set => _outputMode.Value = value;
@@ -200,7 +200,7 @@ public class SymbolSwapStrategy : Strategy
 		_level1Subscription = SubscribeLevel1(security);
 		_level1Subscription.Bind(level1 => ProcessLevel1(level1, security)).Start();
 
-		if (OutputMode == PanelOutputMode.Chart)
+		if (OutputMode == PanelOutputModes.Chart)
 		{
 			_chartArea ??= CreateChartArea();
 
@@ -252,7 +252,7 @@ public class SymbolSwapStrategy : Strategy
 
 		switch (OutputMode)
 		{
-			case PanelOutputMode.Log:
+			case PanelOutputModes.Log:
 			{
 				if (text == _lastLoggedText)
 					return;
@@ -261,7 +261,7 @@ public class SymbolSwapStrategy : Strategy
 				_lastLoggedText = text;
 				break;
 			}
-			case PanelOutputMode.Chart:
+			case PanelOutputModes.Chart:
 			{
 				var area = _chartArea;
 				if (area == null)

--- a/API/3700_FetchNews/CS/FetchNewsStrategy.cs
+++ b/API/3700_FetchNews/CS/FetchNewsStrategy.cs
@@ -22,7 +22,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class FetchNewsStrategy : Strategy
 {
-	private readonly StrategyParam<FetchNewsOperationMode> _mode;
+	private readonly StrategyParam<FetchNewsOperationModes> _mode;
 	private readonly StrategyParam<decimal> _orderVolume;
 	private readonly StrategyParam<int> _takeProfitPoints;
 	private readonly StrategyParam<int> _stopLossPoints;
@@ -32,7 +32,7 @@ public class FetchNewsStrategy : Strategy
 	private readonly StrategyParam<string> _tradingKeywords;
 	private readonly StrategyParam<string> _calendarEventsDefinition;
 	private readonly StrategyParam<int> _timeZoneOffsetHours;
-	private readonly StrategyParam<NewsImportanceLevel> _alertImportance;
+	private readonly StrategyParam<NewsImportanceLevels> _alertImportance;
 	private readonly StrategyParam<bool> _onlySymbolCurrencies;
 
 	private readonly List<CalendarEvent> _calendarEvents = new();
@@ -51,7 +51,7 @@ public class FetchNewsStrategy : Strategy
 	/// </summary>
 	public FetchNewsStrategy()
 	{
-		_mode = Param(nameof(Mode), FetchNewsOperationMode.Alerting)
+		_mode = Param(nameof(Mode), FetchNewsOperationModes.Alerting)
 		.SetDisplay("Mode", "Select alerting or trading behaviour.", "General");
 
 		_orderVolume = Param(nameof(OrderVolume), 0.1m)
@@ -82,7 +82,7 @@ public class FetchNewsStrategy : Strategy
 		_timeZoneOffsetHours = Param(nameof(TimeZoneOffsetHours), 0)
 		.SetDisplay("Calendar TZ Offset (h)", "Offset in hours applied to event timestamps.", "Calendar");
 
-		_alertImportance = Param(nameof(AlertImportance), NewsImportanceLevel.Moderate)
+		_alertImportance = Param(nameof(AlertImportance), NewsImportanceLevels.Moderate)
 		.SetDisplay("Alert Importance", "Minimum importance for alerting mode.", "Alerting");
 
 		_onlySymbolCurrencies = Param(nameof(OnlySymbolCurrencies), true)
@@ -92,7 +92,7 @@ public class FetchNewsStrategy : Strategy
 	/// <summary>
 	/// Mode of operation.
 	/// </summary>
-	public FetchNewsOperationMode Mode
+	public FetchNewsOperationModes Mode
 	{
 		get => _mode.Value;
 		set => _mode.Value = value;
@@ -182,7 +182,7 @@ public class FetchNewsStrategy : Strategy
 	/// <summary>
 	/// Minimum importance processed in alerting mode.
 	/// </summary>
-	public NewsImportanceLevel AlertImportance
+	public NewsImportanceLevels AlertImportance
 	{
 		get => _alertImportance.Value;
 		set => _alertImportance.Value = value;
@@ -313,12 +313,12 @@ public class FetchNewsStrategy : Strategy
 
 			switch (Mode)
 			{
-			case FetchNewsOperationMode.Alerting:
+			case FetchNewsOperationModes.Alerting:
 				ProcessAlert(calendarEvent);
 				_processedEvents.Add(calendarEvent.Id);
 				break;
 
-			case FetchNewsOperationMode.Trading:
+			case FetchNewsOperationModes.Trading:
 				if (ProcessTrading(calendarEvent, now))
 				_processedEvents.Add(calendarEvent.Id);
 				break;
@@ -539,7 +539,7 @@ public class FetchNewsStrategy : Strategy
 		_calendarEvents.Sort((left, right) => left.Time.CompareTo(right.Time));
 	}
 
-	private bool TryParseImportance(string text, out NewsImportanceLevel importance)
+	private bool TryParseImportance(string text, out NewsImportanceLevels importance)
 	{
 		if (Enum.TryParse(text, true, out importance))
 		return true;
@@ -548,16 +548,16 @@ public class FetchNewsStrategy : Strategy
 		{
 		case "medium":
 		case "moderate":
-			importance = NewsImportanceLevel.Moderate;
+			importance = NewsImportanceLevels.Moderate;
 			return true;
 
 		case "high":
 		case "important":
-			importance = NewsImportanceLevel.High;
+			importance = NewsImportanceLevels.High;
 			return true;
 
 		case "low":
-			importance = NewsImportanceLevel.Low;
+			importance = NewsImportanceLevels.Low;
 			return true;
 		}
 
@@ -579,13 +579,13 @@ public class FetchNewsStrategy : Strategy
 		return false;
 	}
 
-	private sealed record CalendarEvent(string Id, DateTimeOffset Time, string Currency, NewsImportanceLevel Importance, string Name);
+	private sealed record CalendarEvent(string Id, DateTimeOffset Time, string Currency, NewsImportanceLevels Importance, string Name);
 }
 
 /// <summary>
 /// Available modes for <see cref="FetchNewsStrategy"/>.
 /// </summary>
-public enum FetchNewsOperationMode
+public enum FetchNewsOperationModes
 {
 	/// <summary>
 	/// Only log matching events.
@@ -601,7 +601,7 @@ public enum FetchNewsOperationMode
 /// <summary>
 /// Importance level used by the macroeconomic calendar.
 /// </summary>
-public enum NewsImportanceLevel
+public enum NewsImportanceLevels
 {
 	/// <summary>
 	/// Low importance release.

--- a/API/3708_RRS_Non_Directional/CS/RrsNonDirectionalStrategy.cs
+++ b/API/3708_RRS_Non_Directional/CS/RrsNonDirectionalStrategy.cs
@@ -19,17 +19,17 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class RrsNonDirectionalStrategy : Strategy
 {
-	private readonly StrategyParam<RrsTradingMode> _tradingMode;
+	private readonly StrategyParam<RrsTradingModes> _tradingMode;
 	private readonly StrategyParam<bool> _allowNewTrades;
 	private readonly StrategyParam<decimal> _tradeVolume;
-	private readonly StrategyParam<RrsStopMode> _stopMode;
+	private readonly StrategyParam<RrsStopModes> _stopMode;
 	private readonly StrategyParam<int> _stopLossPoints;
-	private readonly StrategyParam<RrsTakeMode> _takeMode;
+	private readonly StrategyParam<RrsTakeModes> _takeMode;
 	private readonly StrategyParam<int> _takeProfitPoints;
-	private readonly StrategyParam<RrsTrailingMode> _trailingMode;
+	private readonly StrategyParam<RrsTrailingModes> _trailingMode;
 	private readonly StrategyParam<int> _trailingStartPoints;
 	private readonly StrategyParam<int> _trailingGapPoints;
-	private readonly StrategyParam<RrsRiskMode> _riskMode;
+	private readonly StrategyParam<RrsRiskModes> _riskMode;
 	private readonly StrategyParam<decimal> _moneyInRisk;
 	private readonly StrategyParam<int> _maxSpreadPoints;
 	private readonly StrategyParam<int> _slippagePoints;
@@ -56,7 +56,7 @@ public class RrsNonDirectionalStrategy : Strategy
 	/// </summary>
 	public RrsNonDirectionalStrategy()
 	{
-		_tradingMode = Param(nameof(TradingMode), RrsTradingMode.HedgeStyle)
+		_tradingMode = Param(nameof(TradingMode), RrsTradingModes.HedgeStyle)
 		.SetDisplay("Trading Strategy", "Entry style reproduced from the MT4 extern Trading_Strategy", "General")
 		.SetCanOptimize(true);
 
@@ -68,7 +68,7 @@ public class RrsNonDirectionalStrategy : Strategy
 		.SetDisplay("Trade Volume", "Base volume used for market orders", "General")
 		.SetCanOptimize(true);
 
-		_stopMode = Param(nameof(StopMode), RrsStopMode.Virtual)
+		_stopMode = Param(nameof(StopMode), RrsStopModes.Virtual)
 		.SetDisplay("Stop-Loss Type", "Chooses between virtual or classic stop-loss handling", "Risk")
 		.SetCanOptimize(false);
 
@@ -76,7 +76,7 @@ public class RrsNonDirectionalStrategy : Strategy
 		.SetDisplay("Stop-Loss (points)", "MetaTrader points converted with the instrument price step", "Risk")
 		.SetCanOptimize(true);
 
-		_takeMode = Param(nameof(TakeMode), RrsTakeMode.Virtual)
+		_takeMode = Param(nameof(TakeMode), RrsTakeModes.Virtual)
 		.SetDisplay("Take-Profit Type", "Chooses between virtual or classic take-profit handling", "Risk")
 		.SetCanOptimize(false);
 
@@ -84,7 +84,7 @@ public class RrsNonDirectionalStrategy : Strategy
 		.SetDisplay("Take-Profit (points)", "MetaTrader points converted with the instrument price step", "Risk")
 		.SetCanOptimize(true);
 
-		_trailingMode = Param(nameof(TrailingMode), RrsTrailingMode.Virtual)
+		_trailingMode = Param(nameof(TrailingMode), RrsTrailingModes.Virtual)
 		.SetDisplay("Trailing Type", "Switch between virtual and classic trailing implementation", "Risk")
 		.SetCanOptimize(false);
 
@@ -96,7 +96,7 @@ public class RrsNonDirectionalStrategy : Strategy
 		.SetDisplay("Trailing Gap (points)", "Distance maintained behind the best price once trailing is active", "Risk")
 		.SetCanOptimize(true);
 
-		_riskMode = Param(nameof(RiskMode), RrsRiskMode.BalancePercentage)
+		_riskMode = Param(nameof(RiskMode), RrsRiskModes.BalancePercentage)
 		.SetDisplay("Risk Mode", "Determines how MoneyInRisk is interpreted", "Risk")
 		.SetCanOptimize(false);
 
@@ -120,7 +120,7 @@ public class RrsNonDirectionalStrategy : Strategy
 	/// <summary>
 	/// Selected entry mode from the original EA.
 	/// </summary>
-	public RrsTradingMode TradingMode
+	public RrsTradingModes TradingMode
 	{
 		get => _tradingMode.Value;
 		set => _tradingMode.Value = value;
@@ -147,7 +147,7 @@ public class RrsNonDirectionalStrategy : Strategy
 	/// <summary>
 	/// Stop-loss handling mode.
 	/// </summary>
-	public RrsStopMode StopMode
+	public RrsStopModes StopMode
 	{
 		get => _stopMode.Value;
 		set => _stopMode.Value = value;
@@ -165,7 +165,7 @@ public class RrsNonDirectionalStrategy : Strategy
 	/// <summary>
 	/// Take-profit handling mode.
 	/// </summary>
-	public RrsTakeMode TakeMode
+	public RrsTakeModes TakeMode
 	{
 		get => _takeMode.Value;
 		set => _takeMode.Value = value;
@@ -183,7 +183,7 @@ public class RrsNonDirectionalStrategy : Strategy
 	/// <summary>
 	/// Trailing management mode.
 	/// </summary>
-	public RrsTrailingMode TrailingMode
+	public RrsTrailingModes TrailingMode
 	{
 		get => _trailingMode.Value;
 		set => _trailingMode.Value = value;
@@ -210,7 +210,7 @@ public class RrsNonDirectionalStrategy : Strategy
 	/// <summary>
 	/// Risk management interpretation for <see cref="MoneyInRisk"/>.
 	/// </summary>
-	public RrsRiskMode RiskMode
+	public RrsRiskModes RiskMode
 	{
 		get => _riskMode.Value;
 		set => _riskMode.Value = value;
@@ -296,7 +296,7 @@ public class RrsNonDirectionalStrategy : Strategy
 		if (_tickValue <= 0m)
 		_tickValue = 1m;
 
-		if (TradingMode == RrsTradingMode.AutoSwap)
+		if (TradingMode == RrsTradingModes.AutoSwap)
 		InitializeAutoSwap();
 
 		SubscribeLevel1()
@@ -308,7 +308,7 @@ public class RrsNonDirectionalStrategy : Strategy
 
 	private void InitializeAutoSwap()
 	{
-		TradingMode = RrsTradingMode.HedgeStyle;
+		TradingMode = RrsTradingModes.HedgeStyle;
 		LogInfo("AutoSwap mode falls back to HedgeStyle because swap rates are not available through Level1 data.");
 	}
 
@@ -359,7 +359,7 @@ public class RrsNonDirectionalStrategy : Strategy
 
 	private void UpdateTrailingForLong(decimal bid)
 	{
-		if (TrailingMode == RrsTrailingMode.Disabled)
+		if (TrailingMode == RrsTrailingModes.Disabled)
 		return;
 
 		var activation = GetPriceDistance(TrailingStartPoints);
@@ -387,7 +387,7 @@ public class RrsNonDirectionalStrategy : Strategy
 
 	private void UpdateTrailingForShort(decimal ask)
 	{
-		if (TrailingMode == RrsTrailingMode.Disabled)
+		if (TrailingMode == RrsTrailingModes.Disabled)
 		return;
 
 		var activation = GetPriceDistance(TrailingStartPoints);
@@ -454,7 +454,7 @@ public class RrsNonDirectionalStrategy : Strategy
 	private decimal GetRiskThreshold()
 	{
 		var balance = GetPortfolioValue();
-		if (RiskMode == RrsRiskMode.BalancePercentage)
+		if (RiskMode == RrsRiskModes.BalancePercentage)
 		return -Math.Abs(balance * (MoneyInRisk / 100m));
 
 		return -Math.Abs(MoneyInRisk);
@@ -493,23 +493,23 @@ public class RrsNonDirectionalStrategy : Strategy
 
 		switch (TradingMode)
 		{
-			case RrsTradingMode.HedgeStyle:
-			case RrsTradingMode.AutoSwap:
+			case RrsTradingModes.HedgeStyle:
+			case RrsTradingModes.AutoSwap:
 				OpenHedgeReplacement();
 				break;
-			case RrsTradingMode.BuyOrder:
+			case RrsTradingModes.BuyOrder:
 				OpenLong();
 				break;
-			case RrsTradingMode.SellOrder:
+			case RrsTradingModes.SellOrder:
 				OpenShort();
 				break;
-			case RrsTradingMode.BuySellRandom:
+			case RrsTradingModes.BuySellRandom:
 				if (_random.Next(0, 2) == 0)
 				OpenLong();
 				else
 				OpenShort();
 				break;
-			case RrsTradingMode.BuySell:
+			case RrsTradingModes.BuySell:
 				if (_lastClosedSide == Sides.Sell || _lastClosedSide is null)
 				OpenLong();
 				else
@@ -558,8 +558,8 @@ public class RrsNonDirectionalStrategy : Strategy
 		var stopDistance = GetPriceDistance(StopLossPoints);
 		var takeDistance = GetPriceDistance(TakeProfitPoints);
 
-		_longStopPrice = StopMode == RrsStopMode.Disabled || stopDistance <= 0m ? null : entryPrice - stopDistance;
-		_longTakePrice = TakeMode == RrsTakeMode.Disabled || takeDistance <= 0m ? null : entryPrice + takeDistance;
+		_longStopPrice = StopMode == RrsStopModes.Disabled || stopDistance <= 0m ? null : entryPrice - stopDistance;
+		_longTakePrice = TakeMode == RrsTakeModes.Disabled || takeDistance <= 0m ? null : entryPrice + takeDistance;
 		_longTrailingStop = null;
 	}
 
@@ -572,8 +572,8 @@ public class RrsNonDirectionalStrategy : Strategy
 		var stopDistance = GetPriceDistance(StopLossPoints);
 		var takeDistance = GetPriceDistance(TakeProfitPoints);
 
-		_shortStopPrice = StopMode == RrsStopMode.Disabled || stopDistance <= 0m ? null : entryPrice + stopDistance;
-		_shortTakePrice = TakeMode == RrsTakeMode.Disabled || takeDistance <= 0m ? null : entryPrice - takeDistance;
+		_shortStopPrice = StopMode == RrsStopModes.Disabled || stopDistance <= 0m ? null : entryPrice + stopDistance;
+		_shortTakePrice = TakeMode == RrsTakeModes.Disabled || takeDistance <= 0m ? null : entryPrice - takeDistance;
 		_shortTrailingStop = null;
 	}
 
@@ -623,7 +623,7 @@ public class RrsNonDirectionalStrategy : Strategy
 /// <summary>
 /// Entry modes reproduced from the MT4 enumerations.
 /// </summary>
-public enum RrsTradingMode
+public enum RrsTradingModes
 {
 	HedgeStyle,
 	BuySellRandom,
@@ -636,7 +636,7 @@ public enum RrsTradingMode
 /// <summary>
 /// Stop-loss handling options.
 /// </summary>
-public enum RrsStopMode
+public enum RrsStopModes
 {
 	Disabled,
 	Virtual,
@@ -646,7 +646,7 @@ public enum RrsStopMode
 /// <summary>
 /// Take-profit handling options.
 /// </summary>
-public enum RrsTakeMode
+public enum RrsTakeModes
 {
 	Disabled,
 	Virtual,
@@ -656,7 +656,7 @@ public enum RrsTakeMode
 /// <summary>
 /// Trailing management options.
 /// </summary>
-public enum RrsTrailingMode
+public enum RrsTrailingModes
 {
 	Disabled,
 	Virtual,
@@ -666,7 +666,7 @@ public enum RrsTrailingMode
 /// <summary>
 /// Interpretation modes for the risk threshold.
 /// </summary>
-public enum RrsRiskMode
+public enum RrsRiskModes
 {
 	BalancePercentage,
 	FixedMoney,

--- a/API/3710_RRSRandomness/CS/RrsRandomnessStrategy.cs
+++ b/API/3710_RRSRandomness/CS/RrsRandomnessStrategy.cs
@@ -19,7 +19,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class RrsRandomnessStrategy : Strategy
 {
-	private readonly StrategyParam<TradingMode> _tradingMode;
+	private readonly StrategyParam<TradingModes> _tradingMode;
 	private readonly StrategyParam<decimal> _minVolume;
 	private readonly StrategyParam<decimal> _maxVolume;
 	private readonly StrategyParam<decimal> _takeProfitPoints;
@@ -28,7 +28,7 @@ public class RrsRandomnessStrategy : Strategy
 	private readonly StrategyParam<decimal> _trailingGapPoints;
 	private readonly StrategyParam<decimal> _maxSpreadPoints;
 	private readonly StrategyParam<decimal> _slippagePoints;
-	private readonly StrategyParam<RiskMode> _riskMode;
+	private readonly StrategyParam<RiskModes> _riskMode;
 	private readonly StrategyParam<decimal> _riskValue;
 	private readonly StrategyParam<string> _tradeComment;
 	private readonly StrategyParam<DataType> _candleType;
@@ -43,7 +43,7 @@ public class RrsRandomnessStrategy : Strategy
 	/// <summary>
 	/// Trading direction selection logic.
 	/// </summary>
-	public TradingMode Mode
+	public TradingModes Mode
 	{
 		get => _tradingMode.Value;
 		set => _tradingMode.Value = value;
@@ -124,7 +124,7 @@ public class RrsRandomnessStrategy : Strategy
 	/// <summary>
 	/// Risk management mode.
 	/// </summary>
-	public RiskMode MoneyRiskMode
+	public RiskModes MoneyRiskMode
 	{
 		get => _riskMode.Value;
 		set => _riskMode.Value = value;
@@ -162,7 +162,7 @@ public class RrsRandomnessStrategy : Strategy
 	/// </summary>
 	public RrsRandomnessStrategy()
 	{
-		_tradingMode = Param(nameof(Mode), TradingMode.DoubleSide)
+		_tradingMode = Param(nameof(Mode), TradingModes.DoubleSide)
 			.SetDisplay("Trading Mode", "Select whether a trade is chosen every cycle or only on random matches.", "General");
 
 		_minVolume = Param(nameof(MinVolume), 0.01m)
@@ -197,7 +197,7 @@ public class RrsRandomnessStrategy : Strategy
 			.SetNotNegative()
 			.SetDisplay("Slippage", "Expected slippage in price steps. Used for reference only.", "Filters");
 
-		_riskMode = Param(nameof(MoneyRiskMode), RiskMode.BalancePercentage)
+		_riskMode = Param(nameof(MoneyRiskMode), RiskModes.BalancePercentage)
 			.SetDisplay("Risk Mode", "Choose whether risk is fixed or percentage based.", "Risk Management");
 
 		_riskValue = Param(nameof(RiskValue), 5m)
@@ -429,7 +429,7 @@ public class RrsRandomnessStrategy : Strategy
 		var floatingPnL = steps * stepPrice * Position;
 
 		var portfolioValue = Portfolio?.CurrentValue ?? 0m;
-		var riskThreshold = MoneyRiskMode == RiskMode.BalancePercentage
+		var riskThreshold = MoneyRiskMode == RiskModes.BalancePercentage
 			? -portfolioValue * (RiskValue / 100m)
 			: -RiskValue;
 
@@ -464,7 +464,7 @@ public class RrsRandomnessStrategy : Strategy
 		if (volume <= 0m)
 			return;
 
-		if (Mode == TradingMode.DoubleSide)
+		if (Mode == TradingModes.DoubleSide)
 		{
 			if (_openLongNext)
 			{
@@ -542,7 +542,7 @@ public class RrsRandomnessStrategy : Strategy
 	/// <summary>
 	/// Trading mode options.
 	/// </summary>
-	public enum TradingMode
+	public enum TradingModes
 	{
 		/// <summary>
 		/// Alternate between long and short entries every cycle.
@@ -558,7 +558,7 @@ public class RrsRandomnessStrategy : Strategy
 	/// <summary>
 	/// Risk management configuration.
 	/// </summary>
-	public enum RiskMode
+	public enum RiskModes
 	{
 		/// <summary>
 		/// Risk is defined as a fixed currency value.

--- a/API/3711_RRSChaotic/CS/RrsChaoticStrategy.cs
+++ b/API/3711_RRSChaotic/CS/RrsChaoticStrategy.cs
@@ -27,7 +27,7 @@ public class RrsChaoticStrategy : Strategy
 	private readonly StrategyParam<int> _maxOpenTrades;
 	private readonly StrategyParam<int> _maxSpreadPoints;
 	private readonly StrategyParam<int> _slippagePoints;
-	private readonly StrategyParam<RiskMode> _riskMode;
+	private readonly StrategyParam<RiskModes> _riskMode;
 	private readonly StrategyParam<decimal> _riskValue;
 	private readonly StrategyParam<string> _tradeComment;
 
@@ -42,7 +42,7 @@ public class RrsChaoticStrategy : Strategy
 	/// <summary>
 	/// Trade direction for risk sizing.
 	/// </summary>
-	public enum RiskMode
+	public enum RiskModes
 	{
 		/// <summary>
 		/// Risk a fixed cash amount.
@@ -85,7 +85,7 @@ public class RrsChaoticStrategy : Strategy
 			.SetDisplay("Slippage", "Slippage tolerance in points (informational only).", "Trading")
 			.SetCanOptimize(false);
 
-		_riskMode = Param(nameof(RiskMode), RiskMode.BalancePercentage)
+		_riskMode = Param(nameof(RiskModes), RiskModes.BalancePercentage)
 			.SetDisplay("Risk Mode", "Choose between fixed cash or balance percentage drawdown control.", "Risk");
 
 		_riskValue = Param(nameof(RiskValue), 5m)
@@ -171,7 +171,7 @@ public class RrsChaoticStrategy : Strategy
 	/// <summary>
 	/// Selected risk control mode.
 	/// </summary>
-	public RiskMode RiskControlMode
+	public RiskModes RiskControlMode
 	{
 		get => _riskMode.Value;
 		set => _riskMode.Value = value;
@@ -367,8 +367,8 @@ public class RrsChaoticStrategy : Strategy
 	{
 		return RiskControlMode switch
 		{
-			RiskMode.BalancePercentage => CalculatePercentageThreshold(),
-			RiskMode.FixedMoney => -Math.Abs(RiskValue),
+			RiskModes.BalancePercentage => CalculatePercentageThreshold(),
+			RiskModes.FixedMoney => -Math.Abs(RiskValue),
 			_ => null
 		};
 	}

--- a/API/3713_RRS_Tangled_EA/CS/RrsTangledEaStrategy.cs
+++ b/API/3713_RRS_Tangled_EA/CS/RrsTangledEaStrategy.cs
@@ -23,7 +23,7 @@ public class RrsTangledEaStrategy : Strategy
 	/// <summary>
 	/// Risk handling modes that mirror the original MetaTrader inputs.
 	/// </summary>
-	public enum RiskMode
+	public enum RiskModes
 	{
 		/// <summary>
 		/// Risk a fixed monetary amount.
@@ -43,7 +43,7 @@ public class RrsTangledEaStrategy : Strategy
 	private readonly StrategyParam<decimal> _trailingGapPips;
 	private readonly StrategyParam<decimal> _maxSpreadPips;
 	private readonly StrategyParam<int> _maxOpenTrades;
-	private readonly StrategyParam<RiskMode> _riskMode;
+	private readonly StrategyParam<RiskModes> _riskMode;
 	private readonly StrategyParam<decimal> _riskAmount;
 	private readonly StrategyParam<string> _tradeComment;
 	private readonly StrategyParam<string> _notes;
@@ -96,7 +96,7 @@ public class RrsTangledEaStrategy : Strategy
 			.SetDisplay("Max Open Trades", "Maximum simultaneous random entries", "General")
 			.SetRange(1, 1000);
 
-		_riskMode = Param(nameof(RiskManagementMode), RiskMode.BalancePercentage)
+		_riskMode = Param(nameof(RiskManagementMode), RiskModes.BalancePercentage)
 			.SetDisplay("Risk Mode", "Select fixed risk or balance percentage", "Risk");
 
 		_riskAmount = Param(nameof(RiskAmount), 5m)
@@ -188,7 +188,7 @@ public class RrsTangledEaStrategy : Strategy
 	/// <summary>
 	/// Risk handling mode.
 	/// </summary>
-	public RiskMode RiskManagementMode
+	public RiskModes RiskManagementMode
 	{
 		get => _riskMode.Value;
 		set => _riskMode.Value = value;
@@ -547,7 +547,7 @@ public class RrsTangledEaStrategy : Strategy
 
 		return mode switch
 		{
-			RiskMode.BalancePercentage => -GetCurrentBalance() * risk / 100m,
+			RiskModes.BalancePercentage => -GetCurrentBalance() * risk / 100m,
 			_ => -risk,
 		};
 	}
@@ -567,7 +567,7 @@ public class RrsTangledEaStrategy : Strategy
 	private void UpdateStatus(decimal price, decimal floating)
 	{
 		var balance = GetCurrentBalance();
-		var modeDescription = RiskManagementMode == RiskMode.BalancePercentage
+		var modeDescription = RiskManagementMode == RiskModes.BalancePercentage
 			? $"Balance % ({RiskAmount:F2})"
 			: $"Fixed ({RiskAmount:F2})";
 

--- a/API/3720_Adjustable_Moving_Average/CS/AdjustableMovingAverageStrategy.cs
+++ b/API/3720_Adjustable_Moving_Average/CS/AdjustableMovingAverageStrategy.cs
@@ -23,12 +23,12 @@ public class AdjustableMovingAverageStrategy : Strategy
 	private readonly StrategyParam<TimeFrame> _candleType;
 	private readonly StrategyParam<int> _fastPeriod;
 	private readonly StrategyParam<int> _slowPeriod;
-	private readonly StrategyParam<MovingAverageMethod> _maMethod;
+	private readonly StrategyParam<MovingAverageMethods> _maMethod;
 	private readonly StrategyParam<decimal> _minGapPoints;
 	private readonly StrategyParam<decimal> _stopLossPoints;
 	private readonly StrategyParam<decimal> _takeProfitPoints;
 	private readonly StrategyParam<decimal> _trailingPoints;
-	private readonly StrategyParam<EntryMode> _entryMode;
+	private readonly StrategyParam<EntryModes> _entryMode;
 	private readonly StrategyParam<TimeSpan> _sessionStart;
 	private readonly StrategyParam<TimeSpan> _sessionEnd;
 	private readonly StrategyParam<bool> _closeOutsideSession;
@@ -69,7 +69,7 @@ public class AdjustableMovingAverageStrategy : Strategy
 			.SetCanOptimize(true)
 			.SetOptimize(3, 60, 1);
 
-		_maMethod = Param(nameof(MaMethod), MovingAverageMethod.Exponential)
+		_maMethod = Param(nameof(MaMethod), MovingAverageMethods.Exponential)
 			.SetDisplay("MA method", "Moving average calculation method", "Moving averages")
 			.SetCanOptimize(true);
 
@@ -91,7 +91,7 @@ public class AdjustableMovingAverageStrategy : Strategy
 			.SetNotNegative()
 			.SetDisplay("Trailing stop (points)", "Trailing stop distance in price points", "Risk management");
 
-		_entryMode = Param(nameof(Mode), EntryMode.Both)
+		_entryMode = Param(nameof(Mode), EntryModes.Both)
 			.SetDisplay("Entry mode", "Allowed trade direction", "Trading");
 
 		_sessionStart = Param(nameof(SessionStart), TimeSpan.Zero)
@@ -155,7 +155,7 @@ public class AdjustableMovingAverageStrategy : Strategy
 	/// <summary>
 	/// Moving average calculation method.
 	/// </summary>
-	public MovingAverageMethod MaMethod
+	public MovingAverageMethods MaMethod
 	{
 		get => _maMethod.Value;
 		set => _maMethod.Value = value;
@@ -200,7 +200,7 @@ public class AdjustableMovingAverageStrategy : Strategy
 	/// <summary>
 	/// Allowed trade direction.
 	/// </summary>
-	public EntryMode Mode
+	public EntryModes Mode
 	{
 		get => _entryMode.Value;
 		set => _entryMode.Value = value;
@@ -374,7 +374,7 @@ public class AdjustableMovingAverageStrategy : Strategy
 				if (CloseOutsideSession || inSession)
 					CloseCurrentPosition();
 
-				if (allowTrading && Mode != EntryMode.BuyOnly)
+				if (allowTrading && Mode != EntryModes.BuyOnly)
 				{
 					OpenShort(candle.ClosePrice);
 				}
@@ -390,7 +390,7 @@ public class AdjustableMovingAverageStrategy : Strategy
 				if (CloseOutsideSession || inSession)
 					CloseCurrentPosition();
 
-				if (allowTrading && Mode != EntryMode.SellOnly)
+				if (allowTrading && Mode != EntryModes.SellOnly)
 				{
 					OpenLong(candle.ClosePrice);
 				}
@@ -618,14 +618,14 @@ public class AdjustableMovingAverageStrategy : Strategy
 		return point;
 	}
 
-	private LengthIndicator<decimal> CreateMovingAverage(MovingAverageMethod method, int length)
+	private LengthIndicator<decimal> CreateMovingAverage(MovingAverageMethods method, int length)
 	{
 		LengthIndicator<decimal> indicator = method switch
 		{
-			MovingAverageMethod.Simple => new SimpleMovingAverage { Length = length, CandlePrice = CandlePrice.Close },
-			MovingAverageMethod.Exponential => new ExponentialMovingAverage { Length = length, CandlePrice = CandlePrice.Close },
-			MovingAverageMethod.Smoothed => new SmoothedMovingAverage { Length = length, CandlePrice = CandlePrice.Close },
-			MovingAverageMethod.Weighted => new WeightedMovingAverage { Length = length, CandlePrice = CandlePrice.Close },
+			MovingAverageMethods.Simple => new SimpleMovingAverage { Length = length, CandlePrice = CandlePrice.Close },
+			MovingAverageMethods.Exponential => new ExponentialMovingAverage { Length = length, CandlePrice = CandlePrice.Close },
+			MovingAverageMethods.Smoothed => new SmoothedMovingAverage { Length = length, CandlePrice = CandlePrice.Close },
+			MovingAverageMethods.Weighted => new WeightedMovingAverage { Length = length, CandlePrice = CandlePrice.Close },
 			_ => new ExponentialMovingAverage { Length = length, CandlePrice = CandlePrice.Close }
 		};
 
@@ -642,7 +642,7 @@ public class AdjustableMovingAverageStrategy : Strategy
 /// <summary>
 /// Moving average calculation methods supported by the strategy.
 /// </summary>
-public enum MovingAverageMethod
+public enum MovingAverageMethods
 {
 	/// <summary>
 	/// Simple moving average.
@@ -668,7 +668,7 @@ public enum MovingAverageMethod
 /// <summary>
 /// Directional filter for new positions.
 /// </summary>
-public enum EntryMode
+public enum EntryModes
 {
 	/// <summary>
 	/// Allow both long and short entries.

--- a/API/3740_Multi_EA/CS/MultiEaV12Strategy.cs
+++ b/API/3740_Multi_EA/CS/MultiEaV12Strategy.cs
@@ -332,7 +332,7 @@ public class MultiEaV12Strategy : Strategy
 		if (!ProcessIndicators(candle))
 			return;
 
-		var signals = new List<SignalDirection>();
+		var signals = new List<SignalDirections>();
 
 		if (_acEnabled.Value)
 			CollectSignal(signals, EvaluateAcSignal());
@@ -476,85 +476,85 @@ public class MultiEaV12Strategy : Strategy
 		return true;
 	}
 
-	private void CollectSignal(List<SignalDirection> signals, SignalDirection signal)
+	private void CollectSignal(List<SignalDirections> signals, SignalDirections signal)
 	{
-		if (signal != SignalDirection.None)
+		if (signal != SignalDirections.None)
 			signals.Add(signal);
 	}
 
-	private SignalDirection EvaluateAcSignal()
+	private SignalDirections EvaluateAcSignal()
 	{
 		if (_acLast is not decimal current || _acPrev is not decimal prev)
-			return SignalDirection.None;
+			return SignalDirections.None;
 
 		var level = _acOpenLevel.Value;
 
 		if (current > level && current > prev)
-			return SignalDirection.Buy;
+			return SignalDirections.Buy;
 
 		if (current < -level && current < prev)
-			return SignalDirection.Sell;
+			return SignalDirections.Sell;
 
-		return SignalDirection.None;
+		return SignalDirections.None;
 	}
 
-	private SignalDirection EvaluateAdxSignal()
+	private SignalDirections EvaluateAdxSignal()
 	{
 		if (_adxStrength is not decimal adx || _adxPlus is not decimal plus || _adxMinus is not decimal minus)
-			return SignalDirection.None;
+			return SignalDirections.None;
 
 		if (adx < _adxTrendLevel.Value)
-			return SignalDirection.None;
+			return SignalDirections.None;
 
 		if (plus > minus && plus > _adxDirectionalLevel.Value)
-			return SignalDirection.Buy;
+			return SignalDirections.Buy;
 
 		if (minus > plus && minus > _adxDirectionalLevel.Value)
-			return SignalDirection.Sell;
+			return SignalDirections.Sell;
 
-		return SignalDirection.None;
+		return SignalDirections.None;
 	}
 
-	private SignalDirection EvaluateAoSignal()
+	private SignalDirections EvaluateAoSignal()
 	{
 		if (_aoLast is not decimal current || _aoPrev is not decimal prev)
-			return SignalDirection.None;
+			return SignalDirections.None;
 
 		var level = _aoOpenLevel.Value;
 
 		if (current > level && current > prev)
-			return SignalDirection.Buy;
+			return SignalDirections.Buy;
 
 		if (current < -level && current < prev)
-			return SignalDirection.Sell;
+			return SignalDirections.Sell;
 
-		return SignalDirection.None;
+		return SignalDirections.None;
 	}
 
-	private SignalDirection EvaluateDeMarkerSignal()
+	private SignalDirections EvaluateDeMarkerSignal()
 	{
 		if (_demLast is not decimal current)
-			return SignalDirection.None;
+			return SignalDirections.None;
 
 		var threshold = _demThreshold.Value;
 		var lower = 100m - threshold;
 
 		if (current < lower)
-			return SignalDirection.Buy;
+			return SignalDirections.Buy;
 
 		if (current > threshold)
-			return SignalDirection.Sell;
+			return SignalDirections.Sell;
 
-		return SignalDirection.None;
+		return SignalDirections.None;
 	}
 
-	private SignalDirection EvaluateForceBollingerSignal(ICandleMessage candle)
+	private SignalDirections EvaluateForceBollingerSignal(ICandleMessage candle)
 	{
 		if (_bollingerUpper is not decimal upper || _bollingerLower is not decimal lower)
-			return SignalDirection.None;
+			return SignalDirections.None;
 
 		if (_forceLast is not decimal force)
-			return SignalDirection.None;
+			return SignalDirections.None;
 
 		var distance = (upper - lower) / (_pipSize <= 0m ? 1m : _pipSize);
 		var distanceFilter = _bandDistanceFilter.Value;
@@ -567,45 +567,45 @@ public class MultiEaV12Strategy : Strategy
 		};
 
 		if (!acceptDistance)
-			return SignalDirection.None;
+			return SignalDirections.None;
 
 		var forceLevel = _forceConfirmationLevel.Value;
 		var touchedLower = candle.LowPrice <= lower;
 		var touchedUpper = candle.HighPrice >= upper;
 
 		if (touchedLower && force > forceLevel)
-			return SignalDirection.Buy;
+			return SignalDirections.Buy;
 
 		if (touchedUpper && force < -forceLevel)
-			return SignalDirection.Sell;
+			return SignalDirections.Sell;
 
-		return SignalDirection.None;
+		return SignalDirections.None;
 	}
 
-	private SignalDirection EvaluateMfiSignal()
+	private SignalDirections EvaluateMfiSignal()
 	{
 		if (_mfiLast is not decimal current)
-			return SignalDirection.None;
+			return SignalDirections.None;
 
 		var threshold = _mfiThreshold.Value;
 		var lower = 100m - threshold;
 
 		if (current < lower)
-			return SignalDirection.Buy;
+			return SignalDirections.Buy;
 
 		if (current > threshold)
-			return SignalDirection.Sell;
+			return SignalDirections.Sell;
 
-		return SignalDirection.None;
+		return SignalDirections.None;
 	}
 
-	private SignalDirection EvaluateMacdStochasticSignal()
+	private SignalDirections EvaluateMacdStochasticSignal()
 	{
 		if (_macdMainLast is not decimal macdMain || _macdSignalLast is not decimal macdSignal)
-			return SignalDirection.None;
+			return SignalDirections.None;
 
 		if (_stochasticKLast is not decimal stochK || _stochasticDLast is not decimal stochD)
-			return SignalDirection.None;
+			return SignalDirections.None;
 
 		var macdLevel = _macdLevel.Value;
 		var stochasticLevel = _stochasticLevel.Value;
@@ -618,18 +618,18 @@ public class MultiEaV12Strategy : Strategy
 		var stochasticBearish = stochK < lowerStochastic && stochK < stochD;
 
 		if (macdBullish && stochasticBullish)
-			return SignalDirection.Buy;
+			return SignalDirections.Buy;
 
 		if (macdBearish && stochasticBearish)
-			return SignalDirection.Sell;
+			return SignalDirections.Sell;
 
-		return SignalDirection.None;
+		return SignalDirections.None;
 	}
 
-	private SignalDirection ResolveConsensus(IReadOnlyCollection<SignalDirection> signals)
+	private SignalDirections ResolveConsensus(IReadOnlyCollection<SignalDirections> signals)
 	{
 		if (signals.Count == 0)
-			return SignalDirection.None;
+			return SignalDirections.None;
 
 		var minConfirmations = TradeAllStrategies ? Math.Max(1, _requiredConfirmations.Value) : 1;
 
@@ -638,24 +638,24 @@ public class MultiEaV12Strategy : Strategy
 
 		foreach (var signal in signals)
 		{
-			if (signal == SignalDirection.Buy)
+			if (signal == SignalDirections.Buy)
 				bullish++;
-			else if (signal == SignalDirection.Sell)
+			else if (signal == SignalDirections.Sell)
 				bearish++;
 		}
 
 		if (bullish >= minConfirmations && bearish == 0)
-			return SignalDirection.Buy;
+			return SignalDirections.Buy;
 
 		if (bearish >= minConfirmations && bullish == 0)
-			return SignalDirection.Sell;
+			return SignalDirections.Sell;
 
-		return SignalDirection.None;
+		return SignalDirections.None;
 	}
 
-	private void ManagePositions(SignalDirection decision, ICandleMessage candle)
+	private void ManagePositions(SignalDirections decision, ICandleMessage candle)
 	{
-		if (decision == SignalDirection.Buy)
+		if (decision == SignalDirections.Buy)
 		{
 			if (CloseInReverse && Position < 0)
 				BuyMarket(Math.Abs(Position));
@@ -667,7 +667,7 @@ public class MultiEaV12Strategy : Strategy
 				_shortEntryPrice = null;
 			}
 		}
-		else if (decision == SignalDirection.Sell)
+		else if (decision == SignalDirections.Sell)
 		{
 			if (CloseInReverse && Position > 0)
 				SellMarket(Position);
@@ -748,7 +748,7 @@ public class MultiEaV12Strategy : Strategy
 
 	private bool CloseInReverse => _closeInReverse.Value;
 
-	private enum SignalDirection
+	private enum SignalDirections
 	{
 		None,
 		Buy,

--- a/API/3743_Build_Your_Grid/CS/BuildYourGridStrategy.cs
+++ b/API/3743_Build_Your_Grid/CS/BuildYourGridStrategy.cs
@@ -20,40 +20,40 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class BuildYourGridStrategy : Strategy
 {
-	private enum OrderPlacementMode
+	private enum OrderPlacementModes
 	{
 		Both,
 		LongOnly,
 		ShortOnly,
 	}
 
-	private enum GridDirectionMode
+	private enum GridDirectionModes
 	{
 		WithTrend,
 		AgainstTrend,
 	}
 
-	private enum StepProgressionMode
+	private enum StepProgressionModes
 	{
 		Static,
 		Geometric,
 		Exponential,
 	}
 
-	private enum CloseTargetMode
+	private enum CloseTargetModes
 	{
 		Pips,
 		Currency,
 	}
 
-	private enum LossCloseMode
+	private enum LossCloseModes
 	{
 		DoNothing,
 		CloseFirst,
 		CloseAll,
 	}
 
-	private enum LotProgressionMode
+	private enum LotProgressionModes
 	{
 		Static,
 		Geometric,
@@ -73,14 +73,14 @@ public class BuildYourGridStrategy : Strategy
 		public decimal Volume { get; set; }
 	}
 
-	private readonly StrategyParam<OrderPlacementMode> _orderPlacement;
-	private readonly StrategyParam<GridDirectionMode> _gridDirection;
+	private readonly StrategyParam<OrderPlacementModes> _orderPlacement;
+	private readonly StrategyParam<GridDirectionModes> _gridDirection;
 	private readonly StrategyParam<decimal> _pipsForNextOrder;
-	private readonly StrategyParam<StepProgressionMode> _stepProgression;
-	private readonly StrategyParam<CloseTargetMode> _closeTargetMode;
+	private readonly StrategyParam<StepProgressionModes> _stepProgression;
+	private readonly StrategyParam<CloseTargetModes> _closeTargetMode;
 	private readonly StrategyParam<decimal> _pipsCloseInProfit;
 	private readonly StrategyParam<decimal> _currencyCloseInProfit;
-	private readonly StrategyParam<LossCloseMode> _lossCloseMode;
+	private readonly StrategyParam<LossCloseModes> _lossCloseMode;
 	private readonly StrategyParam<decimal> _pipsForCloseInLoss;
 	private readonly StrategyParam<bool> _placeHedgeOrder;
 	private readonly StrategyParam<decimal> _hedgeLossThreshold;
@@ -88,7 +88,7 @@ public class BuildYourGridStrategy : Strategy
 	private readonly StrategyParam<bool> _autoLotSize;
 	private readonly StrategyParam<decimal> _riskFactor;
 	private readonly StrategyParam<decimal> _manualLotSize;
-	private readonly StrategyParam<LotProgressionMode> _lotProgression;
+	private readonly StrategyParam<LotProgressionModes> _lotProgression;
 	private readonly StrategyParam<decimal> _maxMultiplierLot;
 	private readonly StrategyParam<int> _maxOrders;
 	private readonly StrategyParam<decimal> _maxSpread;
@@ -127,7 +127,7 @@ public class BuildYourGridStrategy : Strategy
 	/// <summary>
 	/// Controls whether the strategy may open both directions or a single side only.
 	/// </summary>
-	public OrderPlacementMode OrderPlacement
+	public OrderPlacementModes OrderPlacement
 	{
 		get => _orderPlacement.Value;
 		set => _orderPlacement.Value = value;
@@ -136,7 +136,7 @@ public class BuildYourGridStrategy : Strategy
 	/// <summary>
 	/// Determines if new grid layers follow the trend or fade the movement.
 	/// </summary>
-	public GridDirectionMode GridDirection
+	public GridDirectionModes GridDirection
 	{
 		get => _gridDirection.Value;
 		set => _gridDirection.Value = value;
@@ -154,7 +154,7 @@ public class BuildYourGridStrategy : Strategy
 	/// <summary>
 	/// Defines how the grid step evolves with each new order.
 	/// </summary>
-	public StepProgressionMode StepProgression
+	public StepProgressionModes StepProgression
 	{
 		get => _stepProgression.Value;
 		set => _stepProgression.Value = value;
@@ -163,7 +163,7 @@ public class BuildYourGridStrategy : Strategy
 	/// <summary>
 	/// Target type used for closing the basket in profit.
 	/// </summary>
-	public CloseTargetMode CloseTarget
+	public CloseTargetModes CloseTarget
 	{
 		get => _closeTargetMode.Value;
 		set => _closeTargetMode.Value = value;
@@ -190,7 +190,7 @@ public class BuildYourGridStrategy : Strategy
 	/// <summary>
 	/// Defines how the basket is closed when the floating loss limit is reached.
 	/// </summary>
-	public LossCloseMode LossMode
+	public LossCloseModes LossMode
 	{
 		get => _lossCloseMode.Value;
 		set => _lossCloseMode.Value = value;
@@ -262,7 +262,7 @@ public class BuildYourGridStrategy : Strategy
 	/// <summary>
 	/// Controls how the lot size grows with new orders.
 	/// </summary>
-	public LotProgressionMode LotProgression
+	public LotProgressionModes LotProgression
 	{
 		get => _lotProgression.Value;
 		set => _lotProgression.Value = value;
@@ -318,20 +318,20 @@ public class BuildYourGridStrategy : Strategy
 	/// </summary>
 	public BuildYourGridStrategy()
 	{
-		_orderPlacement = Param(nameof(OrderPlacement), OrderPlacementMode.Both)
+		_orderPlacement = Param(nameof(OrderPlacement), OrderPlacementModes.Both)
 			.SetDisplay("Order Placement", "Allowed entry direction", "General");
 
-		_gridDirection = Param(nameof(GridDirection), GridDirectionMode.AgainstTrend)
+		_gridDirection = Param(nameof(GridDirection), GridDirectionModes.AgainstTrend)
 			.SetDisplay("Grid Direction", "Whether layers follow or fade the trend", "Grid");
 
 		_pipsForNextOrder = Param(nameof(PipsForNextOrder), 50m)
 			.SetDisplay("Grid Step (pips)", "Base spacing between grid levels", "Grid")
 			.SetGreaterThanZero();
 
-		_stepProgression = Param(nameof(StepProgression), StepProgressionMode.Geometric)
+		_stepProgression = Param(nameof(StepProgression), StepProgressionModes.Geometric)
 			.SetDisplay("Step Progression", "How the distance grows with each layer", "Grid");
 
-		_closeTargetMode = Param(nameof(CloseTarget), CloseTargetMode.Pips)
+		_closeTargetMode = Param(nameof(CloseTarget), CloseTargetModes.Pips)
 			.SetDisplay("Close Target", "Profit target type", "Risk");
 
 		_pipsCloseInProfit = Param(nameof(PipsCloseInProfit), 10m)
@@ -342,7 +342,7 @@ public class BuildYourGridStrategy : Strategy
 			.SetDisplay("Target (currency)", "Basket profit target in account currency", "Risk")
 			.SetGreaterThanZero();
 
-		_lossCloseMode = Param(nameof(LossMode), LossCloseMode.CloseAll)
+		_lossCloseMode = Param(nameof(LossMode), LossCloseModes.CloseAll)
 			.SetDisplay("Loss Handling", "Action when the loss threshold is hit", "Risk");
 
 		_pipsForCloseInLoss = Param(nameof(PipsForCloseInLoss), 100m)
@@ -371,7 +371,7 @@ public class BuildYourGridStrategy : Strategy
 			.SetDisplay("Manual Volume", "Order size when auto sizing is disabled", "Volume")
 			.SetGreaterThanZero();
 
-		_lotProgression = Param(nameof(LotProgression), LotProgressionMode.Static)
+		_lotProgression = Param(nameof(LotProgression), LotProgressionModes.Static)
 			.SetDisplay("Lot Progression", "How volumes scale with each layer", "Volume");
 
 		_maxMultiplierLot = Param(nameof(MaxMultiplierLot), 50m)
@@ -519,9 +519,9 @@ public class BuildYourGridStrategy : Strategy
 						return;
 				}
 
-				if (LossMode != LossCloseMode.DoNothing && ShouldCloseInLoss())
+				if (LossMode != LossCloseModes.DoNothing && ShouldCloseInLoss())
 				{
-					var closed = LossMode == LossCloseMode.CloseFirst ? CloseFirstPositions() : CloseAllPositions();
+					var closed = LossMode == LossCloseModes.CloseFirst ? CloseFirstPositions() : CloseAllPositions();
 					if (closed)
 						return;
 				}
@@ -608,8 +608,8 @@ public class BuildYourGridStrategy : Strategy
 	{
 		return CloseTarget switch
 		{
-			CloseTargetMode.Pips => (_buyPips + _sellPips) >= PipsCloseInProfit,
-			CloseTargetMode.Currency => (_buyProfit + _sellProfit) >= CurrencyCloseInProfit,
+			CloseTargetModes.Pips => (_buyPips + _sellPips) >= PipsCloseInProfit,
+			CloseTargetModes.Currency => (_buyProfit + _sellProfit) >= CurrencyCloseInProfit,
 			_ => false,
 		};
 	}
@@ -719,14 +719,14 @@ public class BuildYourGridStrategy : Strategy
 		if (!CanOpenMoreOrders())
 			return false;
 
-		if (_buyOrders == 0 && (OrderPlacement == OrderPlacementMode.Both || OrderPlacement == OrderPlacementMode.LongOnly))
+		if (_buyOrders == 0 && (OrderPlacement == OrderPlacementModes.Both || OrderPlacement == OrderPlacementModes.LongOnly))
 		{
 			var volume = GetOrderVolume(Sides.Buy);
 			if (SendMarketOrder(Sides.Buy, volume))
 				return true;
 		}
 
-		if (_sellOrders == 0 && (OrderPlacement == OrderPlacementMode.Both || OrderPlacement == OrderPlacementMode.ShortOnly))
+		if (_sellOrders == 0 && (OrderPlacement == OrderPlacementModes.Both || OrderPlacement == OrderPlacementModes.ShortOnly))
 		{
 			var volume = GetOrderVolume(Sides.Sell);
 			if (SendMarketOrder(Sides.Sell, volume))
@@ -741,19 +741,19 @@ public class BuildYourGridStrategy : Strategy
 		if (!CanOpenMoreOrders())
 			return;
 
-		var allowBuy = OrderPlacement != OrderPlacementMode.ShortOnly;
-		var allowSell = OrderPlacement != OrderPlacementMode.LongOnly;
+		var allowBuy = OrderPlacement != OrderPlacementModes.ShortOnly;
+		var allowSell = OrderPlacement != OrderPlacementModes.LongOnly;
 
 		if (!allowBuy && !allowSell)
 			return;
 
-		if ((_buyOrders > 0 || OrderPlacement == OrderPlacementMode.ShortOnly)
-			&& (_sellOrders > 0 || OrderPlacement == OrderPlacementMode.LongOnly))
+		if ((_buyOrders > 0 || OrderPlacement == OrderPlacementModes.ShortOnly)
+			&& (_sellOrders > 0 || OrderPlacement == OrderPlacementModes.LongOnly))
 		{
 			var buyDistance = allowBuy ? GetNextDistance(Sides.Buy) : 0m;
 			var sellDistance = allowSell ? GetNextDistance(Sides.Sell) : 0m;
 
-			if (GridDirection == GridDirectionMode.WithTrend)
+			if (GridDirection == GridDirectionModes.WithTrend)
 			{
 				if (allowBuy && _lastBuyPrice.HasValue && buyDistance > 0m)
 				{
@@ -819,9 +819,9 @@ public class BuildYourGridStrategy : Strategy
 
 		var multiplier = StepProgression switch
 		{
-			StepProgressionMode.Static => 1m,
-			StepProgressionMode.Geometric => Math.Max(1, count),
-			StepProgressionMode.Exponential => count <= 0 ? 1m : (decimal)Math.Max(1, Math.Pow(2, count - 1)),
+			StepProgressionModes.Static => 1m,
+			StepProgressionModes.Geometric => Math.Max(1, count),
+			StepProgressionModes.Exponential => count <= 0 ? 1m : (decimal)Math.Max(1, Math.Pow(2, count - 1)),
 			_ => 1m,
 		};
 
@@ -838,10 +838,10 @@ public class BuildYourGridStrategy : Strategy
 
 		switch (LotProgression)
 		{
-			case LotProgressionMode.Static:
+			case LotProgressionModes.Static:
 				result = orders == 0 ? baseVolume : (firstVolume > 0m ? firstVolume : baseVolume);
 				break;
-			case LotProgressionMode.Geometric:
+			case LotProgressionModes.Geometric:
 				if (orders == 0)
 				{
 					result = baseVolume;
@@ -855,7 +855,7 @@ public class BuildYourGridStrategy : Strategy
 					result = lastVolume + (firstVolume > 0m ? firstVolume : baseVolume);
 				}
 				break;
-			case LotProgressionMode.Exponential:
+			case LotProgressionModes.Exponential:
 				result = orders == 0 ? baseVolume : lastVolume * 2m;
 				break;
 			default:

--- a/API/3745_TradePad_Sample/CS/TradePadSampleStrategy.cs
+++ b/API/3745_TradePad_Sample/CS/TradePadSampleStrategy.cs
@@ -30,14 +30,14 @@ private readonly StrategyParam<decimal> _lowerLevel;
 private readonly StrategyParam<DataType> _candleType;
 
 private readonly Dictionary<Security, StochasticOscillator> _stochastics = new();
-private readonly Dictionary<string, TrendState> _trendStates = new();
+private readonly Dictionary<string, TrendStates> _trendStates = new();
 private readonly Dictionary<string, decimal> _latestK = new();
 private readonly Dictionary<string, DateTimeOffset> _lastUpdateTime = new();
 
 /// <summary>
 /// Represents the simplified trend state of a monitored symbol.
 /// </summary>
-public enum TrendState
+public enum TrendStates
 {
 /// <summary>No reading calculated yet.</summary>
 Unknown,
@@ -166,7 +166,7 @@ set => _candleType.Value = value;
 /// <summary>
 /// Returns the latest trend state per symbol.
 /// </summary>
-public IReadOnlyDictionary<string, TrendState> TrendStates => _trendStates;
+public IReadOnlyDictionary<string, TrendStates> TrendStates => _trendStates;
 
 /// <summary>
 /// Returns the latest %K oscillator readings per symbol.
@@ -201,7 +201,7 @@ subscription.BindEx(stochastic, (candle, indicatorValue) => ProcessStochastic(se
 var symbolId = security.Id;
 if (!_trendStates.ContainsKey(symbolId))
 {
-_trendStates[symbolId] = TrendState.Unknown;
+_trendStates[symbolId] = TrendStates.Unknown;
 }
 }
 }
@@ -291,19 +291,19 @@ LogInfo("{0}: {1} (K={2:0.##})", symbolId, currentState, kValue);
 }
 }
 
-private TrendState DetermineState(decimal kValue)
+private TrendStates DetermineState(decimal kValue)
 {
 if (kValue >= UpperLevel)
 {
-return TrendState.Uptrend;
+return TrendStates.Uptrend;
 }
 
 if (kValue <= LowerLevel)
 {
-return TrendState.Downtrend;
+return TrendStates.Downtrend;
 }
 
-return TrendState.Flat;
+return TrendStates.Flat;
 }
 }
 

--- a/API/3746_Exp_TrendMagic/CS/ExpTrendMagicStrategy.cs
+++ b/API/3746_Exp_TrendMagic/CS/ExpTrendMagicStrategy.cs
@@ -21,7 +21,7 @@ namespace StockSharp.Samples.Strategies;
 public class ExpTrendMagicStrategy : Strategy
 {
 	private readonly StrategyParam<decimal> _moneyManagement;
-	private readonly StrategyParam<MarginModeOption> _marginMode;
+	private readonly StrategyParam<MarginModeOptions> _marginMode;
 	private readonly StrategyParam<decimal> _stopLossPoints;
 	private readonly StrategyParam<decimal> _takeProfitPoints;
 	private readonly StrategyParam<decimal> _deviationPoints;
@@ -31,7 +31,7 @@ public class ExpTrendMagicStrategy : Strategy
 	private readonly StrategyParam<bool> _allowSellExit;
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<int> _cciPeriod;
-	private readonly StrategyParam<AppliedPriceMode> _cciPrice;
+	private readonly StrategyParam<AppliedPriceModes> _cciPrice;
 	private readonly StrategyParam<int> _atrPeriod;
 	private readonly StrategyParam<int> _signalBar;
 
@@ -54,7 +54,7 @@ public class ExpTrendMagicStrategy : Strategy
 		.SetCanOptimize(true)
 		.SetOptimize(0.05m, 0.5m, 0.05m);
 
-		_marginMode = Param(nameof(MarginMode), MarginModeOption.Lot)
+		_marginMode = Param(nameof(MarginMode), MarginModeOptions.Lot)
 		.SetDisplay("Margin Mode", "Mode used to translate MM into volume", "Trading");
 
 		_stopLossPoints = Param(nameof(StopLossPoints), 1000m)
@@ -89,7 +89,7 @@ public class ExpTrendMagicStrategy : Strategy
 		.SetDisplay("CCI Period", "Length of the CCI", "Indicator")
 		.SetGreaterThanZero();
 
-		_cciPrice = Param(nameof(CciPrice), AppliedPriceMode.Median)
+		_cciPrice = Param(nameof(CciPrice), AppliedPriceModes.Median)
 		.SetDisplay("CCI Price", "Applied price for the CCI", "Indicator");
 
 		_atrPeriod = Param(nameof(AtrPeriod), 5)
@@ -113,7 +113,7 @@ public class ExpTrendMagicStrategy : Strategy
 	/// <summary>
 	/// Mode used to convert the money management value into an order volume.
 	/// </summary>
-	public MarginModeOption MarginMode
+	public MarginModeOptions MarginMode
 	{
 		get => _marginMode.Value;
 		set => _marginMode.Value = value;
@@ -203,7 +203,7 @@ public class ExpTrendMagicStrategy : Strategy
 	/// <summary>
 	/// Applied price used as the CCI input.
 	/// </summary>
-	public AppliedPriceMode CciPrice
+	public AppliedPriceModes CciPrice
 	{
 		get => _cciPrice.Value;
 		set => _cciPrice.Value = value;
@@ -496,15 +496,15 @@ public class ExpTrendMagicStrategy : Strategy
 
 		switch (MarginMode)
 		{
-			case MarginModeOption.FreeMargin:
-			case MarginModeOption.Balance:
+			case MarginModeOptions.FreeMargin:
+			case MarginModeOptions.Balance:
 			{
 				var amount = capital * mm;
 				volume = amount / price;
 				break;
 			}
-			case MarginModeOption.LossFreeMargin:
-			case MarginModeOption.LossBalance:
+			case MarginModeOptions.LossFreeMargin:
+			case MarginModeOptions.LossBalance:
 			{
 				if (StopLossPoints <= 0m)
 					return NormalizeVolume(Volume);
@@ -521,7 +521,7 @@ public class ExpTrendMagicStrategy : Strategy
 				volume = lossAmount / riskPerContract;
 				break;
 			}
-			case MarginModeOption.Lot:
+			case MarginModeOptions.Lot:
 			default:
 				volume = mm;
 				break;
@@ -554,18 +554,18 @@ public class ExpTrendMagicStrategy : Strategy
 		return volume;
 	}
 
-	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPriceMode mode)
+	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPriceModes mode)
 	{
 		return mode switch
 		{
-			AppliedPriceMode.Close => candle.ClosePrice,
-			AppliedPriceMode.Open => candle.OpenPrice,
-			AppliedPriceMode.High => candle.HighPrice,
-			AppliedPriceMode.Low => candle.LowPrice,
-			AppliedPriceMode.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-			AppliedPriceMode.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-			AppliedPriceMode.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
-			AppliedPriceMode.Average => (candle.OpenPrice + candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 4m,
+			AppliedPriceModes.Close => candle.ClosePrice,
+			AppliedPriceModes.Open => candle.OpenPrice,
+			AppliedPriceModes.High => candle.HighPrice,
+			AppliedPriceModes.Low => candle.LowPrice,
+			AppliedPriceModes.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+			AppliedPriceModes.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+			AppliedPriceModes.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
+			AppliedPriceModes.Average => (candle.OpenPrice + candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 4m,
 			_ => candle.ClosePrice,
 		};
 	}
@@ -573,7 +573,7 @@ public class ExpTrendMagicStrategy : Strategy
 	/// <summary>
 	/// Available money-management modes.
 	/// </summary>
-	public enum MarginModeOption
+	public enum MarginModeOptions
 	{
 		/// <summary>
 		/// Use the account free margin share.
@@ -604,7 +604,7 @@ public class ExpTrendMagicStrategy : Strategy
 	/// <summary>
 	/// Applied price options for the CCI input.
 	/// </summary>
-	public enum AppliedPriceMode
+	public enum AppliedPriceModes
 	{
 		/// <summary>
 		/// Close price.

--- a/API/3750_Frank_Ud_Minimal/CS/FrankUdMinimalStrategy.cs
+++ b/API/3750_Frank_Ud_Minimal/CS/FrankUdMinimalStrategy.cs
@@ -28,7 +28,7 @@ public class FrankUdMinimalStrategy : Strategy
 
 	private readonly List<PositionEntry> _longEntries = new();
 	private readonly List<PositionEntry> _shortEntries = new();
-	private readonly Dictionary<long, OrderAction> _orderActions = new();
+	private readonly Dictionary<long, OrderActions> _orderActions = new();
 
 	private decimal _pointValue;
 	private decimal _takeProfitThreshold;
@@ -239,7 +239,7 @@ public class FrankUdMinimalStrategy : Strategy
 		return;
 
 		var order = BuyMarket(volume);
-		RegisterOrder(order, OrderAction.OpenLong);
+		RegisterOrder(order, OrderActions.OpenLong);
 	}
 
 	private void OpenShortPosition()
@@ -249,7 +249,7 @@ public class FrankUdMinimalStrategy : Strategy
 		return;
 
 		var order = SellMarket(volume);
-		RegisterOrder(order, OrderAction.OpenShort);
+		RegisterOrder(order, OrderActions.OpenShort);
 	}
 
 	private void CloseLongPositions()
@@ -259,7 +259,7 @@ public class FrankUdMinimalStrategy : Strategy
 		return;
 
 		var order = SellMarket(volume);
-		RegisterOrder(order, OrderAction.CloseLong);
+		RegisterOrder(order, OrderActions.CloseLong);
 	}
 
 	private void CloseShortPositions()
@@ -269,10 +269,10 @@ public class FrankUdMinimalStrategy : Strategy
 		return;
 
 		var order = BuyMarket(volume);
-		RegisterOrder(order, OrderAction.CloseShort);
+		RegisterOrder(order, OrderActions.CloseShort);
 	}
 
-	private void RegisterOrder(Order order, OrderAction action)
+	private void RegisterOrder(Order order, OrderActions action)
 	{
 		if (order == null)
 		return;
@@ -293,19 +293,19 @@ public class FrankUdMinimalStrategy : Strategy
 
 		switch (action)
 		{
-			case OrderAction.OpenLong:
+			case OrderActions.OpenLong:
 			AddEntry(_longEntries, price, volume);
 			break;
 
-			case OrderAction.OpenShort:
+			case OrderActions.OpenShort:
 			AddEntry(_shortEntries, price, volume);
 			break;
 
-			case OrderAction.CloseLong:
+			case OrderActions.CloseLong:
 			RemoveVolume(_longEntries, volume);
 			break;
 
-			case OrderAction.CloseShort:
+			case OrderActions.CloseShort:
 			RemoveVolume(_shortEntries, volume);
 			break;
 		}
@@ -499,7 +499,7 @@ public class FrankUdMinimalStrategy : Strategy
 		}
 	}
 
-	private enum OrderAction
+	private enum OrderActions
 	{
 		OpenLong,
 		CloseLong,

--- a/API/3757_Cloudzs_Trade_2/CS/CloudzsTrade2Strategy.cs
+++ b/API/3757_Cloudzs_Trade_2/CS/CloudzsTrade2Strategy.cs
@@ -55,8 +55,8 @@ public class CloudzsTrade2Strategy : Strategy
 	private decimal _low3;
 	private decimal _low4;
 	private decimal _low5;
-	private FractalType? _latestFractal;
-	private FractalType? _previousFractal;
+	private FractalTypes? _latestFractal;
+	private FractalTypes? _previousFractal;
 	private int _fractalSeedCount;
 
 	private decimal? _stopPrice;
@@ -65,7 +65,7 @@ public class CloudzsTrade2Strategy : Strategy
 	private decimal _maxFavorableMove;
 	private DateTime? _lastExitDate;
 
-	private enum FractalType
+	private enum FractalTypes
 	{
 		Up,
 		Down
@@ -463,13 +463,13 @@ public class CloudzsTrade2Strategy : Strategy
 		var downFractal = _low3 < _low1 && _low3 < _low2 && _low3 < _low4 && _low3 < _low5;
 
 		if (upFractal)
-			RegisterFractal(FractalType.Up);
+			RegisterFractal(FractalTypes.Up);
 
 		if (downFractal)
-			RegisterFractal(FractalType.Down);
+			RegisterFractal(FractalTypes.Down);
 	}
 
-	private void RegisterFractal(FractalType type)
+	private void RegisterFractal(FractalTypes type)
 	{
 		_previousFractal = _latestFractal;
 		_latestFractal = type;
@@ -480,10 +480,10 @@ public class CloudzsTrade2Strategy : Strategy
 		if (_latestFractal is null || _previousFractal is null)
 			return 0;
 
-		if (_latestFractal == FractalType.Up && _previousFractal == FractalType.Up)
+		if (_latestFractal == FractalTypes.Up && _previousFractal == FractalTypes.Up)
 			return 2;
 
-		if (_latestFractal == FractalType.Down && _previousFractal == FractalType.Down)
+		if (_latestFractal == FractalTypes.Down && _previousFractal == FractalTypes.Down)
 			return 1;
 
 		return 0;

--- a/API/3759_DAlembert_Exposure_Balancer/CS/DAlembertExposureBalancerStrategy.cs
+++ b/API/3759_DAlembert_Exposure_Balancer/CS/DAlembertExposureBalancerStrategy.cs
@@ -261,9 +261,9 @@ public class DAlembertExposureBalancerStrategy : Strategy
 		_states.Clear();
 		_currencyExposure.Clear();
 
-		CreateState(EurUsd, InvertSignals ? SymbolBias.Sell : SymbolBias.Buy);
-		CreateState(EurGbp, InvertSignals ? SymbolBias.Buy : SymbolBias.Sell);
-		CreateState(GbpUsd, InvertSignals ? SymbolBias.Buy : SymbolBias.Sell);
+		CreateState(EurUsd, InvertSignals ? SymbolBiases.Sell : SymbolBiases.Buy);
+		CreateState(EurGbp, InvertSignals ? SymbolBiases.Buy : SymbolBiases.Sell);
+		CreateState(GbpUsd, InvertSignals ? SymbolBiases.Buy : SymbolBiases.Sell);
 
 		foreach (var state in _states.Values)
 		{
@@ -272,7 +272,7 @@ public class DAlembertExposureBalancerStrategy : Strategy
 		}
 	}
 
-	private void CreateState(Security security, SymbolBias bias)
+	private void CreateState(Security security, SymbolBiases bias)
 	{
 		if (security == null)
 		return;
@@ -316,11 +316,11 @@ public class DAlembertExposureBalancerStrategy : Strategy
 		var bullish = state.IsBullish;
 		var bearish = state.IsBearish;
 
-		if (bias == SymbolBias.Neutral)
+		if (bias == SymbolBiases.Neutral)
 		return;
 
-		var openLong = (bias == SymbolBias.Buy && bullish) || (bias == SymbolBias.Sell && bearish);
-		var openShort = (bias == SymbolBias.Sell && bullish) || (bias == SymbolBias.Buy && bearish);
+		var openLong = (bias == SymbolBiases.Buy && bullish) || (bias == SymbolBiases.Sell && bearish);
+		var openShort = (bias == SymbolBiases.Sell && bullish) || (bias == SymbolBiases.Buy && bearish);
 
 		var volume = CalculateVolume(state, 0m);
 		if (volume <= 0m)
@@ -587,7 +587,7 @@ public class DAlembertExposureBalancerStrategy : Strategy
 
 	private sealed class SymbolState
 	{
-		public SymbolState(Security security, SymbolBias bias, int startLevel)
+		public SymbolState(Security security, SymbolBiases bias, int startLevel)
 		{
 			Security = security;
 			Bias = bias;
@@ -595,7 +595,7 @@ public class DAlembertExposureBalancerStrategy : Strategy
 		}
 
 		public Security Security { get; }
-		public SymbolBias Bias { get; }
+		public SymbolBiases Bias { get; }
 		public decimal Position { get; set; }
 		public decimal? AverageEntryPrice { get; set; }
 		public decimal LastClosedPnL { get; set; }
@@ -629,7 +629,7 @@ public class DAlembertExposureBalancerStrategy : Strategy
 		}
 	}
 
-	private enum SymbolBias
+	private enum SymbolBiases
 	{
 		Neutral,
 		Buy,

--- a/API/3767_Zs1_Forex_Instruments/CS/Zs1ForexInstrumentsStrategy.cs
+++ b/API/3767_Zs1_Forex_Instruments/CS/Zs1ForexInstrumentsStrategy.cs
@@ -31,7 +31,7 @@ public class Zs1ForexInstrumentsStrategy : Strategy
 	private readonly StrategyParam<decimal> _initialVolume;
 	private readonly StrategyParam<decimal> _volumeTolerance;
 
-	private readonly Dictionary<Order, OrderIntent> _orderIntents = new();
+	private readonly Dictionary<Order, OrderIntents> _orderIntents = new();
 	private readonly List<Entry> _longEntries = new();
 	private readonly List<Entry> _shortEntries = new();
 
@@ -49,7 +49,7 @@ public class Zs1ForexInstrumentsStrategy : Strategy
 	private bool _hasBestBid;
 	private bool _hasBestAsk;
 
-	private enum OrderIntent
+	private enum OrderIntents
 	{
 		OpenLong,
 		OpenShort,
@@ -186,21 +186,21 @@ public class Zs1ForexInstrumentsStrategy : Strategy
 
 		switch (intent)
 		{
-			case OrderIntent.OpenLong:
+			case OrderIntents.OpenLong:
 				_longEntries.Add(new Entry(price, volume));
 				_lastOrderDirection = Sides.Buy;
 				break;
 
-			case OrderIntent.OpenShort:
+			case OrderIntents.OpenShort:
 				_shortEntries.Add(new Entry(price, volume));
 				_lastOrderDirection = Sides.Sell;
 				break;
 
-			case OrderIntent.CloseLong:
+			case OrderIntents.CloseLong:
 				ReduceEntries(_longEntries, volume);
 				break;
 
-			case OrderIntent.CloseShort:
+			case OrderIntents.CloseShort:
 				ReduceEntries(_shortEntries, volume);
 				break;
 		}
@@ -396,13 +396,13 @@ public class Zs1ForexInstrumentsStrategy : Strategy
 		var buyOrder = BuyMarket(volume);
 		if (buyOrder != null)
 		{
-			_orderIntents[buyOrder] = OrderIntent.OpenLong;
+			_orderIntents[buyOrder] = OrderIntents.OpenLong;
 		}
 
 		var sellOrder = SellMarket(volume);
 		if (sellOrder != null)
 		{
-			_orderIntents[sellOrder] = OrderIntent.OpenShort;
+			_orderIntents[sellOrder] = OrderIntents.OpenShort;
 		}
 
 		_firstStage = 1;
@@ -445,7 +445,7 @@ public class Zs1ForexInstrumentsStrategy : Strategy
 		var order = BuyMarket(volume);
 		if (order != null)
 		{
-			_orderIntents[order] = OrderIntent.OpenLong;
+			_orderIntents[order] = OrderIntents.OpenLong;
 		}
 	}
 
@@ -460,7 +460,7 @@ public class Zs1ForexInstrumentsStrategy : Strategy
 		var order = SellMarket(volume);
 		if (order != null)
 		{
-			_orderIntents[order] = OrderIntent.OpenShort;
+			_orderIntents[order] = OrderIntents.OpenShort;
 		}
 	}
 
@@ -518,13 +518,13 @@ public class Zs1ForexInstrumentsStrategy : Strategy
 		{
 			order = SellMarket(totalVolume);
 			if (order != null)
-				_orderIntents[order] = OrderIntent.CloseLong;
+				_orderIntents[order] = OrderIntents.CloseLong;
 		}
 		else
 		{
 			order = BuyMarket(totalVolume);
 			if (order != null)
-				_orderIntents[order] = OrderIntent.CloseShort;
+				_orderIntents[order] = OrderIntents.CloseShort;
 		}
 	}
 
@@ -539,13 +539,13 @@ public class Zs1ForexInstrumentsStrategy : Strategy
 		{
 			order = SellMarket(volume);
 			if (order != null)
-				_orderIntents[order] = OrderIntent.CloseLong;
+				_orderIntents[order] = OrderIntents.CloseLong;
 		}
 		else
 		{
 			order = BuyMarket(volume);
 			if (order != null)
-				_orderIntents[order] = OrderIntent.CloseShort;
+				_orderIntents[order] = OrderIntents.CloseShort;
 		}
 	}
 

--- a/API/3772_Universal_MA_Cross_V4/CS/UniversalMaCrossV4Strategy.cs
+++ b/API/3772_Universal_MA_Cross_V4/CS/UniversalMaCrossV4Strategy.cs
@@ -50,7 +50,7 @@ public class UniversalMaCrossV4Strategy : Strategy
 	private decimal? _slowPrevPrev;
 
 	private DateTimeOffset? _lastEntryBar;
-	private TradeDirection _lastTrade = TradeDirection.None;
+	private TradeDirections _lastTrade = TradeDirections.None;
 
 	private decimal? _entryPrice;
 	private decimal? _stopPrice;
@@ -331,7 +331,7 @@ public class UniversalMaCrossV4Strategy : Strategy
 		_slowPrev = null;
 		_slowPrevPrev = null;
 		_lastEntryBar = null;
-		_lastTrade = TradeDirection.None;
+		_lastTrade = TradeDirections.None;
 		_entryPrice = null;
 		_stopPrice = null;
 		_takeProfitPrice = null;
@@ -438,14 +438,14 @@ public class UniversalMaCrossV4Strategy : Strategy
 
 		if (StopAndReverse && Position != 0)
 		{
-			var reverseToShort = _lastTrade == TradeDirection.Long && sellSignal;
-			var reverseToLong = _lastTrade == TradeDirection.Short && buySignal;
+			var reverseToShort = _lastTrade == TradeDirections.Long && sellSignal;
+			var reverseToLong = _lastTrade == TradeDirections.Short && buySignal;
 
 			if (reverseToLong || reverseToShort)
 			{
 				ClosePosition();
 				ResetProtection();
-				_lastTrade = TradeDirection.None;
+				_lastTrade = TradeDirections.None;
 			}
 		}
 
@@ -459,14 +459,14 @@ public class UniversalMaCrossV4Strategy : Strategy
 		{
 			BuyMarket(TradeVolume);
 			SetProtectionLevels(candle.ClosePrice, true);
-			_lastTrade = TradeDirection.Long;
+			_lastTrade = TradeDirections.Long;
 			_lastEntryBar = candle.OpenTime;
 		}
 		else if (sellSignal)
 		{
 			SellMarket(TradeVolume);
 			SetProtectionLevels(candle.ClosePrice, false);
-			_lastTrade = TradeDirection.Short;
+			_lastTrade = TradeDirections.Short;
 			_lastEntryBar = candle.OpenTime;
 		}
 	}
@@ -636,7 +636,7 @@ public class UniversalMaCrossV4Strategy : Strategy
 		return points;
 	}
 
-	private enum TradeDirection
+	private enum TradeDirections
 	{
 		None,
 		Long,

--- a/API/3780_Starter_V6Mod_E/CS/StarterV6ModEStrategy.cs
+++ b/API/3780_Starter_V6Mod_E/CS/StarterV6ModEStrategy.cs
@@ -433,8 +433,8 @@ public class StarterV6ModEStrategy : Strategy
 			return;
 
 		var trendBias = EvaluateTrendBias(slope.Value);
-		var allowLong = trendBias == TrendBias.Bullish;
-		var allowShort = trendBias == TrendBias.Bearish;
+		var allowLong = trendBias == TrendBiases.Bullish;
+		var allowShort = trendBias == TrendBiases.Bearish;
 
 		var laguerreOkLong = prevLaguerre <= LaguerreOversold && laguerre <= LaguerreOversold;
 		var laguerreOkShort = prevLaguerre >= LaguerreOverbought && laguerre >= LaguerreOverbought;
@@ -610,13 +610,13 @@ public class StarterV6ModEStrategy : Strategy
 		return Orders.Any(o => o.State.IsActive());
 	}
 
-	private static TrendBias EvaluateTrendBias(decimal slope)
+	private static TrendBiases EvaluateTrendBias(decimal slope)
 	{
 		if (slope > 0)
-			return TrendBias.Bullish;
+			return TrendBiases.Bullish;
 		if (slope < 0)
-			return TrendBias.Bearish;
-		return TrendBias.Flat;
+			return TrendBiases.Bearish;
+		return TrendBiases.Flat;
 	}
 
 	/// <inheritdoc />
@@ -662,7 +662,7 @@ public class StarterV6ModEStrategy : Strategy
 		}
 	}
 
-	private enum TrendBias
+	private enum TrendBiases
 	{
 		Flat,
 		Bullish,

--- a/API/3793_Pedro_Mod/CS/PedroModStrategy.cs
+++ b/API/3793_Pedro_Mod/CS/PedroModStrategy.cs
@@ -34,7 +34,7 @@ public class PedroModStrategy : Strategy
 	private decimal _pointValue;
 	private decimal? _entryPrice;
 	private decimal? _reEntryPrice;
-	private TradeSide _lastDirection;
+	private TradeSides _lastDirection;
 	private decimal _bestBid;
 	private decimal _bestAsk;
 	private decimal _previousPosition;
@@ -223,7 +223,7 @@ public class PedroModStrategy : Strategy
 		_pointValue = 0m;
 		_entryPrice = null;
 		_reEntryPrice = null;
-		_lastDirection = TradeSide.None;
+		_lastDirection = TradeSides.None;
 		_bestBid = 0m;
 		_bestAsk = 0m;
 		_previousPosition = 0m;
@@ -255,7 +255,7 @@ public class PedroModStrategy : Strategy
 
 		if (Position == 0m)
 		{
-			_lastDirection = TradeSide.None;
+			_lastDirection = TradeSides.None;
 		}
 	}
 
@@ -313,7 +313,7 @@ public class PedroModStrategy : Strategy
 				_entryPrice = _bestAsk;
 				// When a fresh session starts no averaging is allowed yet.
 				_reEntryPrice = null;
-				_lastDirection = TradeSide.None;
+				_lastDirection = TradeSides.None;
 			}
 			else
 			{
@@ -336,7 +336,7 @@ public class PedroModStrategy : Strategy
 			// Price moved up far enough to trigger a contrarian sell order.
 			if (TryOpenSell())
 			{
-				_lastDirection = TradeSide.Sell;
+				_lastDirection = TradeSides.Sell;
 				_reEntryPrice = _bestAsk;
 				_entryPrice = null;
 			}
@@ -348,7 +348,7 @@ public class PedroModStrategy : Strategy
 			// Price dropped enough to trigger a contrarian buy order.
 			if (TryOpenBuy())
 			{
-				_lastDirection = TradeSide.Buy;
+				_lastDirection = TradeSides.Buy;
 				_reEntryPrice = _bestAsk;
 				_entryPrice = null;
 			}
@@ -369,7 +369,7 @@ public class PedroModStrategy : Strategy
 		var reference = _reEntryPrice.Value;
 		var nextCount = openTrades + 1;
 
-		if (_lastDirection == TradeSide.Buy)
+		if (_lastDirection == TradeSides.Buy)
 		{
 			// Keep adding to the long basket while the price stays near the reference.
 			if (_bestAsk <= reference + reEntryDistance && TryOpenBuy())
@@ -377,7 +377,7 @@ public class PedroModStrategy : Strategy
 				_reEntryPrice = nextCount < MaxTrades ? _bestAsk : null;
 			}
 		}
-		else if (_lastDirection == TradeSide.Sell)
+		else if (_lastDirection == TradeSides.Sell)
 		{
 			// Mirror logic for the short basket.
 			if (_bestAsk >= reference - reEntryDistance && TryOpenSell())
@@ -567,10 +567,10 @@ public class PedroModStrategy : Strategy
 	{
 		_entryPrice = null;
 		_reEntryPrice = null;
-		_lastDirection = TradeSide.None;
+		_lastDirection = TradeSides.None;
 	}
 
-	private enum TradeSide
+	private enum TradeSides
 	{
 		None,
 		Buy,

--- a/API/3814_Avalanche/CS/AvalancheStrategy.cs
+++ b/API/3814_Avalanche/CS/AvalancheStrategy.cs
@@ -55,7 +55,7 @@ public class AvalancheStrategy : Strategy
 	private SMA _erpSma;
 	private decimal? _currentErp;
 	private decimal _pipSize;
-	private ErpPosition _erpPosition;
+	private ErpPositions _erpPosition;
 	private Sides? _interestSide;
 	private Sides? _gridDirection;
 	private Sides? _pendingEntrySide;
@@ -64,7 +64,7 @@ public class AvalancheStrategy : Strategy
 	private bool _startingOrdersOpened;
 	private bool _isClosingAll;
 
-	private enum ErpPosition
+	private enum ErpPositions
 	{
 		None,
 		Above,
@@ -263,7 +263,7 @@ public class AvalancheStrategy : Strategy
 		_erpSma = null;
 		_currentErp = null;
 		_pipSize = 0m;
-		_erpPosition = ErpPosition.None;
+		_erpPosition = ErpPositions.None;
 		_interestSide = null;
 		_gridDirection = null;
 		_pendingEntrySide = null;
@@ -342,10 +342,10 @@ public class AvalancheStrategy : Strategy
 		if (_isClosingAll)
 			return;
 
-		if (_erpPosition == ErpPosition.None)
+		if (_erpPosition == ErpPositions.None)
 			return;
 
-		var desiredSide = _erpPosition == ErpPosition.Below ? Sides.Buy : Sides.Sell;
+		var desiredSide = _erpPosition == ErpPositions.Below ? Sides.Buy : Sides.Sell;
 
 		if (_entries.Count == 0)
 		{
@@ -358,20 +358,20 @@ public class AvalancheStrategy : Strategy
 		HandleGridEntries(desiredSide, candle.ClosePrice);
 	}
 
-	private ErpPosition DetermineErpPosition(decimal price, decimal erp)
+	private ErpPositions DetermineErpPosition(decimal price, decimal erp)
 	{
 		var buffer = ErpChangeBuffer * _pipSize;
 
 		return _erpPosition switch
 		{
-			ErpPosition.None => price >= erp ? ErpPosition.Above : ErpPosition.Below,
-			ErpPosition.Above => price >= erp - buffer ? ErpPosition.Above : ErpPosition.Below,
-			ErpPosition.Below => price >= erp + buffer ? ErpPosition.Above : ErpPosition.Below,
-			_ => ErpPosition.None,
+			ErpPositions.None => price >= erp ? ErpPositions.Above : ErpPositions.Below,
+			ErpPositions.Above => price >= erp - buffer ? ErpPositions.Above : ErpPositions.Below,
+			ErpPositions.Below => price >= erp + buffer ? ErpPositions.Above : ErpPositions.Below,
+			_ => ErpPositions.None,
 		};
 	}
 
-	private void OnErpPositionChanged(ErpPosition newPosition, decimal price)
+	private void OnErpPositionChanged(ErpPositions newPosition, decimal price)
 	{
 		var previous = _erpPosition;
 		_erpPosition = newPosition;

--- a/API/3815_Simple_FX_Crossover/CS/SimpleFxCrossoverStrategy.cs
+++ b/API/3815_Simple_FX_Crossover/CS/SimpleFxCrossoverStrategy.cs
@@ -21,7 +21,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class SimpleFxCrossoverStrategy : Strategy
 {
-	private enum TrendDirection
+	private enum TrendDirections
 	{
 		None,
 		Bullish,
@@ -39,7 +39,7 @@ public class SimpleFxCrossoverStrategy : Strategy
 
 	private decimal? _previousShortValue;
 	private decimal? _previousLongValue;
-	private TrendDirection _lastTrend = TrendDirection.None;
+	private TrendDirections _lastTrend = TrendDirections.None;
 
 	/// <summary>
 /// Initializes a new instance of the <see cref="SimpleFxCrossoverStrategy"/> class.
@@ -130,7 +130,7 @@ public SimpleFxCrossoverStrategy()
 
 		_previousShortValue = null;
 		_previousLongValue = null;
-		_lastTrend = TrendDirection.None;
+		_lastTrend = TrendDirections.None;
 	}
 
 	/// <inheritdoc />
@@ -173,27 +173,27 @@ public SimpleFxCrossoverStrategy()
 		var previousShort = _previousShortValue;
 		var previousLong = _previousLongValue;
 
-		TrendDirection currentTrend = TrendDirection.None;
+		TrendDirections currentTrend = TrendDirections.None;
 
 		if (previousShort is decimal prevShort && previousLong is decimal prevLong)
 		{
 			if (shortMaValue > longMaValue && prevShort > prevLong)
 			{
-				currentTrend = TrendDirection.Bullish;
+				currentTrend = TrendDirections.Bullish;
 			}
 			else if (shortMaValue < longMaValue && prevShort < prevLong)
 			{
-				currentTrend = TrendDirection.Bearish;
+				currentTrend = TrendDirections.Bearish;
 			}
 		}
 
 		_previousShortValue = shortMaValue;
 		_previousLongValue = longMaValue;
 
-		if (currentTrend == TrendDirection.None)
+		if (currentTrend == TrendDirections.None)
 			return;
 
-		if (_lastTrend == TrendDirection.None)
+		if (_lastTrend == TrendDirections.None)
 		{
 			_lastTrend = currentTrend;
 			return;
@@ -203,16 +203,16 @@ public SimpleFxCrossoverStrategy()
 			return;
 
 		// Close the opposite position before opening a new trade.
-		if (Position > 0 && currentTrend == TrendDirection.Bearish)
+		if (Position > 0 && currentTrend == TrendDirections.Bearish)
 		{
 			ClosePosition();
 		}
-		else if (Position < 0 && currentTrend == TrendDirection.Bullish)
+		else if (Position < 0 && currentTrend == TrendDirections.Bullish)
 		{
 			ClosePosition();
 		}
 
-		if (currentTrend == TrendDirection.Bullish && Position <= 0)
+		if (currentTrend == TrendDirections.Bullish && Position <= 0)
 		{
 			// Fast MA crossed above the slow MA for at least two candles -> open long.
 			BuyMarket(Volume);
@@ -221,7 +221,7 @@ public SimpleFxCrossoverStrategy()
 			return;
 		}
 
-		if (currentTrend == TrendDirection.Bearish && Position >= 0)
+		if (currentTrend == TrendDirections.Bearish && Position >= 0)
 		{
 			// Fast MA crossed below the slow MA for at least two candles -> open short.
 			SellMarket(Volume);

--- a/API/3818_Bago_EA/CS/BagoEaClassicStrategy.cs
+++ b/API/3818_Bago_EA/CS/BagoEaClassicStrategy.cs
@@ -40,10 +40,10 @@ public class BagoEaClassicStrategy : Strategy
 	private readonly StrategyParam<int> _fastPeriod;
 	private readonly StrategyParam<int> _slowPeriod;
 	private readonly StrategyParam<int> _maShift;
-	private readonly StrategyParam<MovingAverageType> _maMethod;
-	private readonly StrategyParam<AppliedPriceType> _maAppliedPrice;
+	private readonly StrategyParam<MovingAverageTypes> _maMethod;
+	private readonly StrategyParam<AppliedPriceTypes> _maAppliedPrice;
 	private readonly StrategyParam<int> _rsiPeriod;
-	private readonly StrategyParam<AppliedPriceType> _rsiAppliedPrice;
+	private readonly StrategyParam<AppliedPriceTypes> _rsiAppliedPrice;
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<int> _historyLimit;
 	private readonly StrategyParam<decimal> _fiftyLevel;
@@ -157,17 +157,17 @@ public class BagoEaClassicStrategy : Strategy
 		_maShift = Param(nameof(MaShift), 0)
 		.SetDisplay("MA Shift", "Horizontal displacement in bars", "Indicator");
 
-		_maMethod = Param(nameof(MaMethod), MovingAverageType.Exponential)
+		_maMethod = Param(nameof(MaMethod), MovingAverageTypes.Exponential)
 		.SetDisplay("MA Method", "Moving average calculation mode", "Indicator");
 
-		_maAppliedPrice = Param(nameof(MaAppliedPrice), AppliedPriceType.Close)
+		_maAppliedPrice = Param(nameof(MaAppliedPrice), AppliedPriceTypes.Close)
 		.SetDisplay("MA Price", "Applied price for moving averages", "Indicator");
 
 		_rsiPeriod = Param(nameof(RsiPeriod), 21)
 		.SetGreaterThanZero()
 		.SetDisplay("RSI Period", "RSI averaging length", "Indicator");
 
-		_rsiAppliedPrice = Param(nameof(RsiAppliedPrice), AppliedPriceType.Close)
+		_rsiAppliedPrice = Param(nameof(RsiAppliedPrice), AppliedPriceTypes.Close)
 		.SetDisplay("RSI Price", "Applied price for RSI", "Indicator");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(1).TimeFrame())
@@ -345,7 +345,7 @@ public int MaShift
 /// <summary>
 /// Moving average calculation method.
 /// </summary>
-public MovingAverageType MaMethod
+public MovingAverageTypes MaMethod
 {
 	get => _maMethod.Value;
 	set => _maMethod.Value = value;
@@ -354,7 +354,7 @@ public MovingAverageType MaMethod
 /// <summary>
 /// Applied price for the moving averages.
 /// </summary>
-public AppliedPriceType MaAppliedPrice
+public AppliedPriceTypes MaAppliedPrice
 {
 	get => _maAppliedPrice.Value;
 	set => _maAppliedPrice.Value = value;
@@ -372,7 +372,7 @@ public int RsiPeriod
 /// <summary>
 /// Applied price for the RSI indicator.
 /// </summary>
-public AppliedPriceType RsiAppliedPrice
+public AppliedPriceTypes RsiAppliedPrice
 {
 	get => _rsiAppliedPrice.Value;
 	set => _rsiAppliedPrice.Value = value;
@@ -992,27 +992,27 @@ else if (belowTunnel && prevAbove)
 }
 }
 
-private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPriceType type)
+private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPriceTypes type)
 {
 	return type switch
 	{
-		AppliedPriceType.Open => candle.OpenPrice,
-		AppliedPriceType.High => candle.HighPrice,
-		AppliedPriceType.Low => candle.LowPrice,
-		AppliedPriceType.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-		AppliedPriceType.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-		AppliedPriceType.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
+		AppliedPriceTypes.Open => candle.OpenPrice,
+		AppliedPriceTypes.High => candle.HighPrice,
+		AppliedPriceTypes.Low => candle.LowPrice,
+		AppliedPriceTypes.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+		AppliedPriceTypes.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+		AppliedPriceTypes.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
 		_ => candle.ClosePrice,
 	};
 }
 
-private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageType type, int length)
+private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageTypes type, int length)
 {
 	return type switch
 	{
-		MovingAverageType.Simple => new SimpleMovingAverage { Length = length },
-		MovingAverageType.Smoothed => new SmoothedMovingAverage { Length = length },
-		MovingAverageType.LinearWeighted => new WeightedMovingAverage { Length = length },
+		MovingAverageTypes.Simple => new SimpleMovingAverage { Length = length },
+		MovingAverageTypes.Smoothed => new SmoothedMovingAverage { Length = length },
+		MovingAverageTypes.LinearWeighted => new WeightedMovingAverage { Length = length },
 		_ => new ExponentialMovingAverage { Length = length },
 	};
 }
@@ -1100,7 +1100,7 @@ public decimal Close { get; }
 /// <summary>
 /// Moving average calculation options supported by the strategy.
 /// </summary>
-public enum MovingAverageType
+public enum MovingAverageTypes
 {
 	/// <summary>
 	/// Simple moving average.
@@ -1126,7 +1126,7 @@ public enum MovingAverageType
 /// <summary>
 /// Price extraction modes replicated from MetaTrader.
 /// </summary>
-public enum AppliedPriceType
+public enum AppliedPriceTypes
 {
 	/// <summary>
 	/// Closing price.

--- a/API/3822_BreakOut15/CS/BreakOut15Strategy.cs
+++ b/API/3822_BreakOut15/CS/BreakOut15Strategy.cs
@@ -26,7 +26,7 @@ public class BreakOut15Strategy : Strategy
 	private readonly StrategyParam<decimal> _takeProfitPips;
 	private readonly StrategyParam<decimal> _stopLossPips;
 	private readonly StrategyParam<bool> _useTrailingStop;
-	private readonly StrategyParam<TrailingStopMode> _trailingStopType;
+	private readonly StrategyParam<TrailingStopModes> _trailingStopType;
 	private readonly StrategyParam<decimal> _trailingStopPips;
 	private readonly StrategyParam<decimal> _level1TriggerPips;
 	private readonly StrategyParam<decimal> _level1StopPips;
@@ -34,15 +34,15 @@ public class BreakOut15Strategy : Strategy
 	private readonly StrategyParam<decimal> _level2StopPips;
 	private readonly StrategyParam<decimal> _level3TriggerPips;
 	private readonly StrategyParam<decimal> _level3TrailingPips;
-	private readonly StrategyParam<MovingAverageMethod> _fastMethod;
+	private readonly StrategyParam<MovingAverageMethods> _fastMethod;
 	private readonly StrategyParam<int> _fastPeriod;
 	private readonly StrategyParam<int> _fastShift;
-	private readonly StrategyParam<AppliedPrice> _fastPriceType;
-	private readonly StrategyParam<MovingAverageMethod> _slowMethod;
+	private readonly StrategyParam<AppliedPrices> _fastPriceType;
+	private readonly StrategyParam<MovingAverageMethods> _slowMethod;
 	private readonly StrategyParam<int> _slowPeriod;
 	private readonly StrategyParam<int> _slowShift;
 	private readonly StrategyParam<int> _signalBarShift;
-	private readonly StrategyParam<AppliedPrice> _slowPriceType;
+	private readonly StrategyParam<AppliedPrices> _slowPriceType;
 	private readonly StrategyParam<decimal> _breakoutLevelPips;
 	private readonly StrategyParam<bool> _useTimeLimit;
 	private readonly StrategyParam<int> _startHour;
@@ -96,7 +96,7 @@ public class BreakOut15Strategy : Strategy
 		_useTrailingStop = Param(nameof(UseTrailingStop), true)
 			.SetDisplay("Use Trailing Stop", "Activate trailing stop logic", "Risk");
 
-		_trailingStopType = Param(nameof(TrailingStopType), TrailingStopMode.Delayed)
+		_trailingStopType = Param(nameof(TrailingStopType), TrailingStopModes.Delayed)
 			.SetDisplay("Trailing Stop Type", "Select trailing stop behavior", "Risk");
 
 		_trailingStopPips = Param(nameof(TrailingStopPips), 45m)
@@ -120,7 +120,7 @@ public class BreakOut15Strategy : Strategy
 		_level3TrailingPips = Param(nameof(Level3TrailingPips), 20m)
 			.SetDisplay("Level 3 Trailing", "Distance maintained once the third level is active", "Risk");
 
-		_fastMethod = Param(nameof(FastMethod), MovingAverageMethod.Exponential)
+		_fastMethod = Param(nameof(FastMethod), MovingAverageMethods.Exponential)
 			.SetDisplay("Fast MA Method", "Calculation method for the fast average", "Indicators");
 
 		_fastPeriod = Param(nameof(FastPeriod), 10)
@@ -130,10 +130,10 @@ public class BreakOut15Strategy : Strategy
 		_fastShift = Param(nameof(FastShift), 0)
 			.SetDisplay("Fast MA Shift", "Bar shift applied to the fast average", "Indicators");
 
-		_fastPriceType = Param(nameof(FastPriceType), AppliedPrice.Close)
+		_fastPriceType = Param(nameof(FastPriceType), AppliedPrices.Close)
 			.SetDisplay("Fast MA Price", "Applied price for the fast average", "Indicators");
 
-		_slowMethod = Param(nameof(SlowMethod), MovingAverageMethod.Exponential)
+		_slowMethod = Param(nameof(SlowMethod), MovingAverageMethods.Exponential)
 			.SetDisplay("Slow MA Method", "Calculation method for the slow average", "Indicators");
 
 		_slowPeriod = Param(nameof(SlowPeriod), 80)
@@ -146,7 +146,7 @@ public class BreakOut15Strategy : Strategy
 			.SetDisplay("Signal Bar Shift", "Offset applied when evaluating breakout signals", "Indicators")
 			.SetNotNegative();
 
-		_slowPriceType = Param(nameof(SlowPriceType), AppliedPrice.Close)
+		_slowPriceType = Param(nameof(SlowPriceType), AppliedPrices.Close)
 			.SetDisplay("Slow MA Price", "Applied price for the slow average", "Indicators");
 
 		_breakoutLevelPips = Param(nameof(BreakoutLevelPips), 35m)
@@ -241,7 +241,7 @@ public class BreakOut15Strategy : Strategy
 	/// <summary>
 	/// Trailing stop behavior type.
 	/// </summary>
-	public TrailingStopMode TrailingStopType
+	public TrailingStopModes TrailingStopType
 	{
 		get => _trailingStopType.Value;
 		set => _trailingStopType.Value = value;
@@ -313,7 +313,7 @@ public class BreakOut15Strategy : Strategy
 	/// <summary>
 	/// Moving average method for the fast line.
 	/// </summary>
-	public MovingAverageMethod FastMethod
+	public MovingAverageMethods FastMethod
 	{
 		get => _fastMethod.Value;
 		set => _fastMethod.Value = value;
@@ -340,7 +340,7 @@ public class BreakOut15Strategy : Strategy
 	/// <summary>
 	/// Applied price for the fast moving average.
 	/// </summary>
-	public AppliedPrice FastPriceType
+	public AppliedPrices FastPriceType
 	{
 		get => _fastPriceType.Value;
 		set => _fastPriceType.Value = value;
@@ -349,7 +349,7 @@ public class BreakOut15Strategy : Strategy
 	/// <summary>
 	/// Moving average method for the slow line.
 	/// </summary>
-	public MovingAverageMethod SlowMethod
+	public MovingAverageMethods SlowMethod
 	{
 		get => _slowMethod.Value;
 		set => _slowMethod.Value = value;
@@ -384,7 +384,7 @@ public class BreakOut15Strategy : Strategy
 	/// <summary>
 	/// Applied price for the slow moving average.
 	/// </summary>
-	public AppliedPrice SlowPriceType
+	public AppliedPrices SlowPriceType
 	{
 		get => _slowPriceType.Value;
 		set => _slowPriceType.Value = value;
@@ -713,13 +713,13 @@ var takeHit = _shortTakeProfitPrice.HasValue && candle.LowPrice <= _shortTakePro
 
 		switch (TrailingStopType)
 		{
-			case TrailingStopMode.Immediate:
+			case TrailingStopModes.Immediate:
 				ApplyLongImmediateTrailing(current, step);
 				break;
-			case TrailingStopMode.Delayed:
+			case TrailingStopModes.Delayed:
 				ApplyLongDelayedTrailing(current, step, entry);
 				break;
-			case TrailingStopMode.MultiLevel:
+			case TrailingStopModes.MultiLevel:
 				ApplyLongMultiLevelTrailing(entry, current, step);
 				break;
 		}
@@ -788,13 +788,13 @@ var takeHit = _shortTakeProfitPrice.HasValue && candle.LowPrice <= _shortTakePro
 
 		switch (TrailingStopType)
 		{
-			case TrailingStopMode.Immediate:
+			case TrailingStopModes.Immediate:
 				ApplyShortImmediateTrailing(current, step);
 				break;
-			case TrailingStopMode.Delayed:
+			case TrailingStopModes.Delayed:
 				ApplyShortDelayedTrailing(current, step, entry);
 				break;
-			case TrailingStopMode.MultiLevel:
+			case TrailingStopModes.MultiLevel:
 				ApplyShortMultiLevelTrailing(entry, current, step);
 				break;
 		}
@@ -960,17 +960,17 @@ var takeHit = _shortTakeProfitPrice.HasValue && candle.LowPrice <= _shortTakePro
 		return Security?.PriceStep ?? 0m;
 	}
 
-	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPrice priceType)
+	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPrices priceType)
 	{
 		return priceType switch
 		{
-			AppliedPrice.Close => candle.ClosePrice,
-			AppliedPrice.Open => candle.OpenPrice,
-			AppliedPrice.High => candle.HighPrice,
-			AppliedPrice.Low => candle.LowPrice,
-			AppliedPrice.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-			AppliedPrice.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-			AppliedPrice.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice + candle.ClosePrice) / 4m,
+			AppliedPrices.Close => candle.ClosePrice,
+			AppliedPrices.Open => candle.OpenPrice,
+			AppliedPrices.High => candle.HighPrice,
+			AppliedPrices.Low => candle.LowPrice,
+			AppliedPrices.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+			AppliedPrices.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+			AppliedPrices.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice + candle.ClosePrice) / 4m,
 			_ => candle.ClosePrice,
 		};
 	}
@@ -1004,15 +1004,15 @@ var takeHit = _shortTakeProfitPrice.HasValue && candle.LowPrice <= _shortTakePro
 		return index >= 0 ? history[index] : null;
 	}
 
-	private static IndicatorBase<decimal> CreateMovingAverage(MovingAverageMethod method, int length)
+	private static IndicatorBase<decimal> CreateMovingAverage(MovingAverageMethods method, int length)
 	{
 		return method switch
 		{
-			MovingAverageMethod.Simple => new SimpleMovingAverage { Length = length },
-			MovingAverageMethod.Exponential => new ExponentialMovingAverage { Length = length },
-			MovingAverageMethod.Smoothed => new SmoothedMovingAverage { Length = length },
-			MovingAverageMethod.LinearWeighted => new WeightedMovingAverage { Length = length },
-			MovingAverageMethod.LeastSquares => new LinearRegression { Length = length },
+			MovingAverageMethods.Simple => new SimpleMovingAverage { Length = length },
+			MovingAverageMethods.Exponential => new ExponentialMovingAverage { Length = length },
+			MovingAverageMethods.Smoothed => new SmoothedMovingAverage { Length = length },
+			MovingAverageMethods.LinearWeighted => new WeightedMovingAverage { Length = length },
+			MovingAverageMethods.LeastSquares => new LinearRegression { Length = length },
 			_ => new SimpleMovingAverage { Length = length }
 		};
 	}
@@ -1020,7 +1020,7 @@ var takeHit = _shortTakeProfitPrice.HasValue && candle.LowPrice <= _shortTakePro
 	/// <summary>
 	/// Supported moving average calculation methods.
 	/// </summary>
-	public enum MovingAverageMethod
+	public enum MovingAverageMethods
 	{
 		/// <summary>Simple moving average.</summary>
 		Simple,
@@ -1037,7 +1037,7 @@ var takeHit = _shortTakeProfitPrice.HasValue && candle.LowPrice <= _shortTakePro
 	/// <summary>
 	/// Price selection compatible with MetaTrader applied price modes.
 	/// </summary>
-	public enum AppliedPrice
+	public enum AppliedPrices
 	{
 		/// <summary>Use the closing price of the candle.</summary>
 		Close,
@@ -1058,7 +1058,7 @@ var takeHit = _shortTakeProfitPrice.HasValue && candle.LowPrice <= _shortTakePro
 	/// <summary>
 	/// Trailing stop configurations available in the strategy.
 	/// </summary>
-	public enum TrailingStopMode
+	public enum TrailingStopModes
 	{
 		/// <summary>Adjust stops as soon as price moves by the stop-loss distance.</summary>
 		Immediate,

--- a/API/3830_DoubleMA_Breakout/CS/DoubleMaBreakoutStrategy.cs
+++ b/API/3830_DoubleMA_Breakout/CS/DoubleMaBreakoutStrategy.cs
@@ -22,10 +22,10 @@ public class DoubleMaBreakoutStrategy : Strategy
 {
 	private readonly StrategyParam<int> _fastMaPeriod;
 	private readonly StrategyParam<int> _slowMaPeriod;
-	private readonly StrategyParam<MovingAverageMode> _fastMaMode;
-	private readonly StrategyParam<MovingAverageMode> _slowMaMode;
-	private readonly StrategyParam<AppliedPriceMode> _fastAppliedPrice;
-	private readonly StrategyParam<AppliedPriceMode> _slowAppliedPrice;
+	private readonly StrategyParam<MovingAverageModes> _fastMaMode;
+	private readonly StrategyParam<MovingAverageModes> _slowMaMode;
+	private readonly StrategyParam<AppliedPriceModes> _fastAppliedPrice;
+	private readonly StrategyParam<AppliedPriceModes> _slowAppliedPrice;
 	private readonly StrategyParam<int> _signalShift;
 	private readonly StrategyParam<decimal> _breakoutDistancePoints;
 	private readonly StrategyParam<bool> _useTimeWindow;
@@ -69,7 +69,7 @@ public class DoubleMaBreakoutStrategy : Strategy
 	/// <summary>
 	/// Fast moving average calculation mode.
 	/// </summary>
-	public MovingAverageMode FastMaMode
+	public MovingAverageModes FastMaMode
 	{
 		get => _fastMaMode.Value;
 		set => _fastMaMode.Value = value;
@@ -78,7 +78,7 @@ public class DoubleMaBreakoutStrategy : Strategy
 	/// <summary>
 	/// Slow moving average calculation mode.
 	/// </summary>
-	public MovingAverageMode SlowMaMode
+	public MovingAverageModes SlowMaMode
 	{
 		get => _slowMaMode.Value;
 		set => _slowMaMode.Value = value;
@@ -87,7 +87,7 @@ public class DoubleMaBreakoutStrategy : Strategy
 	/// <summary>
 	/// Price source for the fast moving average.
 	/// </summary>
-	public AppliedPriceMode FastAppliedPrice
+	public AppliedPriceModes FastAppliedPrice
 	{
 		get => _fastAppliedPrice.Value;
 		set => _fastAppliedPrice.Value = value;
@@ -96,7 +96,7 @@ public class DoubleMaBreakoutStrategy : Strategy
 	/// <summary>
 	/// Price source for the slow moving average.
 	/// </summary>
-	public AppliedPriceMode SlowAppliedPrice
+	public AppliedPriceModes SlowAppliedPrice
 	{
 		get => _slowAppliedPrice.Value;
 		set => _slowAppliedPrice.Value = value;
@@ -209,16 +209,16 @@ public class DoubleMaBreakoutStrategy : Strategy
 			.SetCanOptimize(true)
 			.SetOptimize(5, 60, 5);
 
-		_fastMaMode = Param(nameof(FastMaMode), MovingAverageMode.Simple)
+		_fastMaMode = Param(nameof(FastMaMode), MovingAverageModes.Simple)
 			.SetDisplay("Fast MA Mode", "Type of the fast moving average", "Moving Averages");
 
-		_slowMaMode = Param(nameof(SlowMaMode), MovingAverageMode.Simple)
+		_slowMaMode = Param(nameof(SlowMaMode), MovingAverageModes.Simple)
 			.SetDisplay("Slow MA Mode", "Type of the slow moving average", "Moving Averages");
 
-		_fastAppliedPrice = Param(nameof(FastAppliedPrice), AppliedPriceMode.Close)
+		_fastAppliedPrice = Param(nameof(FastAppliedPrice), AppliedPriceModes.Close)
 			.SetDisplay("Fast Price", "Applied price for the fast MA", "Moving Averages");
 
-		_slowAppliedPrice = Param(nameof(SlowAppliedPrice), AppliedPriceMode.Close)
+		_slowAppliedPrice = Param(nameof(SlowAppliedPrice), AppliedPriceModes.Close)
 			.SetDisplay("Slow Price", "Applied price for the slow MA", "Moving Averages");
 
 		_signalShift = Param(nameof(SignalShift), 1)
@@ -411,16 +411,16 @@ public class DoubleMaBreakoutStrategy : Strategy
 
 	private bool ValidateIndicators()
 	{
-		if (FastMaMode == MovingAverageMode.LeastSquares && _fastLsma == null)
+		if (FastMaMode == MovingAverageModes.LeastSquares && _fastLsma == null)
 			return false;
 
-		if (FastMaMode != MovingAverageMode.LeastSquares && _fastMa == null)
+		if (FastMaMode != MovingAverageModes.LeastSquares && _fastMa == null)
 			return false;
 
-		if (SlowMaMode == MovingAverageMode.LeastSquares && _slowLsma == null)
+		if (SlowMaMode == MovingAverageModes.LeastSquares && _slowLsma == null)
 			return false;
 
-		if (SlowMaMode != MovingAverageMode.LeastSquares && _slowMa == null)
+		if (SlowMaMode != MovingAverageModes.LeastSquares && _slowMa == null)
 			return false;
 
 		return true;
@@ -567,30 +567,30 @@ public class DoubleMaBreakoutStrategy : Strategy
 		return values[^required];
 	}
 
-	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPriceMode mode)
+	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPriceModes mode)
 	{
 		return mode switch
 		{
-			AppliedPriceMode.Open => candle.OpenPrice,
-			AppliedPriceMode.High => candle.HighPrice,
-			AppliedPriceMode.Low => candle.LowPrice,
-			AppliedPriceMode.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-			AppliedPriceMode.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-			AppliedPriceMode.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
+			AppliedPriceModes.Open => candle.OpenPrice,
+			AppliedPriceModes.High => candle.HighPrice,
+			AppliedPriceModes.Low => candle.LowPrice,
+			AppliedPriceModes.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+			AppliedPriceModes.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+			AppliedPriceModes.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
 			_ => candle.ClosePrice,
 		};
 	}
 
-	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageMode mode, int length, out LinearRegression lsma)
+	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageModes mode, int length, out LinearRegression lsma)
 	{
 		lsma = null;
 		return mode switch
 		{
-			MovingAverageMode.Simple => new SimpleMovingAverage { Length = length },
-			MovingAverageMode.Exponential => new ExponentialMovingAverage { Length = length },
-			MovingAverageMode.Smoothed => new SmoothedMovingAverage { Length = length },
-			MovingAverageMode.LinearWeighted => new WeightedMovingAverage { Length = length },
-			MovingAverageMode.LeastSquares => lsma = new LinearRegression { Length = length },
+			MovingAverageModes.Simple => new SimpleMovingAverage { Length = length },
+			MovingAverageModes.Exponential => new ExponentialMovingAverage { Length = length },
+			MovingAverageModes.Smoothed => new SmoothedMovingAverage { Length = length },
+			MovingAverageModes.LinearWeighted => new WeightedMovingAverage { Length = length },
+			MovingAverageModes.LeastSquares => lsma = new LinearRegression { Length = length },
 			_ => new SimpleMovingAverage { Length = length },
 		};
 	}
@@ -598,7 +598,7 @@ public class DoubleMaBreakoutStrategy : Strategy
 	/// <summary>
 	/// Available moving average types matching the original EA modes.
 	/// </summary>
-	public enum MovingAverageMode
+	public enum MovingAverageModes
 	{
 		Simple = 0,
 		Exponential = 1,
@@ -610,7 +610,7 @@ public class DoubleMaBreakoutStrategy : Strategy
 	/// <summary>
 	/// Applied price selection options.
 	/// </summary>
-	public enum AppliedPriceMode
+	public enum AppliedPriceModes
 	{
 		Close = 0,
 		Open = 1,

--- a/API/3832_Envelope_Limit_Ladder/CS/EnvelopeLimitLadderStrategy.cs
+++ b/API/3832_Envelope_Limit_Ladder/CS/EnvelopeLimitLadderStrategy.cs
@@ -24,7 +24,7 @@ public class EnvelopeLimitLadderStrategy : Strategy
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<DataType> _envelopeCandleType;
 	private readonly StrategyParam<int> _envelopePeriod;
-	private readonly StrategyParam<EnvelopeMaMethod> _maMethod;
+	private readonly StrategyParam<EnvelopeMaMethods> _maMethod;
 	private readonly StrategyParam<decimal> _envelopeDeviation;
 	private readonly StrategyParam<int> _tradingStartHour;
 	private readonly StrategyParam<int> _tradingEndHour;
@@ -73,7 +73,7 @@ public class EnvelopeLimitLadderStrategy : Strategy
 	/// <summary>
 	/// Moving average method matching the MetaTrader <c>MODE_*</c> options.
 	/// </summary>
-	public EnvelopeMaMethod MaMethod
+	public EnvelopeMaMethods MaMethod
 	{
 		get => _maMethod.Value;
 		set => _maMethod.Value = value;
@@ -166,7 +166,7 @@ public class EnvelopeLimitLadderStrategy : Strategy
 		.SetGreaterThanZero()
 		.SetDisplay("Envelope period", "Moving average period of the envelope.", "Indicator");
 
-		_maMethod = Param(nameof(MaMethod), EnvelopeMaMethod.Ema)
+		_maMethod = Param(nameof(MaMethod), EnvelopeMaMethods.Ema)
 		.SetDisplay("MA method", "Moving average method for the envelope.", "Indicator");
 
 		_envelopeDeviation = Param(nameof(EnvelopeDeviation), 0.05m)
@@ -419,10 +419,10 @@ public class EnvelopeLimitLadderStrategy : Strategy
 	{
 		return MaMethod switch
 		{
-			EnvelopeMaMethod.Sma => new SimpleMovingAverage { Length = EnvelopePeriod },
-			EnvelopeMaMethod.Ema => new ExponentialMovingAverage { Length = EnvelopePeriod },
-			EnvelopeMaMethod.Smma => new SmoothedMovingAverage { Length = EnvelopePeriod },
-			EnvelopeMaMethod.Lwma => new WeightedMovingAverage { Length = EnvelopePeriod },
+			EnvelopeMaMethods.Sma => new SimpleMovingAverage { Length = EnvelopePeriod },
+			EnvelopeMaMethods.Ema => new ExponentialMovingAverage { Length = EnvelopePeriod },
+			EnvelopeMaMethods.Smma => new SmoothedMovingAverage { Length = EnvelopePeriod },
+			EnvelopeMaMethods.Lwma => new WeightedMovingAverage { Length = EnvelopePeriod },
 			_ => new SimpleMovingAverage { Length = EnvelopePeriod }
 		};
 	}
@@ -714,7 +714,7 @@ public class EnvelopeLimitLadderStrategy : Strategy
 		}
 	}
 
-	private enum EnvelopeMaMethod
+	private enum EnvelopeMaMethods
 	{
 		Sma = 0,
 		Ema = 1,

--- a/API/3837_Farhad_Hill_Version_2/CS/FarhadHillVersion2Strategy.cs
+++ b/API/3837_Farhad_Hill_Version_2/CS/FarhadHillVersion2Strategy.cs
@@ -57,8 +57,8 @@ public class FarhadHillVersion2Strategy : Strategy
 	private readonly StrategyParam<decimal> _momentumLow;
 	private readonly StrategyParam<int> _slowMaPeriod;
 	private readonly StrategyParam<int> _fastMaPeriod;
-	private readonly StrategyParam<MovingAverageMode> _maMode;
-	private readonly StrategyParam<AppliedPriceMode> _maPrice;
+	private readonly StrategyParam<MovingAverageModes> _maMode;
+	private readonly StrategyParam<AppliedPriceModes> _maPrice;
 
 	private LengthIndicator<decimal> _fastMa;
 	private LengthIndicator<decimal> _slowMa;
@@ -212,10 +212,10 @@ public class FarhadHillVersion2Strategy : Strategy
 		_fastMaPeriod.SetGreaterThanZero();
 		_fastMaPeriod.SetDisplay("Fast MA", "Fast moving average period", "Indicators");
 
-		_maMode = Param(nameof(MaMode), MovingAverageMode.Smoothed);
+		_maMode = Param(nameof(MaMode), MovingAverageModes.Smoothed);
 		_maMode.SetDisplay("MA Mode", "Moving average calculation", "Indicators");
 
-		_maPrice = Param(nameof(MaPrice), AppliedPriceMode.Typical);
+		_maPrice = Param(nameof(MaPrice), AppliedPriceModes.Typical);
 		_maPrice.SetDisplay("MA Price", "Applied price for moving averages", "Indicators");
 	}
 
@@ -439,17 +439,17 @@ public class FarhadHillVersion2Strategy : Strategy
 		return true;
 	}
 
-	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPriceMode mode)
+	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPriceModes mode)
 	{
 		return mode switch
 		{
-			AppliedPriceMode.Close => candle.ClosePrice,
-			AppliedPriceMode.Open => candle.OpenPrice,
-			AppliedPriceMode.High => candle.HighPrice,
-			AppliedPriceMode.Low => candle.LowPrice,
-			AppliedPriceMode.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-			AppliedPriceMode.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-			AppliedPriceMode.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice + candle.ClosePrice) / 4m,
+			AppliedPriceModes.Close => candle.ClosePrice,
+			AppliedPriceModes.Open => candle.OpenPrice,
+			AppliedPriceModes.High => candle.HighPrice,
+			AppliedPriceModes.Low => candle.LowPrice,
+			AppliedPriceModes.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+			AppliedPriceModes.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+			AppliedPriceModes.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice + candle.ClosePrice) / 4m,
 			_ => candle.ClosePrice,
 		};
 	}
@@ -883,16 +883,16 @@ public class FarhadHillVersion2Strategy : Strategy
 		}
 	}
 
-	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageMode mode, int length, out LinearRegression lsma)
+	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageModes mode, int length, out LinearRegression lsma)
 	{
 		lsma = null;
 		return mode switch
 		{
-			MovingAverageMode.Simple => new SimpleMovingAverage { Length = length },
-			MovingAverageMode.Exponential => new ExponentialMovingAverage { Length = length },
-			MovingAverageMode.Smoothed => new SmoothedMovingAverage { Length = length },
-			MovingAverageMode.LinearWeighted => new WeightedMovingAverage { Length = length },
-			MovingAverageMode.LeastSquares => lsma = new LinearRegression { Length = length },
+			MovingAverageModes.Simple => new SimpleMovingAverage { Length = length },
+			MovingAverageModes.Exponential => new ExponentialMovingAverage { Length = length },
+			MovingAverageModes.Smoothed => new SmoothedMovingAverage { Length = length },
+			MovingAverageModes.LinearWeighted => new WeightedMovingAverage { Length = length },
+			MovingAverageModes.LeastSquares => lsma = new LinearRegression { Length = length },
 			_ => new SimpleMovingAverage { Length = length },
 		};
 	}
@@ -933,13 +933,13 @@ public class FarhadHillVersion2Strategy : Strategy
 	private decimal MomentumLow => _momentumLow.Value;
 	private int SlowMaPeriod => _slowMaPeriod.Value;
 	private int FastMaPeriod => _fastMaPeriod.Value;
-	private MovingAverageMode MaMode => _maMode.Value;
-	private AppliedPriceMode MaPrice => _maPrice.Value;
+	private MovingAverageModes MaMode => _maMode.Value;
+	private AppliedPriceModes MaPrice => _maPrice.Value;
 
 	/// <summary>
 	/// Moving average modes compatible with the original EA options.
 	/// </summary>
-	public enum MovingAverageMode
+	public enum MovingAverageModes
 	{
 		Simple = 0,
 		Exponential = 1,
@@ -951,7 +951,7 @@ public class FarhadHillVersion2Strategy : Strategy
 	/// <summary>
 	/// Applied price selection for moving averages.
 	/// </summary>
-	public enum AppliedPriceMode
+	public enum AppliedPriceModes
 	{
 		Close = 0,
 		Open = 1,

--- a/API/3839_Flat_Trend/CS/FlatTrendStrategy.cs
+++ b/API/3839_Flat_Trend/CS/FlatTrendStrategy.cs
@@ -18,7 +18,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class FlatTrendStrategy : Strategy
 {
-	private enum TrendState
+	private enum TrendStates
 	{
 		Neutral,
 		Bull,
@@ -565,57 +565,57 @@ public class FlatTrendStrategy : Strategy
 		return hour >= TradingHourBegin || hour < TradingHourEnd;
 	}
 
-	private TrendState ResolveState(decimal price, decimal ema, decimal? prevEma)
+	private TrendStates ResolveState(decimal price, decimal ema, decimal? prevEma)
 	{
 		if (prevEma is null)
-		return TrendState.Neutral;
+		return TrendStates.Neutral;
 
 		var slope = ema - prevEma.Value;
 
 		if (price > ema && slope > 0m)
-		return TrendState.StrongBull;
+		return TrendStates.StrongBull;
 
 		if (price > ema)
-		return TrendState.Bull;
+		return TrendStates.Bull;
 
 		if (price < ema && slope < 0m)
-		return TrendState.StrongBear;
+		return TrendStates.StrongBear;
 
 		if (price < ema)
-		return TrendState.Bear;
+		return TrendStates.Bear;
 
-		return TrendState.Neutral;
+		return TrendStates.Neutral;
 	}
 
-	private bool CanEnterLong(TrendState triggerState, TrendState filterState1, TrendState filterState2)
+	private bool CanEnterLong(TrendStates triggerState, TrendStates filterState1, TrendStates filterState2)
 	{
-		var triggerOk = triggerState == TrendState.StrongBull || (!IgnoreModerateForEntry && triggerState == TrendState.Bull);
-		var filter1Ok = filterState1 == TrendState.StrongBull || (!IgnoreModerateForEntry && filterState1 == TrendState.Bull);
-		var filter2Ok = UseOnlyPrimaryIndicators || filterState2 == TrendState.StrongBull || (!IgnoreModerateForEntry && filterState2 == TrendState.Bull);
+		var triggerOk = triggerState == TrendStates.StrongBull || (!IgnoreModerateForEntry && triggerState == TrendStates.Bull);
+		var filter1Ok = filterState1 == TrendStates.StrongBull || (!IgnoreModerateForEntry && filterState1 == TrendStates.Bull);
+		var filter2Ok = UseOnlyPrimaryIndicators || filterState2 == TrendStates.StrongBull || (!IgnoreModerateForEntry && filterState2 == TrendStates.Bull);
 
 		return triggerOk && filter1Ok && filter2Ok;
 	}
 
-	private bool CanEnterShort(TrendState triggerState, TrendState filterState1, TrendState filterState2)
+	private bool CanEnterShort(TrendStates triggerState, TrendStates filterState1, TrendStates filterState2)
 	{
-		var triggerOk = triggerState == TrendState.StrongBear || (!IgnoreModerateForEntry && triggerState == TrendState.Bear);
-		var filter1Ok = filterState1 == TrendState.StrongBear || (!IgnoreModerateForEntry && filterState1 == TrendState.Bear);
-		var filter2Ok = UseOnlyPrimaryIndicators || filterState2 == TrendState.StrongBear || (!IgnoreModerateForEntry && filterState2 == TrendState.Bear);
+		var triggerOk = triggerState == TrendStates.StrongBear || (!IgnoreModerateForEntry && triggerState == TrendStates.Bear);
+		var filter1Ok = filterState1 == TrendStates.StrongBear || (!IgnoreModerateForEntry && filterState1 == TrendStates.Bear);
+		var filter2Ok = UseOnlyPrimaryIndicators || filterState2 == TrendStates.StrongBear || (!IgnoreModerateForEntry && filterState2 == TrendStates.Bear);
 
 		return triggerOk && filter1Ok && filter2Ok;
 	}
 
-	private bool ShouldExitLong(TrendState triggerState)
+	private bool ShouldExitLong(TrendStates triggerState)
 	{
-		return IgnoreModerateForExit ? triggerState == TrendState.StrongBear : triggerState == TrendState.Bear || triggerState == TrendState.StrongBear;
+		return IgnoreModerateForExit ? triggerState == TrendStates.StrongBear : triggerState == TrendStates.Bear || triggerState == TrendStates.StrongBear;
 	}
 
-	private bool ShouldExitShort(TrendState triggerState)
+	private bool ShouldExitShort(TrendStates triggerState)
 	{
-		return IgnoreModerateForExit ? triggerState == TrendState.StrongBull : triggerState == TrendState.Bull || triggerState == TrendState.StrongBull;
+		return IgnoreModerateForExit ? triggerState == TrendStates.StrongBull : triggerState == TrendStates.Bull || triggerState == TrendStates.StrongBull;
 	}
 
-	private void UpdateRiskManagement(ICandleMessage candle, TrendState triggerState)
+	private void UpdateRiskManagement(ICandleMessage candle, TrendStates triggerState)
 	{
 		var step = Security?.PriceStep ?? 0.0001m;
 		if (step <= 0m)

--- a/API/3867_Equal_Volume_Range_Bars/CS/EqualVolumeRangeBarsStrategy.cs
+++ b/API/3867_Equal_Volume_Range_Bars/CS/EqualVolumeRangeBarsStrategy.cs
@@ -19,7 +19,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class EqualVolumeRangeBarsStrategy : Strategy
 {
-	private readonly StrategyParam<EqualVolumeBarsMode> _workMode;
+	private readonly StrategyParam<EqualVolumeBarsModes> _workMode;
 	private readonly StrategyParam<int> _ticksInBar;
 	private readonly StrategyParam<bool> _fromMinuteHistory;
 	private readonly StrategyParam<DataType> _minuteCandleType;
@@ -41,7 +41,7 @@ public class EqualVolumeRangeBarsStrategy : Strategy
 	/// <summary>
 	/// Candle construction mode that matches the MT4 offline chart options.
 	/// </summary>
-	public EqualVolumeBarsMode WorkMode
+	public EqualVolumeBarsModes WorkMode
 	{
 		get => _workMode.Value;
 		set => _workMode.Value = value;
@@ -79,7 +79,7 @@ public class EqualVolumeRangeBarsStrategy : Strategy
 	/// </summary>
 	public EqualVolumeRangeBarsStrategy()
 	{
-		_workMode = Param(nameof(WorkMode), EqualVolumeBarsMode.EqualVolumeBars)
+		_workMode = Param(nameof(WorkMode), EqualVolumeBarsModes.EqualVolumeBars)
 			.SetDisplay("Work Mode", "Choose equal volume or range bars", "General");
 
 		_ticksInBar = Param(nameof(TicksInBar), 100)
@@ -136,7 +136,7 @@ public class EqualVolumeRangeBarsStrategy : Strategy
 
 		_rangeThreshold = _tickSize * TicksInBar;
 		_seriesName = BuildSeriesName();
-		LogInfo($"{_seriesName}: starting in {WorkMode} mode with threshold {TicksInBar} {(WorkMode == EqualVolumeBarsMode.EqualVolumeBars ? "ticks" : "points")}");
+		LogInfo($"{_seriesName}: starting in {WorkMode} mode with threshold {TicksInBar} {(WorkMode == EqualVolumeBarsModes.EqualVolumeBars ? "ticks" : "points")}");
 
 		if (FromMinuteHistory)
 		{
@@ -264,8 +264,8 @@ public class EqualVolumeRangeBarsStrategy : Strategy
 	{
 		return WorkMode switch
 		{
-			EqualVolumeBarsMode.EqualVolumeBars => volume > TicksInBar,
-			EqualVolumeBarsMode.RangeBars => high - low > _rangeThreshold,
+			EqualVolumeBarsModes.EqualVolumeBars => volume > TicksInBar,
+			EqualVolumeBarsModes.RangeBars => high - low > _rangeThreshold,
 			_ => false,
 		};
 	}
@@ -302,7 +302,7 @@ public class EqualVolumeRangeBarsStrategy : Strategy
 	/// <summary>
 	/// Operation mode copied from the MT4 script.
 	/// </summary>
-	public enum EqualVolumeBarsMode
+	public enum EqualVolumeBarsModes
 	{
 		/// <summary>
 		/// Create bars once the configured number of ticks has been accumulated.

--- a/API/3877_LoongClock/CS/LoongClockStrategy.cs
+++ b/API/3877_LoongClock/CS/LoongClockStrategy.cs
@@ -22,7 +22,7 @@ namespace StockSharp.Samples.Strategies;
 public class LoongClockStrategy : Strategy
 {
 	private readonly StrategyParam<DataType> _candleType;
-	private readonly StrategyParam<ClockTimeSource> _timeSource;
+	private readonly StrategyParam<ClockTimeSources> _timeSource;
 	private readonly StrategyParam<TimeSpan> _hourTimeRadius;
 	private readonly StrategyParam<TimeSpan> _minuteTimeRadius;
 	private readonly StrategyParam<TimeSpan> _secondTimeRadius;
@@ -42,7 +42,7 @@ public class LoongClockStrategy : Strategy
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(1).TimeFrame())
 		.SetDisplay("Candle Type", "Type of candles used to anchor the drawing area.", "General");
 
-		_timeSource = Param(nameof(TimeSource), ClockTimeSource.Local)
+		_timeSource = Param(nameof(TimeSource), ClockTimeSources.Local)
 		.SetDisplay("Time Source", "Select which time base should be shown by the clock.", "Clock");
 
 		_hourTimeRadius = Param(nameof(HourTimeRadius), TimeSpan.FromMinutes(8))
@@ -76,7 +76,7 @@ public class LoongClockStrategy : Strategy
 	/// <summary>
 	/// Selects which time base should be visualized.
 	/// </summary>
-	public ClockTimeSource TimeSource
+	public ClockTimeSources TimeSource
 	{
 		get => _timeSource.Value;
 		set => _timeSource.Value = value;
@@ -251,8 +251,8 @@ public class LoongClockStrategy : Strategy
 	{
 		return TimeSource switch
 		{
-			ClockTimeSource.Server => CurrentTime,
-			ClockTimeSource.Utc => DateTimeOffset.UtcNow,
+			ClockTimeSources.Server => CurrentTime,
+			ClockTimeSources.Utc => DateTimeOffset.UtcNow,
 			_ => DateTimeOffset.Now,
 		};
 	}
@@ -261,7 +261,7 @@ public class LoongClockStrategy : Strategy
 /// <summary>
 /// Defines available sources for the displayed clock time.
 /// </summary>
-public enum ClockTimeSource
+public enum ClockTimeSources
 {
 	/// <summary>
 	/// Uses the local machine time.

--- a/API/3888_Nextbar/CS/NextbarStrategy.cs
+++ b/API/3888_Nextbar/CS/NextbarStrategy.cs
@@ -21,7 +21,7 @@ public class NextbarStrategy : Strategy
 	/// <summary>
 	/// Trading direction modes supported by the original expert advisor.
 	/// </summary>
-	public enum NextbarDirection
+	public enum NextbarDirections
 	{
 		/// <summary>
 		/// Follow the detected momentum (buy after a rise, sell after a drop).
@@ -40,7 +40,7 @@ public class NextbarStrategy : Strategy
 	private readonly StrategyParam<int> _minMovePoints;
 	private readonly StrategyParam<int> _takeProfitPoints;
 	private readonly StrategyParam<int> _stopLossPoints;
-	private readonly StrategyParam<NextbarDirection> _direction;
+	private readonly StrategyParam<NextbarDirections> _direction;
 
 	private readonly List<decimal> _closeHistory = new();
 
@@ -80,7 +80,7 @@ public class NextbarStrategy : Strategy
 			.SetDisplay("Stop Loss (points)", "Protective distance expressed in MetaTrader points", "Risk")
 			.SetCanOptimize(true);
 
-		_direction = Param(nameof(Direction), NextbarDirection.Follow)
+		_direction = Param(nameof(Direction), NextbarDirections.Follow)
 			.SetDisplay("Direction", "Choose between trend-following or contrarian behaviour", "Trading Rules");
 	}
 
@@ -141,7 +141,7 @@ public class NextbarStrategy : Strategy
 	/// <summary>
 	/// Defines whether the strategy follows or fades the detected momentum swing.
 	/// </summary>
-	public NextbarDirection Direction
+	public NextbarDirections Direction
 	{
 		get => _direction.Value;
 		set => _direction.Value = value;
@@ -239,15 +239,15 @@ public class NextbarStrategy : Strategy
 
 		var direction = Direction;
 
-		if ((direction == NextbarDirection.Follow && bullishMove) ||
-			(direction == NextbarDirection.Reverse && bearishMove))
+		if ((direction == NextbarDirections.Follow && bullishMove) ||
+			(direction == NextbarDirections.Reverse && bearishMove))
 		{
 			BuyMarket(volume);
 			_entryPrice = currentClose;
 			_barsSinceEntry = 0;
 		}
-		else if ((direction == NextbarDirection.Follow && bearishMove) ||
-			(direction == NextbarDirection.Reverse && bullishMove))
+		else if ((direction == NextbarDirections.Follow && bearishMove) ||
+			(direction == NextbarDirections.Reverse && bullishMove))
 		{
 			SellMarket(volume);
 			_entryPrice = currentClose;

--- a/API/3917_TCP_Pivot_Limit_Reversal/CS/TcpPivotReversalLimitStrategy.cs
+++ b/API/3917_TCP_Pivot_Limit_Reversal/CS/TcpPivotReversalLimitStrategy.cs
@@ -45,7 +45,7 @@ public class TcpPivotReversalLimitStrategy : Strategy
 	private ICandleMessage _previousCandle;
 	private ICandleMessage _previousPreviousCandle;
 
-	private PositionSide _positionSide = PositionSide.Flat;
+	private PositionSides _positionSide = PositionSides.Flat;
 	private decimal? _currentStopPrice;
 	private decimal? _currentTargetPrice;
 	private decimal? _trailingExtreme;
@@ -150,7 +150,7 @@ public class TcpPivotReversalLimitStrategy : Strategy
 		_previousDayClose = 0m;
 		_previousCandle = null;
 		_previousPreviousCandle = null;
-		_positionSide = PositionSide.Flat;
+		_positionSide = PositionSides.Flat;
 		_currentStopPrice = null;
 		_currentTargetPrice = null;
 		_trailingExtreme = null;
@@ -253,8 +253,8 @@ public class TcpPivotReversalLimitStrategy : Strategy
 			return;
 		}
 
-		if (_positionSide == PositionSide.Flat)
-		_positionSide = Position > 0m ? PositionSide.Long : PositionSide.Short;
+		if (_positionSide == PositionSides.Flat)
+		_positionSide = Position > 0m ? PositionSides.Long : PositionSides.Short;
 
 		if (IntradayTrading && candle.CloseTime.Hour == 23)
 		{
@@ -264,7 +264,7 @@ public class TcpPivotReversalLimitStrategy : Strategy
 			return;
 		}
 
-		if (_positionSide == PositionSide.Long)
+		if (_positionSide == PositionSides.Long)
 		{
 			if (_currentStopPrice.HasValue && candle.LowPrice <= _currentStopPrice.Value)
 			{
@@ -284,7 +284,7 @@ public class TcpPivotReversalLimitStrategy : Strategy
 
 			UpdateLongTrailing(candle);
 		}
-		else if (_positionSide == PositionSide.Short)
+		else if (_positionSide == PositionSides.Short)
 		{
 			if (_currentStopPrice.HasValue && candle.HighPrice >= _currentStopPrice.Value)
 			{
@@ -382,7 +382,7 @@ public class TcpPivotReversalLimitStrategy : Strategy
 		{
 			LogInfo($"Opening short. Level={sellLevel:F5}, Stop={sellStop:F5}, Target={sellTarget:F5}");
 			SellMarket(Volume);
-			_positionSide = PositionSide.Short;
+			_positionSide = PositionSides.Short;
 			_currentStopPrice = sellStop;
 			_currentTargetPrice = sellTarget;
 			_trailingExtreme = null;
@@ -393,7 +393,7 @@ public class TcpPivotReversalLimitStrategy : Strategy
 		{
 			LogInfo($"Opening long. Level={buyLevel:F5}, Stop={buyStop:F5}, Target={buyTarget:F5}");
 			BuyMarket(Volume);
-			_positionSide = PositionSide.Long;
+			_positionSide = PositionSides.Long;
 			_currentStopPrice = buyStop;
 			_currentTargetPrice = buyTarget;
 			_trailingExtreme = null;
@@ -444,14 +444,14 @@ public class TcpPivotReversalLimitStrategy : Strategy
 	{
 		if (Position == 0m)
 		{
-			_positionSide = PositionSide.Flat;
+			_positionSide = PositionSides.Flat;
 			_currentStopPrice = null;
 			_currentTargetPrice = null;
 			_trailingExtreme = null;
 		}
 	}
 
-	private enum PositionSide
+	private enum PositionSides
 	{
 		Flat,
 		Long,

--- a/API/3943_AMATraderV21/CS/AmaTraderV21Strategy.cs
+++ b/API/3943_AMATraderV21/CS/AmaTraderV21Strategy.cs
@@ -27,8 +27,8 @@ public class AmaTraderV21Strategy : Strategy
 	private readonly StrategyParam<decimal> _amaThreshold;
 	private readonly StrategyParam<int> _firstMaPeriod;
 	private readonly StrategyParam<int> _secondMaPeriod;
-	private readonly StrategyParam<HeikenMaMethod> _firstMaMethod;
-	private readonly StrategyParam<HeikenMaMethod> _secondMaMethod;
+	private readonly StrategyParam<HeikenMaMethods> _firstMaMethod;
+	private readonly StrategyParam<HeikenMaMethods> _secondMaMethod;
 	private readonly StrategyParam<int> _rsiPeriod;
 	private readonly StrategyParam<decimal> _partialClosePercent;
 	private readonly StrategyParam<int> _stopLossSteps;
@@ -84,10 +84,10 @@ public class AmaTraderV21Strategy : Strategy
 		.SetDisplay("Heiken Second MA", "Length of the second smoothing moving average.", "Heiken")
 		.SetGreaterThanZero();
 
-		_firstMaMethod = Param(nameof(FirstMaMethod), HeikenMaMethod.Smoothed)
+		_firstMaMethod = Param(nameof(FirstMaMethod), HeikenMaMethods.Smoothed)
 		.SetDisplay("First MA Method", "Moving average applied to raw prices before Heiken Ashi calculation.", "Heiken");
 
-		_secondMaMethod = Param(nameof(SecondMaMethod), HeikenMaMethod.LinearWeighted)
+		_secondMaMethod = Param(nameof(SecondMaMethod), HeikenMaMethods.LinearWeighted)
 		.SetDisplay("Second MA Method", "Moving average used to smooth the Heiken Ashi buffers.", "Heiken");
 
 		_rsiPeriod = Param(nameof(RsiPeriod), 14)
@@ -195,7 +195,7 @@ public class AmaTraderV21Strategy : Strategy
 	/// <summary>
 	/// First smoothing moving average method.
 	/// </summary>
-	public HeikenMaMethod FirstMaMethod
+	public HeikenMaMethods FirstMaMethod
 	{
 		get => _firstMaMethod.Value;
 		set => _firstMaMethod.Value = value;
@@ -204,7 +204,7 @@ public class AmaTraderV21Strategy : Strategy
 	/// <summary>
 	/// Second smoothing moving average method.
 	/// </summary>
-	public HeikenMaMethod SecondMaMethod
+	public HeikenMaMethods SecondMaMethod
 	{
 		get => _secondMaMethod.Value;
 		set => _secondMaMethod.Value = value;
@@ -483,7 +483,7 @@ public class AmaTraderV21Strategy : Strategy
 	/// <summary>
 	/// Available moving average methods for Heiken Ashi smoothing.
 	/// </summary>
-	public enum HeikenMaMethod
+	public enum HeikenMaMethods
 	{
 		Simple,
 		Exponential,
@@ -505,7 +505,7 @@ public class AmaTraderV21Strategy : Strategy
 		private decimal? _previousHaOpen;
 		private decimal? _previousHaClose;
 
-		public HeikenAshiSmoothedCalculator(HeikenMaMethod firstMethod, HeikenMaMethod secondMethod, int firstLength, int secondLength)
+		public HeikenAshiSmoothedCalculator(HeikenMaMethods firstMethod, HeikenMaMethods secondMethod, int firstLength, int secondLength)
 		{
 			_openMa = CreateMovingAverage(firstMethod, firstLength);
 			_closeMa = CreateMovingAverage(firstMethod, firstLength);
@@ -566,14 +566,14 @@ public class AmaTraderV21Strategy : Strategy
 			};
 		}
 
-		private static IIndicator CreateMovingAverage(HeikenMaMethod method, int length)
+		private static IIndicator CreateMovingAverage(HeikenMaMethods method, int length)
 		{
 			return method switch
 			{
-				HeikenMaMethod.Simple => new SimpleMovingAverage { Length = length },
-				HeikenMaMethod.Exponential => new ExponentialMovingAverage { Length = length },
-				HeikenMaMethod.Smoothed => new SmoothedMovingAverage { Length = length },
-				HeikenMaMethod.LinearWeighted => new WeightedMovingAverage { Length = length },
+				HeikenMaMethods.Simple => new SimpleMovingAverage { Length = length },
+				HeikenMaMethods.Exponential => new ExponentialMovingAverage { Length = length },
+				HeikenMaMethods.Smoothed => new SmoothedMovingAverage { Length = length },
+				HeikenMaMethods.LinearWeighted => new WeightedMovingAverage { Length = length },
 				_ => new SimpleMovingAverage { Length = length }
 			};
 		}

--- a/API/3953_ZigAndZag_Trader/CS/ZigAndZagTraderStrategy.cs
+++ b/API/3953_ZigAndZag_Trader/CS/ZigAndZagTraderStrategy.cs
@@ -50,7 +50,7 @@ public class ZigAndZagTraderStrategy : Strategy
 	private bool _sellArmed;
 	private bool _limitArmed;
 
-	private PivotType _lastPivot;
+	private PivotTypes _lastPivot;
 
 	/// <summary>
 	/// Trading candles.
@@ -173,7 +173,7 @@ public class ZigAndZagTraderStrategy : Strategy
 		_buyArmed = false;
 		_sellArmed = false;
 		_limitArmed = false;
-		_lastPivot = PivotType.None;
+		_lastPivot = PivotTypes.None;
 	}
 
 	/// <inheritdoc />
@@ -258,7 +258,7 @@ public class ZigAndZagTraderStrategy : Strategy
 		{
 			if (candle.LowPrice == shortLow && (_lastShortLow == null || shortLow != _lastShortLow))
 			{
-				_lastPivot = PivotType.Low;
+				_lastPivot = PivotTypes.Low;
 				_lastShortLow = shortLow;
 				_lastSlalomZig = navel;
 				_buyArmed = false;
@@ -268,7 +268,7 @@ public class ZigAndZagTraderStrategy : Strategy
 
 			if (candle.HighPrice == shortHigh && (_lastShortHigh == null || shortHigh != _lastShortHigh))
 			{
-				_lastPivot = PivotType.High;
+				_lastPivot = PivotTypes.High;
 				_lastShortHigh = shortHigh;
 				_lastSlalomZag = navel;
 				_buyArmed = false;
@@ -286,7 +286,7 @@ public class ZigAndZagTraderStrategy : Strategy
 
 		switch (_lastPivot)
 		{
-			case PivotType.Low when _lastSlalomZig != null:
+			case PivotTypes.Low when _lastSlalomZig != null:
 			{
 				if (_trendUp)
 				{
@@ -322,7 +322,7 @@ public class ZigAndZagTraderStrategy : Strategy
 
 				break;
 			}
-			case PivotType.High when _lastSlalomZag != null:
+			case PivotTypes.High when _lastSlalomZag != null:
 			{
 				if (!_trendUp)
 				{
@@ -400,7 +400,7 @@ public class ZigAndZagTraderStrategy : Strategy
 			CloseAll();
 	}
 
-	private enum PivotType
+	private enum PivotTypes
 	{
 		None,
 		Low,

--- a/API/3966_Three_MA_Cross_Channel/CS/ThreeMaCrossChannelStrategy.cs
+++ b/API/3966_Three_MA_Cross_Channel/CS/ThreeMaCrossChannelStrategy.cs
@@ -24,9 +24,9 @@ private readonly StrategyParam<int> _fastLength;
 private readonly StrategyParam<int> _mediumLength;
 private readonly StrategyParam<int> _slowLength;
 private readonly StrategyParam<int> _channelLength;
-private readonly StrategyParam<MovingAverageTypeEnum> _fastType;
-private readonly StrategyParam<MovingAverageTypeEnum> _mediumType;
-private readonly StrategyParam<MovingAverageTypeEnum> _slowType;
+private readonly StrategyParam<MovingAverageTypes> _fastType;
+private readonly StrategyParam<MovingAverageTypes> _mediumType;
+private readonly StrategyParam<MovingAverageTypes> _slowType;
 private readonly StrategyParam<decimal> _takeProfit;
 private readonly StrategyParam<decimal> _stopLoss;
 private readonly StrategyParam<bool> _useChannelStop;
@@ -80,7 +80,7 @@ set => _channelLength.Value = value;
 /// <summary>
 /// Moving-average type applied to the fast average.
 /// </summary>
-public MovingAverageTypeEnum FastType
+public MovingAverageTypes FastType
 {
 get => _fastType.Value;
 set => _fastType.Value = value;
@@ -89,7 +89,7 @@ set => _fastType.Value = value;
 /// <summary>
 /// Moving-average type applied to the medium average.
 /// </summary>
-public MovingAverageTypeEnum MediumType
+public MovingAverageTypes MediumType
 {
 get => _mediumType.Value;
 set => _mediumType.Value = value;
@@ -98,7 +98,7 @@ set => _mediumType.Value = value;
 /// <summary>
 /// Moving-average type applied to the slow average.
 /// </summary>
-public MovingAverageTypeEnum SlowType
+public MovingAverageTypes SlowType
 {
 get => _slowType.Value;
 set => _slowType.Value = value;
@@ -161,13 +161,13 @@ _channelLength = Param(nameof(ChannelLength), 15)
 .SetGreaterThanZero()
 .SetDisplay("Channel", "Donchian channel lookback period", "Risk Management");
 
-_fastType = Param(nameof(FastType), MovingAverageTypeEnum.EMA)
+_fastType = Param(nameof(FastType), MovingAverageTypes.EMA)
 .SetDisplay("Fast MA Type", "Algorithm used for the fast average", "Moving Averages");
 
-_mediumType = Param(nameof(MediumType), MovingAverageTypeEnum.EMA)
+_mediumType = Param(nameof(MediumType), MovingAverageTypes.EMA)
 .SetDisplay("Medium MA Type", "Algorithm used for the medium average", "Moving Averages");
 
-_slowType = Param(nameof(SlowType), MovingAverageTypeEnum.EMA)
+_slowType = Param(nameof(SlowType), MovingAverageTypes.EMA)
 .SetDisplay("Slow MA Type", "Algorithm used for the slow average", "Moving Averages");
 
 _takeProfit = Param(nameof(TakeProfit), 0m)
@@ -315,14 +315,14 @@ _entryPrice = candle.ClosePrice;
 }
 }
 
-private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageTypeEnum type, int length)
+private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageTypes type, int length)
 {
 return type switch
 {
-MovingAverageTypeEnum.SMA => new SimpleMovingAverage { Length = length },
-MovingAverageTypeEnum.EMA => new ExponentialMovingAverage { Length = length },
-MovingAverageTypeEnum.SMMA => new SmoothedMovingAverage { Length = length },
-MovingAverageTypeEnum.WMA => new WeightedMovingAverage { Length = length },
+MovingAverageTypes.SMA => new SimpleMovingAverage { Length = length },
+MovingAverageTypes.EMA => new ExponentialMovingAverage { Length = length },
+MovingAverageTypes.SMMA => new SmoothedMovingAverage { Length = length },
+MovingAverageTypes.WMA => new WeightedMovingAverage { Length = length },
 _ => throw new ArgumentOutOfRangeException(nameof(type), type, "Unsupported moving average type."),
 };
 }
@@ -331,7 +331,7 @@ _ => throw new ArgumentOutOfRangeException(nameof(type), type, "Unsupported movi
 /// Moving-average algorithms supported by the strategy.
 /// Matches the modes available in the original MetaTrader script.
 /// </summary>
-public enum MovingAverageTypeEnum
+public enum MovingAverageTypes
 {
 /// <summary>
 /// Simple moving average.

--- a/API/3975_ZigAndZag_Scalpel/CS/ZigAndZagScalpelStrategy.cs
+++ b/API/3975_ZigAndZag_Scalpel/CS/ZigAndZagScalpelStrategy.cs
@@ -40,7 +40,7 @@ public class ZigAndZagScalpelStrategy : Strategy
 	private DateTime _currentDay = DateTime.MinValue;
 	private int _tradesToday;
 	private bool _trendUp;
-	private PivotType _lastMinorPivotType = PivotType.None;
+	private PivotTypes _lastMinorPivotType = PivotTypes.None;
 	private bool _minorPivotUsed;
 
 	/// <summary>
@@ -204,7 +204,7 @@ public class ZigAndZagScalpelStrategy : Strategy
 		if (_minorPivotUsed)
 		return;
 
-		if (_lastMinorPivotType == PivotType.None)
+		if (_lastMinorPivotType == PivotTypes.None)
 		return;
 
 		if (_tradesToday >= MaxTradesPerDay)
@@ -212,7 +212,7 @@ public class ZigAndZagScalpelStrategy : Strategy
 
 		var navel = CalculateNavel(candle);
 
-		if (_lastMinorPivotType == PivotType.Low && _trendUp)
+		if (_lastMinorPivotType == PivotTypes.Low && _trendUp)
 		{
 			if (navel - _lastMinorPivot >= _breakoutDistance)
 			{
@@ -221,7 +221,7 @@ public class ZigAndZagScalpelStrategy : Strategy
 				_tradesToday++;
 			}
 		}
-		else if (_lastMinorPivotType == PivotType.High && !_trendUp)
+		else if (_lastMinorPivotType == PivotTypes.High && !_trendUp)
 		{
 			if (_lastMinorPivot - navel >= _breakoutDistance)
 			{
@@ -271,7 +271,7 @@ public class ZigAndZagScalpelStrategy : Strategy
 		{
 			_lastMinorPivot = minorValue;
 			_previousMinorPivot = minorValue;
-			_lastMinorPivotType = PivotType.Low;
+			_lastMinorPivotType = PivotTypes.Low;
 			_minorPivotUsed = false;
 			return;
 		}
@@ -281,7 +281,7 @@ public class ZigAndZagScalpelStrategy : Strategy
 
 		_previousMinorPivot = _lastMinorPivot;
 		_lastMinorPivot = minorValue;
-		_lastMinorPivotType = _lastMinorPivot < _previousMinorPivot ? PivotType.Low : PivotType.High;
+		_lastMinorPivotType = _lastMinorPivot < _previousMinorPivot ? PivotTypes.Low : PivotTypes.High;
 		_minorPivotUsed = false;
 	}
 
@@ -289,12 +289,12 @@ public class ZigAndZagScalpelStrategy : Strategy
 	{
 		if (Position > 0)
 		{
-			if (!_trendUp || (CloseOnOppositePivot && _lastMinorPivotType == PivotType.High))
+			if (!_trendUp || (CloseOnOppositePivot && _lastMinorPivotType == PivotTypes.High))
 			ClosePosition();
 		}
 		else if (Position < 0)
 		{
-			if (_trendUp || (CloseOnOppositePivot && _lastMinorPivotType == PivotType.Low))
+			if (_trendUp || (CloseOnOppositePivot && _lastMinorPivotType == PivotTypes.Low))
 			ClosePosition();
 		}
 	}
@@ -304,7 +304,7 @@ public class ZigAndZagScalpelStrategy : Strategy
 		return (5m * candle.ClosePrice + 2m * candle.OpenPrice + candle.HighPrice + candle.LowPrice) / 9m;
 	}
 
-	private enum PivotType
+	private enum PivotTypes
 	{
 		None,
 		Low,

--- a/API/3978_Moving_Average_Position_System/CS/MovingAveragePositionSystemStrategy.cs
+++ b/API/3978_Moving_Average_Position_System/CS/MovingAveragePositionSystemStrategy.cs
@@ -26,7 +26,7 @@ public class MovingAveragePositionSystemStrategy : Strategy
 	/// <summary>
 	/// Moving average calculation mode.
 	/// </summary>
-	public enum MovingAverageMode
+	public enum MovingAverageModes
 	{
 		Simple,
 		Exponential,
@@ -34,7 +34,7 @@ public class MovingAveragePositionSystemStrategy : Strategy
 		LinearWeighted,
 	}
 
-	private readonly StrategyParam<MovingAverageMode> _maType;
+	private readonly StrategyParam<MovingAverageModes> _maType;
 	private readonly StrategyParam<int> _maPeriod;
 	private readonly StrategyParam<int> _maShift;
 	private readonly StrategyParam<decimal> _initialVolume;
@@ -57,7 +57,7 @@ public class MovingAveragePositionSystemStrategy : Strategy
 	/// <summary>
 	/// Moving average type used for signal calculation.
 	/// </summary>
-	public MovingAverageMode MaType
+	public MovingAverageModes MaType
 	{
 		get => _maType.Value;
 		set => _maType.Value = value;
@@ -158,7 +158,7 @@ public class MovingAveragePositionSystemStrategy : Strategy
 	/// </summary>
 	public MovingAveragePositionSystemStrategy()
 	{
-		_maType = Param(nameof(MaType), MovingAverageMode.LinearWeighted)
+		_maType = Param(nameof(MaType), MovingAverageModes.LinearWeighted)
 		.SetDisplay("MA Type", "Moving average method", "Indicators");
 
 		_maPeriod = Param(nameof(MaPeriod), 240)
@@ -255,9 +255,9 @@ public class MovingAveragePositionSystemStrategy : Strategy
 	{
 		return MaType switch
 		{
-			MovingAverageMode.Exponential => new ExponentialMovingAverage { Length = MaPeriod },
-			MovingAverageMode.Smoothed => new SmoothedMovingAverage { Length = MaPeriod },
-			MovingAverageMode.LinearWeighted => new LinearWeightedMovingAverage { Length = MaPeriod },
+			MovingAverageModes.Exponential => new ExponentialMovingAverage { Length = MaPeriod },
+			MovingAverageModes.Smoothed => new SmoothedMovingAverage { Length = MaPeriod },
+			MovingAverageModes.LinearWeighted => new LinearWeightedMovingAverage { Length = MaPeriod },
 			_ => new SimpleMovingAverage { Length = MaPeriod },
 		};
 	}

--- a/API/3986_Straddle_Trail_V240/CS/StraddleTrailV240Strategy.cs
+++ b/API/3986_Straddle_Trail_V240/CS/StraddleTrailV240Strategy.cs
@@ -21,7 +21,7 @@ namespace StockSharp.Samples.Strategies;
 public class StraddleTrailV240Strategy : Strategy
 {
 	private readonly StrategyParam<bool> _shutdownNow;
-	private readonly StrategyParam<ShutdownMode> _shutdownMode;
+	private readonly StrategyParam<ShutdownModes> _shutdownMode;
 	private readonly StrategyParam<decimal> _distanceFromPrice;
 	private readonly StrategyParam<decimal> _stopLossPips;
 	private readonly StrategyParam<decimal> _takeProfitPips;
@@ -56,7 +56,7 @@ public class StraddleTrailV240Strategy : Strategy
 	private bool _straddleFilled;
 
 	public bool ShutdownNow { get => _shutdownNow.Value; set => _shutdownNow.Value = value; }
-	public ShutdownMode ShutdownOption { get => _shutdownMode.Value; set => _shutdownMode.Value = value; }
+	public ShutdownModes ShutdownOption { get => _shutdownMode.Value; set => _shutdownMode.Value = value; }
 	public decimal DistanceFromPrice { get => _distanceFromPrice.Value; set => _distanceFromPrice.Value = value; }
 	public decimal StopLossPips { get => _stopLossPips.Value; set => _stopLossPips.Value = value; }
 	public decimal TakeProfitPips { get => _takeProfitPips.Value; set => _takeProfitPips.Value = value; }
@@ -81,7 +81,7 @@ public class StraddleTrailV240Strategy : Strategy
 		_shutdownNow = Param(nameof(ShutdownNow), false)
 			.SetDisplay("Shutdown", "Force closing and cancelling", "Risk");
 
-		_shutdownMode = Param(nameof(ShutdownOption), ShutdownMode.All)
+		_shutdownMode = Param(nameof(ShutdownOption), ShutdownModes.All)
 			.SetDisplay("Shutdown Mode", "What to close or cancel", "Risk");
 
 		_distanceFromPrice = Param(nameof(DistanceFromPrice), 30m)
@@ -465,32 +465,32 @@ public class StraddleTrailV240Strategy : Strategy
 	{
 		switch (ShutdownOption)
 		{
-			case ShutdownMode.All:
+			case ShutdownModes.All:
 				CancelActiveStraddle();
 				if (Position != 0)
 					ClosePosition();
 				return true;
-			case ShutdownMode.TriggeredPositions:
+			case ShutdownModes.TriggeredPositions:
 				if (Position != 0)
 					ClosePosition();
 				return true;
-			case ShutdownMode.TriggeredLong:
+			case ShutdownModes.TriggeredLong:
 				if (Position > 0)
 					ClosePosition();
 				return true;
-			case ShutdownMode.TriggeredShort:
+			case ShutdownModes.TriggeredShort:
 				if (Position < 0)
 					ClosePosition();
 				return true;
-			case ShutdownMode.PendingOrders:
+			case ShutdownModes.PendingOrders:
 				CancelActiveStraddle();
 				return true;
-			case ShutdownMode.PendingLong:
+			case ShutdownModes.PendingLong:
 				if (_buyStopOrder != null && !_buyStopOrder.State.IsFinal())
 					CancelOrder(_buyStopOrder);
 				_buyStopOrder = null;
 				return true;
-			case ShutdownMode.PendingShort:
+			case ShutdownModes.PendingShort:
 				if (_sellStopOrder != null && !_sellStopOrder.State.IsFinal())
 					CancelOrder(_sellStopOrder);
 				_sellStopOrder = null;
@@ -610,7 +610,7 @@ public class StraddleTrailV240Strategy : Strategy
 		return rounded;
 	}
 
-	public enum ShutdownMode
+	public enum ShutdownModes
 	{
 		All = 0,
 		TriggeredPositions = 1,

--- a/API/3989_Cyberia_Trader/CS/CyberiaTraderAdaptiveStrategy.cs
+++ b/API/3989_Cyberia_Trader/CS/CyberiaTraderAdaptiveStrategy.cs
@@ -67,14 +67,14 @@ public class CyberiaTraderAdaptiveStrategy : Strategy
 	private decimal? _lastCciValue;
 	private decimal? _lastPlusDi;
 	private decimal? _lastMinusDi;
-	private FractalDirection _fractalDirection = FractalDirection.None;
+	private FractalDirections _fractalDirection = FractalDirections.None;
 
 	private bool _disableBuy;
 	private bool _disableSell;
 	private bool _blockBuyFlag;
 	private bool _blockSellFlag;
 
-	private DecisionType _currentDecision = DecisionType.Unknown;
+	private DecisionTypes _currentDecision = DecisionTypes.Unknown;
 	private decimal _buyPossibility;
 	private decimal _sellPossibility;
 	private decimal _undefinedPossibility;
@@ -544,7 +544,7 @@ public class CyberiaTraderAdaptiveStrategy : Strategy
 		var allowBuy = !_disableBuy && !_blockBuyFlag;
 		var allowSell = !_disableSell && !_blockSellFlag;
 
-		if (_currentDecision == DecisionType.Buy && allowBuy)
+		if (_currentDecision == DecisionTypes.Buy && allowBuy)
 		{
 			if (Position < 0)
 			BuyMarket(Math.Abs(Position));
@@ -552,7 +552,7 @@ public class CyberiaTraderAdaptiveStrategy : Strategy
 			if (Position <= 0)
 			BuyMarket(Volume);
 		}
-		else if (_currentDecision == DecisionType.Sell && allowSell)
+		else if (_currentDecision == DecisionTypes.Sell && allowSell)
 		{
 			if (Position > 0)
 			SellMarket(Position);
@@ -560,7 +560,7 @@ public class CyberiaTraderAdaptiveStrategy : Strategy
 			if (Position >= 0)
 			SellMarket(Volume);
 		}
-		else if (_currentDecision == DecisionType.Unknown)
+		else if (_currentDecision == DecisionTypes.Unknown)
 		{
 			if (_possibilityQuality < 0.5m)
 			ClosePosition();
@@ -692,12 +692,12 @@ public class CyberiaTraderAdaptiveStrategy : Strategy
 
 	private void ApplyFractalFilter()
 	{
-		if (_fractalDirection == FractalDirection.Up)
+		if (_fractalDirection == FractalDirections.Up)
 		{
 			_blockBuyFlag = true;
 			_blockSellFlag = false;
 		}
-		else if (_fractalDirection == FractalDirection.Down)
+		else if (_fractalDirection == FractalDirections.Down)
 		{
 			_blockSellFlag = true;
 			_blockBuyFlag = false;
@@ -769,11 +769,11 @@ public class CyberiaTraderAdaptiveStrategy : Strategy
 
 		if (isUpper)
 		{
-			_fractalDirection = FractalDirection.Up;
+			_fractalDirection = FractalDirections.Up;
 		}
 		else if (isLower)
 		{
-			_fractalDirection = FractalDirection.Down;
+			_fractalDirection = FractalDirections.Down;
 		}
 	}
 
@@ -855,7 +855,7 @@ public class CyberiaTraderAdaptiveStrategy : Strategy
 		var sellSuccessQuality = 0m;
 		var undefinedSuccessQuality = 0m;
 
-		DecisionType currentDecision = DecisionType.Unknown;
+		DecisionTypes currentDecision = DecisionTypes.Unknown;
 		decimal currentBuy = 0m;
 		decimal currentSell = 0m;
 		decimal currentUndefined = 0m;
@@ -877,9 +877,9 @@ public class CyberiaTraderAdaptiveStrategy : Strategy
 				previousDecisionValue = result.PreviousDecisionValue;
 			}
 
-			if (result.Decision == DecisionType.Buy)
+			if (result.Decision == DecisionTypes.Buy)
 			buyQuality += 1m;
-			else if (result.Decision == DecisionType.Sell)
+			else if (result.Decision == DecisionTypes.Sell)
 			sellQuality += 1m;
 			else
 			undefinedQuality += 1m;
@@ -983,18 +983,18 @@ public class CyberiaTraderAdaptiveStrategy : Strategy
 		decimal buyPossibility = 0m;
 		decimal sellPossibility = 0m;
 		decimal undefinedPossibility = 0m;
-		var decision = DecisionType.Unknown;
+		var decision = DecisionTypes.Unknown;
 
 		if (decisionValue > 0m)
 		{
 			if (previousDecisionValue < 0m)
 			{
-				decision = DecisionType.Sell;
+				decision = DecisionTypes.Sell;
 				sellPossibility = decisionValue;
 			}
 			else
 			{
-				decision = DecisionType.Unknown;
+				decision = DecisionTypes.Unknown;
 				undefinedPossibility = decisionValue;
 			}
 		}
@@ -1002,12 +1002,12 @@ public class CyberiaTraderAdaptiveStrategy : Strategy
 		{
 			if (previousDecisionValue > 0m)
 			{
-				decision = DecisionType.Buy;
+				decision = DecisionTypes.Buy;
 				buyPossibility = -decisionValue;
 			}
 			else
 			{
-				decision = DecisionType.Unknown;
+				decision = DecisionTypes.Unknown;
 				undefinedPossibility = -decisionValue;
 			}
 		}
@@ -1026,24 +1026,24 @@ public class CyberiaTraderAdaptiveStrategy : Strategy
 
 	private readonly record struct CandleSnapshot(decimal Open, decimal High, decimal Low, decimal Close);
 
-	private enum DecisionType
+	private enum DecisionTypes
 	{
 		Sell,
 		Buy,
 		Unknown,
 	}
 
-	private enum FractalDirection
+	private enum FractalDirections
 	{
 		None,
 		Up,
 		Down,
 	}
 
-	private readonly record struct PossibilityResult(DecisionType Decision, decimal BuyPossibility, decimal SellPossibility, decimal UndefinedPossibility, decimal DecisionValue, decimal PreviousDecisionValue);
+	private readonly record struct PossibilityResult(DecisionTypes Decision, decimal BuyPossibility, decimal SellPossibility, decimal UndefinedPossibility, decimal DecisionValue, decimal PreviousDecisionValue);
 
 	private readonly record struct PossibilityStats(
-	DecisionType Decision,
+	DecisionTypes Decision,
 	decimal BuyPossibility,
 	decimal SellPossibility,
 	decimal UndefinedPossibility,
@@ -1065,7 +1065,7 @@ public class CyberiaTraderAdaptiveStrategy : Strategy
 	decimal PossibilitySuccessQuality,
 	bool HasValue)
 	{
-		public static PossibilityStats Invalid { get; } = new PossibilityStats(DecisionType.Unknown, 0m, 0m, 0m, 0m, 0m, 0m, 0m, 0m, 0m, 0m, 0m, 0m, 0m, 0m, 0m, 0m, 0m, 0m, 0m, false);
+		public static PossibilityStats Invalid { get; } = new PossibilityStats(DecisionTypes.Unknown, 0m, 0m, 0m, 0m, 0m, 0m, 0m, 0m, 0m, 0m, 0m, 0m, 0m, 0m, 0m, 0m, 0m, 0m, 0m, false);
 
 		public bool IsValid => HasValue;
 	}

--- a/API/3995_ZigZag_EvgeTrofi_1/CS/ZigZagEvgeTrofi1Strategy.cs
+++ b/API/3995_ZigZag_EvgeTrofi_1/CS/ZigZagEvgeTrofi1Strategy.cs
@@ -21,7 +21,7 @@ using StockSharp.Algo;
 /// </summary>
 public class ZigZagEvgeTrofi1Strategy : Strategy
 {
-	private enum PivotType
+	private enum PivotTypes
 	{
 		None,
 		High,
@@ -37,7 +37,7 @@ public class ZigZagEvgeTrofi1Strategy : Strategy
 
 	private Highest _highest;
 	private Lowest _lowest;
-	private PivotType _pivotType;
+	private PivotTypes _pivotType;
 	private decimal _pivotPrice;
 	private int _barsSincePivot;
 	private bool _signalHandled;
@@ -147,7 +147,7 @@ public class ZigZagEvgeTrofi1Strategy : Strategy
 
 		_highest = null;
 		_lowest = null;
-		_pivotType = PivotType.None;
+		_pivotType = PivotTypes.None;
 		_pivotPrice = 0m;
 		_barsSincePivot = int.MaxValue;
 		_signalHandled = true;
@@ -187,29 +187,29 @@ public class ZigZagEvgeTrofi1Strategy : Strategy
 			return;
 
 		// Track how many bars have passed since the latest identified pivot.
-		if (_pivotType != PivotType.None && _barsSincePivot < int.MaxValue)
+		if (_pivotType != PivotTypes.None && _barsSincePivot < int.MaxValue)
 			_barsSincePivot++;
 
 		var deviationPrice = GetDeviationPrice();
-		var canSwitch = _pivotType == PivotType.None || _barsSincePivot >= Backstep;
+		var canSwitch = _pivotType == PivotTypes.None || _barsSincePivot >= Backstep;
 
 		// Detect a new swing high whenever price matches the tracked maximum.
 		if (candle.HighPrice >= highestValue && highestValue > 0m)
 		{
 			var difference = candle.HighPrice - _pivotPrice;
-			if ((_pivotType != PivotType.High && canSwitch) || (_pivotType == PivotType.High && difference >= deviationPrice))
-				SetPivot(PivotType.High, candle.HighPrice);
+			if ((_pivotType != PivotTypes.High && canSwitch) || (_pivotType == PivotTypes.High && difference >= deviationPrice))
+				SetPivot(PivotTypes.High, candle.HighPrice);
 		}
 		// Detect a new swing low whenever price touches the tracked minimum.
 		else if (candle.LowPrice <= lowestValue && lowestValue > 0m)
 		{
 			var difference = _pivotPrice - candle.LowPrice;
-			if ((_pivotType != PivotType.Low && canSwitch) || (_pivotType == PivotType.Low && difference >= deviationPrice))
-				SetPivot(PivotType.Low, candle.LowPrice);
+			if ((_pivotType != PivotTypes.Low && canSwitch) || (_pivotType == PivotTypes.Low && difference >= deviationPrice))
+				SetPivot(PivotTypes.Low, candle.LowPrice);
 		}
 
 		// Stop if no pivot is available after the checks above.
-		if (_pivotType == PivotType.None)
+		if (_pivotType == PivotTypes.None)
 			return;
 
 		// Skip if the pivot is already considered stale by the urgency filter.
@@ -231,7 +231,7 @@ public class ZigZagEvgeTrofi1Strategy : Strategy
 			return;
 		}
 
-		var isBuySignal = _pivotType == PivotType.High;
+		var isBuySignal = _pivotType == PivotTypes.High;
 
 		// Do nothing if a position in the same direction is already open.
 		if (isBuySignal)
@@ -277,7 +277,7 @@ public class ZigZagEvgeTrofi1Strategy : Strategy
 	}
 
 	// Update the internal pivot state when a new turning point is registered.
-	private void SetPivot(PivotType type, decimal price)
+	private void SetPivot(PivotTypes type, decimal price)
 	{
 		_pivotType = type;
 		_pivotPrice = price;

--- a/API/3998_Support_Resistance_Breakout/CS/SupportResistanceBreakoutStrategy.cs
+++ b/API/3998_Support_Resistance_Breakout/CS/SupportResistanceBreakoutStrategy.cs
@@ -29,7 +29,7 @@ public class SupportResistanceBreakoutStrategy : Strategy
 
 	private decimal _support;
 	private decimal _resistance;
-	private TrendDirection _trend;
+	private TrendDirections _trend;
 
 	private decimal _point;
 	private Order _stopOrder;
@@ -37,7 +37,7 @@ public class SupportResistanceBreakoutStrategy : Strategy
 	private decimal? _entryPrice;
 	private int _trailingStage;
 
-	private enum TrendDirection
+	private enum TrendDirections
 	{
 		None,
 		Bullish,
@@ -105,7 +105,7 @@ public class SupportResistanceBreakoutStrategy : Strategy
 
 		_support = 0m;
 		_resistance = 0m;
-		_trend = TrendDirection.None;
+		_trend = TrendDirections.None;
 		_point = 0m;
 		_stopOrder = null;
 		_stopPrice = null;
@@ -159,11 +159,11 @@ public class SupportResistanceBreakoutStrategy : Strategy
 
 		var emaDecimal = emaValue.ToDecimal();
 
-		_trend = TrendDirection.None;
+		_trend = TrendDirections.None;
 		if (candle.OpenPrice > emaDecimal)
-		_trend = TrendDirection.Bullish;
+		_trend = TrendDirections.Bullish;
 		else if (candle.OpenPrice < emaDecimal)
-		_trend = TrendDirection.Bearish;
+		_trend = TrendDirections.Bearish;
 
 		var canTrade = IsFormedAndOnlineAndAllowTrading();
 
@@ -181,7 +181,7 @@ public class SupportResistanceBreakoutStrategy : Strategy
 		return;
 
 		// Buy the breakout when the market is trending higher.
-		if (_trend == TrendDirection.Bullish && Position <= 0 && candle.ClosePrice > _resistance)
+		if (_trend == TrendDirections.Bullish && Position <= 0 && candle.ClosePrice > _resistance)
 		{
 			var volume = Volume + Math.Abs(Position);
 			if (volume > 0m)
@@ -191,7 +191,7 @@ public class SupportResistanceBreakoutStrategy : Strategy
 			}
 		}
 		// Sell the breakdown when the market is trending lower.
-		else if (_trend == TrendDirection.Bearish && Position >= 0 && candle.ClosePrice < _support)
+		else if (_trend == TrendDirections.Bearish && Position >= 0 && candle.ClosePrice < _support)
 		{
 			var volume = Volume + Math.Abs(Position);
 			if (volume > 0m)


### PR DESCRIPTION
## Summary
- rename enumeration types across API strategies 3001-4000 so their names are plural (e.g., `MaMethods`, `CloseProfitModes`) and remove any lingering `Enum` suffixes to align the naming convention

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8378f2d608323881bbf2c5b278c1d