### PR TITLE
Pluralize enums for API strategies 4001-4227

### DIFF
--- a/API/4003_MA_Cross_Method_PriceMode/CS/MaCrossMethodPriceModeStrategy.cs
+++ b/API/4003_MA_Cross_Method_PriceMode/CS/MaCrossMethodPriceModeStrategy.cs
@@ -21,10 +21,10 @@ public class MaCrossMethodPriceModeStrategy : Strategy
 {
 	private readonly StrategyParam<int> _firstPeriod;
 	private readonly StrategyParam<int> _secondPeriod;
-	private readonly StrategyParam<MaMethod> _firstMethod;
-	private readonly StrategyParam<MaMethod> _secondMethod;
-	private readonly StrategyParam<AppliedPriceMode> _firstPriceMode;
-	private readonly StrategyParam<AppliedPriceMode> _secondPriceMode;
+	private readonly StrategyParam<MaMethods> _firstMethod;
+	private readonly StrategyParam<MaMethods> _secondMethod;
+	private readonly StrategyParam<AppliedPriceModes> _firstPriceMode;
+	private readonly StrategyParam<AppliedPriceModes> _secondPriceMode;
 	private readonly StrategyParam<int> _firstShift;
 	private readonly StrategyParam<int> _secondShift;
 	private readonly StrategyParam<decimal> _orderVolume;
@@ -53,19 +53,19 @@ public class MaCrossMethodPriceModeStrategy : Strategy
 			.SetCanOptimize(true)
 			.SetOptimize(5, 100, 1);
 
-		_firstMethod = Param(nameof(FirstMethod), MaMethod.Simple)
+		_firstMethod = Param(nameof(FirstMethod), MaMethods.Simple)
 			.SetDisplay("Fast MA Method", "Smoothing method applied to the first moving average.", "Indicators")
 			.SetCanOptimize(true);
 
-		_secondMethod = Param(nameof(SecondMethod), MaMethod.LinearWeighted)
+		_secondMethod = Param(nameof(SecondMethod), MaMethods.LinearWeighted)
 			.SetDisplay("Slow MA Method", "Smoothing method applied to the second moving average.", "Indicators")
 			.SetCanOptimize(true);
 
-		_firstPriceMode = Param(nameof(FirstPriceMode), AppliedPriceMode.Close)
+		_firstPriceMode = Param(nameof(FirstPriceMode), AppliedPriceModes.Close)
 			.SetDisplay("Fast MA Price", "Price source used for the first moving average.", "Indicators")
 			.SetCanOptimize(true);
 
-		_secondPriceMode = Param(nameof(SecondPriceMode), AppliedPriceMode.Median)
+		_secondPriceMode = Param(nameof(SecondPriceMode), AppliedPriceModes.Median)
 			.SetDisplay("Slow MA Price", "Price source used for the second moving average.", "Indicators")
 			.SetCanOptimize(true);
 
@@ -107,7 +107,7 @@ public class MaCrossMethodPriceModeStrategy : Strategy
 	/// <summary>
 	/// Smoothing method applied to the first moving average.
 	/// </summary>
-	public MaMethod FirstMethod
+	public MaMethods FirstMethod
 	{
 		get => _firstMethod.Value;
 		set => _firstMethod.Value = value;
@@ -116,7 +116,7 @@ public class MaCrossMethodPriceModeStrategy : Strategy
 	/// <summary>
 	/// Smoothing method applied to the second moving average.
 	/// </summary>
-	public MaMethod SecondMethod
+	public MaMethods SecondMethod
 	{
 		get => _secondMethod.Value;
 		set => _secondMethod.Value = value;
@@ -125,7 +125,7 @@ public class MaCrossMethodPriceModeStrategy : Strategy
 	/// <summary>
 	/// Applied price mode for the first moving average.
 	/// </summary>
-	public AppliedPriceMode FirstPriceMode
+	public AppliedPriceModes FirstPriceMode
 	{
 		get => _firstPriceMode.Value;
 		set => _firstPriceMode.Value = value;
@@ -134,7 +134,7 @@ public class MaCrossMethodPriceModeStrategy : Strategy
 	/// <summary>
 	/// Applied price mode for the second moving average.
 	/// </summary>
-	public AppliedPriceMode SecondPriceMode
+	public AppliedPriceModes SecondPriceMode
 	{
 		get => _secondPriceMode.Value;
 		set => _secondPriceMode.Value = value;
@@ -294,29 +294,29 @@ public class MaCrossMethodPriceModeStrategy : Strategy
 			|| (previousFast > currentSlow && currentFast <= currentSlow);
 	}
 
-	private static decimal SelectPrice(ICandleMessage candle, AppliedPriceMode mode)
+	private static decimal SelectPrice(ICandleMessage candle, AppliedPriceModes mode)
 	{
 		return mode switch
 		{
-			AppliedPriceMode.Close => candle.ClosePrice,
-			AppliedPriceMode.Open => candle.OpenPrice,
-			AppliedPriceMode.High => candle.HighPrice,
-			AppliedPriceMode.Low => candle.LowPrice,
-			AppliedPriceMode.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-			AppliedPriceMode.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-			AppliedPriceMode.Weighted => (candle.HighPrice + candle.LowPrice + (2m * candle.ClosePrice)) / 4m,
+			AppliedPriceModes.Close => candle.ClosePrice,
+			AppliedPriceModes.Open => candle.OpenPrice,
+			AppliedPriceModes.High => candle.HighPrice,
+			AppliedPriceModes.Low => candle.LowPrice,
+			AppliedPriceModes.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+			AppliedPriceModes.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+			AppliedPriceModes.Weighted => (candle.HighPrice + candle.LowPrice + (2m * candle.ClosePrice)) / 4m,
 			_ => candle.ClosePrice
 		};
 	}
 
-	private static LengthIndicator<decimal> CreateMovingAverage(MaMethod method, int period)
+	private static LengthIndicator<decimal> CreateMovingAverage(MaMethods method, int period)
 	{
 		return method switch
 		{
-			MaMethod.Simple => new SimpleMovingAverage { Length = period },
-			MaMethod.Exponential => new ExponentialMovingAverage { Length = period },
-			MaMethod.Smoothed => new SmoothedMovingAverage { Length = period },
-			MaMethod.LinearWeighted => new WeightedMovingAverage { Length = period },
+			MaMethods.Simple => new SimpleMovingAverage { Length = period },
+			MaMethods.Exponential => new ExponentialMovingAverage { Length = period },
+			MaMethods.Smoothed => new SmoothedMovingAverage { Length = period },
+			MaMethods.LinearWeighted => new WeightedMovingAverage { Length = period },
 			_ => new SimpleMovingAverage { Length = period }
 		};
 	}
@@ -324,7 +324,7 @@ public class MaCrossMethodPriceModeStrategy : Strategy
 	/// <summary>
 	/// Moving average smoothing methods that mirror the MetaTrader inputs.
 	/// </summary>
-	public enum MaMethod
+	public enum MaMethods
 	{
 		Simple,
 		Exponential,
@@ -335,7 +335,7 @@ public class MaCrossMethodPriceModeStrategy : Strategy
 	/// <summary>
 	/// Applied price options equivalent to the MetaTrader constants.
 	/// </summary>
-	public enum AppliedPriceMode
+	public enum AppliedPriceModes
 	{
 		Close,
 		Open,

--- a/API/4004_FT_BillWillams_Trader/CS/FTBillWillamsTraderStrategy.cs
+++ b/API/4004_FT_BillWillams_Trader/CS/FTBillWillamsTraderStrategy.cs
@@ -23,14 +23,14 @@ public class FTBillWillamsTraderStrategy : Strategy
 	private readonly StrategyParam<decimal> _orderVolume;
 	private readonly StrategyParam<int> _fractalPeriod;
 	private readonly StrategyParam<int> _indentPoints;
-	private readonly StrategyParam<EntryMode> _entryMode;
+	private readonly StrategyParam<EntryModes> _entryMode;
 	private readonly StrategyParam<bool> _useTeethFilter;
 	private readonly StrategyParam<int> _maxDistancePoints;
 	private readonly StrategyParam<bool> _useTrendAlignment;
 	private readonly StrategyParam<int> _jawTeethDistancePoints;
 	private readonly StrategyParam<int> _teethLipsDistancePoints;
-	private readonly StrategyParam<JawExitMode> _jawExitMode;
-	private readonly StrategyParam<ReverseExitMode> _reverseExitMode;
+	private readonly StrategyParam<JawExitModes> _jawExitMode;
+	private readonly StrategyParam<ReverseExitModes> _reverseExitMode;
 	private readonly StrategyParam<bool> _enableTrailing;
 	private readonly StrategyParam<int> _slopeSmaPeriod;
 	private readonly StrategyParam<decimal> _stopLossPoints;
@@ -41,7 +41,7 @@ public class FTBillWillamsTraderStrategy : Strategy
 	private readonly StrategyParam<int> _teethShift;
 	private readonly StrategyParam<int> _lipsPeriod;
 	private readonly StrategyParam<int> _lipsShift;
-	private readonly StrategyParam<MovingAverageMethod> _maMethod;
+	private readonly StrategyParam<MovingAverageMethods> _maMethod;
 	private readonly StrategyParam<CandlePrice> _appliedPrice;
 	private readonly StrategyParam<DataType> _candleType;
 
@@ -107,7 +107,7 @@ public class FTBillWillamsTraderStrategy : Strategy
 	/// <summary>
 	/// Breakout confirmation method.
 	/// </summary>
-	public EntryMode EntryConfirmation
+	public EntryModes EntryConfirmation
 	{
 		get => _entryMode.Value;
 		set => _entryMode.Value = value;
@@ -161,7 +161,7 @@ public class FTBillWillamsTraderStrategy : Strategy
 	/// <summary>
 	/// Exit mode when price falls back to the Alligator jaw.
 	/// </summary>
-	public JawExitMode JawExit
+	public JawExitModes JawExit
 	{
 		get => _jawExitMode.Value;
 		set => _jawExitMode.Value = value;
@@ -170,7 +170,7 @@ public class FTBillWillamsTraderStrategy : Strategy
 	/// <summary>
 	/// Exit mode triggered by opposite signals.
 	/// </summary>
-	public ReverseExitMode ReverseExit
+	public ReverseExitModes ReverseExit
 	{
 		get => _reverseExitMode.Value;
 		set => _reverseExitMode.Value = value;
@@ -269,7 +269,7 @@ public class FTBillWillamsTraderStrategy : Strategy
 	/// <summary>
 	/// Moving-average algorithm used for all Alligator lines.
 	/// </summary>
-	public MovingAverageMethod MaMethod
+	public MovingAverageMethods MaMethod
 	{
 		get => _maMethod.Value;
 		set => _maMethod.Value = value;
@@ -310,7 +310,7 @@ public class FTBillWillamsTraderStrategy : Strategy
 		.SetRange(0, 1000)
 		.SetDisplay("Indent", "Points added to the breakout price", "Signals");
 
-		_entryMode = Param(nameof(EntryConfirmation), EntryMode.CloseBreakout)
+		_entryMode = Param(nameof(EntryConfirmation), EntryModes.CloseBreakout)
 		.SetDisplay("Entry Mode", "Breakout confirmation method", "Trading");
 
 		_useTeethFilter = Param(nameof(UseTeethFilter), true)
@@ -331,10 +331,10 @@ public class FTBillWillamsTraderStrategy : Strategy
 		.SetRange(0, 1000)
 		.SetDisplay("Teeth-Lips Distance", "Minimum gap between teeth and lips", "Filters");
 
-		_jawExitMode = Param(nameof(JawExit), JawExitMode.CloseCross)
+		_jawExitMode = Param(nameof(JawExit), JawExitModes.CloseCross)
 		.SetDisplay("Jaw Exit", "Exit condition when price crosses the jaw", "Risk Management");
 
-		_reverseExitMode = Param(nameof(ReverseExit), ReverseExitMode.OppositePosition)
+		_reverseExitMode = Param(nameof(ReverseExit), ReverseExitModes.OppositePosition)
 		.SetDisplay("Reverse Exit", "Exit behavior on opposite signals", "Risk Management");
 
 		_enableTrailing = Param(nameof(EnableTrailing), true)
@@ -376,7 +376,7 @@ public class FTBillWillamsTraderStrategy : Strategy
 		.SetRange(0, 30)
 		.SetDisplay("Lips Shift", "Forward shift of the lips line", "Alligator");
 
-		_maMethod = Param(nameof(MaMethod), MovingAverageMethod.Simple)
+		_maMethod = Param(nameof(MaMethod), MovingAverageMethods.Simple)
 		.SetDisplay("MA Method", "Moving-average type used for Alligator lines", "Alligator");
 
 		_appliedPrice = Param(nameof(AppliedPrice), CandlePrice.Median)
@@ -571,9 +571,9 @@ public class FTBillWillamsTraderStrategy : Strategy
 				return;
 			}
 
-			if (JawExit != JawExitMode.Disabled && hasJaw)
+			if (JawExit != JawExitModes.Disabled && hasJaw)
 			{
-				var threshold = JawExit == JawExitMode.PriceCross ? candle.LowPrice : candle.ClosePrice;
+				var threshold = JawExit == JawExitModes.PriceCross ? candle.LowPrice : candle.ClosePrice;
 				if (threshold <= jawPrev)
 				{
 					CloseLong();
@@ -606,7 +606,7 @@ public class FTBillWillamsTraderStrategy : Strategy
 				}
 			}
 
-			if (ReverseExit == ReverseExitMode.OppositeFractal && _newDownFractal)
+			if (ReverseExit == ReverseExitModes.OppositeFractal && _newDownFractal)
 			{
 				CloseLong();
 				_newDownFractal = false;
@@ -621,9 +621,9 @@ public class FTBillWillamsTraderStrategy : Strategy
 				return;
 			}
 
-			if (JawExit != JawExitMode.Disabled && hasJaw)
+			if (JawExit != JawExitModes.Disabled && hasJaw)
 			{
-				var threshold = JawExit == JawExitMode.PriceCross ? candle.HighPrice : candle.ClosePrice;
+				var threshold = JawExit == JawExitModes.PriceCross ? candle.HighPrice : candle.ClosePrice;
 				if (threshold >= jawPrev)
 				{
 					CloseShort();
@@ -656,7 +656,7 @@ public class FTBillWillamsTraderStrategy : Strategy
 				}
 			}
 
-			if (ReverseExit == ReverseExitMode.OppositeFractal && _newUpFractal)
+			if (ReverseExit == ReverseExitModes.OppositeFractal && _newUpFractal)
 			{
 				CloseShort();
 				_newUpFractal = false;
@@ -681,8 +681,8 @@ public class FTBillWillamsTraderStrategy : Strategy
 
 		var breakout = EntryConfirmation switch
 		{
-			EntryMode.PriceBreakout => candle.HighPrice > buyLevel,
-			EntryMode.CloseBreakout => _previousClose is decimal prev && prev > buyLevel,
+			EntryModes.PriceBreakout => candle.HighPrice > buyLevel,
+			EntryModes.CloseBreakout => _previousClose is decimal prev && prev > buyLevel,
 			_ => false,
 		};
 
@@ -709,7 +709,7 @@ public class FTBillWillamsTraderStrategy : Strategy
 			return;
 		}
 
-		if (Position < 0 && ReverseExit == ReverseExitMode.OppositePosition)
+		if (Position < 0 && ReverseExit == ReverseExitModes.OppositePosition)
 		{
 			CloseShort();
 		}
@@ -740,8 +740,8 @@ public class FTBillWillamsTraderStrategy : Strategy
 
 		var breakout = EntryConfirmation switch
 		{
-			EntryMode.PriceBreakout => candle.LowPrice < sellLevel,
-			EntryMode.CloseBreakout => _previousClose is decimal prev && prev < sellLevel,
+			EntryModes.PriceBreakout => candle.LowPrice < sellLevel,
+			EntryModes.CloseBreakout => _previousClose is decimal prev && prev < sellLevel,
 			_ => false,
 		};
 
@@ -768,7 +768,7 @@ public class FTBillWillamsTraderStrategy : Strategy
 			return;
 		}
 
-		if (Position > 0 && ReverseExit == ReverseExitMode.OppositePosition)
+		if (Position > 0 && ReverseExit == ReverseExitModes.OppositePosition)
 		{
 			CloseLong();
 		}
@@ -949,14 +949,14 @@ public class FTBillWillamsTraderStrategy : Strategy
 		return Math.Abs(first - second) <= _point / 2m;
 	}
 
-	private LengthIndicator<decimal> CreateMovingAverage(MovingAverageMethod method, int length)
+	private LengthIndicator<decimal> CreateMovingAverage(MovingAverageMethods method, int length)
 	{
 		LengthIndicator<decimal> indicator = method switch
 		{
-			MovingAverageMethod.Simple => new SimpleMovingAverage { Length = length },
-			MovingAverageMethod.Exponential => new ExponentialMovingAverage { Length = length },
-			MovingAverageMethod.Smoothed => new SmoothedMovingAverage { Length = length },
-			MovingAverageMethod.Weighted => new WeightedMovingAverage { Length = length },
+			MovingAverageMethods.Simple => new SimpleMovingAverage { Length = length },
+			MovingAverageMethods.Exponential => new ExponentialMovingAverage { Length = length },
+			MovingAverageMethods.Smoothed => new SmoothedMovingAverage { Length = length },
+			MovingAverageMethods.Weighted => new WeightedMovingAverage { Length = length },
 			_ => new SimpleMovingAverage { Length = length },
 		};
 
@@ -966,7 +966,7 @@ public class FTBillWillamsTraderStrategy : Strategy
 	/// <summary>
 	/// Breakout confirmation methods.
 	/// </summary>
-	public enum EntryMode
+	public enum EntryModes
 	{
 		/// <summary>
 		/// Confirm using intrabar high/low penetration.
@@ -982,7 +982,7 @@ public class FTBillWillamsTraderStrategy : Strategy
 	/// <summary>
 	/// Jaw exit options.
 	/// </summary>
-	public enum JawExitMode
+	public enum JawExitModes
 	{
 		/// <summary>
 		/// Do not close positions when price crosses the jaw.
@@ -1003,7 +1003,7 @@ public class FTBillWillamsTraderStrategy : Strategy
 	/// <summary>
 	/// Reverse signal exit options.
 	/// </summary>
-	public enum ReverseExitMode
+	public enum ReverseExitModes
 	{
 		/// <summary>
 		/// Ignore opposite signals.
@@ -1024,7 +1024,7 @@ public class FTBillWillamsTraderStrategy : Strategy
 	/// <summary>
 	/// Moving-average types supported by the original expert advisor.
 	/// </summary>
-	public enum MovingAverageMethod
+	public enum MovingAverageMethods
 	{
 		/// <summary>
 		/// Simple moving average.

--- a/API/4005_FT_Bill_Williams_AO/CS/FtBillWilliamsAoStrategy.cs
+++ b/API/4005_FT_Bill_Williams_AO/CS/FtBillWilliamsAoStrategy.cs
@@ -32,8 +32,8 @@ public class FtBillWilliamsAoStrategy : Strategy
 	private readonly StrategyParam<int> _teethShift;
 	private readonly StrategyParam<int> _lipsPeriod;
 	private readonly StrategyParam<int> _lipsShift;
-	private readonly StrategyParam<CloseDropTeethMode> _closeDropTeethMode;
-	private readonly StrategyParam<CloseReverseSignalMode> _closeReverseSignalMode;
+	private readonly StrategyParam<CloseDropTeethModes> _closeDropTeethMode;
+	private readonly StrategyParam<CloseReverseSignalModes> _closeReverseSignalMode;
 	private readonly StrategyParam<bool> _useTrailing;
 	private readonly StrategyParam<int> _trendSmaPeriod;
 	private readonly StrategyParam<decimal> _stopLossPoints;
@@ -161,7 +161,7 @@ public class FtBillWilliamsAoStrategy : Strategy
 	/// <summary>
 	/// Defines how long positions are closed when price touches the jaw line.
 	/// </summary>
-	public CloseDropTeethMode CloseDropTeeth
+	public CloseDropTeethModes CloseDropTeeth
 	{
 		get => _closeDropTeethMode.Value;
 		set => _closeDropTeethMode.Value = value;
@@ -170,7 +170,7 @@ public class FtBillWilliamsAoStrategy : Strategy
 	/// <summary>
 	/// Defines when the strategy exits on an opposite reversal signal.
 	/// </summary>
-	public CloseReverseSignalMode CloseReverseSignal
+	public CloseReverseSignalModes CloseReverseSignal
 	{
 		get => _closeReverseSignalMode.Value;
 		set => _closeReverseSignalMode.Value = value;
@@ -267,10 +267,10 @@ public class FtBillWilliamsAoStrategy : Strategy
 			.SetDisplay("Lips Shift", "Forward shift for the lips line", "Alligator")
 			.SetRange(0, 30);
 
-		_closeDropTeethMode = Param(nameof(CloseDropTeeth), CloseDropTeethMode.PreviousCloseBelowJaw)
+		_closeDropTeethMode = Param(nameof(CloseDropTeeth), CloseDropTeethModes.PreviousCloseBelowJaw)
 			.SetDisplay("Close Drop Teeth", "How long positions close relative to the jaw", "Risk");
 
-		_closeReverseSignalMode = Param(nameof(CloseReverseSignal), CloseReverseSignalMode.OnShortSignal)
+		_closeReverseSignalMode = Param(nameof(CloseReverseSignal), CloseReverseSignalModes.OnShortSignal)
 			.SetDisplay("Close Reverse", "When to close on opposite signals", "Risk");
 
 		_useTrailing = Param(nameof(UseTrailing), true)
@@ -529,14 +529,14 @@ public class FtBillWilliamsAoStrategy : Strategy
 		}
 
 		var jaw = GetShiftedValue(_jawHistory, JawShift, 1);
-		if (CloseDropTeeth == CloseDropTeethMode.BidBelowJaw && jaw is decimal jawValue && candle.ClosePrice <= jawValue)
+		if (CloseDropTeeth == CloseDropTeethModes.BidBelowJaw && jaw is decimal jawValue && candle.ClosePrice <= jawValue)
 		{
 			SellMarket(volume);
 			ResetLongState();
 			return;
 		}
 
-		if (CloseDropTeeth == CloseDropTeethMode.PreviousCloseBelowJaw && jaw is decimal jawPrev)
+		if (CloseDropTeeth == CloseDropTeethModes.PreviousCloseBelowJaw && jaw is decimal jawPrev)
 		{
 			var prevClose = GetValueBarsAgo(_closeHistory, 1);
 			if (prevClose is decimal closeValue && closeValue <= jawPrev)
@@ -547,14 +547,14 @@ public class FtBillWilliamsAoStrategy : Strategy
 			}
 		}
 
-		if (CloseReverseSignal == CloseReverseSignalMode.OnOppositeFractal && downFractalTriggered)
+		if (CloseReverseSignal == CloseReverseSignalModes.OnOppositeFractal && downFractalTriggered)
 		{
 			SellMarket(volume);
 			ResetLongState();
 			return;
 		}
 
-		if (CloseReverseSignal == CloseReverseSignalMode.OnShortSignal && _pendingShortLevel is not null)
+		if (CloseReverseSignal == CloseReverseSignalModes.OnShortSignal && _pendingShortLevel is not null)
 		{
 			SellMarket(volume);
 			ResetLongState();
@@ -591,14 +591,14 @@ public class FtBillWilliamsAoStrategy : Strategy
 		}
 
 		var jaw = GetShiftedValue(_jawHistory, JawShift, 1);
-		if (CloseDropTeeth == CloseDropTeethMode.BidBelowJaw && jaw is decimal jawValue && candle.ClosePrice >= jawValue)
+		if (CloseDropTeeth == CloseDropTeethModes.BidBelowJaw && jaw is decimal jawValue && candle.ClosePrice >= jawValue)
 		{
 			BuyMarket(volume);
 			ResetShortState();
 			return;
 		}
 
-		if (CloseDropTeeth == CloseDropTeethMode.PreviousCloseBelowJaw && jaw is decimal jawPrev)
+		if (CloseDropTeeth == CloseDropTeethModes.PreviousCloseBelowJaw && jaw is decimal jawPrev)
 		{
 			var prevClose = GetValueBarsAgo(_closeHistory, 1);
 			if (prevClose is decimal closeValue && closeValue >= jawPrev)
@@ -609,14 +609,14 @@ public class FtBillWilliamsAoStrategy : Strategy
 			}
 		}
 
-		if (CloseReverseSignal == CloseReverseSignalMode.OnOppositeFractal && upFractalTriggered)
+		if (CloseReverseSignal == CloseReverseSignalModes.OnOppositeFractal && upFractalTriggered)
 		{
 			BuyMarket(volume);
 			ResetShortState();
 			return;
 		}
 
-		if (CloseReverseSignal == CloseReverseSignalMode.OnShortSignal && _pendingLongLevel is not null)
+		if (CloseReverseSignal == CloseReverseSignalModes.OnShortSignal && _pendingLongLevel is not null)
 		{
 			BuyMarket(volume);
 			ResetShortState();
@@ -949,7 +949,7 @@ public class FtBillWilliamsAoStrategy : Strategy
 	/// <summary>
 	/// Defines how long trades are closed relative to the Alligator jaw.
 	/// </summary>
-	public enum CloseDropTeethMode
+	public enum CloseDropTeethModes
 	{
 	/// <summary>
 	/// Do not close positions based on the jaw line.
@@ -970,7 +970,7 @@ public class FtBillWilliamsAoStrategy : Strategy
 	/// <summary>
 	/// Defines when to exit an existing trade on opposite signals.
 	/// </summary>
-	public enum CloseReverseSignalMode
+	public enum CloseReverseSignalModes
 	{
 	/// <summary>
 	/// Keep the position despite opposite signals.

--- a/API/4011_Ilan1_4_Grid/CS/Ilan14GridStrategy.cs
+++ b/API/4011_Ilan1_4_Grid/CS/Ilan14GridStrategy.cs
@@ -22,7 +22,7 @@ public class Ilan14GridStrategy : Strategy
 {
 	private readonly StrategyParam<decimal> _initialVolume;
 	private readonly StrategyParam<int> _volumeDigits;
-	private readonly StrategyParam<MoneyManagementMode> _moneyManagementMode;
+	private readonly StrategyParam<MoneyManagementModes> _moneyManagementMode;
 	private readonly StrategyParam<bool> _useCloseBeforeAdding;
 	private readonly StrategyParam<bool> _useAdd;
 	private readonly StrategyParam<decimal> _lotExponent;
@@ -52,7 +52,7 @@ public class Ilan14GridStrategy : Strategy
 	private DateTimeOffset? _basketExpiration;
 	private Sides? _basketDirection;
 
-	private enum MoneyManagementMode
+	private enum MoneyManagementModes
 	{
 		Fixed,
 		Geometric,
@@ -74,7 +74,7 @@ public Ilan14GridStrategy()
 			.SetNotNegative()
 			.SetDisplay("Volume digits", "Number of decimal places used to round trade volume.", "Trading");
 
-		_moneyManagementMode = Param(nameof(MoneyManagementMode), MoneyManagementMode.Geometric)
+		_moneyManagementMode = Param(nameof(MoneyManagementModes), MoneyManagementModes.Geometric)
 			.SetDisplay("Money management", "Volume calculation mode: fixed, geometric martingale or recover last loss.", "Trading");
 
 		_lotExponent = Param(nameof(LotExponent), 1.667m)
@@ -155,7 +155,7 @@ public Ilan14GridStrategy()
 		set => _volumeDigits.Value = value;
 	}
 
-	public MoneyManagementMode MoneyManagementMode
+	public MoneyManagementModes MoneyManagementModes
 	{
 		get => _moneyManagementMode.Value;
 		set => _moneyManagementMode.Value = value;
@@ -540,16 +540,16 @@ public Ilan14GridStrategy()
 	{
 		decimal volume;
 
-		switch (MoneyManagementMode)
+		switch (MoneyManagementModes)
 		{
-			case MoneyManagementMode.Fixed:
+			case MoneyManagementModes.Fixed:
 				volume = InitialVolume;
 				break;
-			case MoneyManagementMode.Geometric:
+			case MoneyManagementModes.Geometric:
 				var power = _tradeCount;
 				volume = InitialVolume * (decimal)Math.Pow((double)LotExponent, power);
 				break;
-			case MoneyManagementMode.RecoverLastLoss:
+			case MoneyManagementModes.RecoverLastLoss:
 				volume = _lastClosedWasLoss
 					? (_lastClosedOrderVolume > 0m ? _lastClosedOrderVolume : InitialVolume) * LotExponent
 					: InitialVolume;

--- a/API/4013_FT_TrendFollower/CS/FtTrendFollowerStrategy.cs
+++ b/API/4013_FT_TrendFollower/CS/FtTrendFollowerStrategy.cs
@@ -712,20 +712,20 @@ ProcessExitModules(candle, channelHigh, channelLow);
 		}
 	}
 
-	private void UpdateLaguerreStates(TrendDirection trend, decimal laguerreValue, decimal close, decimal low, decimal high, decimal fastestGmma, decimal slowestGmma)
+	private void UpdateLaguerreStates(TrendDirections trend, decimal laguerreValue, decimal close, decimal low, decimal high, decimal fastestGmma, decimal slowestGmma)
 	{
-		if (trend == TrendDirection.Up && close > slowestGmma && low < fastestGmma && laguerreValue < LaguerreOversold)
+		if (trend == TrendDirections.Up && close > slowestGmma && low < fastestGmma && laguerreValue < LaguerreOversold)
 			_laguerreArmedLong = true;
 
-		if (trend == TrendDirection.Down && close < slowestGmma && high > fastestGmma && laguerreValue > LaguerreOverbought)
+		if (trend == TrendDirections.Down && close < slowestGmma && high > fastestGmma && laguerreValue > LaguerreOverbought)
 			_laguerreArmedShort = true;
 	}
 
-	private void UpdateEmaStates(TrendDirection trend, decimal emaFastValue, decimal emaSlowValue)
+	private void UpdateEmaStates(TrendDirections trend, decimal emaFastValue, decimal emaSlowValue)
 	{
-		if (trend == TrendDirection.Up && emaFastValue < emaSlowValue)
+		if (trend == TrendDirections.Up && emaFastValue < emaSlowValue)
 			_emaArmedLong = true;
-		if (trend == TrendDirection.Down && emaFastValue > emaSlowValue)
+		if (trend == TrendDirections.Down && emaFastValue > emaSlowValue)
 			_emaArmedShort = true;
 	}
 
@@ -772,7 +772,7 @@ ProcessExitModules(candle, channelHigh, channelLow);
 		return (up, down);
 	}
 
-	private TrendDirection DetermineTrend(decimal[] gmmaValues)
+	private TrendDirections DetermineTrend(decimal[] gmmaValues)
 	{
 		var total = gmmaValues.Length;
 		var group = BandsPerGroup;
@@ -780,16 +780,16 @@ ProcessExitModules(candle, channelHigh, channelLow);
 		var bIndex = total - group;
 
 		if (aIndex < 0 || bIndex < 0 || aIndex >= total || bIndex >= total)
-			return TrendDirection.Flat;
+			return TrendDirections.Flat;
 
 		var slow = gmmaValues[bIndex];
 		var slower = gmmaValues[aIndex];
 
 		if (slower > slow)
-			return TrendDirection.Up;
+			return TrendDirections.Up;
 		if (slower < slow)
-			return TrendDirection.Down;
-		return TrendDirection.Flat;
+			return TrendDirections.Down;
+		return TrendDirections.Flat;
 	}
 
 	private void UpdateGmmaHistory(decimal[] currentValues)
@@ -927,7 +927,7 @@ ProcessExitModules(candle, channelHigh, channelLow);
 			throw new InvalidOperationException("Enable only one exit module at a time.");
 	}
 
-	private enum TrendDirection
+	private enum TrendDirections
 	{
 		Flat,
 		Up,

--- a/API/4015_CorrectedAverageChannel/CS/CorrectedAverageChannelStrategy.cs
+++ b/API/4015_CorrectedAverageChannel/CS/CorrectedAverageChannelStrategy.cs
@@ -26,7 +26,7 @@ public class CorrectedAverageChannelStrategy : Strategy
 	private readonly StrategyParam<int> _trailingPoints;
 	private readonly StrategyParam<int> _trailingStepPoints;
 	private readonly StrategyParam<int> _maPeriod;
-	private readonly StrategyParam<MaType> _maType;
+	private readonly StrategyParam<MaTypes> _maType;
 	private readonly StrategyParam<int> _sigmaBuyPoints;
 	private readonly StrategyParam<int> _sigmaSellPoints;
 	private readonly StrategyParam<DataType> _candleType;
@@ -111,7 +111,7 @@ public class CorrectedAverageChannelStrategy : Strategy
 	/// <summary>
 	/// Moving average type replicated from the MetaTrader input.
 	/// </summary>
-	public MaType MaTypeOption
+	public MaTypes MaTypesOption
 	{
 		get => _maType.Value;
 		set => _maType.Value = value;
@@ -179,7 +179,7 @@ public class CorrectedAverageChannelStrategy : Strategy
 			.SetDisplay("MA Period", "Period of the moving average and standard deviation", "Indicator")
 			.SetCanOptimize(true);
 
-		_maType = Param(nameof(MaTypeOption), MaType.Sma)
+		_maType = Param(nameof(MaTypesOption), MaTypes.Sma)
 			.SetDisplay("MA Type", "Moving average type used inside the Corrected Average", "Indicator");
 
 		_sigmaBuyPoints = Param(nameof(SigmaBuyPoints), 5)
@@ -233,7 +233,7 @@ public class CorrectedAverageChannelStrategy : Strategy
 	{
 		base.OnStarted(time);
 
-		_ma = CreateMa(MaTypeOption, MaPeriod);
+		_ma = CreateMa(MaTypesOption, MaPeriod);
 		_std = new StandardDeviation
 		{
 			Length = MaPeriod
@@ -506,14 +506,14 @@ public class CorrectedAverageChannelStrategy : Strategy
 		return points * _priceStep;
 	}
 
-	private static LengthIndicator<decimal> CreateMa(MaType type, int length)
+	private static LengthIndicator<decimal> CreateMa(MaTypes type, int length)
 	{
 		return type switch
 		{
-			MaType.Sma => new SimpleMovingAverage { Length = length },
-			MaType.Ema => new ExponentialMovingAverage { Length = length },
-			MaType.Smma => new SmoothedMovingAverage { Length = length },
-			MaType.Lwma => new WeightedMovingAverage { Length = length },
+			MaTypes.Sma => new SimpleMovingAverage { Length = length },
+			MaTypes.Ema => new ExponentialMovingAverage { Length = length },
+			MaTypes.Smma => new SmoothedMovingAverage { Length = length },
+			MaTypes.Lwma => new WeightedMovingAverage { Length = length },
 			_ => throw new ArgumentOutOfRangeException(nameof(type))
 		};
 	}
@@ -521,7 +521,7 @@ public class CorrectedAverageChannelStrategy : Strategy
 	/// <summary>
 	/// Supported moving average types.
 	/// </summary>
-	public enum MaType
+	public enum MaTypes
 	{
 		Sma,
 		Ema,

--- a/API/4023_Rabbit_M3/CS/RabbitM3Strategy.cs
+++ b/API/4023_Rabbit_M3/CS/RabbitM3Strategy.cs
@@ -54,7 +54,7 @@ public class RabbitM3Strategy : Strategy
 	private decimal? _previousDonchianUpper;
 	private decimal? _previousDonchianLower;
 
-	private TrendDirection _trendDirection;
+	private TrendDirections _trendDirection;
 	private bool _allowBuy;
 	private bool _allowSell;
 
@@ -67,7 +67,7 @@ public class RabbitM3Strategy : Strategy
 	private decimal _shortStopPrice;
 	private decimal _shortTakeProfitPrice;
 
-	private enum TrendDirection
+	private enum TrendDirections
 	{
 		Neutral,
 		Bullish,
@@ -312,7 +312,7 @@ public class RabbitM3Strategy : Strategy
 		_currentDonchianLower = null;
 		_previousDonchianUpper = null;
 		_previousDonchianLower = null;
-		_trendDirection = TrendDirection.Neutral;
+		_trendDirection = TrendDirections.Neutral;
 		_allowBuy = false;
 		_allowSell = false;
 		_longActive = false;
@@ -430,7 +430,7 @@ public class RabbitM3Strategy : Strategy
 	{
 		if (fastValue < slowValue)
 		{
-			if (_trendDirection == TrendDirection.Bearish)
+			if (_trendDirection == TrendDirections.Bearish)
 			return;
 
 			if (Position > 0m)
@@ -438,11 +438,11 @@ public class RabbitM3Strategy : Strategy
 
 			_allowSell = true;
 			_allowBuy = false;
-			_trendDirection = TrendDirection.Bearish;
+			_trendDirection = TrendDirections.Bearish;
 		}
 		else if (fastValue > slowValue)
 		{
-			if (_trendDirection == TrendDirection.Bullish)
+			if (_trendDirection == TrendDirections.Bullish)
 			return;
 
 			if (Position < 0m)
@@ -450,7 +450,7 @@ public class RabbitM3Strategy : Strategy
 
 			_allowSell = false;
 			_allowBuy = true;
-			_trendDirection = TrendDirection.Bullish;
+			_trendDirection = TrendDirections.Bullish;
 		}
 	}
 

--- a/API/4027_CyberiaTraderAI/CS/CyberiaTraderAiStrategy.cs
+++ b/API/4027_CyberiaTraderAI/CS/CyberiaTraderAiStrategy.cs
@@ -392,10 +392,10 @@ public class CyberiaTraderAiStrategy : Strategy
 		// Manage existing positions first to mirror the MQL behaviour.
 		if (Position > 0)
 		{
-			var shouldExitLong = (stats.CurrentDecision == TradeDecision.Sell &&
+			var shouldExitLong = (stats.CurrentDecision == TradeDecisions.Sell &&
 			stats.SellPossibility >= stats.SellSucPossibilityMid &&
 			stats.SellSucPossibilityMid > 0m) ||
-			(flags.DisableBuy && stats.CurrentDecision != TradeDecision.Buy);
+			(flags.DisableBuy && stats.CurrentDecision != TradeDecisions.Buy);
 
 			if (shouldExitLong)
 			{
@@ -405,10 +405,10 @@ public class CyberiaTraderAiStrategy : Strategy
 		}
 		else if (Position < 0)
 		{
-			var shouldExitShort = (stats.CurrentDecision == TradeDecision.Buy &&
+			var shouldExitShort = (stats.CurrentDecision == TradeDecisions.Buy &&
 			stats.BuyPossibility >= stats.BuySucPossibilityMid &&
 			stats.BuySucPossibilityMid > 0m) ||
-			(flags.DisableSell && stats.CurrentDecision != TradeDecision.Sell);
+			(flags.DisableSell && stats.CurrentDecision != TradeDecisions.Sell);
 
 			if (shouldExitShort)
 			{
@@ -418,7 +418,7 @@ public class CyberiaTraderAiStrategy : Strategy
 		}
 
 		// Evaluate fresh entries only when the probability module allows it.
-		if (stats.CurrentDecision == TradeDecision.Buy &&
+		if (stats.CurrentDecision == TradeDecisions.Buy &&
 		!flags.DisableBuy &&
 		stats.BuyPossibility >= stats.BuySucPossibilityMid &&
 		stats.BuySucPossibilityMid > 0m &&
@@ -429,7 +429,7 @@ public class CyberiaTraderAiStrategy : Strategy
 			return;
 		}
 
-		if (stats.CurrentDecision == TradeDecision.Sell &&
+		if (stats.CurrentDecision == TradeDecisions.Sell &&
 		!flags.DisableSell &&
 		stats.SellPossibility >= stats.SellSucPossibilityMid &&
 		stats.SellSucPossibilityMid > 0m &&
@@ -662,13 +662,13 @@ public class CyberiaTraderAiStrategy : Strategy
 			var buyPossibility = 0m;
 			var sellPossibility = 0m;
 			var undefinedPossibility = 0m;
-			var decision = TradeDecision.Unknown;
+			var decision = TradeDecisions.Unknown;
 
 			if (decisionValue > 0m)
 			{
 				if (previousValue < 0m)
 				{
-					decision = TradeDecision.Sell;
+					decision = TradeDecisions.Sell;
 					sellPossibility = decisionValue;
 				}
 				else
@@ -680,7 +680,7 @@ public class CyberiaTraderAiStrategy : Strategy
 			{
 				if (previousValue > 0m)
 				{
-					decision = TradeDecision.Buy;
+					decision = TradeDecisions.Buy;
 					buyPossibility = -decisionValue;
 				}
 				else
@@ -699,7 +699,7 @@ public class CyberiaTraderAiStrategy : Strategy
 
 			switch (decision)
 			{
-			case TradeDecision.Buy:
+			case TradeDecisions.Buy:
 				buyQuality++;
 				buySum += buyPossibility;
 				if (buyPossibility > spreadThreshold)
@@ -709,7 +709,7 @@ public class CyberiaTraderAiStrategy : Strategy
 				}
 				break;
 
-			case TradeDecision.Sell:
+			case TradeDecisions.Sell:
 				sellQuality++;
 				sellSum += sellPossibility;
 				if (sellPossibility > spreadThreshold)
@@ -790,7 +790,7 @@ public class CyberiaTraderAiStrategy : Strategy
 	{
 		public bool IsValid;
 		public int Period;
-		public TradeDecision CurrentDecision;
+		public TradeDecisions CurrentDecision;
 		public decimal BuyPossibility;
 		public decimal SellPossibility;
 		public decimal UndefinedPossibility;
@@ -809,7 +809,7 @@ public class CyberiaTraderAiStrategy : Strategy
 		public decimal PossibilitySuccessRatio;
 	}
 
-	private enum TradeDecision
+	private enum TradeDecisions
 	{
 		Unknown,
 		Buy,

--- a/API/4029_ExpertClor2MaStopAtr/CS/ExpertClor2MaStopAtrStrategy.cs
+++ b/API/4029_ExpertClor2MaStopAtr/CS/ExpertClor2MaStopAtrStrategy.cs
@@ -21,11 +21,11 @@ public class ExpertClor2MaStopAtrStrategy : Strategy
 	private readonly StrategyParam<bool> _maCloseEnabled;
 	private readonly StrategyParam<bool> _atrCloseEnabled;
 	private readonly StrategyParam<int> _fastMaPeriod;
-	private readonly StrategyParam<MovingAverageMethod> _fastMaMethod;
-	private readonly StrategyParam<PriceTypeEnum> _fastPriceType;
+	private readonly StrategyParam<MovingAverageMethods> _fastMaMethod;
+	private readonly StrategyParam<PriceTypes> _fastPriceType;
 	private readonly StrategyParam<int> _slowMaPeriod;
-	private readonly StrategyParam<MovingAverageMethod> _slowMaMethod;
-	private readonly StrategyParam<PriceTypeEnum> _slowPriceType;
+	private readonly StrategyParam<MovingAverageMethods> _slowMaMethod;
+	private readonly StrategyParam<PriceTypes> _slowPriceType;
 	private readonly StrategyParam<int> _breakevenPoints;
 	private readonly StrategyParam<int> _atrShiftBars;
 	private readonly StrategyParam<int> _atrPeriod;
@@ -66,13 +66,13 @@ public class ExpertClor2MaStopAtrStrategy : Strategy
 		set => _fastMaPeriod.Value = value;
 	}
 
-	public MovingAverageMethod FastMaMethod
+	public MovingAverageMethods FastMaMethod
 	{
 		get => _fastMaMethod.Value;
 		set => _fastMaMethod.Value = value;
 	}
 
-	public PriceTypeEnum FastPriceType
+	public PriceTypes FastPriceType
 	{
 		get => _fastPriceType.Value;
 		set => _fastPriceType.Value = value;
@@ -84,13 +84,13 @@ public class ExpertClor2MaStopAtrStrategy : Strategy
 		set => _slowMaPeriod.Value = value;
 	}
 
-	public MovingAverageMethod SlowMaMethod
+	public MovingAverageMethods SlowMaMethod
 	{
 		get => _slowMaMethod.Value;
 		set => _slowMaMethod.Value = value;
 	}
 
-	public PriceTypeEnum SlowPriceType
+	public PriceTypes SlowPriceType
 	{
 		get => _slowPriceType.Value;
 		set => _slowPriceType.Value = value;
@@ -139,10 +139,10 @@ public class ExpertClor2MaStopAtrStrategy : Strategy
 			.SetCanOptimize(true)
 			.SetOptimize(3, 30, 1);
 
-		_fastMaMethod = Param(nameof(FastMaMethod), MovingAverageMethod.Exponential)
+		_fastMaMethod = Param(nameof(FastMaMethod), MovingAverageMethods.Exponential)
 			.SetDisplay("Fast MA Method", "Type of the fast moving average", "Moving Averages");
 
-		_fastPriceType = Param(nameof(FastPriceType), PriceTypeEnum.Close)
+		_fastPriceType = Param(nameof(FastPriceType), PriceTypes.Close)
 			.SetDisplay("Fast Price", "Applied price for the fast moving average", "Moving Averages");
 
 		_slowMaPeriod = Param(nameof(SlowMaPeriod), 7)
@@ -150,10 +150,10 @@ public class ExpertClor2MaStopAtrStrategy : Strategy
 			.SetCanOptimize(true)
 			.SetOptimize(5, 60, 1);
 
-		_slowMaMethod = Param(nameof(SlowMaMethod), MovingAverageMethod.Exponential)
+		_slowMaMethod = Param(nameof(SlowMaMethod), MovingAverageMethods.Exponential)
 			.SetDisplay("Slow MA Method", "Type of the slow moving average", "Moving Averages");
 
-		_slowPriceType = Param(nameof(SlowPriceType), PriceTypeEnum.Open)
+		_slowPriceType = Param(nameof(SlowPriceType), PriceTypes.Open)
 			.SetDisplay("Slow Price", "Applied price for the slow moving average", "Moving Averages");
 
 		_breakevenPoints = Param(nameof(BreakevenPoints), 15)
@@ -453,33 +453,33 @@ public class ExpertClor2MaStopAtrStrategy : Strategy
 		return step;
 	}
 
-	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageMethod method, int length)
+	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageMethods method, int length)
 	{
 		return method switch
 		{
-			MovingAverageMethod.Simple => new SimpleMovingAverage { Length = length },
-			MovingAverageMethod.Exponential => new ExponentialMovingAverage { Length = length },
-			MovingAverageMethod.Smoothed => new SmoothedMovingAverage { Length = length },
-			MovingAverageMethod.Weighted => new WeightedMovingAverage { Length = length },
+			MovingAverageMethods.Simple => new SimpleMovingAverage { Length = length },
+			MovingAverageMethods.Exponential => new ExponentialMovingAverage { Length = length },
+			MovingAverageMethods.Smoothed => new SmoothedMovingAverage { Length = length },
+			MovingAverageMethods.Weighted => new WeightedMovingAverage { Length = length },
 			_ => new ExponentialMovingAverage { Length = length },
 		};
 	}
 
-	private static decimal GetPrice(ICandleMessage candle, PriceTypeEnum type)
+	private static decimal GetPrice(ICandleMessage candle, PriceTypes type)
 	{
 		return type switch
 		{
-			PriceTypeEnum.Open => candle.OpenPrice,
-			PriceTypeEnum.High => candle.HighPrice,
-			PriceTypeEnum.Low => candle.LowPrice,
-			PriceTypeEnum.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-			PriceTypeEnum.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-			PriceTypeEnum.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
+			PriceTypes.Open => candle.OpenPrice,
+			PriceTypes.High => candle.HighPrice,
+			PriceTypes.Low => candle.LowPrice,
+			PriceTypes.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+			PriceTypes.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+			PriceTypes.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
 			_ => candle.ClosePrice,
 		};
 	}
 
-	public enum MovingAverageMethod
+	public enum MovingAverageMethods
 	{
 		Simple,
 		Exponential,
@@ -487,7 +487,7 @@ public class ExpertClor2MaStopAtrStrategy : Strategy
 		Weighted
 	}
 
-	public enum PriceTypeEnum
+	public enum PriceTypes
 	{
 		Close,
 		Open,

--- a/API/4042_Jims_Close_Orders/CS/JimsCloseOrdersStrategy.cs
+++ b/API/4042_Jims_Close_Orders/CS/JimsCloseOrdersStrategy.cs
@@ -19,7 +19,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class JimsCloseOrdersStrategy : Strategy
 {
-	private enum CloseMode
+	private enum CloseModes
 	{
 		All,
 		Positive,
@@ -98,33 +98,33 @@ public class JimsCloseOrdersStrategy : Strategy
 		Stop();
 	}
 
-	private CloseMode? DetermineMode()
+	private CloseModes? DetermineMode()
 	{
 		var selected = 0;
-		CloseMode mode = CloseMode.All;
+		CloseModes mode = CloseModes.All;
 
 		if (CloseOpenOrders)
 		{
 			selected++;
-			mode = CloseMode.All;
+			mode = CloseModes.All;
 		}
 
 		if (CloseOrdersWithPlusProfit)
 		{
 			selected++;
-			mode = CloseMode.Positive;
+			mode = CloseModes.Positive;
 		}
 
 		if (CloseOrdersWithMinusProfit)
 		{
 			selected++;
-			mode = CloseMode.Negative;
+			mode = CloseModes.Negative;
 		}
 
-		return selected == 1 ? mode : (CloseMode?)null;
+		return selected == 1 ? mode : (CloseModes?)null;
 	}
 
-	private void ClosePositions(Portfolio portfolio, CloseMode mode)
+	private void ClosePositions(Portfolio portfolio, CloseModes mode)
 	{
 		// Create a snapshot because the collection can change while orders are being sent.
 		var positions = portfolio.Positions.ToArray();
@@ -138,13 +138,13 @@ public class JimsCloseOrdersStrategy : Strategy
 		}
 	}
 
-	private void ProcessPosition(Position position, CloseMode mode)
+	private void ProcessPosition(Position position, CloseModes mode)
 	{
 		var signedVolume = position.CurrentValue ?? 0m;
 		if (signedVolume == 0m)
 			return;
 
-		if (mode != CloseMode.All)
+		if (mode != CloseModes.All)
 		{
 			var profit = EstimateProfit(position, signedVolume);
 			if (profit == null)
@@ -153,10 +153,10 @@ public class JimsCloseOrdersStrategy : Strategy
 				return;
 			}
 
-			if (mode == CloseMode.Positive && profit < 0m)
+			if (mode == CloseModes.Positive && profit < 0m)
 				return;
 
-			if (mode == CloseMode.Negative && profit > 0m)
+			if (mode == CloseModes.Negative && profit > 0m)
 				return;
 		}
 

--- a/API/4049_Hans123Trader_RangeBreakout/CS/Hans123TraderRangeBreakoutStrategy.cs
+++ b/API/4049_Hans123Trader_RangeBreakout/CS/Hans123TraderRangeBreakoutStrategy.cs
@@ -271,10 +271,10 @@ public class Hans123TraderRangeBreakoutStrategy : Strategy
 
 		// Arm breakout orders at configured hours for session 1 and session 2.
 		if (candle.CloseTime.Hour == EndSession1)
-			PlaceSessionOrders(SessionSlot.First, highest, lowest, currentDate);
+			PlaceSessionOrders(SessionSlots.First, highest, lowest, currentDate);
 
 		if (candle.CloseTime.Hour == EndSession2)
-			PlaceSessionOrders(SessionSlot.Second, highest, lowest, currentDate);
+			PlaceSessionOrders(SessionSlots.Second, highest, lowest, currentDate);
 	}
 
 	private void ManageOpenPosition(ICandleMessage candle, DateTime currentDate)
@@ -375,11 +375,11 @@ public class Hans123TraderRangeBreakoutStrategy : Strategy
 		_session2OrderDate = null;
 	}
 
-	private void PlaceSessionOrders(SessionSlot slot, decimal highest, decimal lowest, DateTime date)
+	private void PlaceSessionOrders(SessionSlots slot, decimal highest, decimal lowest, DateTime date)
 	{
-		ref Order buyOrder = ref slot == SessionSlot.First ? ref _session1BuyStop : ref _session2BuyStop;
-		ref Order sellOrder = ref slot == SessionSlot.First ? ref _session1SellStop : ref _session2SellStop;
-		ref DateTime? placedDate = ref slot == SessionSlot.First ? ref _session1OrderDate : ref _session2OrderDate;
+		ref Order buyOrder = ref slot == SessionSlots.First ? ref _session1BuyStop : ref _session2BuyStop;
+		ref Order sellOrder = ref slot == SessionSlots.First ? ref _session1SellStop : ref _session2SellStop;
+		ref DateTime? placedDate = ref slot == SessionSlots.First ? ref _session1OrderDate : ref _session2OrderDate;
 
 		if (placedDate == date)
 			return;
@@ -483,7 +483,7 @@ public class Hans123TraderRangeBreakoutStrategy : Strategy
 		return Security?.ShrinkPrice(price) ?? price;
 	}
 
-	private enum SessionSlot
+	private enum SessionSlots
 	{
 		First,
 		Second

--- a/API/4051_Profit_Hunter_HSI_with_Fibonacci/CS/ProfitHunterHsiWithFibonacciStrategy.cs
+++ b/API/4051_Profit_Hunter_HSI_with_Fibonacci/CS/ProfitHunterHsiWithFibonacciStrategy.cs
@@ -58,8 +58,8 @@ public class ProfitHunterHsiWithFibonacciStrategy : Strategy
 	private bool? _highFirst;
 	private bool _fibLevelsReady;
 
-	private TrendDirection _trend;
-	private StrategySignal _signal;
+	private TrendDirections _trend;
+	private StrategySignals _signal;
 
 	private decimal _pipSize;
 	private decimal _entryPrice;
@@ -69,14 +69,14 @@ public class ProfitHunterHsiWithFibonacciStrategy : Strategy
 	private decimal? _pendingStopLossPrice;
 	private Sides? _currentPositionSide;
 
-	private enum TrendDirection
+	private enum TrendDirections
 	{
 		Unknown,
 		Up,
 		Down
 	}
 
-	private enum StrategySignal
+	private enum StrategySignals
 	{
 		None,
 		ReverseBuy,
@@ -321,15 +321,15 @@ public class ProfitHunterHsiWithFibonacciStrategy : Strategy
 	{
 		if (bid < emaValue)
 		{
-			_trend = TrendDirection.Down;
+			_trend = TrendDirections.Down;
 		}
 		else if (ask > emaValue)
 		{
-			_trend = TrendDirection.Up;
+			_trend = TrendDirections.Up;
 		}
 		else
 		{
-			_trend = TrendDirection.Unknown;
+			_trend = TrendDirections.Unknown;
 		}
 	}
 
@@ -337,7 +337,7 @@ public class ProfitHunterHsiWithFibonacciStrategy : Strategy
 	{
 		if (!_fibLevelsReady || !_highFirst.HasValue || !_fib146.HasValue || !_fib236.HasValue || !_fib764.HasValue || !_fib91.HasValue)
 		{
-			_signal = StrategySignal.None;
+			_signal = StrategySignals.None;
 			return;
 		}
 
@@ -345,46 +345,46 @@ public class ProfitHunterHsiWithFibonacciStrategy : Strategy
 		{
 			if (ask < _fib236.Value)
 			{
-				_signal = StrategySignal.ReverseBuy;
+				_signal = StrategySignals.ReverseBuy;
 			}
 			else if (bid > _fib764.Value)
 			{
-				_signal = StrategySignal.ReverseSell;
+				_signal = StrategySignals.ReverseSell;
 			}
 			else if (bid > _fib236.Value && bid < _fib764.Value)
 			{
-				_signal = StrategySignal.TradingArea;
+				_signal = StrategySignals.TradingArea;
 			}
 			else if (bid > _fib91.Value || ask < _fib146.Value)
 			{
-				_signal = StrategySignal.Continuation;
+				_signal = StrategySignals.Continuation;
 			}
 			else
 			{
-				_signal = StrategySignal.None;
+				_signal = StrategySignals.None;
 			}
 		}
 		else
 		{
 			if (bid > _fib236.Value)
 			{
-				_signal = StrategySignal.ReverseSell;
+				_signal = StrategySignals.ReverseSell;
 			}
 			else if (ask < _fib764.Value)
 			{
-				_signal = StrategySignal.ReverseBuy;
+				_signal = StrategySignals.ReverseBuy;
 			}
 			else if (bid < _fib236.Value && bid > _fib764.Value)
 			{
-				_signal = StrategySignal.TradingArea;
+				_signal = StrategySignals.TradingArea;
 			}
 			else if (ask < _fib91.Value || bid > _fib146.Value)
 			{
-				_signal = StrategySignal.Continuation;
+				_signal = StrategySignals.Continuation;
 			}
 			else
 			{
-				_signal = StrategySignal.None;
+				_signal = StrategySignals.None;
 			}
 		}
 	}
@@ -403,34 +403,34 @@ public class ProfitHunterHsiWithFibonacciStrategy : Strategy
 
 		switch (_trend)
 		{
-			case TrendDirection.Up:
+			case TrendDirections.Up:
 			{
-				if (_signal == StrategySignal.TradingArea && ask > _resistance.Value)
+				if (_signal == StrategySignals.TradingArea && ask > _resistance.Value)
 				{
 					SendEntryOrder(Sides.Buy, volume, _support);
 				}
-				else if (_signal == StrategySignal.ReverseSell && _highFirst == false && ask < _resistance.Value)
+				else if (_signal == StrategySignals.ReverseSell && _highFirst == false && ask < _resistance.Value)
 				{
 					SendEntryOrder(Sides.Sell, volume, _fib146);
 				}
-				else if (_signal == StrategySignal.ReverseBuy && _highFirst == false && bid < _resistance.Value)
+				else if (_signal == StrategySignals.ReverseBuy && _highFirst == false && bid < _resistance.Value)
 				{
 					SendEntryOrder(Sides.Buy, volume, _fib91);
 				}
 				break;
 			}
 
-			case TrendDirection.Down:
+			case TrendDirections.Down:
 			{
-				if (_signal == StrategySignal.TradingArea && bid < _support.Value)
+				if (_signal == StrategySignals.TradingArea && bid < _support.Value)
 				{
 					SendEntryOrder(Sides.Sell, volume, _resistance);
 				}
-				else if (_signal == StrategySignal.ReverseSell && _highFirst == true && bid < _resistance.Value)
+				else if (_signal == StrategySignals.ReverseSell && _highFirst == true && bid < _resistance.Value)
 				{
 					SendEntryOrder(Sides.Sell, volume, _fib91);
 				}
-				else if (_signal == StrategySignal.ReverseBuy && _highFirst == true && bid < _resistance.Value)
+				else if (_signal == StrategySignals.ReverseBuy && _highFirst == true && bid < _resistance.Value)
 				{
 					SendEntryOrder(Sides.Buy, volume, _fib146);
 				}
@@ -617,8 +617,8 @@ public class ProfitHunterHsiWithFibonacciStrategy : Strategy
 		_fib000 = _fib146 = _fib236 = _fib382 = _fib50 = _fib618 = _fib764 = _fib91 = _fib100 = _fib1618 = _fib2618 = _fib4236 = null;
 		_highFirst = null;
 		_fibLevelsReady = false;
-		_trend = TrendDirection.Unknown;
-		_signal = StrategySignal.None;
+		_trend = TrendDirections.Unknown;
+		_signal = StrategySignals.None;
 		_pipSize = 0m;
 		_entryPrice = 0m;
 		_stopLossPrice = null;

--- a/API/4052_MTrendLine/CS/MTrendLineStrategy.cs
+++ b/API/4052_MTrendLine/CS/MTrendLineStrategy.cs
@@ -24,17 +24,17 @@ public class MTrendLineStrategy : Strategy
 	private readonly StrategyParam<decimal> _minDistancePoints;
 
 	private readonly StrategyParam<bool> _slot1Enabled;
-	private readonly StrategyParam<PendingOrderType> _slot1Mode;
+	private readonly StrategyParam<PendingOrderTypes> _slot1Mode;
 	private readonly StrategyParam<decimal> _slot1DistancePoints;
 	private readonly StrategyParam<decimal> _slot1Volume;
 
 	private readonly StrategyParam<bool> _slot2Enabled;
-	private readonly StrategyParam<PendingOrderType> _slot2Mode;
+	private readonly StrategyParam<PendingOrderTypes> _slot2Mode;
 	private readonly StrategyParam<decimal> _slot2DistancePoints;
 	private readonly StrategyParam<decimal> _slot2Volume;
 
 	private readonly StrategyParam<bool> _slot3Enabled;
-	private readonly StrategyParam<PendingOrderType> _slot3Mode;
+	private readonly StrategyParam<PendingOrderTypes> _slot3Mode;
 	private readonly StrategyParam<decimal> _slot3DistancePoints;
 	private readonly StrategyParam<decimal> _slot3Volume;
 
@@ -53,7 +53,7 @@ public class MTrendLineStrategy : Strategy
 	/// <summary>
 	/// Supported pending order styles.
 	/// </summary>
-	public enum PendingOrderType
+	public enum PendingOrderTypes
 	{
 		/// <summary>
 		/// Buys below the current market with a limit order.
@@ -116,7 +116,7 @@ public class MTrendLineStrategy : Strategy
 		_slot1Enabled = Param(nameof(PendingOrder1Enabled), true)
 			.SetDisplay("Slot 1 Enabled", "Enable the first pending order slot.", "Pending Order #1");
 
-		_slot1Mode = Param(nameof(PendingOrder1Mode), PendingOrderType.BuyLimit)
+		_slot1Mode = Param(nameof(PendingOrder1Mode), PendingOrderTypes.BuyLimit)
 			.SetDisplay("Slot 1 Type", "Pending order style used by the first slot.", "Pending Order #1");
 
 		_slot1DistancePoints = Param(nameof(PendingOrder1DistancePoints), 10m)
@@ -129,7 +129,7 @@ public class MTrendLineStrategy : Strategy
 		_slot2Enabled = Param(nameof(PendingOrder2Enabled), false)
 			.SetDisplay("Slot 2 Enabled", "Enable the second pending order slot.", "Pending Order #2");
 
-		_slot2Mode = Param(nameof(PendingOrder2Mode), PendingOrderType.SellLimit)
+		_slot2Mode = Param(nameof(PendingOrder2Mode), PendingOrderTypes.SellLimit)
 			.SetDisplay("Slot 2 Type", "Pending order style used by the second slot.", "Pending Order #2");
 
 		_slot2DistancePoints = Param(nameof(PendingOrder2DistancePoints), 10m)
@@ -142,7 +142,7 @@ public class MTrendLineStrategy : Strategy
 		_slot3Enabled = Param(nameof(PendingOrder3Enabled), false)
 			.SetDisplay("Slot 3 Enabled", "Enable the third pending order slot.", "Pending Order #3");
 
-		_slot3Mode = Param(nameof(PendingOrder3Mode), PendingOrderType.BuyStop)
+		_slot3Mode = Param(nameof(PendingOrder3Mode), PendingOrderTypes.BuyStop)
 			.SetDisplay("Slot 3 Type", "Pending order style used by the third slot.", "Pending Order #3");
 
 		_slot3DistancePoints = Param(nameof(PendingOrder3DistancePoints), 10m)
@@ -208,7 +208,7 @@ public class MTrendLineStrategy : Strategy
 		set => _slot1Enabled.Value = value;
 	}
 
-	public PendingOrderType PendingOrder1Mode
+	public PendingOrderTypes PendingOrder1Mode
 	{
 		get => _slot1Mode.Value;
 		set => _slot1Mode.Value = value;
@@ -232,7 +232,7 @@ public class MTrendLineStrategy : Strategy
 		set => _slot2Enabled.Value = value;
 	}
 
-	public PendingOrderType PendingOrder2Mode
+	public PendingOrderTypes PendingOrder2Mode
 	{
 		get => _slot2Mode.Value;
 		set => _slot2Mode.Value = value;
@@ -256,7 +256,7 @@ public class MTrendLineStrategy : Strategy
 		set => _slot3Enabled.Value = value;
 	}
 
-	public PendingOrderType PendingOrder3Mode
+	public PendingOrderTypes PendingOrder3Mode
 	{
 		get => _slot3Mode.Value;
 		set => _slot3Mode.Value = value;
@@ -400,7 +400,7 @@ public class MTrendLineStrategy : Strategy
 			0 => PendingOrder1Mode,
 			1 => PendingOrder2Mode,
 			2 => PendingOrder3Mode,
-			_ => PendingOrderType.BuyLimit
+			_ => PendingOrderTypes.BuyLimit
 		};
 
 		var distance = index switch
@@ -433,10 +433,10 @@ public class MTrendLineStrategy : Strategy
 		// Translate the slot mode into a StockSharp order helper and target order type.
 		var (side, orderType) = mode switch
 		{
-			PendingOrderType.BuyLimit => (Sides.Buy, OrderTypes.Limit),
-			PendingOrderType.BuyStop => (Sides.Buy, OrderTypes.Stop),
-			PendingOrderType.SellLimit => (Sides.Sell, OrderTypes.Limit),
-			PendingOrderType.SellStop => (Sides.Sell, OrderTypes.Stop),
+			PendingOrderTypes.BuyLimit => (Sides.Buy, OrderTypes.Limit),
+			PendingOrderTypes.BuyStop => (Sides.Buy, OrderTypes.Stop),
+			PendingOrderTypes.SellLimit => (Sides.Sell, OrderTypes.Limit),
+			PendingOrderTypes.SellStop => (Sides.Sell, OrderTypes.Stop),
 			_ => (Sides.Buy, OrderTypes.Limit)
 		};
 

--- a/API/4054_N7SAO772012/CS/N7SAo772012Strategy.cs
+++ b/API/4054_N7SAO772012/CS/N7SAo772012Strategy.cs
@@ -770,10 +770,10 @@ private void ProcessMinuteCandle(ICandleMessage candle)
 	var signal = EvaluateSignal();
 	switch (signal.Direction)
 	{
-		case SignalDirection.Long:
+		case SignalDirections.Long:
 			TryEnterLong(candle.ClosePrice, signal.StopDistance, signal.TakeDistance);
 			break;
-		case SignalDirection.Short:
+		case SignalDirections.Short:
 			TryEnterShort(candle.ClosePrice, signal.StopDistance, signal.TakeDistance);
 			break;
 	}
@@ -915,21 +915,21 @@ private SignalResult EvaluateVsr(decimal priceSignal)
 			if (_perceptronUpperZ > 0m)
 			{
 			if (_perceptronUpperX > 0m)
-			return CreateSignal(SignalDirection.Long, NeuroStopLossPointsLong, NeuroTakeProfitFactorLong * NeuroStopLossPointsLong);
+			return CreateSignal(SignalDirections.Long, NeuroStopLossPointsLong, NeuroTakeProfitFactorLong * NeuroStopLossPointsLong);
 		}
 	else
 	{
 		if (_perceptronUpperY > 0m)
-		return CreateSignal(SignalDirection.Short, NeuroStopLossPointsShort, NeuroTakeProfitFactorShort * NeuroStopLossPointsShort);
+		return CreateSignal(SignalDirections.Short, NeuroStopLossPointsShort, NeuroTakeProfitFactorShort * NeuroStopLossPointsShort);
 	}
 return EvaluateBts(priceSignal);
 case 3:
 	if (_perceptronUpperY > 0m)
-	return CreateSignal(SignalDirection.Short, NeuroStopLossPointsShort, NeuroTakeProfitFactorShort * NeuroStopLossPointsShort);
+	return CreateSignal(SignalDirections.Short, NeuroStopLossPointsShort, NeuroTakeProfitFactorShort * NeuroStopLossPointsShort);
 	return EvaluateBts(priceSignal);
 case 2:
 	if (_perceptronUpperX > 0m)
-	return CreateSignal(SignalDirection.Long, NeuroStopLossPointsLong, NeuroTakeProfitFactorLong * NeuroStopLossPointsLong);
+	return CreateSignal(SignalDirections.Long, NeuroStopLossPointsLong, NeuroTakeProfitFactorLong * NeuroStopLossPointsLong);
 	return EvaluateBts(priceSignal);
 default:
 	return EvaluateBts(priceSignal);
@@ -945,22 +945,22 @@ private SignalResult EvaluateBts(decimal priceSignal)
 	{
 		var stop = BaseStopLossPointsLong;
 		var take = BaseTakeProfitFactorLong * stop;
-		return CreateSignal(SignalDirection.Long, stop, take);
+		return CreateSignal(SignalDirections.Long, stop, take);
 	}
 
 if (allowShortCheck && _perceptronLowerY > 0m && _deltaG12 < 0m)
 {
 	var stop = BaseStopLossPointsShort;
 	var take = BaseTakeProfitFactorShort * stop;
-	return CreateSignal(SignalDirection.Short, stop, take);
+	return CreateSignal(SignalDirections.Short, stop, take);
 }
 
 return SignalResult.None;
 }
 
-private SignalResult CreateSignal(SignalDirection direction, decimal stopPoints, decimal takePoints)
+private SignalResult CreateSignal(SignalDirections direction, decimal stopPoints, decimal takePoints)
 {
-	if (direction == SignalDirection.None)
+	if (direction == SignalDirections.None)
 	return SignalResult.None;
 
 	var stopDistance = stopPoints > 0m ? stopPoints * _pointValue : 0m;
@@ -1075,21 +1075,21 @@ private static bool IsTradingTime(DateTimeOffset time)
 
 private readonly struct SignalResult
 {
-	public static readonly SignalResult None = new(SignalDirection.None, 0m, 0m);
+	public static readonly SignalResult None = new(SignalDirections.None, 0m, 0m);
 
-	public SignalResult(SignalDirection direction, decimal stopDistance, decimal takeDistance)
+	public SignalResult(SignalDirections direction, decimal stopDistance, decimal takeDistance)
 	{
 		Direction = direction;
 		StopDistance = stopDistance;
 		TakeDistance = takeDistance;
 	}
 
-public SignalDirection Direction { get; }
+public SignalDirections Direction { get; }
 public decimal StopDistance { get; }
 public decimal TakeDistance { get; }
 }
 
-private enum SignalDirection
+private enum SignalDirections
 {
 	None,
 	Long,

--- a/API/4057_Future_Pattern_Memory/CS/FuturePatternMemoryStrategy.cs
+++ b/API/4057_Future_Pattern_Memory/CS/FuturePatternMemoryStrategy.cs
@@ -22,7 +22,7 @@ namespace StockSharp.Samples.Strategies;
 public class FuturePatternMemoryStrategy : Strategy
 {
 	private readonly StrategyParam<DataType> _candleType;
-	private readonly StrategyParam<PatternSource> _source;
+	private readonly StrategyParam<PatternSources> _source;
 	private readonly StrategyParam<int> _fastMaLength;
 	private readonly StrategyParam<int> _slowMaLength;
 	private readonly StrategyParam<int> _macdFastLength;
@@ -66,7 +66,7 @@ public class FuturePatternMemoryStrategy : Strategy
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(30).TimeFrame())
 		.SetDisplay("Candle Type", "Primary timeframe for pattern detection", "General");
 
-		_source = Param(nameof(Source), PatternSource.MaSpread)
+		_source = Param(nameof(Source), PatternSources.MaSpread)
 		.SetDisplay("Pattern Source", "Indicator used to build pattern signatures", "Pattern Memory");
 
 		_fastMaLength = Param(nameof(FastMaLength), 6)
@@ -140,7 +140,7 @@ public class FuturePatternMemoryStrategy : Strategy
 	/// <summary>
 	/// Indicator used to build the pattern signature.
 	/// </summary>
-	public PatternSource Source
+	public PatternSources Source
 	{
 		get => _source.Value;
 		set => _source.Value = value;
@@ -379,7 +379,7 @@ public class FuturePatternMemoryStrategy : Strategy
 
 		switch (Source)
 		{
-		case PatternSource.MaSpread:
+		case PatternSources.MaSpread:
 			{
 				var median = (candle.HighPrice + candle.LowPrice) / 2m;
 				var fastValue = _fastSmma.Process(median, candle.OpenTime, true);
@@ -392,7 +392,7 @@ public class FuturePatternMemoryStrategy : Strategy
 				break;
 			}
 
-		case PatternSource.MacdHistogram:
+		case PatternSources.MacdHistogram:
 			{
 				var macdValue = (MovingAverageConvergenceDivergenceSignalValue)_macd.Process(candle.ClosePrice, candle.OpenTime, true);
 
@@ -732,7 +732,7 @@ public class FuturePatternMemoryStrategy : Strategy
 	/// <summary>
 	/// Data source used to build pattern hashes.
 	/// </summary>
-	public enum PatternSource
+	public enum PatternSources
 	{
 		/// <summary>
 		/// Use the spread between slow and fast SMMAs.

--- a/API/4069_NTK07Grid/CS/Ntk07Strategy.cs
+++ b/API/4069_NTK07Grid/CS/Ntk07Strategy.cs
@@ -21,7 +21,7 @@ public class Ntk07Strategy : Strategy
 	/// <summary>
 	/// Money management modes supported by the strategy.
 	/// </summary>
-	public enum MoneyManagementMode
+	public enum MoneyManagementModes
 	{
 		/// <summary>
 		/// Use the <see cref="InitialLot"/> and <see cref="LotLimit"/> values without modification.
@@ -45,7 +45,7 @@ public class Ntk07Strategy : Strategy
 	private readonly StrategyParam<int> _trailingStopPips;
 	private readonly StrategyParam<decimal> _multiplier;
 	private readonly StrategyParam<bool> _trailProfit;
-	private readonly StrategyParam<MoneyManagementMode> _moneyManagementMode;
+	private readonly StrategyParam<MoneyManagementModes> _moneyManagementMode;
 	private readonly StrategyParam<decimal> _initialLot;
 	private readonly StrategyParam<decimal> _lotLimit;
 	private readonly StrategyParam<int> _maxTrades;
@@ -128,7 +128,7 @@ public class Ntk07Strategy : Strategy
 		_trailProfit = Param(nameof(TrailProfit), true)
 		.SetDisplay("Trail Profit", "Extend take-profit while trailing", "Risk");
 
-		_moneyManagementMode = Param(nameof(ManagementMode), MoneyManagementMode.Progressive)
+		_moneyManagementMode = Param(nameof(ManagementMode), MoneyManagementModes.Progressive)
 		.SetDisplay("Money Management", "How lot sizes are recalculated", "Money Management");
 
 		_initialLot = Param(nameof(InitialLot), 1m)
@@ -255,7 +255,7 @@ public class Ntk07Strategy : Strategy
 	/// <summary>
 	/// Selected money management mode.
 	/// </summary>
-	public MoneyManagementMode ManagementMode
+	public MoneyManagementModes ManagementMode
 	{
 		get => _moneyManagementMode.Value;
 		set => _moneyManagementMode.Value = value;
@@ -614,13 +614,13 @@ public class Ntk07Strategy : Strategy
 
 		switch (mode)
 		{
-		case MoneyManagementMode.Fixed:
+		case MoneyManagementModes.Fixed:
 			{
 				_calculatedBaseVolume = lot;
 				_calculatedLotLimit = limit;
 				break;
 			}
-		case MoneyManagementMode.BalanceBased:
+		case MoneyManagementModes.BalanceBased:
 			{
 				var balance = Portfolio?.CurrentValue ?? 0m;
 				if (balance <= 0m)
@@ -646,7 +646,7 @@ public class Ntk07Strategy : Strategy
 				_calculatedLotLimit = Math.Max(rounded, baseVolume);
 				break;
 			}
-		case MoneyManagementMode.Progressive:
+		case MoneyManagementModes.Progressive:
 			{
 				var projected = lot;
 				for (var i = 0; i < MaxTrades; i++)

--- a/API/4078_Alliheik_Trader/CS/AlliheikTraderStrategy.cs
+++ b/API/4078_Alliheik_Trader/CS/AlliheikTraderStrategy.cs
@@ -22,11 +22,11 @@ public class AlliheikTraderStrategy : Strategy
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<int> _jawsPeriod;
 	private readonly StrategyParam<int> _jawsShift;
-	private readonly StrategyParam<MovingAverageType> _jawsMethod;
-	private readonly StrategyParam<AppliedPriceType> _jawsPrice;
-	private readonly StrategyParam<MovingAverageType> _preSmoothMethod;
+	private readonly StrategyParam<MovingAverageTypes> _jawsMethod;
+	private readonly StrategyParam<AppliedPriceTypes> _jawsPrice;
+	private readonly StrategyParam<MovingAverageTypes> _preSmoothMethod;
 	private readonly StrategyParam<int> _preSmoothPeriod;
-	private readonly StrategyParam<MovingAverageType> _postSmoothMethod;
+	private readonly StrategyParam<MovingAverageTypes> _postSmoothMethod;
 	private readonly StrategyParam<int> _postSmoothPeriod;
 	private readonly StrategyParam<int> _stopLossPoints;
 	private readonly StrategyParam<int> _trailingStopPoints;
@@ -89,7 +89,7 @@ public class AlliheikTraderStrategy : Strategy
 	/// <summary>
 	/// Moving average type used to build the jaw line.
 	/// </summary>
-	public MovingAverageType JawsMethod
+	public MovingAverageTypes JawsMethod
 	{
 		get => _jawsMethod.Value;
 		set => _jawsMethod.Value = value;
@@ -98,7 +98,7 @@ public class AlliheikTraderStrategy : Strategy
 	/// <summary>
 	/// Price component supplied to the jaw moving average.
 	/// </summary>
-	public AppliedPriceType JawsPrice
+	public AppliedPriceTypes JawsPrice
 	{
 		get => _jawsPrice.Value;
 		set => _jawsPrice.Value = value;
@@ -107,7 +107,7 @@ public class AlliheikTraderStrategy : Strategy
 	/// <summary>
 	/// Moving average used to pre-smooth raw OHLC prices for Heiken Ashi.
 	/// </summary>
-	public MovingAverageType PreSmoothMethod
+	public MovingAverageTypes PreSmoothMethod
 	{
 		get => _preSmoothMethod.Value;
 		set => _preSmoothMethod.Value = value;
@@ -125,7 +125,7 @@ public class AlliheikTraderStrategy : Strategy
 	/// <summary>
 	/// Moving average used to smooth Heiken Ashi derived buffers.
 	/// </summary>
-	public MovingAverageType PostSmoothMethod
+	public MovingAverageTypes PostSmoothMethod
 	{
 		get => _postSmoothMethod.Value;
 		set => _postSmoothMethod.Value = value;
@@ -192,20 +192,20 @@ public class AlliheikTraderStrategy : Strategy
 		.SetNotNegative()
 		.SetDisplay("Jaw Shift", "Forward shift applied to the jaw moving average.", "Alligator");
 
-		_jawsMethod = Param(nameof(JawsMethod), MovingAverageType.Simple)
+		_jawsMethod = Param(nameof(JawsMethod), MovingAverageTypes.Simple)
 		.SetDisplay("Jaw MA Type", "Moving average type used by the jaw.", "Alligator");
 
-		_jawsPrice = Param(nameof(JawsPrice), AppliedPriceType.Close)
+		_jawsPrice = Param(nameof(JawsPrice), AppliedPriceTypes.Close)
 		.SetDisplay("Jaw Applied Price", "Price component passed into the jaw moving average.", "Alligator");
 
-		_preSmoothMethod = Param(nameof(PreSmoothMethod), MovingAverageType.Exponential)
+		_preSmoothMethod = Param(nameof(PreSmoothMethod), MovingAverageTypes.Exponential)
 		.SetDisplay("Pre-smooth MA", "Moving average for smoothing OHLC prices.", "Heiken Ashi");
 
 		_preSmoothPeriod = Param(nameof(PreSmoothPeriod), 21)
 		.SetGreaterThanZero()
 		.SetDisplay("Pre-smooth Period", "Length used by the OHLC smoothers.", "Heiken Ashi");
 
-		_postSmoothMethod = Param(nameof(PostSmoothMethod), MovingAverageType.Weighted)
+		_postSmoothMethod = Param(nameof(PostSmoothMethod), MovingAverageTypes.Weighted)
 		.SetDisplay("Post-smooth MA", "Moving average used on Heiken Ashi buffers.", "Heiken Ashi");
 
 		_postSmoothPeriod = Param(nameof(PostSmoothPeriod), 1)
@@ -564,27 +564,27 @@ public class AlliheikTraderStrategy : Strategy
 		return _lastEntryBarTime != candle.OpenTime;
 	}
 
-	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageType type, int length)
+	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageTypes type, int length)
 	{
 		return type switch
 		{
-			MovingAverageType.Exponential => new ExponentialMovingAverage { Length = length },
-			MovingAverageType.Smoothed => new SmoothedMovingAverage { Length = length },
-			MovingAverageType.Weighted => new WeightedMovingAverage { Length = length },
+			MovingAverageTypes.Exponential => new ExponentialMovingAverage { Length = length },
+			MovingAverageTypes.Smoothed => new SmoothedMovingAverage { Length = length },
+			MovingAverageTypes.Weighted => new WeightedMovingAverage { Length = length },
 			_ => new SimpleMovingAverage { Length = length },
 		};
 	}
 
-	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPriceType type)
+	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPriceTypes type)
 	{
 		return type switch
 		{
-			AppliedPriceType.Open => candle.OpenPrice,
-			AppliedPriceType.High => candle.HighPrice,
-			AppliedPriceType.Low => candle.LowPrice,
-			AppliedPriceType.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-			AppliedPriceType.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-			AppliedPriceType.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
+			AppliedPriceTypes.Open => candle.OpenPrice,
+			AppliedPriceTypes.High => candle.HighPrice,
+			AppliedPriceTypes.Low => candle.LowPrice,
+			AppliedPriceTypes.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+			AppliedPriceTypes.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+			AppliedPriceTypes.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
 			_ => candle.ClosePrice,
 		};
 	}
@@ -592,7 +592,7 @@ public class AlliheikTraderStrategy : Strategy
 	/// <summary>
 	/// Moving average families supported by the conversion.
 	/// </summary>
-	public enum MovingAverageType
+	public enum MovingAverageTypes
 	{
 		Simple,
 		Exponential,
@@ -603,7 +603,7 @@ public class AlliheikTraderStrategy : Strategy
 	/// <summary>
 	/// Price sources that can be supplied to the jaw moving average.
 	/// </summary>
-	public enum AppliedPriceType
+	public enum AppliedPriceTypes
 	{
 		Close,
 		Open,

--- a/API/4081_Two_MA_Four_Level_Bands/CS/TwoMaFourLevelBandsStrategy.cs
+++ b/API/4081_Two_MA_Four_Level_Bands/CS/TwoMaFourLevelBandsStrategy.cs
@@ -27,10 +27,10 @@ public class TwoMaFourLevelBandsStrategy : Strategy
 	private readonly StrategyParam<decimal> _tradeVolume;
 	private readonly StrategyParam<int> _calculationBar;
 	private readonly StrategyParam<int> _fastPeriod;
-	private readonly StrategyParam<MovingAverageMethod> _fastMethod;
+	private readonly StrategyParam<MovingAverageMethods> _fastMethod;
 	private readonly StrategyParam<CandlePrice> _fastPrice;
 	private readonly StrategyParam<int> _slowPeriod;
-	private readonly StrategyParam<MovingAverageMethod> _slowMethod;
+	private readonly StrategyParam<MovingAverageMethods> _slowMethod;
 	private readonly StrategyParam<CandlePrice> _slowPrice;
 	private readonly StrategyParam<int> _upperLevel1;
 	private readonly StrategyParam<int> _upperLevel2;
@@ -74,7 +74,7 @@ public class TwoMaFourLevelBandsStrategy : Strategy
 			.SetCanOptimize(true)
 			.SetOptimize(5, 40, 5);
 
-		_fastMethod = Param(nameof(FastMethod), MovingAverageMethod.Smoothed)
+		_fastMethod = Param(nameof(FastMethod), MovingAverageMethods.Smoothed)
 			.SetDisplay("Fast MA method", "Type of moving average used for the fast line.", "Indicators");
 
 		_fastPrice = Param(nameof(FastPrice), CandlePrice.Median)
@@ -86,7 +86,7 @@ public class TwoMaFourLevelBandsStrategy : Strategy
 			.SetCanOptimize(true)
 			.SetOptimize(60, 300, 20);
 
-		_slowMethod = Param(nameof(SlowMethod), MovingAverageMethod.Smoothed)
+		_slowMethod = Param(nameof(SlowMethod), MovingAverageMethods.Smoothed)
 			.SetDisplay("Slow MA method", "Type of moving average used for the slow line.", "Indicators");
 
 		_slowPrice = Param(nameof(SlowPrice), CandlePrice.Median)
@@ -168,7 +168,7 @@ public class TwoMaFourLevelBandsStrategy : Strategy
 	/// <summary>
 	/// Moving average method for the fast line.
 	/// </summary>
-	public MovingAverageMethod FastMethod
+	public MovingAverageMethods FastMethod
 	{
 		get => _fastMethod.Value;
 		set => _fastMethod.Value = value;
@@ -195,7 +195,7 @@ public class TwoMaFourLevelBandsStrategy : Strategy
 	/// <summary>
 	/// Moving average method for the slow line.
 	/// </summary>
-	public MovingAverageMethod SlowMethod
+	public MovingAverageMethods SlowMethod
 	{
 		get => _slowMethod.Value;
 		set => _slowMethod.Value = value;
@@ -383,14 +383,14 @@ public class TwoMaFourLevelBandsStrategy : Strategy
 		return prevFast >= prevSlow && currentFast < currentSlow;
 	}
 
-	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageMethod method, int period, CandlePrice price)
+	private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageMethods method, int period, CandlePrice price)
 	{
 		var indicator = method switch
 		{
-			MovingAverageMethod.Simple => new SimpleMovingAverage(),
-			MovingAverageMethod.Exponential => new ExponentialMovingAverage(),
-			MovingAverageMethod.Smoothed => new SmoothedMovingAverage(),
-			MovingAverageMethod.LinearWeighted => new WeightedMovingAverage(),
+			MovingAverageMethods.Simple => new SimpleMovingAverage(),
+			MovingAverageMethods.Exponential => new ExponentialMovingAverage(),
+			MovingAverageMethods.Smoothed => new SmoothedMovingAverage(),
+			MovingAverageMethods.LinearWeighted => new WeightedMovingAverage(),
 			_ => new SimpleMovingAverage(),
 		};
 
@@ -476,7 +476,7 @@ public class TwoMaFourLevelBandsStrategy : Strategy
 	/// <summary>
 	/// Moving average methods available in MetaTrader.
 	/// </summary>
-	public enum MovingAverageMethod
+	public enum MovingAverageMethods
 	{
 		Simple = 0,
 		Exponential = 1,

--- a/API/4083_AIS_Trade_Machine/CS/AisTradeMachineStrategy.cs
+++ b/API/4083_AIS_Trade_Machine/CS/AisTradeMachineStrategy.cs
@@ -19,13 +19,13 @@ namespace StockSharp.Samples.Strategies;
 public class AisTradeMachineStrategy : Strategy
 {
 	private readonly StrategyParam<DataType> _candleType;
-	private readonly StrategyParam<ManualCommand> _command;
+	private readonly StrategyParam<ManualCommands> _command;
 	private readonly StrategyParam<decimal> _stopPrice;
 	private readonly StrategyParam<decimal> _takePrice;
 	private readonly StrategyParam<decimal> _accountReserve;
 	private readonly StrategyParam<decimal> _orderReserve;
 
-	private ManualCommand _lastCommand;
+	private ManualCommands _lastCommand;
 	private bool _commandHandled;
 	private decimal _peakEquity;
 	private Order _stopOrder;
@@ -36,7 +36,7 @@ public class AisTradeMachineStrategy : Strategy
 	/// <summary>
 	/// Available manual commands.
 	/// </summary>
-	public enum ManualCommand
+	public enum ManualCommands
 	{
 		/// <summary>
 		/// Idle state, no action is performed.
@@ -72,7 +72,7 @@ public AisTradeMachineStrategy()
 	_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(1).TimeFrame())
 	.SetDisplay("Candle Type", "Type of candles used to read current prices.", "Market Data");
 
-	_command = Param(nameof(Command), ManualCommand.Wait)
+	_command = Param(nameof(Command), ManualCommands.Wait)
 	.SetDisplay("Command", "Manual command to execute. The value resets to Wait after handling.", "Control");
 
 	_stopPrice = Param(nameof(StopPrice), 0m)
@@ -108,7 +108,7 @@ public DataType CandleType
 /// <summary>
 /// Manual command parameter.
 /// </summary>
-public ManualCommand Command
+public ManualCommands Command
 {
 	get => _command.Value;
 	set => _command.Value = value;
@@ -231,22 +231,22 @@ private void ProcessCandle(ICandleMessage candle)
 
 switch (command)
 {
-	case ManualCommand.Wait:
+	case ManualCommands.Wait:
 	_commandHandled = true;
 	break;
 
-	case ManualCommand.Buy:
-	case ManualCommand.Sell:
+	case ManualCommands.Buy:
+	case ManualCommands.Sell:
 	TryHandleEntry(command, candle);
 	ResetCommandToWait();
 	break;
 
-	case ManualCommand.Modify:
+	case ManualCommands.Modify:
 	TryHandleModify(candle);
 	ResetCommandToWait();
 	break;
 
-	case ManualCommand.Close:
+	case ManualCommands.Close:
 	HandleCloseCommand();
 	ResetCommandToWait();
 	break;
@@ -260,7 +260,7 @@ switch (command)
 _lastCommand = Command;
 }
 
-private void TryHandleEntry(ManualCommand command, ICandleMessage candle)
+private void TryHandleEntry(ManualCommands command, ICandleMessage candle)
 {
 	if (!TryGetEquity(out var equity))
 	{
@@ -283,7 +283,7 @@ if (Security is null)
 	return;
 }
 
-var isLong = command == ManualCommand.Buy;
+var isLong = command == ManualCommands.Buy;
 var price = candle.ClosePrice;
 var stopPrice = StopPrice;
 var takePrice = TakePrice;
@@ -588,8 +588,8 @@ private void UpdatePeakEquity()
 
 private void ResetCommandToWait()
 {
-	Command = ManualCommand.Wait;
+	Command = ManualCommands.Wait;
 	_commandHandled = true;
-	_lastCommand = ManualCommand.Wait;
+	_lastCommand = ManualCommands.Wait;
 }
 }

--- a/API/4090_Multi_Stoch/CS/YtgMultiStochStrategy.cs
+++ b/API/4090_Multi_Stoch/CS/YtgMultiStochStrategy.cs
@@ -306,7 +306,7 @@ public class YtgMultiStochStrategy : Strategy
 
 		if (position > 0m)
 		{
-			context.Direction = TradeDirection.Long;
+			context.Direction = TradeDirections.Long;
 
 			if (TryCloseLongByTargets(context, candle, position))
 			{
@@ -317,7 +317,7 @@ public class YtgMultiStochStrategy : Strategy
 		}
 		else if (position < 0m)
 		{
-			context.Direction = TradeDirection.Short;
+			context.Direction = TradeDirections.Short;
 
 			if (TryCloseShortByTargets(context, candle, position))
 			{
@@ -328,7 +328,7 @@ public class YtgMultiStochStrategy : Strategy
 		}
 		else
 		{
-			context.Direction = TradeDirection.Flat;
+			context.Direction = TradeDirections.Flat;
 
 			if (context.StopLossPrice.HasValue || context.TakeProfitPrice.HasValue)
 				context.ResetTargets();
@@ -341,7 +341,7 @@ public class YtgMultiStochStrategy : Strategy
 			return;
 		}
 
-		if (context.Direction == TradeDirection.Flat && position == 0m && context.PreviousK is decimal prevK && context.PreviousD is decimal prevD)
+		if (context.Direction == TradeDirections.Flat && position == 0m && context.PreviousK is decimal prevK && context.PreviousD is decimal prevD)
 		{
 			var buySignal = currentK < OversoldLevel && prevK < prevD && currentK > currentD;
 			var sellSignal = currentK > OverboughtLevel && prevK > prevD && currentK < currentD;
@@ -355,7 +355,7 @@ public class YtgMultiStochStrategy : Strategy
 				context.EntryPrice = candle.ClosePrice;
 				context.StopLossPrice = StopLossPips > 0m && pip > 0m ? candle.ClosePrice - StopLossPips * pip : null;
 				context.TakeProfitPrice = TakeProfitPips > 0m && pip > 0m ? candle.ClosePrice + TakeProfitPips * pip : null;
-				context.Direction = TradeDirection.Long;
+				context.Direction = TradeDirections.Long;
 			}
 			else if (sellSignal && TradeVolume > 0m)
 			{
@@ -366,7 +366,7 @@ public class YtgMultiStochStrategy : Strategy
 				context.EntryPrice = candle.ClosePrice;
 				context.StopLossPrice = StopLossPips > 0m && pip > 0m ? candle.ClosePrice + StopLossPips * pip : null;
 				context.TakeProfitPrice = TakeProfitPips > 0m && pip > 0m ? candle.ClosePrice - TakeProfitPips * pip : null;
-				context.Direction = TradeDirection.Short;
+				context.Direction = TradeDirections.Short;
 			}
 		}
 
@@ -459,7 +459,7 @@ public class YtgMultiStochStrategy : Strategy
 		return step;
 	}
 
-	private enum TradeDirection
+	private enum TradeDirections
 	{
 		Flat,
 		Long,
@@ -481,14 +481,14 @@ public class YtgMultiStochStrategy : Strategy
 		public decimal? StopLossPrice { get; set; }
 		public decimal? TakeProfitPrice { get; set; }
 		public decimal? EntryPrice { get; set; }
-		public TradeDirection Direction { get; set; } = TradeDirection.Flat;
+		public TradeDirections Direction { get; set; } = TradeDirections.Flat;
 
 		public void ResetTargets()
 		{
 			StopLossPrice = null;
 			TakeProfitPrice = null;
 			EntryPrice = null;
-			Direction = TradeDirection.Flat;
+			Direction = TradeDirections.Flat;
 		}
 	}
 }

--- a/API/4094_Fractal_ZigZag/CS/FractalZigZagStrategy.cs
+++ b/API/4094_Fractal_ZigZag/CS/FractalZigZagStrategy.cs
@@ -34,7 +34,7 @@ public class FractalZigZagStrategy : Strategy
 	private DateTimeOffset? _lastUpTime;
 	private DateTimeOffset? _lastDownTime;
 	private DateTimeOffset? _lastFractalTime;
-	private FractalType? _lastFractalType;
+	private FractalTypes? _lastFractalTypes;
 	private int _trend = 2;
 
 	private decimal _entryPrice;
@@ -42,7 +42,7 @@ public class FractalZigZagStrategy : Strategy
 	private decimal? _takeProfitPrice;
 	private decimal? _trailingStopPrice;
 
-	private enum FractalType
+	private enum FractalTypes
 	{
 		High,
 		Low
@@ -169,7 +169,7 @@ public class FractalZigZagStrategy : Strategy
 		_lastUpTime = null;
 		_lastDownTime = null;
 		_lastFractalTime = null;
-		_lastFractalType = null;
+		_lastFractalTypes = null;
 		_trend = 2;
 
 		ResetPositionState();
@@ -264,15 +264,15 @@ public class FractalZigZagStrategy : Strategy
 		}
 
 		if (isHigh && (_lastUpTime is null || center.Time > _lastUpTime.Value))
-		RegisterFractal(FractalType.High, center);
+		RegisterFractal(FractalTypes.High, center);
 
 		if (isLow && (_lastDownTime is null || center.Time > _lastDownTime.Value))
-		RegisterFractal(FractalType.Low, center);
+		RegisterFractal(FractalTypes.Low, center);
 	}
 
-	private void RegisterFractal(FractalType type, CandleInfo info)
+	private void RegisterFractal(FractalTypes type, CandleInfo info)
 	{
-		if (type == FractalType.High)
+		if (type == FractalTypes.High)
 		{
 			_lastUpFractal = info.High;
 			_lastUpTime = info.Time;
@@ -286,14 +286,14 @@ public class FractalZigZagStrategy : Strategy
 		if (_lastFractalTime is null || info.Time >= _lastFractalTime.Value)
 		{
 			_lastFractalTime = info.Time;
-			_lastFractalType = type;
-			_trend = type == FractalType.High ? 1 : 2;
+			_lastFractalTypes = type;
+			_trend = type == FractalTypes.High ? 1 : 2;
 		}
 	}
 
 	private void TryEnterPosition(ICandleMessage candle)
 	{
-		if (_lastFractalType is null)
+		if (_lastFractalTypes is null)
 		return;
 
 		var volume = Lots;

--- a/API/4097_Simple/CS/SimpleStrategy.cs
+++ b/API/4097_Simple/CS/SimpleStrategy.cs
@@ -49,14 +49,14 @@ public class SimpleStrategy : Strategy
 
 	private bool _stepConversionWarningIssued;
 
-	private enum SignalDirection
+	private enum SignalDirections
 	{
 		None,
 		Buy,
 		Sell
 	}
 
-	private enum TrendDirection
+	private enum TrendDirections
 	{
 		Wait,
 		Up,
@@ -283,10 +283,10 @@ public class SimpleStrategy : Strategy
 
 		switch (signal)
 		{
-			case SignalDirection.Buy:
+			case SignalDirections.Buy:
 				HandleBuySignal(candle);
 				break;
-			case SignalDirection.Sell:
+			case SignalDirections.Sell:
 				HandleSellSignal(candle);
 				break;
 		}
@@ -409,19 +409,19 @@ public class SimpleStrategy : Strategy
 		}
 	}
 
-	private SignalDirection DetectSignal()
+	private SignalDirections DetectSignal()
 	{
 		if (_fastPrev2 is decimal fastHist && _fastPrev is decimal fastPrev &&
 			_slowPrev2 is decimal slowHist && _slowPrev is decimal slowPrev)
 		{
 			if (fastHist < slowHist && fastPrev > slowPrev)
-				return SignalDirection.Buy;
+				return SignalDirections.Buy;
 
 			if (fastHist > slowHist && fastPrev < slowPrev)
-				return SignalDirection.Sell;
+				return SignalDirections.Sell;
 		}
 
-		return SignalDirection.None;
+		return SignalDirections.None;
 	}
 
 	private void UpdateMovingAverageHistory(decimal fastValue, decimal slowValue)
@@ -453,18 +453,18 @@ public class SimpleStrategy : Strategy
 		_trendReference = _slowTrendValues.Count > margin ? _slowTrendValues.Peek() : null;
 	}
 
-	private (TrendDirection Direction, decimal? Difference) GetTrendState(decimal slowValue)
+	private (TrendDirections Direction, decimal? Difference) GetTrendState(decimal slowValue)
 	{
 		if (_trendReference is not decimal reference)
-			return (TrendDirection.Wait, null);
+			return (TrendDirections.Wait, null);
 
 		if (slowValue > reference)
-			return (TrendDirection.Up, CalculateStepDifference(slowValue, reference));
+			return (TrendDirections.Up, CalculateStepDifference(slowValue, reference));
 
 		if (slowValue < reference)
-			return (TrendDirection.Down, CalculateStepDifference(slowValue, reference));
+			return (TrendDirections.Down, CalculateStepDifference(slowValue, reference));
 
-		return (TrendDirection.Wait, 0m);
+		return (TrendDirections.Wait, 0m);
 	}
 
 	private decimal? CalculateStepDifference(decimal value1, decimal value2)
@@ -506,20 +506,20 @@ public class SimpleStrategy : Strategy
 		return steps * priceStep;
 	}
 
-	private void LogSignal(ICandleMessage candle, decimal fastValue, decimal slowValue, SignalDirection signal, decimal? diffSteps, (TrendDirection Direction, decimal? Difference) trendState)
+	private void LogSignal(ICandleMessage candle, decimal fastValue, decimal slowValue, SignalDirections signal, decimal? diffSteps, (TrendDirections Direction, decimal? Difference) trendState)
 	{
 		var signalText = signal switch
 		{
-			SignalDirection.Buy => "BUY",
-			SignalDirection.Sell => "SELL",
+			SignalDirections.Buy => "BUY",
+			SignalDirections.Sell => "SELL",
 			_ => "WAIT"
 		};
 
 		var diffText = diffSteps.HasValue ? diffSteps.Value.ToString("0.0", CultureInfo.InvariantCulture) : "n/a";
 		var trendText = trendState.Direction switch
 		{
-			TrendDirection.Up => "UP",
-			TrendDirection.Down => "DOWN",
+			TrendDirections.Up => "UP",
+			TrendDirections.Down => "DOWN",
 			_ => "WAIT"
 		};
 		var trendDiffText = trendState.Difference.HasValue ? trendState.Difference.Value.ToString("0.0", CultureInfo.InvariantCulture) : "n/a";

--- a/API/4105_Symbol_Synthesizer/CS/SymbolSynthesizerStrategy.cs
+++ b/API/4105_Symbol_Synthesizer/CS/SymbolSynthesizerStrategy.cs
@@ -42,7 +42,7 @@ public class SymbolSynthesizerStrategy : Strategy
 	};
 
 	private readonly StrategyParam<int> _combinationParam;
-	private readonly StrategyParam<SyntheticTradeAction> _tradeActionParam;
+	private readonly StrategyParam<SyntheticTradeActions> _tradeActionParam;
 
 	private SyntheticCombination _combination;
 	private Security _firstLeg;
@@ -71,7 +71,7 @@ public class SymbolSynthesizerStrategy : Strategy
 	/// <summary>
 	/// Manual action that emulates the Buy/Sell buttons from the original panel.
 	/// </summary>
-	public SyntheticTradeAction TradeAction
+	public SyntheticTradeActions TradeAction
 	{
 		get => _tradeActionParam.Value;
 		set => _tradeActionParam.Value = value;
@@ -86,7 +86,7 @@ public class SymbolSynthesizerStrategy : Strategy
 		.SetDisplay("Combination Index", "Predefined synthetic pair index (0-12)", "Synthetic")
 		.SetNotNegative();
 
-		_tradeActionParam = Param(nameof(TradeAction), SyntheticTradeAction.None)
+		_tradeActionParam = Param(nameof(TradeAction), SyntheticTradeActions.None)
 		.SetDisplay("Trade Action", "Set to Buy or Sell to place paired orders", "Manual")
 		.SetCanOptimize(false);
 	}
@@ -269,7 +269,7 @@ public class SymbolSynthesizerStrategy : Strategy
 
 		var action = TradeAction;
 
-		if (action == SyntheticTradeAction.None)
+		if (action == SyntheticTradeActions.None)
 			return;
 
 		_isPlacingOrders = true;
@@ -277,12 +277,12 @@ public class SymbolSynthesizerStrategy : Strategy
 		try
 		{
 			ExecuteSyntheticTrade(action);
-			TradeAction = SyntheticTradeAction.None;
+			TradeAction = SyntheticTradeActions.None;
 		}
 		catch (Exception ex)
 		{
 			LogError($"Failed to execute synthetic {action}. {ex.Message}");
-			TradeAction = SyntheticTradeAction.None;
+			TradeAction = SyntheticTradeActions.None;
 		}
 		finally
 		{
@@ -290,7 +290,7 @@ public class SymbolSynthesizerStrategy : Strategy
 		}
 	}
 
-	private void ExecuteSyntheticTrade(SyntheticTradeAction action)
+	private void ExecuteSyntheticTrade(SyntheticTradeActions action)
 	{
 		if (_combination == null || _firstLeg == null || _secondLeg == null)
 			throw new InvalidOperationException("Strategy legs are not initialized.");
@@ -308,10 +308,10 @@ public class SymbolSynthesizerStrategy : Strategy
 			throw new InvalidOperationException("Synthetic quotes are not ready yet.");
 
 		var firstSide = _combination.IsProduct
-		? (action == SyntheticTradeAction.Buy ? Sides.Buy : Sides.Sell)
-		: (action == SyntheticTradeAction.Buy ? Sides.Sell : Sides.Buy);
+		? (action == SyntheticTradeActions.Buy ? Sides.Buy : Sides.Sell)
+		: (action == SyntheticTradeActions.Buy ? Sides.Sell : Sides.Buy);
 
-		var secondSide = action == SyntheticTradeAction.Buy ? Sides.Buy : Sides.Sell;
+		var secondSide = action == SyntheticTradeActions.Buy ? Sides.Buy : Sides.Sell;
 
 		var firstPrice = firstSide == Sides.Buy ? firstAsk : firstBid;
 		var secondPrice = secondSide == Sides.Buy ? secondAsk : secondBid;
@@ -331,7 +331,7 @@ public class SymbolSynthesizerStrategy : Strategy
 			throw new InvalidOperationException("Tick value or price step metadata is missing.");
 		}
 
-		var syntheticPrice = action == SyntheticTradeAction.Buy ? synthAsk : synthBid;
+		var syntheticPrice = action == SyntheticTradeActions.Buy ? synthAsk : synthBid;
 
 		if (syntheticPrice <= 0m)
 			throw new InvalidOperationException("Synthetic price must be positive.");
@@ -393,7 +393,7 @@ public class SymbolSynthesizerStrategy : Strategy
 /// <summary>
 /// Manual actions exposed by <see cref="SymbolSynthesizerStrategy"/>.
 /// </summary>
-public enum SyntheticTradeAction
+public enum SyntheticTradeActions
 {
 	/// <summary>
 	/// No action requested.

--- a/API/4107_NtoQf/CS/NtoQfStrategy.cs
+++ b/API/4107_NtoQf/CS/NtoQfStrategy.cs
@@ -60,8 +60,8 @@ public class NtoQfStrategy : Strategy
 	private readonly StrategyParam<bool> _useMa;
 	private readonly StrategyParam<int> _maPeriod;
 	private readonly StrategyParam<int> _maShift;
-	private readonly StrategyParam<MovingAverageMethod> _maMethod;
-	private readonly StrategyParam<AppliedPrice> _maAppliedPrice;
+	private readonly StrategyParam<MovingAverageMethods> _maMethod;
+	private readonly StrategyParam<AppliedPrices> _maAppliedPrices;
 	private readonly StrategyParam<int> _maTimeFrame;
 
 	private decimal _pipSize;
@@ -379,7 +379,7 @@ public class NtoQfStrategy : Strategy
 	/// <summary>
 	/// Moving-average calculation method.
 	/// </summary>
-	public MovingAverageMethod MaMethod
+	public MovingAverageMethods MaMethod
 	{
 		get => _maMethod.Value;
 		set => _maMethod.Value = value;
@@ -388,10 +388,10 @@ public class NtoQfStrategy : Strategy
 	/// <summary>
 	/// Price field applied when calculating the moving average.
 	/// </summary>
-	public AppliedPrice MaAppliedPrice
+	public AppliedPrices MaAppliedPrices
 	{
-		get => _maAppliedPrice.Value;
-		set => _maAppliedPrice.Value = value;
+		get => _maAppliedPrices.Value;
+		set => _maAppliedPrices.Value = value;
 	}
 
 	/// <summary>
@@ -517,10 +517,10 @@ public class NtoQfStrategy : Strategy
 		_maShift = Param(nameof(MaShift), 0)
 		.SetDisplay("MA Shift", "Extra bars applied to MA", "MA");
 
-		_maMethod = Param(nameof(MaMethod), MovingAverageMethod.Simple)
+		_maMethod = Param(nameof(MaMethod), MovingAverageMethods.Simple)
 		.SetDisplay("MA Method", "Moving-average type", "MA");
 
-		_maAppliedPrice = Param(nameof(MaAppliedPrice), AppliedPrice.Close)
+		_maAppliedPrices = Param(nameof(MaAppliedPrices), AppliedPrices.Close)
 		.SetDisplay("MA Price", "Price source for MA", "MA");
 
 		_maTimeFrame = Param(nameof(MaTimeFrame), 0)
@@ -780,7 +780,7 @@ public class NtoQfStrategy : Strategy
 		if (volume <= 0m)
 		return;
 
-		if (signal == TrendDirection.Long)
+		if (signal == TrendDirections.Long)
 		{
 			BuyMarket(volume);
 			LogInfo($"Enter long at {candle.ClosePrice}");
@@ -859,27 +859,27 @@ public class NtoQfStrategy : Strategy
 		return false;
 	}
 
-	private TrendDirection? GenerateSignal()
+	private TrendDirections? GenerateSignal()
 	{
-		var directions = new List<TrendDirection>();
+		var directions = new List<TrendDirections>();
 
 		if (!TryGetRsiSignal(out var rsiDirection))
 		return null;
-		if (rsiDirection is TrendDirection rsi)
+		if (rsiDirection is TrendDirections rsi)
 		directions.Add(rsi);
 		else if (UseRsi)
 		return null;
 
 		if (!TryGetStochasticSignal(out var stoDirection))
 		return null;
-		if (stoDirection is TrendDirection sto)
+		if (stoDirection is TrendDirections sto)
 		directions.Add(sto);
 		else if (UseStochastic)
 		return null;
 
 		if (!TryGetAdxDirection(out var adxDirection))
 		return null;
-		if (adxDirection is TrendDirection adx)
+		if (adxDirection is TrendDirections adx)
 		directions.Add(adx);
 
 		if (!IsAdxMainSatisfied())
@@ -887,14 +887,14 @@ public class NtoQfStrategy : Strategy
 
 		if (!TryGetSarDirection(out var sarDirection))
 		return null;
-		if (sarDirection is TrendDirection sar)
+		if (sarDirection is TrendDirections sar)
 		directions.Add(sar);
 		else if (UseSar)
 		return null;
 
 		if (!TryGetMaDirection(out var maDirection))
 		return null;
-		if (maDirection is TrendDirection ma)
+		if (maDirection is TrendDirections ma)
 		directions.Add(ma);
 		else if (UseMa)
 		return null;
@@ -912,7 +912,7 @@ public class NtoQfStrategy : Strategy
 		return first;
 	}
 
-	private bool TryGetRsiSignal(out TrendDirection? direction)
+	private bool TryGetRsiSignal(out TrendDirections? direction)
 	{
 		direction = null;
 
@@ -928,14 +928,14 @@ public class NtoQfStrategy : Strategy
 		return false;
 
 		if (value > RsiUpper)
-		direction = TrendDirection.Short;
+		direction = TrendDirections.Short;
 		else if (value < RsiLower)
-		direction = TrendDirection.Long;
+		direction = TrendDirections.Long;
 
 		return true;
 	}
 
-	private bool TryGetStochasticSignal(out TrendDirection? direction)
+	private bool TryGetStochasticSignal(out TrendDirections? direction)
 	{
 		direction = null;
 
@@ -953,19 +953,19 @@ public class NtoQfStrategy : Strategy
 		if (UseStochasticHighLow)
 		{
 			if (snapshot.Main > snapshot.Signal && snapshot.Main > StochasticHigh)
-			direction = TrendDirection.Long;
+			direction = TrendDirections.Long;
 			else if (snapshot.Main < snapshot.Signal && snapshot.Main < StochasticLow)
-			direction = TrendDirection.Short;
+			direction = TrendDirections.Short;
 		}
 		else
 		{
-			direction = snapshot.Main > snapshot.Signal ? TrendDirection.Long : TrendDirection.Short;
+			direction = snapshot.Main > snapshot.Signal ? TrendDirections.Long : TrendDirections.Short;
 		}
 
 		return true;
 	}
 
-	private bool TryGetAdxDirection(out TrendDirection? direction)
+	private bool TryGetAdxDirection(out TrendDirections? direction)
 	{
 		direction = null;
 
@@ -980,11 +980,11 @@ public class NtoQfStrategy : Strategy
 		if (!buffer.TryGet(shift, out var snapshot))
 		return false;
 
-		direction = snapshot.PlusDi > snapshot.MinusDi ? TrendDirection.Long : TrendDirection.Short;
+		direction = snapshot.PlusDi > snapshot.MinusDi ? TrendDirections.Long : TrendDirections.Short;
 		return true;
 	}
 
-	private bool TryGetSarDirection(out TrendDirection? direction)
+	private bool TryGetSarDirection(out TrendDirections? direction)
 	{
 		direction = null;
 
@@ -1002,11 +1002,11 @@ public class NtoQfStrategy : Strategy
 		if (!TryGetClose(shift, out var close))
 		return false;
 
-		direction = sarValue > close ? TrendDirection.Long : TrendDirection.Short;
+		direction = sarValue > close ? TrendDirections.Long : TrendDirections.Short;
 		return true;
 	}
 
-	private bool TryGetMaDirection(out TrendDirection? direction)
+	private bool TryGetMaDirection(out TrendDirections? direction)
 	{
 		direction = null;
 
@@ -1024,7 +1024,7 @@ public class NtoQfStrategy : Strategy
 		if (!TryGetClose(Math.Max(0, Shift), out var close))
 		return false;
 
-		direction = maValue < close ? TrendDirection.Long : TrendDirection.Short;
+		direction = maValue < close ? TrendDirections.Long : TrendDirections.Short;
 		return true;
 	}
 
@@ -1095,28 +1095,28 @@ public class NtoQfStrategy : Strategy
 	{
 		var indicator = MaMethod switch
 		{
-			MovingAverageMethod.Simple => new SimpleMovingAverage { Length = MaPeriod },
-			MovingAverageMethod.Exponential => new ExponentialMovingAverage { Length = MaPeriod },
-			MovingAverageMethod.Smoothed => new SmoothedMovingAverage { Length = MaPeriod },
-			MovingAverageMethod.LinearWeighted => new WeightedMovingAverage { Length = MaPeriod },
+			MovingAverageMethods.Simple => new SimpleMovingAverage { Length = MaPeriod },
+			MovingAverageMethods.Exponential => new ExponentialMovingAverage { Length = MaPeriod },
+			MovingAverageMethods.Smoothed => new SmoothedMovingAverage { Length = MaPeriod },
+			MovingAverageMethods.LinearWeighted => new WeightedMovingAverage { Length = MaPeriod },
 			_ => new SimpleMovingAverage { Length = MaPeriod },
 		};
 
-		indicator.CandlePrice = ConvertAppliedPrice(MaAppliedPrice);
+		indicator.CandlePrice = ConvertAppliedPrices(MaAppliedPrices);
 		return indicator;
 	}
 
-	private CandlePrice ConvertAppliedPrice(AppliedPrice price)
+	private CandlePrice ConvertAppliedPrices(AppliedPrices price)
 	{
 		return price switch
 		{
-			AppliedPrice.Close => CandlePrice.Close,
-			AppliedPrice.Open => CandlePrice.Open,
-			AppliedPrice.High => CandlePrice.High,
-			AppliedPrice.Low => CandlePrice.Low,
-			AppliedPrice.Median => CandlePrice.Median,
-			AppliedPrice.Typical => CandlePrice.Typical,
-			AppliedPrice.Weighted => CandlePrice.Weighted,
+			AppliedPrices.Close => CandlePrice.Close,
+			AppliedPrices.Open => CandlePrice.Open,
+			AppliedPrices.High => CandlePrice.High,
+			AppliedPrices.Low => CandlePrice.Low,
+			AppliedPrices.Median => CandlePrice.Median,
+			AppliedPrices.Typical => CandlePrice.Typical,
+			AppliedPrices.Weighted => CandlePrice.Weighted,
 			_ => CandlePrice.Close,
 		};
 	}
@@ -1145,13 +1145,13 @@ public class NtoQfStrategy : Strategy
 		_takePrice = 0m;
 	}
 
-	private enum TrendDirection
+	private enum TrendDirections
 	{
 		Long,
 		Short,
 	}
 
-	public enum MovingAverageMethod
+	public enum MovingAverageMethods
 	{
 		Simple = 0,
 		Exponential = 1,
@@ -1159,7 +1159,7 @@ public class NtoQfStrategy : Strategy
 		LinearWeighted = 3,
 	}
 
-	public enum AppliedPrice
+	public enum AppliedPrices
 	{
 		Close = 0,
 		Open = 1,

--- a/API/4121_ComFracti_Fractal_Rsi/CS/ComFractiFractalRsiStrategy.cs
+++ b/API/4121_ComFracti_Fractal_Rsi/CS/ComFractiFractalRsiStrategy.cs
@@ -478,7 +478,7 @@ public class ComFractiFractalRsiStrategy : Strategy
 	private sealed class FractalSeries
 	{
 		private readonly List<CandleSnapshot> _candles = new();
-		private readonly List<FractalDirection> _signals = new();
+		private readonly List<FractalDirections> _signals = new();
 
 		public void Reset()
 		{
@@ -493,7 +493,7 @@ public class ComFractiFractalRsiStrategy : Strategy
 
 			var data = new CandleSnapshot(candle.HighPrice, candle.LowPrice);
 			_candles.Add(data);
-			_signals.Add(FractalDirection.None);
+			_signals.Add(FractalDirections.None);
 
 			if (_candles.Count < 5)
 			return;
@@ -511,15 +511,15 @@ public class ComFractiFractalRsiStrategy : Strategy
 
 			if (isLower && !isUpper)
 			{
-				_signals[centerIndex] = FractalDirection.Lower;
+				_signals[centerIndex] = FractalDirections.Lower;
 			}
 			else if (isUpper && !isLower)
 			{
-				_signals[centerIndex] = FractalDirection.Upper;
+				_signals[centerIndex] = FractalDirections.Upper;
 			}
 			else if (!isUpper && !isLower)
 			{
-				_signals[centerIndex] = FractalDirection.None;
+				_signals[centerIndex] = FractalDirections.None;
 			}
 		}
 
@@ -531,17 +531,17 @@ public class ComFractiFractalRsiStrategy : Strategy
 			var direction = GetDirection(shift);
 			return direction switch
 			{
-				FractalDirection.Lower => 1,
-				FractalDirection.Upper => -1,
+				FractalDirections.Lower => 1,
+				FractalDirections.Upper => -1,
 				_ => 0,
 			};
 		}
 
-		private FractalDirection GetDirection(int shift)
+		private FractalDirections GetDirection(int shift)
 		{
 			var index = _signals.Count - 1 - shift;
 			if (index < 0 || index >= _signals.Count)
-			return FractalDirection.None;
+			return FractalDirections.None;
 
 			return _signals[index];
 		}
@@ -558,7 +558,7 @@ public class ComFractiFractalRsiStrategy : Strategy
 		public decimal Low { get; }
 		}
 
-		private enum FractalDirection
+		private enum FractalDirections
 		{
 			None,
 			Lower,

--- a/API/4122_Order_Guardian/CS/OrderGuardianStrategy.cs
+++ b/API/4122_Order_Guardian/CS/OrderGuardianStrategy.cs
@@ -22,14 +22,14 @@ namespace StockSharp.Samples.Strategies;
 public class OrderGuardianStrategy : Strategy
 {
 	private readonly StrategyParam<DataType> _candleType;
-	private readonly StrategyParam<TakeProfitMethodOption> _takeProfitMethod;
-	private readonly StrategyParam<StopLossMethodOption> _stopLossMethod;
+	private readonly StrategyParam<TakeProfitMethodOptions> _takeProfitMethod;
+	private readonly StrategyParam<StopLossMethodOptions> _stopLossMethod;
 	private readonly StrategyParam<int> _takeProfitPeriod;
 	private readonly StrategyParam<int> _stopLossPeriod;
-	private readonly StrategyParam<MovingAverageMethodOption> _takeProfitMaMethod;
-	private readonly StrategyParam<MovingAverageMethodOption> _stopLossMaMethod;
-	private readonly StrategyParam<AppliedPriceOption> _takeProfitPriceType;
-	private readonly StrategyParam<AppliedPriceOption> _stopLossPriceType;
+	private readonly StrategyParam<MovingAverageMethodOptions> _takeProfitMaMethod;
+	private readonly StrategyParam<MovingAverageMethodOptions> _stopLossMaMethod;
+	private readonly StrategyParam<AppliedPriceOptions> _takeProfitPriceType;
+	private readonly StrategyParam<AppliedPriceOptions> _stopLossPriceType;
 	private readonly StrategyParam<decimal> _takeProfitDeviation;
 	private readonly StrategyParam<decimal> _stopLossDeviation;
 	private readonly StrategyParam<int> _takeProfitShift;
@@ -71,10 +71,10 @@ public class OrderGuardianStrategy : Strategy
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
 			.SetDisplay("Candle Type", "Type of candles processed by the strategy.", "General");
 
-		_takeProfitMethod = Param(nameof(TakeProfitMethod), TakeProfitMethodOption.ManualLine)
+		_takeProfitMethod = Param(nameof(TakeProfitMethod), TakeProfitMethodOptions.ManualLine)
 			.SetDisplay("Take Profit Method", "Source used to compute the take-profit level.", "Take Profit");
 
-		_stopLossMethod = Param(nameof(StopLossMethod), StopLossMethodOption.ManualLine)
+		_stopLossMethod = Param(nameof(StopLossMethod), StopLossMethodOptions.ManualLine)
 			.SetDisplay("Stop Loss Method", "Source used to compute the stop-loss level.", "Stop Loss");
 
 		_takeProfitPeriod = Param(nameof(TakeProfitPeriod), 31)
@@ -85,16 +85,16 @@ public class OrderGuardianStrategy : Strategy
 			.SetGreaterThanZero()
 			.SetDisplay("SL MA Period", "Moving average length for the stop-loss envelope.", "Stop Loss");
 
-		_takeProfitMaMethod = Param(nameof(TakeProfitMaMethod), MovingAverageMethodOption.Exponential)
+		_takeProfitMaMethod = Param(nameof(TakeProfitMaMethod), MovingAverageMethodOptions.Exponential)
 			.SetDisplay("TP MA Method", "Moving average calculation used for the take-profit envelope.", "Take Profit");
 
-		_stopLossMaMethod = Param(nameof(StopLossMaMethod), MovingAverageMethodOption.Exponential)
+		_stopLossMaMethod = Param(nameof(StopLossMaMethod), MovingAverageMethodOptions.Exponential)
 			.SetDisplay("SL MA Method", "Moving average calculation used for the stop-loss envelope.", "Stop Loss");
 
-		_takeProfitPriceType = Param(nameof(TakeProfitPriceType), AppliedPriceOption.Close)
+		_takeProfitPriceType = Param(nameof(TakeProfitPriceType), AppliedPriceOptions.Close)
 			.SetDisplay("TP Price Source", "Price source fed into the take-profit moving average.", "Take Profit");
 
-		_stopLossPriceType = Param(nameof(StopLossPriceType), AppliedPriceOption.Close)
+		_stopLossPriceType = Param(nameof(StopLossPriceType), AppliedPriceOptions.Close)
 			.SetDisplay("SL Price Source", "Price source fed into the stop-loss moving average.", "Stop Loss");
 
 		_takeProfitDeviation = Param(nameof(TakeProfitDeviation), 0.2m)
@@ -147,7 +147,7 @@ public class OrderGuardianStrategy : Strategy
 	/// <summary>
 	/// Take-profit calculation method.
 	/// </summary>
-	public TakeProfitMethodOption TakeProfitMethod
+	public TakeProfitMethodOptions TakeProfitMethod
 	{
 		get => _takeProfitMethod.Value;
 		set => _takeProfitMethod.Value = value;
@@ -156,7 +156,7 @@ public class OrderGuardianStrategy : Strategy
 	/// <summary>
 	/// Stop-loss calculation method.
 	/// </summary>
-	public StopLossMethodOption StopLossMethod
+	public StopLossMethodOptions StopLossMethod
 	{
 		get => _stopLossMethod.Value;
 		set => _stopLossMethod.Value = value;
@@ -183,7 +183,7 @@ public class OrderGuardianStrategy : Strategy
 	/// <summary>
 	/// Moving average method used to calculate the take-profit envelope.
 	/// </summary>
-	public MovingAverageMethodOption TakeProfitMaMethod
+	public MovingAverageMethodOptions TakeProfitMaMethod
 	{
 		get => _takeProfitMaMethod.Value;
 		set => _takeProfitMaMethod.Value = value;
@@ -192,7 +192,7 @@ public class OrderGuardianStrategy : Strategy
 	/// <summary>
 	/// Moving average method used to calculate the stop-loss envelope.
 	/// </summary>
-	public MovingAverageMethodOption StopLossMaMethod
+	public MovingAverageMethodOptions StopLossMaMethod
 	{
 		get => _stopLossMaMethod.Value;
 		set => _stopLossMaMethod.Value = value;
@@ -201,7 +201,7 @@ public class OrderGuardianStrategy : Strategy
 	/// <summary>
 	/// Price source for the take-profit moving average.
 	/// </summary>
-	public AppliedPriceOption TakeProfitPriceType
+	public AppliedPriceOptions TakeProfitPriceType
 	{
 		get => _takeProfitPriceType.Value;
 		set => _takeProfitPriceType.Value = value;
@@ -210,7 +210,7 @@ public class OrderGuardianStrategy : Strategy
 	/// <summary>
 	/// Price source for the stop-loss moving average.
 	/// </summary>
-	public AppliedPriceOption StopLossPriceType
+	public AppliedPriceOptions StopLossPriceType
 	{
 		get => _stopLossPriceType.Value;
 		set => _stopLossPriceType.Value = value;
@@ -342,7 +342,7 @@ public class OrderGuardianStrategy : Strategy
 		base.OnStarted(time);
 
 		// The original expert enforces a minimum shift of one bar for Parabolic SAR to avoid repainting.
-		if (StopLossMethod == StopLossMethodOption.ParabolicSar && StopLossShift < 1)
+		if (StopLossMethod == StopLossMethodOptions.ParabolicSar && StopLossShift < 1)
 		{
 			StopLossShift = 1;
 		}
@@ -444,7 +444,7 @@ public class OrderGuardianStrategy : Strategy
 	{
 		switch (TakeProfitMethod)
 		{
-			case TakeProfitMethodOption.Envelope:
+			case TakeProfitMethodOptions.Envelope:
 			{
 				if (_takeProfitMaIndicator == null)
 					return (null, null);
@@ -462,7 +462,7 @@ public class OrderGuardianStrategy : Strategy
 				var envelope = shifted.Value * (1m + TakeProfitDeviation / 100m);
 				return (envelope, envelope);
 			}
-			case TakeProfitMethodOption.ManualLine:
+			case TakeProfitMethodOptions.ManualLine:
 			{
 				var longPrice = ManualTakeProfitLong > 0m ? ManualTakeProfitLong : (decimal?)null;
 				var shortPrice = ManualTakeProfitShort > 0m ? ManualTakeProfitShort : (decimal?)null;
@@ -477,7 +477,7 @@ public class OrderGuardianStrategy : Strategy
 	{
 		switch (StopLossMethod)
 		{
-			case StopLossMethodOption.Envelope:
+			case StopLossMethodOptions.Envelope:
 			{
 				if (_stopLossMaIndicator == null)
 					return (null, null);
@@ -495,13 +495,13 @@ public class OrderGuardianStrategy : Strategy
 				var envelope = shifted.Value * (1m + StopLossDeviation / 100m);
 				return (envelope, envelope);
 			}
-			case StopLossMethodOption.ManualLine:
+			case StopLossMethodOptions.ManualLine:
 			{
 				var longPrice = ManualStopLossLong > 0m ? ManualStopLossLong : (decimal?)null;
 				var shortPrice = ManualStopLossShort > 0m ? ManualStopLossShort : (decimal?)null;
 				return (longPrice, shortPrice);
 			}
-			case StopLossMethodOption.ParabolicSar:
+			case StopLossMethodOptions.ParabolicSar:
 			{
 				if (_sarIndicator == null)
 					return (null, null);
@@ -525,15 +525,15 @@ public class OrderGuardianStrategy : Strategy
 
 	private void InitializeIndicators()
 	{
-		_takeProfitMaIndicator = TakeProfitMethod == TakeProfitMethodOption.Envelope
+		_takeProfitMaIndicator = TakeProfitMethod == TakeProfitMethodOptions.Envelope
 			? CreateMovingAverage(TakeProfitMaMethod, TakeProfitPeriod)
 			: null;
 
-		_stopLossMaIndicator = StopLossMethod == StopLossMethodOption.Envelope
+		_stopLossMaIndicator = StopLossMethod == StopLossMethodOptions.Envelope
 			? CreateMovingAverage(StopLossMaMethod, StopLossPeriod)
 			: null;
 
-		_sarIndicator = StopLossMethod == StopLossMethodOption.ParabolicSar
+		_sarIndicator = StopLossMethod == StopLossMethodOptions.ParabolicSar
 			? new ParabolicSar { AccelerationStep = SarStep, AccelerationMax = SarMaximum }
 			: null;
 
@@ -605,14 +605,14 @@ public class OrderGuardianStrategy : Strategy
 			LogInfo(_lastStatusMessage);
 	}
 
-	private static IIndicator CreateMovingAverage(MovingAverageMethodOption method, int period)
+	private static IIndicator CreateMovingAverage(MovingAverageMethodOptions method, int period)
 	{
 		return method switch
 		{
-			MovingAverageMethodOption.Simple => new SimpleMovingAverage { Length = period },
-			MovingAverageMethodOption.Exponential => new ExponentialMovingAverage { Length = period },
-			MovingAverageMethodOption.Smoothed => new SmoothedMovingAverage { Length = period },
-			MovingAverageMethodOption.LinearWeighted => new WeightedMovingAverage { Length = period },
+			MovingAverageMethodOptions.Simple => new SimpleMovingAverage { Length = period },
+			MovingAverageMethodOptions.Exponential => new ExponentialMovingAverage { Length = period },
+			MovingAverageMethodOptions.Smoothed => new SmoothedMovingAverage { Length = period },
+			MovingAverageMethodOptions.LinearWeighted => new WeightedMovingAverage { Length = period },
 			_ => new ExponentialMovingAverage { Length = period }
 		};
 	}
@@ -662,16 +662,16 @@ public class OrderGuardianStrategy : Strategy
 		return buffer[index];
 	}
 
-	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPriceOption priceType)
+	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPriceOptions priceType)
 	{
 		return priceType switch
 		{
-			AppliedPriceOption.Open => candle.OpenPrice,
-			AppliedPriceOption.High => candle.HighPrice,
-			AppliedPriceOption.Low => candle.LowPrice,
-			AppliedPriceOption.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-			AppliedPriceOption.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-			AppliedPriceOption.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice + candle.ClosePrice) / 4m,
+			AppliedPriceOptions.Open => candle.OpenPrice,
+			AppliedPriceOptions.High => candle.HighPrice,
+			AppliedPriceOptions.Low => candle.LowPrice,
+			AppliedPriceOptions.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+			AppliedPriceOptions.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+			AppliedPriceOptions.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice + candle.ClosePrice) / 4m,
 			_ => candle.ClosePrice
 		};
 	}
@@ -679,7 +679,7 @@ public class OrderGuardianStrategy : Strategy
 	/// <summary>
 	/// Take-profit calculation choices.
 	/// </summary>
-	public enum TakeProfitMethodOption
+	public enum TakeProfitMethodOptions
 	{
 		Envelope = 1,
 		ManualLine = 2
@@ -688,7 +688,7 @@ public class OrderGuardianStrategy : Strategy
 	/// <summary>
 	/// Stop-loss calculation choices.
 	/// </summary>
-	public enum StopLossMethodOption
+	public enum StopLossMethodOptions
 	{
 		Envelope = 1,
 		ManualLine = 2,
@@ -698,7 +698,7 @@ public class OrderGuardianStrategy : Strategy
 	/// <summary>
 	/// Moving average calculation types compatible with the MetaTrader constants.
 	/// </summary>
-	public enum MovingAverageMethodOption
+	public enum MovingAverageMethodOptions
 	{
 		Simple = 0,
 		Exponential = 1,
@@ -709,7 +709,7 @@ public class OrderGuardianStrategy : Strategy
 	/// <summary>
 	/// Price sources equivalent to the MetaTrader applied price options.
 	/// </summary>
-	public enum AppliedPriceOption
+	public enum AppliedPriceOptions
 	{
 		Close = 0,
 		Open = 1,

--- a/API/4140_FiftyFiveMedianSlope/CS/FiftyFiveMedianSlopeStrategy.cs
+++ b/API/4140_FiftyFiveMedianSlope/CS/FiftyFiveMedianSlopeStrategy.cs
@@ -27,7 +27,7 @@ public class FiftyFiveMedianSlopeStrategy : Strategy
 	private readonly StrategyParam<int> _stopLossPoints;
 	private readonly StrategyParam<int> _maPeriod;
 	private readonly StrategyParam<int> _maShift;
-	private readonly StrategyParam<MovingAverageKind> _maMethod;
+	private readonly StrategyParam<MovingAverageKinds> _maMethod;
 	private readonly StrategyParam<int> _startHour;
 	private readonly StrategyParam<int> _endHour;
 	private readonly StrategyParam<int> _maxOrders;
@@ -65,7 +65,7 @@ public class FiftyFiveMedianSlopeStrategy : Strategy
 			.SetDisplay("MA shift", "Bars between the recent and historical moving average snapshots.", "Indicators")
 			.SetNotNegative();
 
-		_maMethod = Param(nameof(MaMethod), MovingAverageKind.Exponential)
+		_maMethod = Param(nameof(MaMethod), MovingAverageKinds.Exponential)
 			.SetDisplay("MA method", "Calculation method used for the moving average.", "Indicators");
 
 		_startHour = Param(nameof(StartHour), 8)
@@ -120,7 +120,7 @@ public class FiftyFiveMedianSlopeStrategy : Strategy
 		set => _maShift.Value = value;
 	}
 
-	public MovingAverageKind MaMethod
+	public MovingAverageKinds MaMethod
 	{
 		get => _maMethod.Value;
 		set => _maMethod.Value = value;
@@ -473,14 +473,14 @@ public class FiftyFiveMedianSlopeStrategy : Strategy
 		return hour;
 	}
 
-	private static IIndicator CreateMovingAverage(MovingAverageKind method, int length)
+	private static IIndicator CreateMovingAverage(MovingAverageKinds method, int length)
 	{
 		return method switch
 		{
-			MovingAverageKind.Simple => new SimpleMovingAverage { Length = length },
-			MovingAverageKind.Exponential => new ExponentialMovingAverage { Length = length },
-			MovingAverageKind.Smoothed => new SmoothedMovingAverage { Length = length },
-			MovingAverageKind.LinearWeighted => new WeightedMovingAverage { Length = length },
+			MovingAverageKinds.Simple => new SimpleMovingAverage { Length = length },
+			MovingAverageKinds.Exponential => new ExponentialMovingAverage { Length = length },
+			MovingAverageKinds.Smoothed => new SmoothedMovingAverage { Length = length },
+			MovingAverageKinds.LinearWeighted => new WeightedMovingAverage { Length = length },
 			_ => new ExponentialMovingAverage { Length = length },
 		};
 	}
@@ -489,7 +489,7 @@ public class FiftyFiveMedianSlopeStrategy : Strategy
 /// <summary>
 /// Moving average calculation methods supported by the strategy.
 /// </summary>
-public enum MovingAverageKind
+public enum MovingAverageKinds
 {
 	Simple,
 	Exponential,

--- a/API/4142_CCFp_Advisor/CS/CcfpAdvisorStrategy.cs
+++ b/API/4142_CCFp_Advisor/CS/CcfpAdvisorStrategy.cs
@@ -21,7 +21,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class CcfpAdvisorStrategy : Strategy
 {
-	private readonly StrategyParam<MovingAverageMode> _maType;
+	private readonly StrategyParam<MovingAverageModes> _maType;
 	private readonly StrategyParam<CandlePrice> _priceMode;
 	private readonly StrategyParam<int> _fastPeriod;
 	private readonly StrategyParam<int> _slowPeriod;
@@ -50,7 +50,7 @@ public class CcfpAdvisorStrategy : Strategy
 	/// </summary>
 	public CcfpAdvisorStrategy()
 	{
-		_maType = Param(nameof(MaType), MovingAverageMode.Exponential)
+		_maType = Param(nameof(MaType), MovingAverageModes.Exponential)
 			.SetDisplay("MA Type", "Moving-average algorithm used for the currency strength calculation", "General")
 			.SetCanOptimize(true);
 
@@ -105,7 +105,7 @@ public class CcfpAdvisorStrategy : Strategy
 /// <summary>
 /// Moving-average method applied to every composite MA calculation.
 /// </summary>
-public MovingAverageMode MaType
+public MovingAverageModes MaType
 {
 	get => _maType.Value;
 	set => _maType.Value = value;
@@ -376,7 +376,7 @@ if (_activeWeakTrade is { } weak && weak.Currency != minCurrency)
 }
 }
 
-private void OpenTrade(ref ActiveTrade? slot, CurrencyIndex currency, TradeAction action, string tag)
+private void OpenTrade(ref ActiveTrade? slot, CurrencyIndexes currency, TradeAction action, string tag)
 {
 	if (slot is { Currency: var existing } && existing == currency)
 	return;
@@ -500,7 +500,7 @@ if (!AreValid(eurUsd) || !AreValid(gbpUsd) || !AreValid(audUsd) || !AreValid(nzd
 var strength = new decimal[8];
 
 // USD strength.
-strength[(int)CurrencyIndex.USD] =
+strength[(int)CurrencyIndexes.USD] =
 (SafeDiv(eurUsd.Slow, eurUsd.Fast) - 1m) +
 (SafeDiv(gbpUsd.Slow, gbpUsd.Fast) - 1m) +
 (SafeDiv(audUsd.Slow, audUsd.Fast) - 1m) +
@@ -510,7 +510,7 @@ strength[(int)CurrencyIndex.USD] =
 (SafeDiv(usdJpy.Fast, usdJpy.Slow) - 1m);
 
 // EUR strength.
-strength[(int)CurrencyIndex.EUR] =
+strength[(int)CurrencyIndexes.EUR] =
 (SafeDiv(eurUsd.Fast, eurUsd.Slow) - 1m) +
 (SafeDiv(SafeDiv(eurUsd.Fast, gbpUsd.Fast), SafeDiv(eurUsd.Slow, gbpUsd.Slow)) - 1m) +
 (SafeDiv(SafeDiv(eurUsd.Fast, audUsd.Fast), SafeDiv(eurUsd.Slow, audUsd.Slow)) - 1m) +
@@ -520,7 +520,7 @@ strength[(int)CurrencyIndex.EUR] =
 (SafeDiv(eurUsd.Fast * usdJpy.Fast, eurUsd.Slow * usdJpy.Slow) - 1m);
 
 // GBP strength.
-strength[(int)CurrencyIndex.GBP] =
+strength[(int)CurrencyIndexes.GBP] =
 (SafeDiv(gbpUsd.Fast, gbpUsd.Slow) - 1m) +
 (SafeDiv(SafeDiv(eurUsd.Slow, gbpUsd.Slow), SafeDiv(eurUsd.Fast, gbpUsd.Fast)) - 1m) +
 (SafeDiv(SafeDiv(gbpUsd.Fast, audUsd.Fast), SafeDiv(gbpUsd.Slow, audUsd.Slow)) - 1m) +
@@ -530,7 +530,7 @@ strength[(int)CurrencyIndex.GBP] =
 (SafeDiv(gbpUsd.Fast * usdJpy.Fast, gbpUsd.Slow * usdJpy.Slow) - 1m);
 
 // CHF strength.
-strength[(int)CurrencyIndex.CHF] =
+strength[(int)CurrencyIndexes.CHF] =
 (SafeDiv(usdChf.Slow, usdChf.Fast) - 1m) +
 (SafeDiv(eurUsd.Slow * usdChf.Slow, eurUsd.Fast * usdChf.Fast) - 1m) +
 (SafeDiv(gbpUsd.Slow * usdChf.Slow, gbpUsd.Fast * usdChf.Fast) - 1m) +
@@ -540,7 +540,7 @@ strength[(int)CurrencyIndex.CHF] =
 (SafeDiv(SafeDiv(usdChf.Slow, usdJpy.Slow), SafeDiv(usdChf.Fast, usdJpy.Fast)) - 1m);
 
 // JPY strength.
-strength[(int)CurrencyIndex.JPY] =
+strength[(int)CurrencyIndexes.JPY] =
 (SafeDiv(usdJpy.Slow, usdJpy.Fast) - 1m) +
 (SafeDiv(eurUsd.Slow * usdJpy.Slow, eurUsd.Fast * usdJpy.Fast) - 1m) +
 (SafeDiv(gbpUsd.Slow * usdJpy.Slow, gbpUsd.Fast * usdJpy.Fast) - 1m) +
@@ -550,7 +550,7 @@ strength[(int)CurrencyIndex.JPY] =
 (SafeDiv(SafeDiv(usdJpy.Slow, usdChf.Slow), SafeDiv(usdJpy.Fast, usdChf.Fast)) - 1m);
 
 // AUD strength.
-strength[(int)CurrencyIndex.AUD] =
+strength[(int)CurrencyIndexes.AUD] =
 (SafeDiv(audUsd.Fast, audUsd.Slow) - 1m) +
 (SafeDiv(SafeDiv(eurUsd.Slow, audUsd.Slow), SafeDiv(eurUsd.Fast, audUsd.Fast)) - 1m) +
 (SafeDiv(SafeDiv(gbpUsd.Slow, audUsd.Slow), SafeDiv(gbpUsd.Fast, audUsd.Fast)) - 1m) +
@@ -560,7 +560,7 @@ strength[(int)CurrencyIndex.AUD] =
 (SafeDiv(audUsd.Fast * usdJpy.Fast, audUsd.Slow * usdJpy.Slow) - 1m);
 
 // CAD strength.
-strength[(int)CurrencyIndex.CAD] =
+strength[(int)CurrencyIndexes.CAD] =
 (SafeDiv(usdCad.Slow, usdCad.Fast) - 1m) +
 (SafeDiv(eurUsd.Slow * usdCad.Slow, eurUsd.Fast * usdCad.Fast) - 1m) +
 (SafeDiv(gbpUsd.Slow * usdCad.Slow, gbpUsd.Fast * usdCad.Fast) - 1m) +
@@ -570,7 +570,7 @@ strength[(int)CurrencyIndex.CAD] =
 (SafeDiv(SafeDiv(usdJpy.Fast, usdCad.Fast), SafeDiv(usdJpy.Slow, usdCad.Slow)) - 1m);
 
 // NZD strength.
-strength[(int)CurrencyIndex.NZD] =
+strength[(int)CurrencyIndexes.NZD] =
 (SafeDiv(nzdUsd.Fast, nzdUsd.Slow) - 1m) +
 (SafeDiv(SafeDiv(eurUsd.Slow, nzdUsd.Slow), SafeDiv(eurUsd.Fast, nzdUsd.Fast)) - 1m) +
 (SafeDiv(SafeDiv(gbpUsd.Slow, nzdUsd.Slow), SafeDiv(gbpUsd.Fast, nzdUsd.Fast)) - 1m) +
@@ -635,7 +635,7 @@ private static int GetDecimalDigits(decimal value)
 return digits;
 }
 
-private static (CurrencyIndex currency, decimal value) FindExtremum(IReadOnlyList<decimal> values, bool isMaximum)
+private static (CurrencyIndexes currency, decimal value) FindExtremum(IReadOnlyList<decimal> values, bool isMaximum)
 {
 	var best = values.Count > 0 ? values[0] : 0m;
 	var index = 0;
@@ -661,7 +661,7 @@ else
 }
 }
 
-return ((CurrencyIndex)index, best);
+return ((CurrencyIndexes)index, best);
 }
 
 private static decimal GetExtreme(IReadOnlyList<decimal> values, bool isMaximum)
@@ -688,18 +688,18 @@ private static decimal GetExtreme(IReadOnlyList<decimal> values, bool isMaximum)
 return result;
 }
 
-private bool TryGetTradeAction(CurrencyIndex currency, bool isStrong, out TradeAction action)
+private bool TryGetTradeAction(CurrencyIndexes currency, bool isStrong, out TradeAction action)
 {
 	action = default;
 	return currency switch
 	{
-		CurrencyIndex.EUR => CreateAction(EurUsdSecurity, isStrong ? Sides.Buy : Sides.Sell, out action),
-		CurrencyIndex.GBP => CreateAction(GbpUsdSecurity, isStrong ? Sides.Buy : Sides.Sell, out action),
-		CurrencyIndex.CHF => CreateAction(UsdChfSecurity, isStrong ? Sides.Sell : Sides.Buy, out action),
-		CurrencyIndex.JPY => CreateAction(UsdJpySecurity, isStrong ? Sides.Sell : Sides.Buy, out action),
-		CurrencyIndex.AUD => CreateAction(AudUsdSecurity, isStrong ? Sides.Buy : Sides.Sell, out action),
-		CurrencyIndex.CAD => CreateAction(UsdCadSecurity, isStrong ? Sides.Sell : Sides.Buy, out action),
-		CurrencyIndex.NZD => CreateAction(NzdUsdSecurity, isStrong ? Sides.Buy : Sides.Sell, out action),
+		CurrencyIndexes.EUR => CreateAction(EurUsdSecurity, isStrong ? Sides.Buy : Sides.Sell, out action),
+		CurrencyIndexes.GBP => CreateAction(GbpUsdSecurity, isStrong ? Sides.Buy : Sides.Sell, out action),
+		CurrencyIndexes.CHF => CreateAction(UsdChfSecurity, isStrong ? Sides.Sell : Sides.Buy, out action),
+		CurrencyIndexes.JPY => CreateAction(UsdJpySecurity, isStrong ? Sides.Sell : Sides.Buy, out action),
+		CurrencyIndexes.AUD => CreateAction(AudUsdSecurity, isStrong ? Sides.Buy : Sides.Sell, out action),
+		CurrencyIndexes.CAD => CreateAction(UsdCadSecurity, isStrong ? Sides.Sell : Sides.Buy, out action),
+		CurrencyIndexes.NZD => CreateAction(NzdUsdSecurity, isStrong ? Sides.Buy : Sides.Sell, out action),
 		_ => false,
 	};
 }
@@ -724,7 +724,7 @@ private void AddPair(string symbol, Security security, IReadOnlyList<int> multip
 	_pairBySecurity[security] = pair;
 }
 
-private static AggregatedMovingAverage CreateAggregatedAverage(MovingAverageMode type, int period, IReadOnlyList<int> multipliers)
+private static AggregatedMovingAverage CreateAggregatedAverage(MovingAverageModes type, int period, IReadOnlyList<int> multipliers)
 {
 	var indicators = new List<LengthIndicator<decimal>>(multipliers.Count);
 	for (var i = 0; i < multipliers.Count; i++)
@@ -736,13 +736,13 @@ private static AggregatedMovingAverage CreateAggregatedAverage(MovingAverageMode
 return new AggregatedMovingAverage(indicators);
 }
 
-private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageMode type, int length)
+private static LengthIndicator<decimal> CreateMovingAverage(MovingAverageModes type, int length)
 {
 	LengthIndicator<decimal> indicator = type switch
 	{
-		MovingAverageMode.Exponential => new ExponentialMovingAverage(),
-		MovingAverageMode.Smoothed => new SmoothedMovingAverage(),
-		MovingAverageMode.Weighted => new WeightedMovingAverage(),
+		MovingAverageModes.Exponential => new ExponentialMovingAverage(),
+		MovingAverageModes.Smoothed => new SmoothedMovingAverage(),
+		MovingAverageModes.Weighted => new WeightedMovingAverage(),
 		_ => new SimpleMovingAverage(),
 	};
 
@@ -888,7 +888,7 @@ public Sides Side { get; }
 
 private struct ActiveTrade
 {
-	public CurrencyIndex Currency { get; set; }
+	public CurrencyIndexes Currency { get; set; }
 	public Security Security { get; set; }
 	public Sides Side { get; set; }
 	public decimal Volume { get; set; }
@@ -898,7 +898,7 @@ private struct ActiveTrade
 /// <summary>
 /// Moving-average calculation modes supported by the strategy.
 /// </summary>
-public enum MovingAverageMode
+public enum MovingAverageModes
 {
 	Simple,
 	Exponential,
@@ -906,7 +906,7 @@ public enum MovingAverageMode
 	Weighted,
 }
 
-private enum CurrencyIndex
+private enum CurrencyIndexes
 {
 	USD,
 	EUR,

--- a/API/4146_Trade_Arbitrage/CS/TradeArbitrageStrategy.cs
+++ b/API/4146_Trade_Arbitrage/CS/TradeArbitrageStrategy.cs
@@ -313,12 +313,12 @@ private bool TryComputeVariantQuotes(Variant variant, out decimal bid, out decim
 
 	switch (variant.Math)
 		{
-			case VariantMath.Direct:
+			case VariantMaths.Direct:
 				{
 					return TryGetQuote(variant.PrimarySecurity, out bid, out ask);
 				}
 
-				case VariantMath.Inverse:
+				case VariantMaths.Inverse:
 					{
 						if (!TryGetQuote(variant.PrimarySecurity, out var baseBid, out var baseAsk))
 						return false;
@@ -331,7 +331,7 @@ private bool TryComputeVariantQuotes(Variant variant, out decimal bid, out decim
 						return true;
 					}
 
-					case VariantMath.Ratio:
+					case VariantMaths.Ratio:
 						{
 							if (!TryGetQuote(variant.PrimarySecurity, out var bid1, out var ask1))
 							return false;
@@ -347,7 +347,7 @@ private bool TryComputeVariantQuotes(Variant variant, out decimal bid, out decim
 							return true;
 						}
 
-						case VariantMath.Product:
+						case VariantMaths.Product:
 							{
 								if (!TryGetQuote(variant.PrimarySecurity, out var bid1, out var ask1))
 								return false;
@@ -360,7 +360,7 @@ private bool TryComputeVariantQuotes(Variant variant, out decimal bid, out decim
 								return true;
 							}
 
-							case VariantMath.InverseProduct:
+							case VariantMaths.InverseProduct:
 								{
 									if (!TryGetQuote(variant.PrimarySecurity, out var bid1, out var ask1))
 									return false;
@@ -379,7 +379,7 @@ private bool TryComputeVariantQuotes(Variant variant, out decimal bid, out decim
 									return true;
 								}
 
-								case VariantMath.ReverseRatio:
+								case VariantMaths.ReverseRatio:
 									{
 										if (!TryGetQuote(variant.PrimarySecurity, out var bid1, out var ask1))
 										return false;
@@ -459,13 +459,13 @@ private bool TryComputeVariantQuotes(Variant variant, out decimal bid, out decim
 
 							switch (variant.Math)
 								{
-									case VariantMath.Direct:
+									case VariantMaths.Direct:
 										{
 											AddPendingVolume(variant.PrimarySecurity, side == Sides.Buy ? volume : -volume);
 											break;
 									}
 
-									case VariantMath.Inverse:
+									case VariantMaths.Inverse:
 										{
 											if (!TryGetQuote(variant.PrimarySecurity, out var bid, out var ask))
 											return;
@@ -490,7 +490,7 @@ private bool TryComputeVariantQuotes(Variant variant, out decimal bid, out decim
 											break;
 									}
 
-									case VariantMath.Ratio:
+									case VariantMaths.Ratio:
 										{
 											if (variant.LastBid is not decimal lastBid || variant.LastAsk is not decimal lastAsk)
 											return;
@@ -509,7 +509,7 @@ private bool TryComputeVariantQuotes(Variant variant, out decimal bid, out decim
 											break;
 									}
 
-									case VariantMath.Product:
+									case VariantMaths.Product:
 										{
 											if (!TryGetQuote(variant.PrimarySecurity, out var bid1, out var ask1))
 											return;
@@ -528,7 +528,7 @@ private bool TryComputeVariantQuotes(Variant variant, out decimal bid, out decim
 											break;
 									}
 
-									case VariantMath.InverseProduct:
+									case VariantMaths.InverseProduct:
 										{
 											if (!TryGetQuote(variant.PrimarySecurity, out var bid1, out var ask1))
 											return;
@@ -556,7 +556,7 @@ private bool TryComputeVariantQuotes(Variant variant, out decimal bid, out decim
 											break;
 									}
 
-									case VariantMath.ReverseRatio:
+									case VariantMaths.ReverseRatio:
 										{
 											if (!TryGetQuote(variant.PrimarySecurity, out var bid1, out var ask1))
 											return;
@@ -681,12 +681,12 @@ private bool TryComputeVariantQuotes(Variant variant, out decimal bid, out decim
 
 						return variant.Math switch
 						{
-							VariantMath.Direct => variant.PrimaryCode,
-							VariantMath.Inverse => $"1 / {variant.PrimaryCode}",
-							VariantMath.Ratio => $"{variant.PrimaryCode} / {variant.SecondaryCode}",
-							VariantMath.Product => $"{variant.PrimaryCode} * {variant.SecondaryCode}",
-							VariantMath.InverseProduct => $"1 / ({variant.PrimaryCode} * {variant.SecondaryCode})",
-							VariantMath.ReverseRatio => $"{variant.SecondaryCode} / {variant.PrimaryCode}",
+							VariantMaths.Direct => variant.PrimaryCode,
+							VariantMaths.Inverse => $"1 / {variant.PrimaryCode}",
+							VariantMaths.Ratio => $"{variant.PrimaryCode} / {variant.SecondaryCode}",
+							VariantMaths.Product => $"{variant.PrimaryCode} * {variant.SecondaryCode}",
+							VariantMaths.InverseProduct => $"1 / ({variant.PrimaryCode} * {variant.SecondaryCode})",
+							VariantMaths.ReverseRatio => $"{variant.SecondaryCode} / {variant.PrimaryCode}",
 							_ => variant.PrimaryCode,
 						};
 					}
@@ -751,11 +751,11 @@ SymbolSuffix = suffix;
 
 				var combination = new Combination(baseCurrency, quoteCurrency);
 
-				var direct = CreateDirectVariant(resolved, baseCurrency + quoteCurrency, VariantMath.Direct);
+				var direct = CreateDirectVariant(resolved, baseCurrency + quoteCurrency, VariantMaths.Direct);
 				if (direct != null)
 				combination.Variants.Add(direct);
 
-				var inverse = CreateDirectVariant(resolved, quoteCurrency + baseCurrency, VariantMath.Inverse);
+				var inverse = CreateDirectVariant(resolved, quoteCurrency + baseCurrency, VariantMaths.Inverse);
 				if (inverse != null)
 				combination.Variants.Add(inverse);
 
@@ -764,10 +764,10 @@ SymbolSuffix = suffix;
 					if (cross.Equals(baseCurrency, StringComparison.OrdinalIgnoreCase) || cross.Equals(quoteCurrency, StringComparison.OrdinalIgnoreCase))
 					continue;
 
-				TryAddCrossVariant(combination, resolved, baseCurrency + cross, quoteCurrency + cross, VariantMath.Ratio);
-				TryAddCrossVariant(combination, resolved, baseCurrency + cross, cross + quoteCurrency, VariantMath.Product);
-				TryAddCrossVariant(combination, resolved, cross + baseCurrency, quoteCurrency + cross, VariantMath.InverseProduct);
-				TryAddCrossVariant(combination, resolved, cross + baseCurrency, cross + quoteCurrency, VariantMath.ReverseRatio);
+				TryAddCrossVariant(combination, resolved, baseCurrency + cross, quoteCurrency + cross, VariantMaths.Ratio);
+				TryAddCrossVariant(combination, resolved, baseCurrency + cross, cross + quoteCurrency, VariantMaths.Product);
+				TryAddCrossVariant(combination, resolved, cross + baseCurrency, quoteCurrency + cross, VariantMaths.InverseProduct);
+				TryAddCrossVariant(combination, resolved, cross + baseCurrency, cross + quoteCurrency, VariantMaths.ReverseRatio);
 			}
 
 			if (combination.Variants.Count >= 2)
@@ -833,7 +833,7 @@ private Security ResolveSecurity(ISecurityProvider provider, string symbol)
 	return security;
 }
 
-private Variant CreateDirectVariant(Dictionary<string, Security> resolved, string code, VariantMath math)
+private Variant CreateDirectVariant(Dictionary<string, Security> resolved, string code, VariantMaths math)
 {
 	if (!resolved.TryGetValue(code, out var security))
 	return null;
@@ -848,7 +848,7 @@ private Variant CreateDirectVariant(Dictionary<string, Security> resolved, strin
 	};
 }
 
-private void TryAddCrossVariant(Combination combination, Dictionary<string, Security> resolved, string firstCode, string secondCode, VariantMath math)
+private void TryAddCrossVariant(Combination combination, Dictionary<string, Security> resolved, string firstCode, string secondCode, VariantMaths math)
 {
 	if (!resolved.TryGetValue(firstCode, out var first))
 	return;
@@ -905,7 +905,7 @@ private sealed class Combination
 
 private sealed class Variant
 {
-	public VariantMath Math { get; set; }
+	public VariantMaths Math { get; set; }
 	public Security PrimarySecurity { get; set; }
 	public Security SecondarySecurity { get; set; }
 	public string PrimaryCode { get; set; }
@@ -914,7 +914,7 @@ private sealed class Variant
 	public decimal? LastAsk { get; set; }
 }
 
-private enum VariantMath
+private enum VariantMaths
 {
 	Inverse = -2,
 	Direct = -1,

--- a/API/4157_Combo_Ea4FsfrUpdated5/CS/ComboEa4FsfrUpdated5Strategy.cs
+++ b/API/4157_Combo_Ea4FsfrUpdated5/CS/ComboEa4FsfrUpdated5Strategy.cs
@@ -21,22 +21,22 @@ namespace StockSharp.Samples.Strategies;
 public class ComboEa4FsfrUpdated5Strategy : Strategy
 {
 	private readonly StrategyParam<bool> _useMa;
-	private readonly StrategyParam<MaSignalMode> _maMode;
+	private readonly StrategyParam<MaSignalModes> _maMode;
 	private readonly StrategyParam<int> _ma1Period;
 	private readonly StrategyParam<int> _ma2Period;
 	private readonly StrategyParam<int> _ma3Period;
 	private readonly StrategyParam<int> _ma1BufferPeriod;
 	private readonly StrategyParam<int> _ma2BufferPeriod;
-	private readonly StrategyParam<MovingAverageMethod> _ma1Method;
-	private readonly StrategyParam<MovingAverageMethod> _ma2Method;
-	private readonly StrategyParam<MovingAverageMethod> _ma3Method;
-	private readonly StrategyParam<AppliedPrice> _ma1Price;
-	private readonly StrategyParam<AppliedPrice> _ma2Price;
-	private readonly StrategyParam<AppliedPrice> _ma3Price;
+	private readonly StrategyParam<MovingAverageMethods> _ma1Method;
+	private readonly StrategyParam<MovingAverageMethods> _ma2Method;
+	private readonly StrategyParam<MovingAverageMethods> _ma3Method;
+	private readonly StrategyParam<AppliedPrices> _ma1Price;
+	private readonly StrategyParam<AppliedPrices> _ma2Price;
+	private readonly StrategyParam<AppliedPrices> _ma3Price;
 
 	private readonly StrategyParam<bool> _useRsi;
 	private readonly StrategyParam<int> _rsiPeriod;
-	private readonly StrategyParam<RsiSignalMode> _rsiMode;
+	private readonly StrategyParam<RsiSignalModes> _rsiMode;
 	private readonly StrategyParam<decimal> _rsiBuyLevel;
 	private readonly StrategyParam<decimal> _rsiSellLevel;
 	private readonly StrategyParam<decimal> _rsiBuyZone;
@@ -58,8 +58,8 @@ public class ComboEa4FsfrUpdated5Strategy : Strategy
 	private readonly StrategyParam<int> _macdFast;
 	private readonly StrategyParam<int> _macdSlow;
 	private readonly StrategyParam<int> _macdSignal;
-	private readonly StrategyParam<AppliedPrice> _macdPrice;
-	private readonly StrategyParam<MacdSignalMode> _macdMode;
+	private readonly StrategyParam<AppliedPrices> _macdPrice;
+	private readonly StrategyParam<MacdSignalModes> _macdMode;
 
 	private readonly StrategyParam<bool> _useTrailingStop;
 	private readonly StrategyParam<decimal> _trailingStop;
@@ -74,11 +74,11 @@ public class ComboEa4FsfrUpdated5Strategy : Strategy
 	private readonly StrategyParam<bool> _autoClose;
 	private readonly StrategyParam<bool> _openOppositeAfterClose;
 	private readonly StrategyParam<bool> _useMaClosing;
-	private readonly StrategyParam<MaSignalMode> _maModeClosing;
+	private readonly StrategyParam<MaSignalModes> _maModeClosing;
 	private readonly StrategyParam<bool> _useMacdClosing;
-	private readonly StrategyParam<MacdSignalMode> _macdModeClosing;
+	private readonly StrategyParam<MacdSignalModes> _macdModeClosing;
 	private readonly StrategyParam<bool> _useRsiClosing;
-	private readonly StrategyParam<RsiSignalMode> _rsiModeClosing;
+	private readonly StrategyParam<RsiSignalModes> _rsiModeClosing;
 	private readonly StrategyParam<bool> _useStochasticClosing;
 	private readonly StrategyParam<bool> _useSarClosing;
 
@@ -125,7 +125,7 @@ public class ComboEa4FsfrUpdated5Strategy : Strategy
 	private decimal? _shortTakePrice;
 	private decimal? _pendingLongAtr;
 	private decimal? _pendingShortAtr;
-	private SignalDirection? _pendingOppositeEntry;
+	private SignalDirections? _pendingOppositeEntry;
 	private bool _longExitRequested;
 	private bool _shortExitRequested;
 
@@ -141,7 +141,7 @@ public class ComboEa4FsfrUpdated5Strategy : Strategy
 	/// <summary>
 	/// Moving average confirmation mode.
 	/// </summary>
-	public MaSignalMode MaMode
+	public MaSignalModes MaMode
 	{
 		get => _maMode.Value;
 		set => _maMode.Value = value;
@@ -195,7 +195,7 @@ public class ComboEa4FsfrUpdated5Strategy : Strategy
 	/// <summary>
 	/// Method used for the fast moving average.
 	/// </summary>
-	public MovingAverageMethod Ma1Method
+	public MovingAverageMethods Ma1Method
 	{
 		get => _ma1Method.Value;
 		set => _ma1Method.Value = value;
@@ -204,7 +204,7 @@ public class ComboEa4FsfrUpdated5Strategy : Strategy
 	/// <summary>
 	/// Method used for the medium moving average.
 	/// </summary>
-	public MovingAverageMethod Ma2Method
+	public MovingAverageMethods Ma2Method
 	{
 		get => _ma2Method.Value;
 		set => _ma2Method.Value = value;
@@ -213,7 +213,7 @@ public class ComboEa4FsfrUpdated5Strategy : Strategy
 	/// <summary>
 	/// Method used for the slow moving average.
 	/// </summary>
-	public MovingAverageMethod Ma3Method
+	public MovingAverageMethods Ma3Method
 	{
 		get => _ma3Method.Value;
 		set => _ma3Method.Value = value;
@@ -222,7 +222,7 @@ public class ComboEa4FsfrUpdated5Strategy : Strategy
 	/// <summary>
 	/// Applied price for the fast moving average.
 	/// </summary>
-	public AppliedPrice Ma1Price
+	public AppliedPrices Ma1Price
 	{
 		get => _ma1Price.Value;
 		set => _ma1Price.Value = value;
@@ -231,7 +231,7 @@ public class ComboEa4FsfrUpdated5Strategy : Strategy
 	/// <summary>
 	/// Applied price for the medium moving average.
 	/// </summary>
-	public AppliedPrice Ma2Price
+	public AppliedPrices Ma2Price
 	{
 		get => _ma2Price.Value;
 		set => _ma2Price.Value = value;
@@ -240,7 +240,7 @@ public class ComboEa4FsfrUpdated5Strategy : Strategy
 	/// <summary>
 	/// Applied price for the slow moving average.
 	/// </summary>
-	public AppliedPrice Ma3Price
+	public AppliedPrices Ma3Price
 	{
 		get => _ma3Price.Value;
 		set => _ma3Price.Value = value;
@@ -267,7 +267,7 @@ public class ComboEa4FsfrUpdated5Strategy : Strategy
 	/// <summary>
 	/// RSI confirmation mode.
 	/// </summary>
-	public RsiSignalMode RsiMode
+	public RsiSignalModes RsiMode
 	{
 		get => _rsiMode.Value;
 		set => _rsiMode.Value = value;
@@ -438,7 +438,7 @@ public class ComboEa4FsfrUpdated5Strategy : Strategy
 	/// <summary>
 	/// Applied price used for the zero-lag MACD.
 	/// </summary>
-	public AppliedPrice MacdPrice
+	public AppliedPrices MacdPrice
 	{
 		get => _macdPrice.Value;
 		set => _macdPrice.Value = value;
@@ -447,7 +447,7 @@ public class ComboEa4FsfrUpdated5Strategy : Strategy
 	/// <summary>
 	/// MACD confirmation mode.
 	/// </summary>
-	public MacdSignalMode MacdMode
+	public MacdSignalModes MacdMode
 	{
 		get => _macdMode.Value;
 		set => _macdMode.Value = value;
@@ -546,7 +546,7 @@ public class ComboEa4FsfrUpdated5Strategy : Strategy
 	/// <summary>
 	/// Moving average confirmation mode for exits.
 	/// </summary>
-	public MaSignalMode MaModeClosing
+	public MaSignalModes MaModeClosing
 	{
 		get => _maModeClosing.Value;
 		set => _maModeClosing.Value = value;
@@ -564,7 +564,7 @@ public class ComboEa4FsfrUpdated5Strategy : Strategy
 	/// <summary>
 	/// MACD confirmation mode for exits.
 	/// </summary>
-	public MacdSignalMode MacdModeClosing
+	public MacdSignalModes MacdModeClosing
 	{
 		get => _macdModeClosing.Value;
 		set => _macdModeClosing.Value = value;
@@ -582,7 +582,7 @@ public class ComboEa4FsfrUpdated5Strategy : Strategy
 	/// <summary>
 	/// RSI confirmation mode for exits.
 	/// </summary>
-	public RsiSignalMode RsiModeClosing
+	public RsiSignalModes RsiModeClosing
 	{
 		get => _rsiModeClosing.Value;
 		set => _rsiModeClosing.Value = value;
@@ -621,22 +621,22 @@ public class ComboEa4FsfrUpdated5Strategy : Strategy
 	public ComboEa4FsfrUpdated5Strategy()
 	{
 		_useMa = Param(nameof(UseMa), true).SetDisplay("Use MA", "Enable moving averages", "Entries");
-		_maMode = Param(nameof(MaMode), MaSignalMode.AllCombined).SetDisplay("MA Mode", "Moving average mode", "Entries");
+		_maMode = Param(nameof(MaMode), MaSignalModes.AllCombined).SetDisplay("MA Mode", "Moving average mode", "Entries");
 		_ma1Period = Param(nameof(Ma1Period), 5).SetDisplay("MA1 Period", "Fast MA length", "Indicators").SetCanOptimize(true);
 		_ma2Period = Param(nameof(Ma2Period), 13).SetDisplay("MA2 Period", "Medium MA length", "Indicators").SetCanOptimize(true);
 		_ma3Period = Param(nameof(Ma3Period), 62).SetDisplay("MA3 Period", "Slow MA length", "Indicators").SetCanOptimize(true);
 		_ma1BufferPeriod = Param(nameof(Ma1BufferPeriod), 14).SetDisplay("MA1 Buffer", "ATR buffer for MA1", "Indicators").SetCanOptimize(true);
 		_ma2BufferPeriod = Param(nameof(Ma2BufferPeriod), 14).SetDisplay("MA2 Buffer", "ATR buffer for MA2", "Indicators").SetCanOptimize(true);
-		_ma1Method = Param(nameof(Ma1Method), MovingAverageMethod.Exponential).SetDisplay("MA1 Method", "Fast MA method", "Indicators");
-		_ma2Method = Param(nameof(Ma2Method), MovingAverageMethod.Exponential).SetDisplay("MA2 Method", "Medium MA method", "Indicators");
-		_ma3Method = Param(nameof(Ma3Method), MovingAverageMethod.Exponential).SetDisplay("MA3 Method", "Slow MA method", "Indicators");
-		_ma1Price = Param(nameof(Ma1Price), AppliedPrice.Close).SetDisplay("MA1 Price", "Fast MA price", "Indicators");
-		_ma2Price = Param(nameof(Ma2Price), AppliedPrice.Close).SetDisplay("MA2 Price", "Medium MA price", "Indicators");
-		_ma3Price = Param(nameof(Ma3Price), AppliedPrice.Close).SetDisplay("MA3 Price", "Slow MA price", "Indicators");
+		_ma1Method = Param(nameof(Ma1Method), MovingAverageMethods.Exponential).SetDisplay("MA1 Method", "Fast MA method", "Indicators");
+		_ma2Method = Param(nameof(Ma2Method), MovingAverageMethods.Exponential).SetDisplay("MA2 Method", "Medium MA method", "Indicators");
+		_ma3Method = Param(nameof(Ma3Method), MovingAverageMethods.Exponential).SetDisplay("MA3 Method", "Slow MA method", "Indicators");
+		_ma1Price = Param(nameof(Ma1Price), AppliedPrices.Close).SetDisplay("MA1 Price", "Fast MA price", "Indicators");
+		_ma2Price = Param(nameof(Ma2Price), AppliedPrices.Close).SetDisplay("MA2 Price", "Medium MA price", "Indicators");
+		_ma3Price = Param(nameof(Ma3Price), AppliedPrices.Close).SetDisplay("MA3 Price", "Slow MA price", "Indicators");
 
 		_useRsi = Param(nameof(UseRsi), true).SetDisplay("Use RSI", "Enable RSI", "Entries");
 		_rsiPeriod = Param(nameof(RsiPeriod), 21).SetDisplay("RSI Period", "RSI length", "Indicators").SetCanOptimize(true);
-		_rsiMode = Param(nameof(RsiMode), RsiSignalMode.OverboughtOversold).SetDisplay("RSI Mode", "RSI logic", "Entries");
+		_rsiMode = Param(nameof(RsiMode), RsiSignalModes.OverboughtOversold).SetDisplay("RSI Mode", "RSI logic", "Entries");
 		_rsiBuyLevel = Param(nameof(RsiBuyLevel), 12m).SetDisplay("RSI Buy", "Oversold threshold", "Entries").SetCanOptimize(true);
 		_rsiSellLevel = Param(nameof(RsiSellLevel), 88m).SetDisplay("RSI Sell", "Overbought threshold", "Entries").SetCanOptimize(true);
 		_rsiBuyZone = Param(nameof(RsiBuyZone), 55m).SetDisplay("RSI Buy Zone", "Upper zone", "Entries");
@@ -658,8 +658,8 @@ public class ComboEa4FsfrUpdated5Strategy : Strategy
 		_macdFast = Param(nameof(MacdFast), 12).SetDisplay("MACD Fast", "Fast period", "Indicators").SetCanOptimize(true);
 		_macdSlow = Param(nameof(MacdSlow), 24).SetDisplay("MACD Slow", "Slow period", "Indicators").SetCanOptimize(true);
 		_macdSignal = Param(nameof(MacdSignal), 9).SetDisplay("MACD Signal", "Signal period", "Indicators").SetCanOptimize(true);
-		_macdPrice = Param(nameof(MacdPrice), AppliedPrice.Close).SetDisplay("MACD Price", "Applied price", "Indicators");
-		_macdMode = Param(nameof(MacdMode), MacdSignalMode.ZeroCross).SetDisplay("MACD Mode", "MACD logic", "Entries");
+		_macdPrice = Param(nameof(MacdPrice), AppliedPrices.Close).SetDisplay("MACD Price", "Applied price", "Indicators");
+		_macdMode = Param(nameof(MacdMode), MacdSignalModes.ZeroCross).SetDisplay("MACD Mode", "MACD logic", "Entries");
 
 		_useTrailingStop = Param(nameof(UseTrailingStop), false).SetDisplay("Use Trailing", "Enable trailing stop", "Risk");
 		_trailingStop = Param(nameof(TrailingStop), 198m).SetDisplay("Trailing", "Trailing distance", "Risk");
@@ -674,11 +674,11 @@ public class ComboEa4FsfrUpdated5Strategy : Strategy
 		_autoClose = Param(nameof(AutoClose), true).SetDisplay("Auto Close", "Enable exit confirmations", "Exits");
 		_openOppositeAfterClose = Param(nameof(OpenOppositeAfterClose), false).SetDisplay("Flip Position", "Open opposite after exit", "Exits");
 		_useMaClosing = Param(nameof(UseMaClosing), false).SetDisplay("Close MA", "Use MA for exits", "Exits");
-		_maModeClosing = Param(nameof(MaModeClosing), MaSignalMode.MediumSlow).SetDisplay("MA Exit Mode", "MA logic for exits", "Exits");
+		_maModeClosing = Param(nameof(MaModeClosing), MaSignalModes.MediumSlow).SetDisplay("MA Exit Mode", "MA logic for exits", "Exits");
 		_useMacdClosing = Param(nameof(UseMacdClosing), true).SetDisplay("Close MACD", "Use MACD for exits", "Exits");
-		_macdModeClosing = Param(nameof(MacdModeClosing), MacdSignalMode.Combined).SetDisplay("MACD Exit Mode", "MACD logic for exits", "Exits");
+		_macdModeClosing = Param(nameof(MacdModeClosing), MacdSignalModes.Combined).SetDisplay("MACD Exit Mode", "MACD logic for exits", "Exits");
 		_useRsiClosing = Param(nameof(UseRsiClosing), false).SetDisplay("Close RSI", "Use RSI for exits", "Exits");
-		_rsiModeClosing = Param(nameof(RsiModeClosing), RsiSignalMode.Trend).SetDisplay("RSI Exit Mode", "RSI logic for exits", "Exits");
+		_rsiModeClosing = Param(nameof(RsiModeClosing), RsiSignalModes.Trend).SetDisplay("RSI Exit Mode", "RSI logic for exits", "Exits");
 		_useStochasticClosing = Param(nameof(UseStochasticClosing), true).SetDisplay("Close Stoch", "Use stochastic for exits", "Exits");
 		_useSarClosing = Param(nameof(UseSarClosing), true).SetDisplay("Close SAR", "Use SAR for exits", "Exits");
 
@@ -746,11 +746,11 @@ public class ComboEa4FsfrUpdated5Strategy : Strategy
 
 				switch (direction)
 				{
-					case SignalDirection.Buy:
+					case SignalDirections.Buy:
 					_pendingLongAtr = atr;
 					BuyMarket(GetTradeVolume());
 					break;
-					case SignalDirection.Sell:
+					case SignalDirections.Sell:
 					_pendingShortAtr = atr;
 					SellMarket(GetTradeVolume());
 					break;
@@ -804,11 +804,11 @@ public class ComboEa4FsfrUpdated5Strategy : Strategy
 			var entrySignal = CalculateEntrySignal();
 			switch (entrySignal)
 			{
-				case SignalDirection.Buy:
+				case SignalDirections.Buy:
 				_pendingLongAtr = _atrValue;
 				BuyMarket(GetTradeVolume());
 				break;
-				case SignalDirection.Sell:
+				case SignalDirections.Sell:
 				_pendingShortAtr = _atrValue;
 				SellMarket(GetTradeVolume());
 				break;
@@ -952,27 +952,27 @@ public class ComboEa4FsfrUpdated5Strategy : Strategy
 		}
 	}
 
-	private void HandleSignalBasedExit(SignalDirection exitSignal)
+	private void HandleSignalBasedExit(SignalDirections exitSignal)
 	{
 		if (!AutoClose)
 		return;
 
 		switch (exitSignal)
 		{
-			case SignalDirection.Sell when Position > 0 && !_longExitRequested:
+			case SignalDirections.Sell when Position > 0 && !_longExitRequested:
 			SellMarket(Position);
 			_longExitRequested = true;
-			_pendingOppositeEntry = OpenOppositeAfterClose ? SignalDirection.Sell : null;
+			_pendingOppositeEntry = OpenOppositeAfterClose ? SignalDirections.Sell : null;
 			break;
-			case SignalDirection.Buy when Position < 0 && !_shortExitRequested:
+			case SignalDirections.Buy when Position < 0 && !_shortExitRequested:
 			BuyMarket(Math.Abs(Position));
 			_shortExitRequested = true;
-			_pendingOppositeEntry = OpenOppositeAfterClose ? SignalDirection.Buy : null;
+			_pendingOppositeEntry = OpenOppositeAfterClose ? SignalDirections.Buy : null;
 			break;
 		}
 	}
 
-	private SignalDirection CalculateEntrySignal()
+	private SignalDirections CalculateEntrySignal()
 	{
 		var selected = 0;
 		var up = 0;
@@ -1011,7 +1011,7 @@ public class ComboEa4FsfrUpdated5Strategy : Strategy
 		return ResolveSignal(selected, up, down);
 	}
 
-	private SignalDirection CalculateCloseSignal()
+	private SignalDirections CalculateCloseSignal()
 	{
 		var selected = 0;
 		var up = 0;
@@ -1050,39 +1050,39 @@ public class ComboEa4FsfrUpdated5Strategy : Strategy
 		return ResolveSignal(selected, up, down);
 	}
 
-	private void UpdateCounters(SignalDirection direction, ref int up, ref int down)
+	private void UpdateCounters(SignalDirections direction, ref int up, ref int down)
 	{
 		switch (direction)
 		{
-			case SignalDirection.Buy:
+			case SignalDirections.Buy:
 			up++;
 			break;
-			case SignalDirection.Sell:
+			case SignalDirections.Sell:
 			down++;
 			break;
 		}
 	}
 
-	private static SignalDirection ResolveSignal(int selected, int up, int down)
+	private static SignalDirections ResolveSignal(int selected, int up, int down)
 	{
 		if (selected == 0)
-		return SignalDirection.None;
+		return SignalDirections.None;
 
 		if (up == selected)
-		return SignalDirection.Buy;
+		return SignalDirections.Buy;
 
 		if (down == selected)
-		return SignalDirection.Sell;
+		return SignalDirections.Sell;
 
-		return SignalDirection.None;
+		return SignalDirections.None;
 	}
 
-	private SignalDirection EvaluateMa(MaSignalMode mode)
+	private SignalDirections EvaluateMa(MaSignalModes mode)
 	{
 		if (_ma1Current is not decimal ma1 || _ma1Previous is not decimal ma1Prev ||
 		_ma2Current is not decimal ma2 || _ma2Previous is not decimal ma2Prev ||
 		_ma3Current is not decimal ma3 || _ma3Previous is not decimal ma3Prev)
-		return SignalDirection.None;
+		return SignalDirections.None;
 
 		var buffer1 = _ma1BufferValue ?? 0m;
 		var buffer2 = _ma2BufferValue ?? 0m;
@@ -1093,151 +1093,151 @@ public class ComboEa4FsfrUpdated5Strategy : Strategy
 
 		return mode switch
 		{
-			MaSignalMode.FastMedium => ma12,
-			MaSignalMode.MediumSlow => ma23,
-			MaSignalMode.FastMediumCombined => CombineSignals(ma12, ma23),
-			MaSignalMode.FastSlow => ma13,
-			MaSignalMode.AllCombined => CombineSignals(CombineSignals(ma12, ma23), ma13),
-			_ => SignalDirection.None
+			MaSignalModes.FastMedium => ma12,
+			MaSignalModes.MediumSlow => ma23,
+			MaSignalModes.FastMediumCombined => CombineSignals(ma12, ma23),
+			MaSignalModes.FastSlow => ma13,
+			MaSignalModes.AllCombined => CombineSignals(CombineSignals(ma12, ma23), ma13),
+			_ => SignalDirections.None
 		};
 	}
 
-	private static SignalDirection EvaluateMaCross(decimal fast, decimal fastPrev, decimal slow, decimal slowPrev, decimal buffer)
+	private static SignalDirections EvaluateMaCross(decimal fast, decimal fastPrev, decimal slow, decimal slowPrev, decimal buffer)
 	{
 		if (fast >= slow + buffer && fastPrev < slowPrev + buffer)
-		return SignalDirection.Buy;
+		return SignalDirections.Buy;
 
 		if (fast <= slow - buffer && fastPrev > slowPrev - buffer)
-		return SignalDirection.Sell;
+		return SignalDirections.Sell;
 
-		return SignalDirection.None;
+		return SignalDirections.None;
 	}
 
-	private static SignalDirection CombineSignals(SignalDirection first, SignalDirection second)
+	private static SignalDirections CombineSignals(SignalDirections first, SignalDirections second)
 	{
-		if (first == SignalDirection.None || second == SignalDirection.None)
-		return SignalDirection.None;
+		if (first == SignalDirections.None || second == SignalDirections.None)
+		return SignalDirections.None;
 
-		return first == second ? first : SignalDirection.None;
+		return first == second ? first : SignalDirections.None;
 	}
 
-	private SignalDirection EvaluateRsi(RsiSignalMode mode)
+	private SignalDirections EvaluateRsi(RsiSignalModes mode)
 	{
 		if (_rsiCurrent is not decimal current || _rsiPrevious is not decimal previous)
-		return SignalDirection.None;
+		return SignalDirections.None;
 
 		return mode switch
 		{
-			RsiSignalMode.OverboughtOversold => current < RsiBuyLevel ? SignalDirection.Buy : current > RsiSellLevel ? SignalDirection.Sell : SignalDirection.None,
-			RsiSignalMode.Trend => EvaluateRsiTrend(current, previous),
-			RsiSignalMode.Combined => CombineSignals(EvaluateRsiTrend(current, previous), current < RsiBuyLevel ? SignalDirection.Buy : current > RsiSellLevel ? SignalDirection.Sell : SignalDirection.None),
-			RsiSignalMode.Zone => EvaluateRsiZone(current, previous),
-			_ => SignalDirection.None
+			RsiSignalModes.OverboughtOversold => current < RsiBuyLevel ? SignalDirections.Buy : current > RsiSellLevel ? SignalDirections.Sell : SignalDirections.None,
+			RsiSignalModes.Trend => EvaluateRsiTrend(current, previous),
+			RsiSignalModes.Combined => CombineSignals(EvaluateRsiTrend(current, previous), current < RsiBuyLevel ? SignalDirections.Buy : current > RsiSellLevel ? SignalDirections.Sell : SignalDirections.None),
+			RsiSignalModes.Zone => EvaluateRsiZone(current, previous),
+			_ => SignalDirections.None
 		};
 	}
 
-	private SignalDirection EvaluateRsiTrend(decimal current, decimal previous)
+	private SignalDirections EvaluateRsiTrend(decimal current, decimal previous)
 	{
 		if (_prevOpen is not decimal openPrev || _prevClose is not decimal closePrev)
-		return SignalDirection.None;
+		return SignalDirections.None;
 
 		if (current > previous && Security?.LastTrade?.Price is decimal lastPrice && lastPrice > closePrev)
-		return SignalDirection.Buy;
+		return SignalDirections.Buy;
 
 		if (current < previous && Security?.LastTrade?.Price is decimal last && last < closePrev)
-		return SignalDirection.Sell;
+		return SignalDirections.Sell;
 
 		if (current > previous && openPrev < closePrev)
-		return SignalDirection.Buy;
+		return SignalDirections.Buy;
 
 		if (current < previous && openPrev > closePrev)
-		return SignalDirection.Sell;
+		return SignalDirections.Sell;
 
-		return SignalDirection.None;
+		return SignalDirections.None;
 	}
 
-	private SignalDirection EvaluateRsiZone(decimal current, decimal previous)
+	private SignalDirections EvaluateRsiZone(decimal current, decimal previous)
 	{
 		if (current > previous && (current > 50m || previous > RsiSellZone))
-		return SignalDirection.Buy;
+		return SignalDirections.Buy;
 
 		if (current < previous && (current < 50m || previous < RsiBuyZone))
-		return SignalDirection.Sell;
+		return SignalDirections.Sell;
 
-		return SignalDirection.None;
+		return SignalDirections.None;
 	}
 
-	private SignalDirection EvaluateStochastic()
+	private SignalDirections EvaluateStochastic()
 	{
 		if (_stochasticValue is not decimal value || _stochasticSignal is not decimal signal)
-		return SignalDirection.None;
+		return SignalDirections.None;
 
 		if (UseStochasticHighLow)
 		{
 			if (value > signal && value > StochasticHigh)
-			return SignalDirection.Buy;
+			return SignalDirections.Buy;
 
 			if (value < signal && value < StochasticLow)
-			return SignalDirection.Sell;
+			return SignalDirections.Sell;
 
-			return SignalDirection.None;
+			return SignalDirections.None;
 		}
 
 		if (value > signal)
-		return SignalDirection.Buy;
+		return SignalDirections.Buy;
 
 		if (value < signal)
-		return SignalDirection.Sell;
+		return SignalDirections.Sell;
 
-		return SignalDirection.None;
+		return SignalDirections.None;
 	}
 
-	private SignalDirection EvaluateSar()
+	private SignalDirections EvaluateSar()
 	{
 		if (_sarValue is not decimal sar || _prevClose is not decimal prevClose)
-		return SignalDirection.None;
+		return SignalDirections.None;
 
-		return sar < prevClose ? SignalDirection.Buy : SignalDirection.Sell;
+		return sar < prevClose ? SignalDirections.Buy : SignalDirections.Sell;
 	}
 
-	private SignalDirection EvaluateMacd(MacdSignalMode mode)
+	private SignalDirections EvaluateMacd(MacdSignalModes mode)
 	{
 		if (_macdLineCurrent is not decimal current || _macdLinePrevious is not decimal previous ||
 		_macdSignalCurrent is not decimal signal || _macdSignalPrevious is not decimal signalPrev)
-		return SignalDirection.None;
+		return SignalDirections.None;
 
 		return mode switch
 		{
-			MacdSignalMode.Trend => EvaluateMacdTrend(current, previous, signal, signalPrev),
-			MacdSignalMode.ZeroCross => EvaluateMacdCross(current, previous, signal, signalPrev),
-			MacdSignalMode.Combined => CombineSignals(EvaluateMacdTrend(current, previous, signal, signalPrev), EvaluateMacdCross(current, previous, signal, signalPrev)),
-			_ => SignalDirection.None
+			MacdSignalModes.Trend => EvaluateMacdTrend(current, previous, signal, signalPrev),
+			MacdSignalModes.ZeroCross => EvaluateMacdCross(current, previous, signal, signalPrev),
+			MacdSignalModes.Combined => CombineSignals(EvaluateMacdTrend(current, previous, signal, signalPrev), EvaluateMacdCross(current, previous, signal, signalPrev)),
+			_ => SignalDirections.None
 		};
 	}
 
-	private static SignalDirection EvaluateMacdTrend(decimal current, decimal previous, decimal signal, decimal signalPrev)
+	private static SignalDirections EvaluateMacdTrend(decimal current, decimal previous, decimal signal, decimal signalPrev)
 	{
 		if (current > previous && signal > signalPrev && current > signal)
-		return SignalDirection.Buy;
+		return SignalDirections.Buy;
 
 		if (current < previous && signal < signalPrev && current < signal)
-		return SignalDirection.Sell;
+		return SignalDirections.Sell;
 
-		return SignalDirection.None;
+		return SignalDirections.None;
 	}
 
-	private static SignalDirection EvaluateMacdCross(decimal current, decimal previous, decimal signal, decimal signalPrev)
+	private static SignalDirections EvaluateMacdCross(decimal current, decimal previous, decimal signal, decimal signalPrev)
 	{
 		var crossUp = previous <= signalPrev && current > signal;
 		var crossDown = previous >= signalPrev && current < signal;
 
 		if (crossUp && current < 0m && previous < 0m)
-		return SignalDirection.Buy;
+		return SignalDirections.Buy;
 
 		if (crossDown && current > 0m && previous > 0m)
-		return SignalDirection.Sell;
+		return SignalDirections.Sell;
 
-		return SignalDirection.None;
+		return SignalDirections.None;
 	}
 
 	private decimal GetTradeVolume()
@@ -1327,34 +1327,34 @@ public class ComboEa4FsfrUpdated5Strategy : Strategy
 		return step * factor;
 	}
 
-	private static IIndicator CreateMovingAverage(MovingAverageMethod method, int period)
+	private static IIndicator CreateMovingAverage(MovingAverageMethods method, int period)
 	{
 		return method switch
 		{
-			MovingAverageMethod.Simple => new SimpleMovingAverage { Length = period },
-			MovingAverageMethod.Exponential => new ExponentialMovingAverage { Length = period },
-			MovingAverageMethod.Smoothed => new SmoothedMovingAverage { Length = period },
-			MovingAverageMethod.LinearWeighted => new LinearWeightedMovingAverage { Length = period },
+			MovingAverageMethods.Simple => new SimpleMovingAverage { Length = period },
+			MovingAverageMethods.Exponential => new ExponentialMovingAverage { Length = period },
+			MovingAverageMethods.Smoothed => new SmoothedMovingAverage { Length = period },
+			MovingAverageMethods.LinearWeighted => new LinearWeightedMovingAverage { Length = period },
 			_ => new SimpleMovingAverage { Length = period }
 		};
 	}
 
-	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPrice price)
+	private static decimal GetAppliedPrice(ICandleMessage candle, AppliedPrices price)
 	{
 		return price switch
 		{
-			AppliedPrice.Close => candle.ClosePrice,
-			AppliedPrice.Open => candle.OpenPrice,
-			AppliedPrice.High => candle.HighPrice,
-			AppliedPrice.Low => candle.LowPrice,
-			AppliedPrice.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-			AppliedPrice.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-			AppliedPrice.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
+			AppliedPrices.Close => candle.ClosePrice,
+			AppliedPrices.Open => candle.OpenPrice,
+			AppliedPrices.High => candle.HighPrice,
+			AppliedPrices.Low => candle.LowPrice,
+			AppliedPrices.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+			AppliedPrices.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+			AppliedPrices.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
 			_ => candle.ClosePrice
 		};
 	}
 
-	private enum SignalDirection
+	private enum SignalDirections
 	{
 		None,
 		Buy,
@@ -1364,7 +1364,7 @@ public class ComboEa4FsfrUpdated5Strategy : Strategy
 	/// <summary>
 	/// Moving average confirmation modes.
 	/// </summary>
-	public enum MaSignalMode
+	public enum MaSignalModes
 	{
 		FastMedium = 1,
 		MediumSlow = 2,
@@ -1376,7 +1376,7 @@ public class ComboEa4FsfrUpdated5Strategy : Strategy
 	/// <summary>
 	/// RSI confirmation modes.
 	/// </summary>
-	public enum RsiSignalMode
+	public enum RsiSignalModes
 	{
 		OverboughtOversold = 1,
 		Trend = 2,
@@ -1387,7 +1387,7 @@ public class ComboEa4FsfrUpdated5Strategy : Strategy
 	/// <summary>
 	/// MACD confirmation modes.
 	/// </summary>
-	public enum MacdSignalMode
+	public enum MacdSignalModes
 	{
 		Trend = 1,
 		ZeroCross = 2,
@@ -1397,7 +1397,7 @@ public class ComboEa4FsfrUpdated5Strategy : Strategy
 	/// <summary>
 	/// Moving average calculation methods.
 	/// </summary>
-	public enum MovingAverageMethod
+	public enum MovingAverageMethods
 	{
 		Simple = 0,
 		Exponential = 1,
@@ -1408,7 +1408,7 @@ public class ComboEa4FsfrUpdated5Strategy : Strategy
 	/// <summary>
 	/// Available price sources.
 	/// </summary>
-	public enum AppliedPrice
+	public enum AppliedPrices
 	{
 		Close = 0,
 		Open = 1,

--- a/API/4161_Multi_Combo/CS/MultiComboStrategy.cs
+++ b/API/4161_Multi_Combo/CS/MultiComboStrategy.cs
@@ -28,9 +28,9 @@ public class MultiComboStrategy : Strategy
 	private readonly StrategyParam<int> _fastMaLength;
 	private readonly StrategyParam<int> _midMaLength;
 	private readonly StrategyParam<int> _slowMaLength;
-	private readonly StrategyParam<MaMethod> _fastMaMethod;
-	private readonly StrategyParam<MaMethod> _midMaMethod;
-	private readonly StrategyParam<MaMethod> _slowMaMethod;
+	private readonly StrategyParam<MaMethods> _fastMaMethod;
+	private readonly StrategyParam<MaMethods> _midMaMethod;
+	private readonly StrategyParam<MaMethods> _slowMaMethod;
 	private readonly StrategyParam<DataType> _maCandleType;
 
 	private readonly StrategyParam<bool> _useRsi;
@@ -138,11 +138,11 @@ public class MultiComboStrategy : Strategy
 
 	private readonly Queue<decimal> _rsiHistory = new();
 
-	private SignalDirection _lastMaSignal;
-	private SignalDirection _lastRsiSignal;
-	private SignalDirection _lastMacdSignal;
-	private SignalDirection _lastStochasticSignal;
-	private SignalDirection _lastSarSignal;
+	private SignalDirections _lastMaSignal;
+	private SignalDirections _lastRsiSignal;
+	private SignalDirections _lastMacdSignal;
+	private SignalDirections _lastStochasticSignal;
+	private SignalDirections _lastSarSignal;
 
 	private DateTimeOffset _lastTradeBarTime;
 
@@ -174,11 +174,11 @@ public class MultiComboStrategy : Strategy
 		_slowMaLength = Param(nameof(SlowMaLength), 38)
 		.SetDisplay("Slow MA Length", "Period of the slow moving average", "Moving Average")
 		.SetGreaterThanZero();
-		_fastMaMethod = Param(nameof(FastMaMethod), MaMethod.Exponential)
+		_fastMaMethod = Param(nameof(FastMaMethod), MaMethods.Exponential)
 		.SetDisplay("Fast MA Method", "Type of the fast moving average", "Moving Average");
-		_midMaMethod = Param(nameof(MidMaMethod), MaMethod.Exponential)
+		_midMaMethod = Param(nameof(MidMaMethod), MaMethods.Exponential)
 		.SetDisplay("Mid MA Method", "Type of the mid moving average", "Moving Average");
-		_slowMaMethod = Param(nameof(SlowMaMethod), MaMethod.Exponential)
+		_slowMaMethod = Param(nameof(SlowMaMethod), MaMethods.Exponential)
 		.SetDisplay("Slow MA Method", "Type of the slow moving average", "Moving Average");
 		_maCandleType = Param(nameof(MaCandleType), TimeSpan.FromMinutes(15).TimeFrame())
 		.SetDisplay("MA Candle Type", "Candle type for moving averages", "Moving Average");
@@ -388,11 +388,11 @@ public class MultiComboStrategy : Strategy
 
 		_rsiHistory.Clear();
 
-		_lastMaSignal = SignalDirection.None;
-		_lastRsiSignal = SignalDirection.None;
-		_lastMacdSignal = SignalDirection.None;
-		_lastStochasticSignal = SignalDirection.None;
-		_lastSarSignal = SignalDirection.None;
+		_lastMaSignal = SignalDirections.None;
+		_lastRsiSignal = SignalDirections.None;
+		_lastMacdSignal = SignalDirections.None;
+		_lastStochasticSignal = SignalDirections.None;
+		_lastSarSignal = SignalDirections.None;
 
 		_lastTradeBarTime = DateTimeOffset.MinValue;
 	}
@@ -572,11 +572,11 @@ public class MultiComboStrategy : Strategy
 			HandleAutoExit(consensus, candle);
 		}
 
-		if (entrySignal == SignalDirection.Buy)
+		if (entrySignal == SignalDirections.Buy)
 		{
 			TryEnterLong(candle);
 		}
-		else if (entrySignal == SignalDirection.Sell)
+		else if (entrySignal == SignalDirections.Sell)
 		{
 			TryEnterShort(candle);
 		}
@@ -713,7 +713,7 @@ public class MultiComboStrategy : Strategy
 		return true;
 	}
 
-	private SignalDirection EvaluateConsensus()
+	private SignalDirections EvaluateConsensus()
 	{
 		var selected = 0;
 		var up = 0;
@@ -723,9 +723,9 @@ public class MultiComboStrategy : Strategy
 		{
 			selected++;
 			var signal = GetRsiSignal();
-			if (signal == SignalDirection.Buy)
+			if (signal == SignalDirections.Buy)
 			up++;
-			else if (signal == SignalDirection.Sell)
+			else if (signal == SignalDirections.Sell)
 			down++;
 		}
 
@@ -733,9 +733,9 @@ public class MultiComboStrategy : Strategy
 		{
 			selected++;
 			var signal = GetStochasticSignal();
-			if (signal == SignalDirection.Buy)
+			if (signal == SignalDirections.Buy)
 			up++;
-			else if (signal == SignalDirection.Sell)
+			else if (signal == SignalDirections.Sell)
 			down++;
 		}
 
@@ -743,9 +743,9 @@ public class MultiComboStrategy : Strategy
 		{
 			selected++;
 			var signal = GetSarSignal();
-			if (signal == SignalDirection.Buy)
+			if (signal == SignalDirections.Buy)
 			up++;
-			else if (signal == SignalDirection.Sell)
+			else if (signal == SignalDirections.Sell)
 			down++;
 		}
 
@@ -753,9 +753,9 @@ public class MultiComboStrategy : Strategy
 		{
 			selected++;
 			var signal = GetMaSignal();
-			if (signal == SignalDirection.Buy)
+			if (signal == SignalDirections.Buy)
 			up++;
-			else if (signal == SignalDirection.Sell)
+			else if (signal == SignalDirections.Sell)
 			down++;
 		}
 
@@ -763,50 +763,50 @@ public class MultiComboStrategy : Strategy
 		{
 			selected++;
 			var signal = GetMacdSignal();
-			if (signal == SignalDirection.Buy)
+			if (signal == SignalDirections.Buy)
 			up++;
-			else if (signal == SignalDirection.Sell)
+			else if (signal == SignalDirections.Sell)
 			down++;
 		}
 
 		if (selected == 0)
-		return SignalDirection.None;
+		return SignalDirections.None;
 
 		if (up == selected)
-		return SignalDirection.Buy;
+		return SignalDirections.Buy;
 
 		if (down == selected)
-		return SignalDirection.Sell;
+		return SignalDirections.Sell;
 
-		return SignalDirection.None;
+		return SignalDirections.None;
 	}
 
-	private TrendState EvaluateTrend()
+	private TrendStates EvaluateTrend()
 	{
 		if (!UseTrendDetection)
-		return TrendState.None;
+		return TrendStates.None;
 
 		if (_adxValue is not decimal adx || _adxPlus is not decimal plus || _adxMinus is not decimal minus)
-		return TrendState.None;
+		return TrendStates.None;
 
 		if (adx < AdxLevel)
 		{
-			return plus >= minus ? TrendState.RangeUp : TrendState.RangeDown;
+			return plus >= minus ? TrendStates.RangeUp : TrendStates.RangeDown;
 		}
 
-		return plus >= minus ? TrendState.Up : TrendState.Down;
+		return plus >= minus ? TrendStates.Up : TrendStates.Down;
 	}
 
-	private SignalDirection EvaluateBollingerSignal()
+	private SignalDirections EvaluateBollingerSignal()
 	{
 		if (!UseBollingerFilter)
-		return SignalDirection.None;
+		return SignalDirections.None;
 
 		if (_bollingerMediumLower is null || _bollingerMediumUpper is null || _bollingerWideLower is null || _bollingerWideUpper is null)
-		return SignalDirection.None;
+		return SignalDirections.None;
 
 		if (_lastBollingerCandle is null)
-		return SignalDirection.None;
+		return SignalDirections.None;
 
 		var candle = _lastBollingerCandle;
 
@@ -817,15 +817,15 @@ public class MultiComboStrategy : Strategy
 		var hasOverboughtRsi = RangeParameter <= 0 || HasRsiAbove(RsiSellLevel);
 
 		if (buyTouch && hasOversoldRsi)
-		return SignalDirection.Buy;
+		return SignalDirections.Buy;
 
 		if (sellTouch && hasOverboughtRsi)
-		return SignalDirection.Sell;
+		return SignalDirections.Sell;
 
-		return SignalDirection.None;
+		return SignalDirections.None;
 	}
 
-	private SignalDirection CombineSignals(SignalDirection consensus, TrendState trend, SignalDirection rangeSignal)
+	private SignalDirections CombineSignals(SignalDirections consensus, TrendStates trend, SignalDirections rangeSignal)
 	{
 		return ComboFactor switch
 		{
@@ -835,110 +835,110 @@ public class MultiComboStrategy : Strategy
 		};
 	}
 
-	private SignalDirection CombineFactorOne(SignalDirection consensus, TrendState trend, SignalDirection rangeSignal)
+	private SignalDirections CombineFactorOne(SignalDirections consensus, TrendStates trend, SignalDirections rangeSignal)
 	{
 		if (UseTrendDetection || UseBollingerFilter)
 		{
-			if (trend is TrendState.RangeDown or TrendState.RangeUp && UseBollingerFilter)
+			if (trend is TrendStates.RangeDown or TrendStates.RangeUp && UseBollingerFilter)
 			{
-				if (trend == TrendState.RangeUp && rangeSignal == SignalDirection.Buy)
-				return SignalDirection.Buy;
-				if (trend == TrendState.RangeDown && rangeSignal == SignalDirection.Sell)
-				return SignalDirection.Sell;
-				return SignalDirection.None;
+				if (trend == TrendStates.RangeUp && rangeSignal == SignalDirections.Buy)
+				return SignalDirections.Buy;
+				if (trend == TrendStates.RangeDown && rangeSignal == SignalDirections.Sell)
+				return SignalDirections.Sell;
+				return SignalDirections.None;
 			}
 
-			if (trend is TrendState.Up or TrendState.Down)
+			if (trend is TrendStates.Up or TrendStates.Down)
 			{
-				if (trend == TrendState.Up && consensus == SignalDirection.Buy)
-				return SignalDirection.Buy;
-				if (trend == TrendState.Down && consensus == SignalDirection.Sell)
-				return SignalDirection.Sell;
-				return SignalDirection.None;
+				if (trend == TrendStates.Up && consensus == SignalDirections.Buy)
+				return SignalDirections.Buy;
+				if (trend == TrendStates.Down && consensus == SignalDirections.Sell)
+				return SignalDirections.Sell;
+				return SignalDirections.None;
 			}
 		}
 
 		if (UseBollingerFilter)
 		{
-			if (rangeSignal != SignalDirection.None)
+			if (rangeSignal != SignalDirections.None)
 			return rangeSignal;
 		}
 
 		return consensus;
 	}
 
-	private SignalDirection CombineFactorTwo(SignalDirection consensus, TrendState trend, SignalDirection rangeSignal)
+	private SignalDirections CombineFactorTwo(SignalDirections consensus, TrendStates trend, SignalDirections rangeSignal)
 	{
 		if (UseTrendDetection && !UseBollingerFilter)
 		{
-			if (trend is TrendState.Up or TrendState.RangeUp)
-			return consensus == SignalDirection.Buy ? SignalDirection.Buy : SignalDirection.None;
-			if (trend is TrendState.Down or TrendState.RangeDown)
-			return consensus == SignalDirection.Sell ? SignalDirection.Sell : SignalDirection.None;
+			if (trend is TrendStates.Up or TrendStates.RangeUp)
+			return consensus == SignalDirections.Buy ? SignalDirections.Buy : SignalDirections.None;
+			if (trend is TrendStates.Down or TrendStates.RangeDown)
+			return consensus == SignalDirections.Sell ? SignalDirections.Sell : SignalDirections.None;
 		}
 
 		if (UseTrendDetection && UseBollingerFilter)
 		{
-			if (trend == TrendState.Up)
+			if (trend == TrendStates.Up)
 			{
-				if (consensus == SignalDirection.Buy && rangeSignal != SignalDirection.Sell)
-				return SignalDirection.Buy;
-				return SignalDirection.None;
+				if (consensus == SignalDirections.Buy && rangeSignal != SignalDirections.Sell)
+				return SignalDirections.Buy;
+				return SignalDirections.None;
 			}
-			if (trend == TrendState.Down)
+			if (trend == TrendStates.Down)
 			{
-				if (consensus == SignalDirection.Sell && rangeSignal != SignalDirection.Buy)
-				return SignalDirection.Sell;
-				return SignalDirection.None;
+				if (consensus == SignalDirections.Sell && rangeSignal != SignalDirections.Buy)
+				return SignalDirections.Sell;
+				return SignalDirections.None;
 			}
-			if (trend == TrendState.RangeUp)
+			if (trend == TrendStates.RangeUp)
 			{
-				if (consensus == SignalDirection.Buy && rangeSignal == SignalDirection.Buy)
-				return SignalDirection.Buy;
-				return SignalDirection.None;
+				if (consensus == SignalDirections.Buy && rangeSignal == SignalDirections.Buy)
+				return SignalDirections.Buy;
+				return SignalDirections.None;
 			}
-			if (trend == TrendState.RangeDown)
+			if (trend == TrendStates.RangeDown)
 			{
-				if (consensus == SignalDirection.Sell && rangeSignal == SignalDirection.Sell)
-				return SignalDirection.Sell;
-				return SignalDirection.None;
+				if (consensus == SignalDirections.Sell && rangeSignal == SignalDirections.Sell)
+				return SignalDirections.Sell;
+				return SignalDirections.None;
 			}
 		}
 
 		if (!UseTrendDetection && UseBollingerFilter)
 		{
-			if (rangeSignal == SignalDirection.Buy && consensus == SignalDirection.Buy)
-			return SignalDirection.Buy;
-			if (rangeSignal == SignalDirection.Sell && consensus == SignalDirection.Sell)
-			return SignalDirection.Sell;
-			return SignalDirection.None;
+			if (rangeSignal == SignalDirections.Buy && consensus == SignalDirections.Buy)
+			return SignalDirections.Buy;
+			if (rangeSignal == SignalDirections.Sell && consensus == SignalDirections.Sell)
+			return SignalDirections.Sell;
+			return SignalDirections.None;
 		}
 
 		return consensus;
 	}
 
-	private SignalDirection CombineFactorThree(SignalDirection consensus, TrendState trend, SignalDirection rangeSignal)
+	private SignalDirections CombineFactorThree(SignalDirections consensus, TrendStates trend, SignalDirections rangeSignal)
 	{
 		if (UseTrendDetection && UseBollingerFilter)
 		{
-			if (trend == TrendState.Up && consensus == SignalDirection.Buy && (rangeSignal == SignalDirection.Buy || rangeSignal == SignalDirection.None))
-			return SignalDirection.Buy;
-			if (trend == TrendState.Down && consensus == SignalDirection.Sell && (rangeSignal == SignalDirection.Sell || rangeSignal == SignalDirection.None))
-			return SignalDirection.Sell;
-			if (trend == TrendState.RangeUp && consensus == SignalDirection.Buy && rangeSignal == SignalDirection.Buy)
-			return SignalDirection.Buy;
-			if (trend == TrendState.RangeDown && consensus == SignalDirection.Sell && rangeSignal == SignalDirection.Sell)
-			return SignalDirection.Sell;
-			return SignalDirection.None;
+			if (trend == TrendStates.Up && consensus == SignalDirections.Buy && (rangeSignal == SignalDirections.Buy || rangeSignal == SignalDirections.None))
+			return SignalDirections.Buy;
+			if (trend == TrendStates.Down && consensus == SignalDirections.Sell && (rangeSignal == SignalDirections.Sell || rangeSignal == SignalDirections.None))
+			return SignalDirections.Sell;
+			if (trend == TrendStates.RangeUp && consensus == SignalDirections.Buy && rangeSignal == SignalDirections.Buy)
+			return SignalDirections.Buy;
+			if (trend == TrendStates.RangeDown && consensus == SignalDirections.Sell && rangeSignal == SignalDirections.Sell)
+			return SignalDirections.Sell;
+			return SignalDirections.None;
 		}
 
 		if (UseTrendDetection)
 		{
-			if (trend == TrendState.Up && consensus == SignalDirection.Buy)
-			return SignalDirection.Buy;
-			if (trend == TrendState.Down && consensus == SignalDirection.Sell)
-			return SignalDirection.Sell;
-			return SignalDirection.None;
+			if (trend == TrendStates.Up && consensus == SignalDirections.Buy)
+			return SignalDirections.Buy;
+			if (trend == TrendStates.Down && consensus == SignalDirections.Sell)
+			return SignalDirections.Sell;
+			return SignalDirections.None;
 		}
 
 		if (UseBollingerFilter)
@@ -949,16 +949,16 @@ public class MultiComboStrategy : Strategy
 		return consensus;
 	}
 
-	private void HandleAutoExit(SignalDirection consensus, ICandleMessage candle)
+	private void HandleAutoExit(SignalDirections consensus, ICandleMessage candle)
 	{
 		// Mirror the original auto-close logic by reacting immediately to opposite consensus.
-		if (Position > 0 && consensus == SignalDirection.Sell)
+		if (Position > 0 && consensus == SignalDirections.Sell)
 		{
 			SellMarket(Math.Abs(Position));
 			_lastTradeBarTime = candle.OpenTime;
 			LogInfo("Closed long position on opposite consensus.");
 		}
-		else if (Position < 0 && consensus == SignalDirection.Buy)
+		else if (Position < 0 && consensus == SignalDirections.Buy)
 		{
 			BuyMarket(Math.Abs(Position));
 			_lastTradeBarTime = candle.OpenTime;
@@ -1041,12 +1041,12 @@ public class MultiComboStrategy : Strategy
 		return false;
 	}
 
-	private SignalDirection GetMaSignal()
+	private SignalDirections GetMaSignal()
 	{
 		if (_fastMaCurrent is null || _fastMaPrev is null || _midMaCurrent is null || _midMaPrev is null || _slowMaCurrent is null || _slowMaPrev is null)
-		return UseLastMaSignal ? _lastMaSignal : SignalDirection.None;
+		return UseLastMaSignal ? _lastMaSignal : SignalDirections.None;
 
-		SignalDirection signal = MaMode switch
+		SignalDirections signal = MaMode switch
 		{
 			1 => DetectCross(_fastMaPrev.Value, _fastMaCurrent.Value, _midMaPrev.Value, _midMaCurrent.Value),
 			2 => DetectCross(_midMaPrev.Value, _midMaCurrent.Value, _slowMaPrev.Value, _slowMaCurrent.Value),
@@ -1062,12 +1062,12 @@ public class MultiComboStrategy : Strategy
 			),
 			DetectCross(_fastMaPrev.Value, _fastMaCurrent.Value, _slowMaPrev.Value, _slowMaCurrent.Value)
 			),
-			_ => SignalDirection.None
+			_ => SignalDirections.None
 		};
 
 		if (UseLastMaSignal)
 		{
-			if (signal != SignalDirection.None && signal != _lastMaSignal)
+			if (signal != SignalDirections.None && signal != _lastMaSignal)
 			_lastMaSignal = signal;
 			return _lastMaSignal;
 		}
@@ -1075,69 +1075,69 @@ public class MultiComboStrategy : Strategy
 		return signal;
 	}
 
-	private SignalDirection CombineSignals(SignalDirection first, SignalDirection second)
+	private SignalDirections CombineSignals(SignalDirections first, SignalDirections second)
 	{
-		if (first == SignalDirection.Buy || second == SignalDirection.Buy)
+		if (first == SignalDirections.Buy || second == SignalDirections.Buy)
 		{
-			if (first == SignalDirection.Buy && second != SignalDirection.Sell)
-			return SignalDirection.Buy;
-			if (second == SignalDirection.Buy && first != SignalDirection.Sell)
-			return SignalDirection.Buy;
+			if (first == SignalDirections.Buy && second != SignalDirections.Sell)
+			return SignalDirections.Buy;
+			if (second == SignalDirections.Buy && first != SignalDirections.Sell)
+			return SignalDirections.Buy;
 		}
 
-		if (first == SignalDirection.Sell || second == SignalDirection.Sell)
+		if (first == SignalDirections.Sell || second == SignalDirections.Sell)
 		{
-			if (first == SignalDirection.Sell && second != SignalDirection.Buy)
-			return SignalDirection.Sell;
-			if (second == SignalDirection.Sell && first != SignalDirection.Buy)
-			return SignalDirection.Sell;
+			if (first == SignalDirections.Sell && second != SignalDirections.Buy)
+			return SignalDirections.Sell;
+			if (second == SignalDirections.Sell && first != SignalDirections.Buy)
+			return SignalDirections.Sell;
 		}
 
-		return SignalDirection.None;
+		return SignalDirections.None;
 	}
 
-	private static SignalDirection DetectCross(decimal prevA, decimal currentA, decimal prevB, decimal currentB)
+	private static SignalDirections DetectCross(decimal prevA, decimal currentA, decimal prevB, decimal currentB)
 	{
 		var prevDiff = prevA - prevB;
 		var currentDiff = currentA - currentB;
 
 		if (prevDiff <= 0m && currentDiff > 0m)
-		return SignalDirection.Buy;
+		return SignalDirections.Buy;
 
 		if (prevDiff >= 0m && currentDiff < 0m)
-		return SignalDirection.Sell;
+		return SignalDirections.Sell;
 
-		return SignalDirection.None;
+		return SignalDirections.None;
 	}
 
-	private SignalDirection GetRsiSignal()
+	private SignalDirections GetRsiSignal()
 	{
 		if (_rsiCurrent is null || _rsiPrev is null)
-		return UseLastRsiSignal ? _lastRsiSignal : SignalDirection.None;
+		return UseLastRsiSignal ? _lastRsiSignal : SignalDirections.None;
 
 		var current = _rsiCurrent.Value;
 		var previous = _rsiPrev.Value;
 
-		SignalDirection signal = RsiMode switch
+		SignalDirections signal = RsiMode switch
 		{
-			1 => current < RsiBuyLevel ? SignalDirection.Buy : current > RsiSellLevel ? SignalDirection.Sell : SignalDirection.None,
-			2 => current > previous ? SignalDirection.Buy : current < previous ? SignalDirection.Sell : SignalDirection.None,
+			1 => current < RsiBuyLevel ? SignalDirections.Buy : current > RsiSellLevel ? SignalDirections.Sell : SignalDirections.None,
+			2 => current > previous ? SignalDirections.Buy : current < previous ? SignalDirections.Sell : SignalDirections.None,
 			3 => CombineSignals(
-			current < RsiBuyLevel ? SignalDirection.Buy : current > RsiSellLevel ? SignalDirection.Sell : SignalDirection.None,
-			current > previous ? SignalDirection.Buy : current < previous ? SignalDirection.Sell : SignalDirection.None
+			current < RsiBuyLevel ? SignalDirections.Buy : current > RsiSellLevel ? SignalDirections.Sell : SignalDirections.None,
+			current > previous ? SignalDirections.Buy : current < previous ? SignalDirections.Sell : SignalDirections.None
 			),
 			4 =>
 			current > previous && current >= RsiBuyZone && current <= RsiSellLevel
-			? SignalDirection.Buy
+			? SignalDirections.Buy
 			: current < previous && current <= RsiSellZone && current >= RsiBuyLevel
-			? SignalDirection.Sell
-			: SignalDirection.None,
-			_ => SignalDirection.None
+			? SignalDirections.Sell
+			: SignalDirections.None,
+			_ => SignalDirections.None
 		};
 
 		if (UseLastRsiSignal)
 		{
-			if (signal != SignalDirection.None && signal != _lastRsiSignal)
+			if (signal != SignalDirections.None && signal != _lastRsiSignal)
 			_lastRsiSignal = signal;
 			return _lastRsiSignal;
 		}
@@ -1145,50 +1145,50 @@ public class MultiComboStrategy : Strategy
 		return signal;
 	}
 
-	private SignalDirection GetMacdSignal()
+	private SignalDirections GetMacdSignal()
 	{
 		if (_macdMain is null || _macdMainPrev is null || _macdSignal is null || _macdSignalPrev is null)
-		return UseLastMacdSignal ? _lastMacdSignal : SignalDirection.None;
+		return UseLastMacdSignal ? _lastMacdSignal : SignalDirections.None;
 
 		var macd = _macdMain.Value;
 		var macdPrev = _macdMainPrev.Value;
 		var signal = _macdSignal.Value;
 		var signalPrev = _macdSignalPrev.Value;
 
-		SignalDirection result = MacdMode switch
+		SignalDirections result = MacdMode switch
 		{
 			1 =>
 			macd > macdPrev && signal > signalPrev && macd > signal
-			? SignalDirection.Buy
+			? SignalDirections.Buy
 			: macd < macdPrev && signal < signalPrev && macd < signal
-			? SignalDirection.Sell
-			: SignalDirection.None,
+			? SignalDirections.Sell
+			: SignalDirections.None,
 			2 =>
 			macd > signal && macdPrev <= signalPrev && macd < 0m && macdPrev < 0m
-			? SignalDirection.Buy
+			? SignalDirections.Buy
 			: macd < signal && macdPrev >= signalPrev && macd > 0m && macdPrev > 0m
-			? SignalDirection.Sell
-			: SignalDirection.None,
+			? SignalDirections.Sell
+			: SignalDirections.None,
 			3 =>
 			(macd > signal && macdPrev <= signalPrev && macd < 0m && macdPrev < 0m) ||
 			(macd > macdPrev && signal > signalPrev && macd > signal)
-			? SignalDirection.Buy
+			? SignalDirections.Buy
 			: (macd < signal && macdPrev >= signalPrev && macd > 0m && macdPrev > 0m) ||
 			(macd < macdPrev && signal < signalPrev && macd < signal)
-			? SignalDirection.Sell
-			: SignalDirection.None,
+			? SignalDirections.Sell
+			: SignalDirections.None,
 			4 =>
 			signal > 0m && signalPrev < 0m
-			? SignalDirection.Buy
+			? SignalDirections.Buy
 			: signal < 0m && signalPrev > 0m
-			? SignalDirection.Sell
-			: SignalDirection.None,
-			_ => SignalDirection.None
+			? SignalDirections.Sell
+			: SignalDirections.None,
+			_ => SignalDirections.None
 		};
 
 		if (UseLastMacdSignal)
 		{
-			if (result != SignalDirection.None && result != _lastMacdSignal)
+			if (result != SignalDirections.None && result != _lastMacdSignal)
 			_lastMacdSignal = result;
 			return _lastMacdSignal;
 		}
@@ -1196,38 +1196,38 @@ public class MultiComboStrategy : Strategy
 		return result;
 	}
 
-	private SignalDirection GetStochasticSignal()
+	private SignalDirections GetStochasticSignal()
 	{
 		if (_stochasticMain is null || _stochasticSignal is null)
-		return UseLastStochasticSignal ? _lastStochasticSignal : SignalDirection.None;
+		return UseLastStochasticSignal ? _lastStochasticSignal : SignalDirections.None;
 
 		var main = _stochasticMain.Value;
 		var signal = _stochasticSignal.Value;
 
-		SignalDirection result;
+		SignalDirections result;
 
 		if (StochasticUseThresholds)
 		{
 			if (main > signal && main > StochasticUpper)
-			result = SignalDirection.Buy;
+			result = SignalDirections.Buy;
 			else if (main < signal && main < StochasticLower)
-			result = SignalDirection.Sell;
+			result = SignalDirections.Sell;
 			else
-			result = SignalDirection.None;
+			result = SignalDirections.None;
 		}
 		else
 		{
 			if (main > signal)
-			result = SignalDirection.Buy;
+			result = SignalDirections.Buy;
 			else if (main < signal)
-			result = SignalDirection.Sell;
+			result = SignalDirections.Sell;
 			else
-			result = SignalDirection.None;
+			result = SignalDirections.None;
 		}
 
 		if (UseLastStochasticSignal)
 		{
-			if (result != SignalDirection.None && result != _lastStochasticSignal)
+			if (result != SignalDirections.None && result != _lastStochasticSignal)
 			_lastStochasticSignal = result;
 			return _lastStochasticSignal;
 		}
@@ -1235,16 +1235,16 @@ public class MultiComboStrategy : Strategy
 		return result;
 	}
 
-	private SignalDirection GetSarSignal()
+	private SignalDirections GetSarSignal()
 	{
 		if (_sarValue is null || _sarClose is null)
-		return UseLastSarSignal ? _lastSarSignal : SignalDirection.None;
+		return UseLastSarSignal ? _lastSarSignal : SignalDirections.None;
 
-		var result = _sarValue.Value < _sarClose.Value ? SignalDirection.Buy : SignalDirection.Sell;
+		var result = _sarValue.Value < _sarClose.Value ? SignalDirections.Buy : SignalDirections.Sell;
 
 		if (UseLastSarSignal)
 		{
-			if (result != SignalDirection.None && result != _lastSarSignal)
+			if (result != SignalDirections.None && result != _lastSarSignal)
 			_lastSarSignal = result;
 			return _lastSarSignal;
 		}
@@ -1252,15 +1252,15 @@ public class MultiComboStrategy : Strategy
 		return result;
 	}
 
-	private LengthIndicator<decimal> CreateMovingAverage(MaMethod method, int length)
+	private LengthIndicator<decimal> CreateMovingAverage(MaMethods method, int length)
 	{
 		// Map the original MA method integers to StockSharp indicators.
 		return method switch
 		{
-			MaMethod.Simple => new SMA { Length = length },
-			MaMethod.Exponential => new EMA { Length = length },
-			MaMethod.Smoothed => new SMMA { Length = length },
-			MaMethod.Weighted => new WeightedMovingAverage { Length = length },
+			MaMethods.Simple => new SMA { Length = length },
+			MaMethods.Exponential => new EMA { Length = length },
+			MaMethods.Smoothed => new SMMA { Length = length },
+			MaMethods.Weighted => new WeightedMovingAverage { Length = length },
 			_ => new SMA { Length = length }
 		};
 	}
@@ -1287,9 +1287,9 @@ public class MultiComboStrategy : Strategy
 	private int FastMaLength => _fastMaLength.Value;
 	private int MidMaLength => _midMaLength.Value;
 	private int SlowMaLength => _slowMaLength.Value;
-	private MaMethod FastMaMethod => _fastMaMethod.Value;
-	private MaMethod MidMaMethod => _midMaMethod.Value;
-	private MaMethod SlowMaMethod => _slowMaMethod.Value;
+	private MaMethods FastMaMethod => _fastMaMethod.Value;
+	private MaMethods MidMaMethod => _midMaMethod.Value;
+	private MaMethods SlowMaMethod => _slowMaMethod.Value;
 	private DataType MaCandleType => _maCandleType.Value;
 
 	private bool UseRsi => _useRsi.Value;
@@ -1350,14 +1350,14 @@ public class MultiComboStrategy : Strategy
 	private decimal TakeProfitOffset => _takeProfitOffset.Value;
 	private bool UseTrailingStop => _useTrailingStop.Value;
 
-	private enum SignalDirection
+	private enum SignalDirections
 	{
 		None,
 		Buy,
 		Sell
 	}
 
-	private enum TrendState
+	private enum TrendStates
 	{
 		None,
 		Up,
@@ -1369,7 +1369,7 @@ public class MultiComboStrategy : Strategy
 	/// <summary>
 	/// Moving average method.
 	/// </summary>
-	public enum MaMethod
+	public enum MaMethods
 	{
 		Simple,
 		Exponential,

--- a/API/4169_TrailingStopFrCn/CS/TrailingStopFrCnStrategy.cs
+++ b/API/4169_TrailingStopFrCn/CS/TrailingStopFrCnStrategy.cs
@@ -23,7 +23,7 @@ public class TrailingStopFrCnStrategy : Strategy
 	private readonly StrategyParam<bool> _onlyWithoutLoss;
 	private readonly StrategyParam<decimal> _trailingStopPips;
 	private readonly StrategyParam<decimal> _minStopDistancePips;
-	private readonly StrategyParam<TrailingSource> _trailingMode;
+	private readonly StrategyParam<TrailingSources> _trailingMode;
 	private readonly StrategyParam<DataType> _candleType;
 
 	private readonly List<CandleSnapshot> _candles = new();
@@ -80,7 +80,7 @@ public class TrailingStopFrCnStrategy : Strategy
 	/// <summary>
 	/// Trailing source when the fixed trailing distance is disabled.
 	/// </summary>
-	public TrailingSource TrailingMode
+	public TrailingSources TrailingMode
 	{
 		get => _trailingMode.Value;
 		set => _trailingMode.Value = value;
@@ -112,7 +112,7 @@ public class TrailingStopFrCnStrategy : Strategy
 		_minStopDistancePips = Param(nameof(MinStopDistancePips), 0m)
 			.SetDisplay("Min Stop Distance (pips)", "Broker enforced minimal stop distance", "Trailing");
 
-		_trailingMode = Param(nameof(TrailingMode), TrailingSource.Candles)
+		_trailingMode = Param(nameof(TrailingMode), TrailingSources.Candles)
 			.SetDisplay("Trailing Mode", "Data source for adaptive trailing", "Trailing");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(1).TimeFrame())
@@ -294,7 +294,7 @@ public class TrailingStopFrCnStrategy : Strategy
 
 		var minOffset = GetMinStopOffset();
 
-		if (TrailingMode == TrailingSource.Fractals)
+		if (TrailingMode == TrailingSources.Fractals)
 		{
 			for (var i = _fractalLows.Count - 1; i >= 0; i--)
 			{
@@ -333,7 +333,7 @@ public class TrailingStopFrCnStrategy : Strategy
 
 		var minOffset = GetMinStopOffset();
 
-		if (TrailingMode == TrailingSource.Fractals)
+		if (TrailingMode == TrailingSources.Fractals)
 		{
 			for (var i = _fractalHighs.Count - 1; i >= 0; i--)
 			{
@@ -451,7 +451,7 @@ public class TrailingStopFrCnStrategy : Strategy
 			_fractalHighs.RemoveRange(0, _fractalHighs.Count - 100);
 	}
 
-	private enum TrailingSource
+	private enum TrailingSources
 	{
 		Fractals,
 		Candles,

--- a/API/4177_Ema_Wma_Rsi/CS/EmaWmaRsiStrategy.cs
+++ b/API/4177_Ema_Wma_Rsi/CS/EmaWmaRsiStrategy.cs
@@ -30,7 +30,7 @@ public class EmaWmaRsiStrategy : Strategy
 	private readonly StrategyParam<bool> _closeOppositePositions;
 	private readonly StrategyParam<decimal> _fixedVolume;
 	private readonly StrategyParam<decimal> _riskPercent;
-	private readonly StrategyParam<TrailingSource> _trailingMode;
+	private readonly StrategyParam<TrailingSources> _trailingMode;
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<int> _historyLimit;
 	private readonly StrategyParam<decimal> _trailingBufferPoints;
@@ -54,7 +54,7 @@ public class EmaWmaRsiStrategy : Strategy
 	private decimal? _longTake;
 	private decimal? _shortTake;
 
-	private enum TrailingSource
+	private enum TrailingSources
 	{
 		Fractals,
 		CandleExtremes,
@@ -144,7 +144,7 @@ public class EmaWmaRsiStrategy : Strategy
 	/// <summary>
 	/// Source used to build trailing stops when <see cref="TrailingStopPoints"/> is zero.
 	/// </summary>
-	public TrailingSource TrailingMode
+	public TrailingSources TrailingMode
 	{
 		get => _trailingMode.Value;
 		set => _trailingMode.Value = value;
@@ -235,7 +235,7 @@ public class EmaWmaRsiStrategy : Strategy
 			.SetRange(0m, 100m)
 			.SetCanOptimize(true);
 
-		_trailingMode = Param(nameof(TrailingMode), TrailingSource.CandleExtremes)
+		_trailingMode = Param(nameof(TrailingMode), TrailingSources.CandleExtremes)
 			.SetDisplay("Trailing Source", "Price source used when adaptive trailing is enabled", "Risk");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(30).TimeFrame())
@@ -580,7 +580,7 @@ public class EmaWmaRsiStrategy : Strategy
 			buffer = 0m;
 		}
 
-		if (TrailingMode == TrailingSource.Fractals)
+		if (TrailingMode == TrailingSources.Fractals)
 		{
 			for (var i = _history.Count - 3; i >= 2; i--)
 			{

--- a/API/4188_Early_Bird_Range_Breakout/CS/EarlyBirdRangeBreakoutStrategy.cs
+++ b/API/4188_Early_Bird_Range_Breakout/CS/EarlyBirdRangeBreakoutStrategy.cs
@@ -20,7 +20,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class EarlyBirdRangeBreakoutStrategy : Strategy
 {
-	private enum TradeDirection
+	private enum TradeDirections
 	{
 		Both = 0,
 		LongOnly = 1,
@@ -90,7 +90,7 @@ public class EarlyBirdRangeBreakoutStrategy : Strategy
 		.SetDisplay("Allow Hedging", "Permit reversing positions within the session", "Trading")
 		.SetCanOptimize(false);
 
-		_directionMode = Param(nameof(DirectionMode), (int)TradeDirection.Both)
+		_directionMode = Param(nameof(DirectionMode), (int)TradeDirections.Both)
 		.SetDisplay("Trade Direction", "0 = both, 1 = long only, 2 = short only", "Trading")
 		.SetCanOptimize(false);
 
@@ -748,7 +748,7 @@ public class EarlyBirdRangeBreakoutStrategy : Strategy
 
 	private bool AllowLongEntry()
 	{
-		if (DirectionMode == (int)TradeDirection.ShortOnly)
+		if (DirectionMode == (int)TradeDirections.ShortOnly)
 		return false;
 
 		if (_longTradedToday)
@@ -765,7 +765,7 @@ public class EarlyBirdRangeBreakoutStrategy : Strategy
 
 	private bool AllowShortEntry()
 	{
-		if (DirectionMode == (int)TradeDirection.LongOnly)
+		if (DirectionMode == (int)TradeDirections.LongOnly)
 		return false;
 
 		if (_shortTradedToday)

--- a/API/4190_Colibri_Grid_Manager/CS/ColibriGridManagerStrategy.cs
+++ b/API/4190_Colibri_Grid_Manager/CS/ColibriGridManagerStrategy.cs
@@ -21,7 +21,7 @@ using StockSharp.Messages;
 public class ColibriGridManagerStrategy : Strategy
 {
 	private readonly StrategyParam<bool> _enableGrid;
-	private readonly StrategyParam<GridOrderType> _orderType;
+	private readonly StrategyParam<GridOrderTypes> _orderType;
 	private readonly StrategyParam<bool> _allowBuy;
 	private readonly StrategyParam<bool> _allowSell;
 	private readonly StrategyParam<bool> _useCenterLine;
@@ -69,7 +69,7 @@ public class ColibriGridManagerStrategy : Strategy
 	/// <summary>
 	/// Supported entry order types.
 	/// </summary>
-	public enum GridOrderType
+	public enum GridOrderTypes
 	{
 		Limit,
 		Stop,
@@ -84,7 +84,7 @@ public class ColibriGridManagerStrategy : Strategy
 		_enableGrid = Param(nameof(EnableGrid), true)
 			.SetDisplay("Enable Grid", "Toggle automatic grid management", "General");
 
-		_orderType = Param(nameof(OrderType), GridOrderType.Limit)
+		_orderType = Param(nameof(OrderType), GridOrderTypes.Limit)
 			.SetDisplay("Order Type", "Entry order type for the grid", "General");
 
 		_allowBuy = Param(nameof(AllowBuy), true)
@@ -167,7 +167,7 @@ public class ColibriGridManagerStrategy : Strategy
 		set => _enableGrid.Value = value;
 	}
 
-	public GridOrderType OrderType
+	public GridOrderTypes OrderType
 	{
 		get => _orderType.Value;
 		set => _orderType.Value = value;
@@ -542,7 +542,7 @@ public class ColibriGridManagerStrategy : Strategy
 			return;
 
 		var spacing = ConvertPoints(LevelSpacingPoints);
-		if (OrderType != GridOrderType.Market && spacing <= 0m)
+		if (OrderType != GridOrderTypes.Market && spacing <= 0m)
 			return;
 
 		foreach (var side in directions)
@@ -557,7 +557,7 @@ public class ColibriGridManagerStrategy : Strategy
 		if (reference is null || reference.Value <= 0m)
 			return;
 
-		var levels = OrderType == GridOrderType.Market ? 1 : LevelsCount;
+		var levels = OrderType == GridOrderTypes.Market ? 1 : LevelsCount;
 		for (var index = 0; index < levels; index++)
 		{
 			var entry = CalculateEntryPrice(side, index, spacing, reference.Value);
@@ -594,25 +594,25 @@ public class ColibriGridManagerStrategy : Strategy
 	{
 		return OrderType switch
 		{
-			GridOrderType.Limit => side == Sides.Buy ? BuyLimit(volume, price) : SellLimit(volume, price),
-			GridOrderType.Stop => side == Sides.Buy ? BuyStop(volume, price) : SellStop(volume, price),
-			GridOrderType.Market => side == Sides.Buy ? BuyMarket(volume) : SellMarket(volume),
+			GridOrderTypes.Limit => side == Sides.Buy ? BuyLimit(volume, price) : SellLimit(volume, price),
+			GridOrderTypes.Stop => side == Sides.Buy ? BuyStop(volume, price) : SellStop(volume, price),
+			GridOrderTypes.Market => side == Sides.Buy ? BuyMarket(volume) : SellMarket(volume),
 			_ => null,
 		};
 	}
 
 	private decimal? CalculateEntryPrice(Sides side, int index, decimal spacing, decimal referencePrice)
 	{
-		if (OrderType == GridOrderType.Market && index > 0)
+		if (OrderType == GridOrderTypes.Market && index > 0)
 			return null;
 
 		if (UseCenterLine)
 		{
 			var center = CenterPrice > 0m ? CenterPrice : referencePrice;
-			if (OrderType == GridOrderType.Market)
+			if (OrderType == GridOrderTypes.Market)
 				return center;
 
-			if (OrderType == GridOrderType.Limit)
+			if (OrderType == GridOrderTypes.Limit)
 			{
 				var halfSpan = spacing * (Math.Max(LevelsCount, 1) - 1) / 2m;
 				return side == Sides.Buy
@@ -632,13 +632,13 @@ public class ColibriGridManagerStrategy : Strategy
 
 		return OrderType switch
 		{
-			GridOrderType.Limit => side == Sides.Buy
+			GridOrderTypes.Limit => side == Sides.Buy
 				? basePrice - spacing * index
 				: basePrice + spacing * index,
-			GridOrderType.Stop => side == Sides.Buy
+			GridOrderTypes.Stop => side == Sides.Buy
 				? basePrice + spacing * index
 				: basePrice - spacing * index,
-			GridOrderType.Market => basePrice,
+			GridOrderTypes.Market => basePrice,
 			_ => basePrice,
 		};
 	}
@@ -754,9 +754,9 @@ public class ColibriGridManagerStrategy : Strategy
 	{
 		return OrderType switch
 		{
-			GridOrderType.Limit => side == Sides.Buy ? GetBidPrice() : GetAskPrice(),
-			GridOrderType.Stop => side == Sides.Buy ? GetAskPrice() : GetBidPrice(),
-			GridOrderType.Market => GetMidPrice(),
+			GridOrderTypes.Limit => side == Sides.Buy ? GetBidPrice() : GetAskPrice(),
+			GridOrderTypes.Stop => side == Sides.Buy ? GetAskPrice() : GetBidPrice(),
+			GridOrderTypes.Market => GetMidPrice(),
 			_ => GetMidPrice(),
 		};
 	}

--- a/API/4191_Ard_Order_Management_Command/CS/ArdOrderManagementCommandStrategy.cs
+++ b/API/4191_Ard_Order_Management_Command/CS/ArdOrderManagementCommandStrategy.cs
@@ -17,7 +17,7 @@ namespace StockSharp.Samples.Strategies;
 /// Order commands supported by <see cref="ArdOrderManagementCommandStrategy"/>.
 /// Mirrors the constants used by the original MQL expert advisor.
 /// </summary>
-public enum ArdOrderCommand
+public enum ArdOrderCommands
 {
 	/// <summary>
 	/// No action requested.
@@ -60,7 +60,7 @@ public class ArdOrderManagementCommandStrategy : Strategy
 	private readonly StrategyParam<decimal> _modifyTakeProfitPoints;
 	private readonly StrategyParam<decimal> _minimumVolume;
 	private readonly StrategyParam<string> _orderComment;
-	private readonly StrategyParam<ArdOrderCommand> _command;
+	private readonly StrategyParam<ArdOrderCommands> _command;
 
 	private decimal? _lastBid;
 	private decimal? _lastAsk;
@@ -155,7 +155,7 @@ public class ArdOrderManagementCommandStrategy : Strategy
 	/// <summary>
 	/// Command that will be executed on the next market data tick.
 	/// </summary>
-	public ArdOrderCommand Command
+	public ArdOrderCommands Command
 	{
 		get => _command.Value;
 		set => _command.Value = value;
@@ -201,7 +201,7 @@ public class ArdOrderManagementCommandStrategy : Strategy
 		_orderComment = Param(nameof(OrderComment), "Placing Order")
 			.SetDisplay("Order comment", "Comment attached to every order for easier tracking.", "General");
 
-		_command = Param(nameof(Command), ArdOrderCommand.None)
+		_command = Param(nameof(Command), ArdOrderCommands.None)
 			.SetDisplay("Command", "Operation executed on the next tick (set back to None after completion).", "General");
 	}
 
@@ -246,33 +246,33 @@ public class ArdOrderManagementCommandStrategy : Strategy
 			return;
 
 		var command = Command;
-		if (command != ArdOrderCommand.None)
+		if (command != ArdOrderCommands.None)
 			ExecuteCommand(command);
 
 		TrySubmitPendingEntry();
 	}
 
-	private void ExecuteCommand(ArdOrderCommand command)
+	private void ExecuteCommand(ArdOrderCommands command)
 	{
 		switch (command)
 		{
-			case ArdOrderCommand.Buy:
+			case ArdOrderCommands.Buy:
 				ScheduleEntry(Sides.Buy, StopLossPoints, TakeProfitPoints);
 				break;
-			case ArdOrderCommand.Sell:
+			case ArdOrderCommands.Sell:
 				ScheduleEntry(Sides.Sell, StopLossPoints, TakeProfitPoints);
 				break;
-			case ArdOrderCommand.Close:
+			case ArdOrderCommands.Close:
 				HandleCloseCommand();
 				break;
-			case ArdOrderCommand.Modify:
+			case ArdOrderCommands.Modify:
 				HandleModifyCommand();
 				break;
 			default:
 				break;
 		}
 
-		Command = ArdOrderCommand.None;
+		Command = ArdOrderCommands.None;
 	}
 
 	private void ScheduleEntry(Sides side, decimal stopPoints, decimal takePoints)

--- a/API/4196_TrailingStopFrCnSar/CS/TrailingStopFrCnSarStrategy.cs
+++ b/API/4196_TrailingStopFrCnSar/CS/TrailingStopFrCnSarStrategy.cs
@@ -56,7 +56,7 @@ public class TrailingStopFrCnSarStrategy : Strategy
 
 	public TrailingStopFrCnSarStrategy()
 	{
-		_mode = Param(nameof(Mode), (int)TrailingStopMode.Candle)
+		_mode = Param(nameof(Mode), (int)TrailingStopModes.Candle)
 			.SetDisplay("Trailing mode", "Trailing stop calculation mode.", "Trailing");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
@@ -110,9 +110,9 @@ public class TrailingStopFrCnSarStrategy : Strategy
 			.SetDisplay("History Depth", "Number of candles retained for fractal calculations", "Trailing");
 	}
 
-	public TrailingStopMode Mode
+	public TrailingStopModes Mode
 	{
-		get => (TrailingStopMode)_mode.Value;
+		get => (TrailingStopModes)_mode.Value;
 		set => _mode.Value = (int)value;
 	}
 
@@ -304,7 +304,7 @@ public class TrailingStopFrCnSarStrategy : Strategy
 
 		var mode = Mode;
 
-		if (mode == TrailingStopMode.Parabolic && !_parabolicSar.IsFormed)
+		if (mode == TrailingStopModes.Parabolic && !_parabolicSar.IsFormed)
 		{
 			// Wait for the SAR to warm up before using its values.
 			_previousVelocity = currentVelocity ?? previousVelocity;
@@ -409,7 +409,7 @@ public class TrailingStopFrCnSarStrategy : Strategy
 		return average;
 	}
 
-	private decimal? CalculateLongCandidate(ICandleMessage candle, TrailingStopMode mode, decimal sarValue, decimal? currentVelocity, decimal? previousVelocity)
+	private decimal? CalculateLongCandidate(ICandleMessage candle, TrailingStopModes mode, decimal sarValue, decimal? currentVelocity, decimal? previousVelocity)
 	{
 		var point = GetPoint();
 		if (point <= 0m)
@@ -419,30 +419,30 @@ public class TrailingStopFrCnSarStrategy : Strategy
 
 		switch (mode)
 		{
-			case TrailingStopMode.Off:
+			case TrailingStopModes.Off:
 				return null;
-			case TrailingStopMode.Candle:
+			case TrailingStopModes.Candle:
 				if (GetRecentLow() is not decimal candleLow)
 					return null;
 				var candleStop = candleLow - delta;
 				return candleStop > 0m ? candleStop : null;
-			case TrailingStopMode.Fractal:
+			case TrailingStopModes.Fractal:
 				if (_lastDownFractal is not decimal fractal)
 					return null;
 				var fractalStop = fractal - delta;
 				return fractalStop > 0m ? fractalStop : null;
-			case TrailingStopMode.Velocity:
+			case TrailingStopModes.Velocity:
 				return CalculateVelocityStop(true, candle.ClosePrice, delta, currentVelocity, previousVelocity, point);
-			case TrailingStopMode.Parabolic:
+			case TrailingStopModes.Parabolic:
 				return CalculateParabolicStop(true, sarValue, delta, candle.ClosePrice);
-			case TrailingStopMode.FixedPoints:
+			case TrailingStopModes.FixedPoints:
 				return CalculateFixedStop(true, candle.ClosePrice, point);
 			default:
 				return null;
 		}
 	}
 
-	private decimal? CalculateShortCandidate(ICandleMessage candle, TrailingStopMode mode, decimal sarValue, decimal? currentVelocity, decimal? previousVelocity)
+	private decimal? CalculateShortCandidate(ICandleMessage candle, TrailingStopModes mode, decimal sarValue, decimal? currentVelocity, decimal? previousVelocity)
 	{
 		var point = GetPoint();
 		if (point <= 0m)
@@ -452,21 +452,21 @@ public class TrailingStopFrCnSarStrategy : Strategy
 
 		switch (mode)
 		{
-			case TrailingStopMode.Off:
+			case TrailingStopModes.Off:
 				return null;
-			case TrailingStopMode.Candle:
+			case TrailingStopModes.Candle:
 				if (GetRecentHigh() is not decimal candleHigh)
 					return null;
 				return candleHigh + delta;
-			case TrailingStopMode.Fractal:
+			case TrailingStopModes.Fractal:
 				if (_lastUpFractal is not decimal fractal)
 					return null;
 				return fractal + delta;
-			case TrailingStopMode.Velocity:
+			case TrailingStopModes.Velocity:
 				return CalculateVelocityStop(false, candle.ClosePrice, delta, currentVelocity, previousVelocity, point);
-			case TrailingStopMode.Parabolic:
+			case TrailingStopModes.Parabolic:
 				return CalculateParabolicStop(false, sarValue, delta, candle.ClosePrice);
-			case TrailingStopMode.FixedPoints:
+			case TrailingStopModes.FixedPoints:
 				return CalculateFixedStop(false, candle.ClosePrice, point);
 			default:
 				return null;
@@ -724,7 +724,7 @@ public class TrailingStopFrCnSarStrategy : Strategy
 	}
 }
 
-public enum TrailingStopMode
+public enum TrailingStopModes
 {
 	Off = 0,
 	Candle = 1,

--- a/API/4201_Hard_Profit/CS/HardProfitStrategy.cs
+++ b/API/4201_Hard_Profit/CS/HardProfitStrategy.cs
@@ -33,7 +33,7 @@ public class HardProfitStrategy : Strategy
 	private readonly StrategyParam<decimal> _partialRatio2;
 	private readonly StrategyParam<decimal> _takeProfitPips;
 	private readonly StrategyParam<decimal> _maxSpreadPips;
-	private readonly StrategyParam<MoneyManagementMode> _moneyManagementMode;
+	private readonly StrategyParam<MoneyManagementModes> _moneyManagementMode;
 	private readonly StrategyParam<decimal> _fixedVolume;
 	private readonly StrategyParam<decimal> _geometricalFactor;
 	private readonly StrategyParam<decimal> _proportionalRiskPercent;
@@ -77,7 +77,7 @@ public class HardProfitStrategy : Strategy
 	/// <summary>
 	/// Money management behaviour replicated from the original expert advisor.
 	/// </summary>
-	public enum MoneyManagementMode
+	public enum MoneyManagementModes
 	{
 		Fixed = 1,
 		Geometrical = 2,
@@ -149,7 +149,7 @@ public class HardProfitStrategy : Strategy
 			.SetRange(0m, 200m)
 			.SetDisplay("Max Spread (pips)", "Maximum allowed spread before blocking new entries", "Filters");
 
-		_moneyManagementMode = Param(nameof(ManagementMode), MoneyManagementMode.Proportional)
+		_moneyManagementMode = Param(nameof(ManagementMode), MoneyManagementModes.Proportional)
 			.SetDisplay("Money Management", "Volume sizing mode derived from the original EA", "Money Management");
 
 		_fixedVolume = Param(nameof(FixedVolume), 0.1m)
@@ -329,7 +329,7 @@ public class HardProfitStrategy : Strategy
 	/// <summary>
 	/// Money management behaviour used to size new positions.
 	/// </summary>
-	public MoneyManagementMode ManagementMode
+	public MoneyManagementModes ManagementMode
 	{
 		get => _moneyManagementMode.Value;
 		set => _moneyManagementMode.Value = value;
@@ -805,10 +805,10 @@ public class HardProfitStrategy : Strategy
 
 		switch (ManagementMode)
 		{
-			case MoneyManagementMode.Fixed:
+			case MoneyManagementModes.Fixed:
 				volume = FixedVolume;
 				break;
-			case MoneyManagementMode.Geometrical:
+			case MoneyManagementModes.Geometrical:
 			{
 				if (balance > 0m)
 				{
@@ -817,13 +817,13 @@ public class HardProfitStrategy : Strategy
 				}
 				break;
 			}
-			case MoneyManagementMode.Proportional:
+			case MoneyManagementModes.Proportional:
 			{
 				if (closePrice > 0m)
 					volume = freeMargin * riskFraction / (closePrice * 1000m);
 				break;
 			}
-			case MoneyManagementMode.Smart:
+			case MoneyManagementModes.Smart:
 			{
 				volume = freeMargin * riskFraction / 100m;
 				var losses = CountRecentConsecutiveLosses();
@@ -834,7 +834,7 @@ public class HardProfitStrategy : Strategy
 				}
 				break;
 			}
-			case MoneyManagementMode.Tssf:
+			case MoneyManagementModes.Tssf:
 			{
 				volume = CalculateTssfVolume(freeMargin, FixedVolume);
 				break;

--- a/API/4207_Rich_Kohonen_Map/CS/RichKohonenMapStrategy.cs
+++ b/API/4207_Rich_Kohonen_Map/CS/RichKohonenMapStrategy.cs
@@ -46,7 +46,7 @@ private double[] _previousVector = null!;
 	private int _sellCount;
 	private int _holdCount;
 
-	private enum MapAction
+	private enum MapActions
 	{
 		Buy,
 		Sell,
@@ -289,22 +289,22 @@ set => _minPips.Value = value;
 	private void ExecuteSignal(double buyDistance, double sellDistance, double holdDistance, decimal volume)
 	{
 		// Determine which map has the smallest distance.
-		var action = MapAction.Buy;
+		var action = MapActions.Buy;
 		var best = buyDistance;
 
 		if (sellDistance < best)
 		{
 			best = sellDistance;
-			action = MapAction.Sell;
+			action = MapActions.Sell;
 		}
 
 		if (holdDistance < best)
-			action = MapAction.Hold;
+			action = MapActions.Hold;
 
 		var targetPosition = action switch
 		{
-			MapAction.Buy => volume,
-			MapAction.Sell => -volume,
+			MapActions.Buy => volume,
+			MapActions.Sell => -volume,
 			_ => 0m,
 		};
 
@@ -329,26 +329,26 @@ set => _minPips.Value = value;
 
 		if (pipDifference >= min && pipDifference <= max)
 		{
-			TeachMap(MapAction.Buy, _previousVector);
+			TeachMap(MapActions.Buy, _previousVector);
 		}
 		else if (pipDifference <= -min && pipDifference >= -max)
 		{
-			TeachMap(MapAction.Sell, _previousVector);
+			TeachMap(MapActions.Sell, _previousVector);
 		}
 		else
 		{
-			TeachMap(MapAction.Hold, _previousVector);
+			TeachMap(MapActions.Hold, _previousVector);
 		}
 	}
 
-	private void TeachMap(MapAction action, double[] vector)
+	private void TeachMap(MapActions action, double[] vector)
 	{
 		switch (action)
 		{
-			case MapAction.Buy:
+			case MapActions.Buy:
 				AddVector(_mapBuy, ref _buyCount, MapBase, vector);
 				break;
-			case MapAction.Sell:
+			case MapActions.Sell:
 				AddVector(_mapSell, ref _sellCount, MapBase, vector);
 				break;
 			default:

--- a/API/4211_Cyclops_CycleIdentifier/CS/CyclopsCycleIdentifierStrategy.cs
+++ b/API/4211_Cyclops_CycleIdentifier/CS/CyclopsCycleIdentifierStrategy.cs
@@ -25,7 +25,7 @@ public class CyclopsCycleIdentifierStrategy : Strategy
 	private readonly StrategyParam<int> _length;
 	private readonly StrategyParam<int> _majorCycleStrength;
 	private readonly StrategyParam<bool> _useCycleFilter;
-	private readonly StrategyParam<CycleFilterMode> _cycleFilterMode;
+private readonly StrategyParam<CycleFilterModes> _cycleFilterMode;
 	private readonly StrategyParam<int> _filterStrengthSma;
 	private readonly StrategyParam<int> _filterStrengthRsi;
 	private readonly StrategyParam<bool> _useMomentumFilter;
@@ -101,7 +101,7 @@ public class CyclopsCycleIdentifierStrategy : Strategy
 		_useCycleFilter = Param(nameof(UseCycleFilter), false)
 		.SetDisplay("Use Cycle Filter", "Enable zero-lag slope confirmation", "Indicator");
 
-		_cycleFilterMode = Param(nameof(CycleFilterMode), CycleFilterMode.Sma)
+_cycleFilterMode = Param(nameof(CycleFilterMode), CycleFilterModes.Sma)
 		.SetDisplay("Filter Source", "Source used by the zero-lag filter (price or RSI)", "Indicator");
 
 		_filterStrengthSma = Param(nameof(FilterStrengthSma), 12)
@@ -218,11 +218,11 @@ public class CyclopsCycleIdentifierStrategy : Strategy
 	/// <summary>
 	/// Selects the data source for the zero-lag filter.
 	/// </summary>
-	public CycleFilterMode CycleFilterMode
-	{
-		get => _cycleFilterMode.Value;
-		set => _cycleFilterMode.Value = value;
-	}
+public CycleFilterModes CycleFilterMode
+{
+get => _cycleFilterMode.Value;
+set => _cycleFilterMode.Value = value;
+}
 
 	/// <summary>
 	/// Length of the zero-lag filter when price is used as source.
@@ -662,7 +662,7 @@ public class CyclopsCycleIdentifierStrategy : Strategy
 		decimal source;
 		int length;
 
-		if (this.CycleFilterMode == CycleFilterMode.Sma)
+if (this.CycleFilterMode == CycleFilterModes.Sma)
 		{
 			source = cyclePrice;
 			length = Math.Max(FilterStrengthSma, 1);
@@ -796,12 +796,12 @@ public class CyclopsCycleIdentifierStrategy : Strategy
 /// <summary>
 /// Defines the data source used by the zero-lag filter.
 /// </summary>
-public enum CycleFilterMode
+public enum CycleFilterModes
 {
-	/// <summary>
-	/// Use the smoothed price series as filter input.
-	/// </summary>
-	Sma = 1,
+/// <summary>
+/// Use the smoothed price series as filter input.
+/// </summary>
+Sma = 1,
 
 	/// <summary>
 	/// Use a Wilder style RSI computed on the smoothed price series as filter input.

--- a/API/4212_Early_Top_Prorate_V1/CS/EarlyTopProrateV1Strategy.cs
+++ b/API/4212_Early_Top_Prorate_V1/CS/EarlyTopProrateV1Strategy.cs
@@ -21,7 +21,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class EarlyTopProrateV1Strategy : Strategy
 {
-	private enum MoneyManagementMode
+	private enum MoneyManagementModes
 	{
 		Fixed = 0,
 		FixedAlternate = 1,
@@ -322,7 +322,7 @@ public class EarlyTopProrateV1Strategy : Strategy
 		.SetRange(0, 100)
 		.SetDisplay("Ratio 3", "Percentage closed at the final target", "Trade Management");
 
-		_moneyManagementType = Param(nameof(MoneyManagementType), (int)MoneyManagementMode.Fixed)
+		_moneyManagementType = Param(nameof(MoneyManagementType), (int)MoneyManagementModes.Fixed)
 		.SetRange(0, 3)
 		.SetDisplay("Money Management Mode", "Selects how the order volume is calculated", "Money Management");
 
@@ -667,10 +667,10 @@ public class EarlyTopProrateV1Strategy : Strategy
 
 	private decimal CalculateEntryVolume(decimal price)
 	{
-		var mode = (MoneyManagementMode)MoneyManagementType;
+		var mode = (MoneyManagementModes)MoneyManagementType;
 		var volume = BaseVolume;
 
-		if (mode == MoneyManagementMode.BalanceSquareRoot)
+		if (mode == MoneyManagementModes.BalanceSquareRoot)
 		{
 			var balance = Portfolio?.CurrentValue ?? Portfolio?.BeginValue;
 			if (balance != null && balance.Value > 0m)
@@ -679,7 +679,7 @@ public class EarlyTopProrateV1Strategy : Strategy
 				volume = 0.1m * sqrt * MoneyManagementFactor;
 			}
 		}
-		else if (mode == MoneyManagementMode.EquityRisk)
+		else if (mode == MoneyManagementModes.EquityRisk)
 		{
 			var equity = Portfolio?.CurrentValue ?? Portfolio?.BeginValue;
 			if (equity != null && equity.Value > 0m && price > 0m)

--- a/API/4214_Stop_Hunter/CS/StopHunterStrategy.cs
+++ b/API/4214_Stop_Hunter/CS/StopHunterStrategy.cs
@@ -43,9 +43,9 @@ public class StopHunterStrategy : Strategy
 	private decimal _lastPosition;
 	private decimal? _entryPrice;
 	private decimal _entryVolume;
-	private ExitAction _pendingExitAction;
+	private ExitActions _pendingExitAction;
 
-	private enum ExitAction
+	private enum ExitActions
 	{
 		None,
 		PartialLong,
@@ -338,7 +338,7 @@ public class StopHunterStrategy : Strategy
 	{
 		if (Position > 0m)
 		{
-			if (_pendingExitAction != ExitAction.None)
+			if (_pendingExitAction != ExitActions.None)
 				return;
 
 			var entryPrice = Position.AveragePrice ?? _entryPrice;
@@ -357,7 +357,7 @@ public class StopHunterStrategy : Strategy
 					if (volume > 0m)
 					{
 						_exitOrder = SellMarket(volume);
-						_pendingExitAction = ExitAction.PartialLong;
+						_pendingExitAction = ExitActions.PartialLong;
 					}
 				}
 				else
@@ -367,7 +367,7 @@ public class StopHunterStrategy : Strategy
 					if (volume > 0m)
 					{
 						_exitOrder = SellMarket(volume);
-						_pendingExitAction = ExitAction.FullLong;
+						_pendingExitAction = ExitActions.FullLong;
 					}
 				}
 			}
@@ -378,13 +378,13 @@ public class StopHunterStrategy : Strategy
 				if (volume > 0m)
 				{
 					_exitOrder = SellMarket(volume);
-					_pendingExitAction = ExitAction.FullLong;
+					_pendingExitAction = ExitActions.FullLong;
 				}
 			}
 		}
 		else if (Position < 0m)
 		{
-			if (_pendingExitAction != ExitAction.None)
+			if (_pendingExitAction != ExitActions.None)
 				return;
 
 			var entryPrice = Position.AveragePrice ?? _entryPrice;
@@ -403,7 +403,7 @@ public class StopHunterStrategy : Strategy
 					if (volume > 0m)
 					{
 						_exitOrder = BuyMarket(volume);
-						_pendingExitAction = ExitAction.PartialShort;
+						_pendingExitAction = ExitActions.PartialShort;
 					}
 				}
 				else
@@ -413,7 +413,7 @@ public class StopHunterStrategy : Strategy
 					if (volume > 0m)
 					{
 						_exitOrder = BuyMarket(volume);
-						_pendingExitAction = ExitAction.FullShort;
+						_pendingExitAction = ExitActions.FullShort;
 					}
 				}
 			}
@@ -424,7 +424,7 @@ public class StopHunterStrategy : Strategy
 				if (volume > 0m)
 				{
 					_exitOrder = BuyMarket(volume);
-					_pendingExitAction = ExitAction.FullShort;
+					_pendingExitAction = ExitActions.FullShort;
 				}
 			}
 		}
@@ -550,7 +550,7 @@ public class StopHunterStrategy : Strategy
 			_secondTrade = false;
 			_takeProfitExtension = 0;
 			_stopLossExtension = 0;
-			_pendingExitAction = ExitAction.None;
+			_pendingExitAction = ExitActions.None;
 		}
 		else if (_sellStopOrder != null && order == _sellStopOrder)
 		{
@@ -559,21 +559,21 @@ public class StopHunterStrategy : Strategy
 			_secondTrade = false;
 			_takeProfitExtension = 0;
 			_stopLossExtension = 0;
-			_pendingExitAction = ExitAction.None;
+			_pendingExitAction = ExitActions.None;
 		}
 		else if (_exitOrder != null && order == _exitOrder)
 		{
 			switch (_pendingExitAction)
 			{
-				case ExitAction.PartialLong:
-				case ExitAction.PartialShort:
+				case ExitActions.PartialLong:
+				case ExitActions.PartialShort:
 					_secondTrade = true;
 					_takeProfitExtension += TakeProfitPoints;
 					_stopLossExtension += StopLossPoints;
 					_entryVolume = Math.Abs(Position);
 					break;
-				case ExitAction.FullLong:
-				case ExitAction.FullShort:
+				case ExitActions.FullLong:
+				case ExitActions.FullShort:
 					_secondTrade = false;
 					_takeProfitExtension = 0;
 					_stopLossExtension = 0;
@@ -584,7 +584,7 @@ public class StopHunterStrategy : Strategy
 			}
 
 			_exitOrder = null;
-			_pendingExitAction = ExitAction.None;
+			_pendingExitAction = ExitActions.None;
 		}
 	}
 
@@ -608,7 +608,7 @@ public class StopHunterStrategy : Strategy
 		if (_exitOrder != null && order == _exitOrder && order.State is OrderStates.Failed or OrderStates.Canceled)
 		{
 			_exitOrder = null;
-			_pendingExitAction = ExitAction.None;
+			_pendingExitAction = ExitActions.None;
 		}
 	}
 
@@ -627,7 +627,7 @@ public class StopHunterStrategy : Strategy
 			_entryPrice = null;
 			_entryVolume = 0m;
 			_exitOrder = null;
-			_pendingExitAction = ExitAction.None;
+			_pendingExitAction = ExitActions.None;
 		}
 		else
 		{
@@ -670,6 +670,6 @@ public class StopHunterStrategy : Strategy
 		_lastPosition = 0m;
 		_entryPrice = null;
 		_entryVolume = 0m;
-		_pendingExitAction = ExitAction.None;
+		_pendingExitAction = ExitActions.None;
 	}
 }

--- a/API/4217_CCIT3_Zero_Cross/CS/Ccit3ZeroCrossStrategy.cs
+++ b/API/4217_CCIT3_Zero_Cross/CS/Ccit3ZeroCrossStrategy.cs
@@ -16,7 +16,7 @@ namespace StockSharp.Samples.Strategies;
 /// <summary>
 /// Operating modes supported by <see cref="Ccit3ZeroCrossStrategy"/>.
 /// </summary>
-public enum Ccit3Mode
+public enum Ccit3Modes
 {
 	/// <summary>
 	/// Classic CCIT3 calculation with persistent Tillson T3 smoothing.
@@ -32,7 +32,7 @@ public enum Ccit3Mode
 /// <summary>
 /// Applied price options compatible with the CCIT3 port.
 /// </summary>
-public enum CciAppliedPriceType
+public enum CciAppliedPriceTypes
 {
 	/// <summary>
 	/// Use candle close price.
@@ -81,10 +81,10 @@ public class Ccit3ZeroCrossStrategy : Strategy
 	private readonly StrategyParam<decimal> _trailingPoints;
 	private readonly StrategyParam<bool> _tradeOverturn;
 	private readonly StrategyParam<int> _cciPeriod;
-	private readonly StrategyParam<CciAppliedPriceType> _cciPriceType;
+	private readonly StrategyParam<CciAppliedPriceTypes> _cciPriceType;
 	private readonly StrategyParam<int> _t3Period;
 	private readonly StrategyParam<decimal> _volumeFactor;
-	private readonly StrategyParam<Ccit3Mode> _mode;
+	private readonly StrategyParam<Ccit3Modes> _mode;
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<decimal> _maxDrawdownTarget;
 
@@ -133,7 +133,7 @@ public class Ccit3ZeroCrossStrategy : Strategy
 			.SetCanOptimize(true)
 			.SetOptimize(100, 400, 5);
 
-		_cciPriceType = Param(nameof(CciPriceType), CciAppliedPriceType.Typical)
+		_cciPriceType = Param(nameof(CciPriceType), CciAppliedPriceTypes.Typical)
 			.SetDisplay("CCI Price", "Applied price used for the CCI input", "Indicator");
 
 		_t3Period = Param(nameof(T3Period), 60)
@@ -145,7 +145,7 @@ public class Ccit3ZeroCrossStrategy : Strategy
 		_volumeFactor = Param(nameof(VolumeFactor), 0.618m)
 			.SetDisplay("T3 Volume Factor", "Tillson T3 volume factor (B coefficient)", "Indicator");
 
-		_mode = Param(nameof(Mode), Ccit3Mode.Simple)
+		_mode = Param(nameof(Mode), Ccit3Modes.Simple)
 			.SetDisplay("Mode", "Choose between Simple and NoRecalc CCIT3", "Indicator");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(1).TimeFrame())
@@ -213,7 +213,7 @@ public class Ccit3ZeroCrossStrategy : Strategy
 	/// <summary>
 	/// Applied price used as the CCI input.
 	/// </summary>
-	public CciAppliedPriceType CciPriceType
+	public CciAppliedPriceTypes CciPriceType
 	{
 		get => _cciPriceType.Value;
 		set => _cciPriceType.Value = value;
@@ -240,7 +240,7 @@ public class Ccit3ZeroCrossStrategy : Strategy
 	/// <summary>
 	/// Selected CCIT3 calculation mode.
 	/// </summary>
-	public Ccit3Mode Mode
+	public Ccit3Modes Mode
 	{
 		get => _mode.Value;
 		set => _mode.Value = value;
@@ -371,7 +371,7 @@ public class Ccit3ZeroCrossStrategy : Strategy
 
 	private decimal CalculateT3(decimal cciValue)
 	{
-		if (Mode == Ccit3Mode.Simple)
+		if (Mode == Ccit3Modes.Simple)
 		{
 			_simpleE1 = _alpha * cciValue + _beta * _simpleE1;
 			_simpleE2 = _alpha * _simpleE1 + _beta * _simpleE2;
@@ -500,17 +500,17 @@ public class Ccit3ZeroCrossStrategy : Strategy
 		_c4 = 1m + 3m * b + b3 + 3m * b2;
 	}
 
-	private static decimal GetAppliedPrice(ICandleMessage candle, CciAppliedPriceType priceType)
+	private static decimal GetAppliedPrice(ICandleMessage candle, CciAppliedPriceTypes priceType)
 	{
 		return priceType switch
 		{
-			CciAppliedPriceType.Close => candle.ClosePrice,
-			CciAppliedPriceType.Open => candle.OpenPrice,
-			CciAppliedPriceType.High => candle.HighPrice,
-			CciAppliedPriceType.Low => candle.LowPrice,
-			CciAppliedPriceType.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-			CciAppliedPriceType.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-			CciAppliedPriceType.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
+			CciAppliedPriceTypes.Close => candle.ClosePrice,
+			CciAppliedPriceTypes.Open => candle.OpenPrice,
+			CciAppliedPriceTypes.High => candle.HighPrice,
+			CciAppliedPriceTypes.Low => candle.LowPrice,
+			CciAppliedPriceTypes.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+			CciAppliedPriceTypes.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+			CciAppliedPriceTypes.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
 			_ => candle.ClosePrice,
 		};
 	}

--- a/API/4224_Daily_Trend_Reversal/CS/DailyTrendReversalStrategy.cs
+++ b/API/4224_Daily_Trend_Reversal/CS/DailyTrendReversalStrategy.cs
@@ -65,7 +65,7 @@ public class DailyTrendReversalStrategy : Strategy
 	private decimal _shortStopPrice;
 	private bool _shortBreakEvenActive;
 
-	private enum TrendDirection
+	private enum TrendDirections
 	{
 		Flat,
 		Up,
@@ -351,11 +351,11 @@ public class DailyTrendReversalStrategy : Strategy
 		EvaluateEntries(candle, trend, rangeTrend, cciTrend);
 	}
 
-	private void EvaluateEntries(ICandleMessage candle, TrendDirection trend, TrendDirection rangeTrend, TrendDirection cciTrend)
+	private void EvaluateEntries(ICandleMessage candle, TrendDirections trend, TrendDirections rangeTrend, TrendDirections cciTrend)
 	{
 		var price = candle.ClosePrice;
 
-		if (trend == TrendDirection.Up && rangeTrend == TrendDirection.Up && cciTrend == TrendDirection.Up && price > _dailyOpen && Position <= 0m)
+		if (trend == TrendDirections.Up && rangeTrend == TrendDirections.Up && cciTrend == TrendDirections.Up && price > _dailyOpen && Position <= 0m)
 		{
 			var volume = Volume + Math.Max(0m, -Position);
 			if (volume > 0m)
@@ -365,7 +365,7 @@ public class DailyTrendReversalStrategy : Strategy
 			}
 		}
 
-		if (trend == TrendDirection.Down && rangeTrend == TrendDirection.Down && cciTrend == TrendDirection.Down && price < _dailyOpen && Position >= 0m)
+		if (trend == TrendDirections.Down && rangeTrend == TrendDirections.Down && cciTrend == TrendDirections.Down && price < _dailyOpen && Position >= 0m)
 		{
 			var volume = Volume + Math.Max(0m, Position);
 			if (volume > 0m)
@@ -376,7 +376,7 @@ public class DailyTrendReversalStrategy : Strategy
 		}
 	}
 
-	private void ManageExistingPositions(ICandleMessage candle, TrendDirection rangeTrend, TrendDirection cciTrend, decimal riskDistance)
+	private void ManageExistingPositions(ICandleMessage candle, TrendDirections rangeTrend, TrendDirections cciTrend, decimal riskDistance)
 	{
 		if (Position > 0m)
 		{
@@ -388,7 +388,7 @@ public class DailyTrendReversalStrategy : Strategy
 		}
 	}
 
-	private void ManageLongPosition(ICandleMessage candle, TrendDirection rangeTrend, TrendDirection cciTrend, decimal riskDistance)
+	private void ManageLongPosition(ICandleMessage candle, TrendDirections rangeTrend, TrendDirections cciTrend, decimal riskDistance)
 	{
 		var price = candle.ClosePrice;
 
@@ -438,7 +438,7 @@ public class DailyTrendReversalStrategy : Strategy
 			var step1 = TrendSteps >= 0 && price - _dailyLow > riskDistance;
 			var step2 = TrendSteps >= 2 && _dailyHigh - _dailyOpen >= riskDistance && _dailyOpen - price <= _tenPips;
 
-			if (price < _dailyOpen && (step1 || step2) && rangeTrend == TrendDirection.Down && cciTrend == TrendDirection.Down)
+			if (price < _dailyOpen && (step1 || step2) && rangeTrend == TrendDirections.Down && cciTrend == TrendDirections.Down)
 			{
 				SellMarket(Position);
 				LogInfo("Long reversed due to opposite trend confirmation.");
@@ -446,7 +446,7 @@ public class DailyTrendReversalStrategy : Strategy
 		}
 	}
 
-	private void ManageShortPosition(ICandleMessage candle, TrendDirection rangeTrend, TrendDirection cciTrend, decimal riskDistance)
+	private void ManageShortPosition(ICandleMessage candle, TrendDirections rangeTrend, TrendDirections cciTrend, decimal riskDistance)
 	{
 		var price = candle.ClosePrice;
 
@@ -496,7 +496,7 @@ public class DailyTrendReversalStrategy : Strategy
 			var step1 = TrendSteps >= 0 && _dailyHigh - price > riskDistance;
 			var step2 = TrendSteps >= 2 && _dailyOpen - _dailyLow >= riskDistance && price - _dailyOpen <= _tenPips;
 
-			if (price > _dailyOpen && (step1 || step2) && rangeTrend == TrendDirection.Up && cciTrend == TrendDirection.Up)
+			if (price > _dailyOpen && (step1 || step2) && rangeTrend == TrendDirections.Up && cciTrend == TrendDirections.Up)
 			{
 				BuyMarket(Math.Abs(Position));
 				LogInfo("Short reversed due to opposite trend confirmation.");
@@ -573,28 +573,28 @@ public class DailyTrendReversalStrategy : Strategy
 		}
 	}
 
-	private TrendDirection GetCciTrend()
+	private TrendDirections GetCciTrend()
 	{
 		if (_cciHistory.Count < 3)
-		return TrendDirection.Flat;
+		return TrendDirections.Flat;
 
 		var current = _cciHistory[0];
 		var previous = _cciHistory[1];
 		var older = _cciHistory[2];
 
 		if (current >= previous && previous >= older)
-		return TrendDirection.Up;
+		return TrendDirections.Up;
 
 		if (current <= previous && previous <= older)
-		return TrendDirection.Down;
+		return TrendDirections.Down;
 
-		return TrendDirection.Flat;
+		return TrendDirections.Flat;
 	}
 
-	private TrendDirection GetDirectionalTrend(ICandleMessage candle, decimal riskDistance)
+	private TrendDirections GetDirectionalTrend(ICandleMessage candle, decimal riskDistance)
 	{
 		if (_currentDay is null)
-		return TrendDirection.Flat;
+		return TrendDirections.Flat;
 
 		var price = candle.ClosePrice;
 
@@ -605,7 +605,7 @@ public class DailyTrendReversalStrategy : Strategy
 			var step3 = TrendSteps >= 3 && price - _dailyOpen <= _tenPips && candle.ClosePrice > candle.OpenPrice;
 
 			if (step1 || step2 || step3)
-			return TrendDirection.Up;
+			return TrendDirections.Up;
 		}
 		else if (price < _dailyOpen)
 		{
@@ -614,24 +614,24 @@ public class DailyTrendReversalStrategy : Strategy
 			var step3 = TrendSteps >= 3 && _dailyOpen - price <= _tenPips && candle.ClosePrice < candle.OpenPrice;
 
 			if (step1 || step2 || step3)
-			return TrendDirection.Down;
+			return TrendDirections.Down;
 		}
 
-		return TrendDirection.Flat;
+		return TrendDirections.Flat;
 	}
 
-	private TrendDirection GetRangeTrend()
+	private TrendDirections GetRangeTrend()
 	{
 		var upDistance = _dailyHigh - _dailyOpen;
 		var downDistance = _dailyOpen - _dailyLow;
 
 		if (upDistance > downDistance)
-		return TrendDirection.Up;
+		return TrendDirections.Up;
 
 		if (upDistance < downDistance)
-		return TrendDirection.Down;
+		return TrendDirections.Down;
 
-		return TrendDirection.Flat;
+		return TrendDirections.Flat;
 	}
 
 	private bool IsWeekday(DateTimeOffset time)

--- a/API/4226_VivaLasVegas/CS/VivaLasVegasStrategy.cs
+++ b/API/4226_VivaLasVegas/CS/VivaLasVegasStrategy.cs
@@ -19,7 +19,7 @@ public class VivaLasVegasStrategy : Strategy
 {
 	private readonly StrategyParam<int> _stopTakePips;
 	private readonly StrategyParam<decimal> _baseVolume;
-	private readonly StrategyParam<MoneyManagementMode> _moneyManagementMode;
+private readonly StrategyParam<MoneyManagementModes> _moneyManagementMode;
 	private readonly StrategyParam<int> _seed;
 
 	private Random _random = new();
@@ -42,7 +42,7 @@ public class VivaLasVegasStrategy : Strategy
 			.SetCanOptimize(true)
 			.SetOptimize(0.1m, 5m, 0.1m);
 
-		_moneyManagementMode = Param(nameof(MoneyManagement), MoneyManagementMode.Martingale)
+_moneyManagementMode = Param(nameof(MoneyManagement), MoneyManagementModes.Martingale)
 			.SetDisplay("Money management", "Progression model that decides the next order volume.", "General");
 
 		_seed = Param(nameof(Seed), 0)
@@ -61,15 +61,15 @@ public class VivaLasVegasStrategy : Strategy
 		set => _baseVolume.Value = value;
 	}
 
-	public MoneyManagementMode MoneyManagement
-	{
-		get => _moneyManagementMode.Value;
-		set
-		{
-			_moneyManagementMode.Value = value;
-			InitializeMoneyManagement();
-		}
-	}
+public MoneyManagementModes MoneyManagement
+{
+get => _moneyManagementMode.Value;
+set
+{
+_moneyManagementMode.Value = value;
+InitializeMoneyManagement();
+}
+}
 
 	public int Seed
 	{
@@ -144,7 +144,7 @@ public class VivaLasVegasStrategy : Strategy
 			var closedVolume = Math.Abs(_previousPosition);
 			if (closedVolume > 0m && _management != null)
 			{
-				var result = tradePnL > 0m ? TradeResult.Win : TradeResult.Loss;
+				var result = tradePnL > 0m ? TradeResults.Win : TradeResults.Loss;
 				_management.Update(result, closedVolume, BaseVolume);
 			}
 
@@ -225,29 +225,29 @@ public class VivaLasVegasStrategy : Strategy
 		_management.Reset(BaseVolume);
 	}
 
-	private IMoneyManagement CreateMoneyManagement(MoneyManagementMode mode)
-	{
-		return mode switch
-		{
-			MoneyManagementMode.Martingale => new MartingaleManagement(),
-			MoneyManagementMode.NegativePyramid => new NegativePyramidManagement(),
-			MoneyManagementMode.Labouchere => new LabouchereManagement(),
-			MoneyManagementMode.OscarsGrind => new OscarsGrindManagement(),
-			MoneyManagementMode.System31 => new System31Management(),
-			_ => new MartingaleManagement(),
-		};
-	}
+private IMoneyManagement CreateMoneyManagement(MoneyManagementModes mode)
+{
+return mode switch
+{
+MoneyManagementModes.Martingale => new MartingaleManagement(),
+MoneyManagementModes.NegativePyramid => new NegativePyramidManagement(),
+MoneyManagementModes.Labouchere => new LabouchereManagement(),
+MoneyManagementModes.OscarsGrind => new OscarsGrindManagement(),
+MoneyManagementModes.System31 => new System31Management(),
+_ => new MartingaleManagement(),
+};
+}
 
-	public enum MoneyManagementMode
-	{
-		Martingale,
-		NegativePyramid,
-		Labouchere,
-		OscarsGrind,
-		System31,
-	}
+public enum MoneyManagementModes
+{
+Martingale,
+NegativePyramid,
+Labouchere,
+OscarsGrind,
+System31,
+}
 
-	private enum TradeResult
+	private enum TradeResults
 	{
 		Win,
 		Loss,
@@ -256,7 +256,7 @@ public class VivaLasVegasStrategy : Strategy
 	private interface IMoneyManagement
 	{
 		decimal GetVolume(decimal baseVolume);
-		void Update(TradeResult result, decimal closedVolume, decimal baseVolume);
+		void Update(TradeResults result, decimal closedVolume, decimal baseVolume);
 		void Reset(decimal baseVolume);
 	}
 
@@ -272,9 +272,9 @@ public class VivaLasVegasStrategy : Strategy
 			return _nextVolume;
 		}
 
-		public void Update(TradeResult result, decimal closedVolume, decimal baseVolume)
+		public void Update(TradeResults result, decimal closedVolume, decimal baseVolume)
 		{
-			_nextVolume = result == TradeResult.Win ? baseVolume : _nextVolume * 2m;
+			_nextVolume = result == TradeResults.Win ? baseVolume : _nextVolume * 2m;
 		}
 
 		public void Reset(decimal baseVolume)
@@ -295,9 +295,9 @@ public class VivaLasVegasStrategy : Strategy
 			return _nextVolume;
 		}
 
-		public void Update(TradeResult result, decimal closedVolume, decimal baseVolume)
+		public void Update(TradeResults result, decimal closedVolume, decimal baseVolume)
 		{
-			if (result == TradeResult.Win)
+			if (result == TradeResults.Win)
 			{
 				_nextVolume /= 2m;
 				if (_nextVolume < baseVolume)
@@ -331,12 +331,12 @@ public class VivaLasVegasStrategy : Strategy
 			return _series[0] * baseVolume;
 		}
 
-		public void Update(TradeResult result, decimal closedVolume, decimal baseVolume)
+		public void Update(TradeResults result, decimal closedVolume, decimal baseVolume)
 		{
 			if (_series.Count == 0)
 				Reset(baseVolume);
 
-			if (result == TradeResult.Win)
+			if (result == TradeResults.Win)
 			{
 				if (_series.Count > 2)
 				{
@@ -378,9 +378,9 @@ public class VivaLasVegasStrategy : Strategy
 			return _nextVolume;
 		}
 
-		public void Update(TradeResult result, decimal closedVolume, decimal baseVolume)
+		public void Update(TradeResults result, decimal closedVolume, decimal baseVolume)
 		{
-			if (result == TradeResult.Win)
+			if (result == TradeResults.Win)
 			{
 				_currentResult += closedVolume;
 
@@ -424,9 +424,9 @@ public class VivaLasVegasStrategy : Strategy
 			return multiplier * baseVolume;
 		}
 
-		public void Update(TradeResult result, decimal closedVolume, decimal baseVolume)
+		public void Update(TradeResults result, decimal closedVolume, decimal baseVolume)
 		{
-			if (result == TradeResult.Win)
+			if (result == TradeResults.Win)
 			{
 				if (!_doubleUp)
 				{

--- a/API/4227_Daily_STP_Entry_Frame/CS/DailyStpEntryFrameStrategy.cs
+++ b/API/4227_Daily_STP_Entry_Frame/CS/DailyStpEntryFrameStrategy.cs
@@ -19,12 +19,12 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class DailyStpEntryFrameStrategy : Strategy
 {
-	private enum EntrySide
-	{
-		Short = -1,
-		Both = 0,
-		Long = 1,
-	}
+private enum EntrySides
+{
+Short = -1,
+Both = 0,
+Long = 1,
+}
 
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<decimal> _stopLossPoints;
@@ -247,7 +247,7 @@ public class DailyStpEntryFrameStrategy : Strategy
 			.SetNotNegative()
 			.SetDisplay("Trailing Slope", "Portion of profit retained when trailing is active", "Risk");
 
-		_sideFilter = Param(nameof(SideFilter), (int)EntrySide.Short)
+_sideFilter = Param(nameof(SideFilter), (int)EntrySides.Short)
 			.SetDisplay("Side Filter", "Allowed entry direction (-1 short, 0 both, 1 long)", "Signal");
 
 		_thresholdPoints = Param(nameof(ThresholdPoints), 5m)
@@ -667,18 +667,18 @@ public class DailyStpEntryFrameStrategy : Strategy
 
 	private bool AllowsLongEntries()
 	{
-		return GetEntrySide() != EntrySide.Short;
+return GetEntrySide() != EntrySides.Short;
 	}
 
 	private bool AllowsShortEntries()
 	{
-		return GetEntrySide() != EntrySide.Long;
+return GetEntrySide() != EntrySides.Long;
 	}
 
-	private EntrySide GetEntrySide()
-	{
-		return Enum.IsDefined(typeof(EntrySide), SideFilter) ? (EntrySide)SideFilter : EntrySide.Both;
-	}
+private EntrySides GetEntrySide()
+{
+return Enum.IsDefined(typeof(EntrySides), SideFilter) ? (EntrySides)SideFilter : EntrySides.Both;
+}
 
 	private bool IsTradingDay(DateTimeOffset time)
 	{


### PR DESCRIPTION
## Summary
- pluralized enum type names across strategies 4001-4227 so they now use plural forms such as `EntrySides`, `MoneyManagementModes`, and `AppliedPriceModes`
- removed lingering `Enum` suffixes while updating all usages to match the new pluralized names

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d837986c548323a383fee214ebfe11