### PR TITLE
Standardize enum names in API strategies 0501-0997

### DIFF
--- a/API/0504_Advanced_Supertrend/CS/AdvancedSupertrendStrategy.cs
+++ b/API/0504_Advanced_Supertrend/CS/AdvancedSupertrendStrategy.cs
@@ -28,7 +28,7 @@ public class AdvancedSupertrendStrategy : Strategy
 	private readonly StrategyParam<decimal> _rsiOversold;
 	private readonly StrategyParam<bool> _useMaFilter;
 	private readonly StrategyParam<int> _maLength;
-	private readonly StrategyParam<MaTypeEnum> _maType;
+	private readonly StrategyParam<MaTypes> _maType;
 	private readonly StrategyParam<bool> _useStopLoss;
 	private readonly StrategyParam<decimal> _slMultiplier;
 	private readonly StrategyParam<bool> _useTakeProfit;
@@ -126,7 +126,7 @@ public class AdvancedSupertrendStrategy : Strategy
 	/// <summary>
 	/// Moving average type.
 	/// </summary>
-	public MaTypeEnum MaType
+	public MaTypes MaType
 	{
 		get => _maType.Value;
 		set => _maType.Value = value;
@@ -241,7 +241,7 @@ public class AdvancedSupertrendStrategy : Strategy
 			.SetCanOptimize(true)
 			.SetOptimize(20, 100, 10);
 
-		_maType = Param(nameof(MaType), MaTypeEnum.Weighted)
+		_maType = Param(nameof(MaType), MaTypes.Weighted)
 			.SetDisplay("MA Type", "Type of moving average", "MA Filter");
 
 		_useStopLoss = Param(nameof(UseStopLoss), true)
@@ -301,8 +301,8 @@ public class AdvancedSupertrendStrategy : Strategy
 
 		_ma = MaType switch
 		{
-			MaTypeEnum.Exponential => new ExponentialMovingAverage { Length = MaLength },
-			MaTypeEnum.Weighted => new WeightedMovingAverage { Length = MaLength },
+			MaTypes.Exponential => new ExponentialMovingAverage { Length = MaLength },
+			MaTypes.Weighted => new WeightedMovingAverage { Length = MaLength },
 			_ => new SimpleMovingAverage { Length = MaLength }
 		};
 
@@ -398,7 +398,7 @@ public class AdvancedSupertrendStrategy : Strategy
 	/// <summary>
 	/// Moving average types.
 	/// </summary>
-	public enum MaTypeEnum
+	public enum MaTypes
 	{
 		/// <summary>Simple moving average.</summary>
 		Simple,

--- a/API/0505_ADX_CCI_MA/CS/AdxCciMaStrategy.cs
+++ b/API/0505_ADX_CCI_MA/CS/AdxCciMaStrategy.cs
@@ -32,7 +32,7 @@ public class AdxCciMaStrategy : Strategy
 	private readonly StrategyParam<decimal> _adxThreshold;
 	private readonly StrategyParam<bool> _useMaTrend;
 	private readonly StrategyParam<int> _maLength;
-	private readonly StrategyParam<MovingAverageTypeEnum> _maType;
+	private readonly StrategyParam<MovingAverageTypes> _maType;
 	private readonly StrategyParam<bool> _useMaRisk;
 	private readonly StrategyParam<int> _maRiskExitCandles;
 	private readonly StrategyParam<DataType> _candleType;
@@ -55,7 +55,7 @@ public class AdxCciMaStrategy : Strategy
 	public decimal AdxThreshold { get => _adxThreshold.Value; set => _adxThreshold.Value = value; }
 	public bool UseMaTrend { get => _useMaTrend.Value; set => _useMaTrend.Value = value; }
 	public int MaLength { get => _maLength.Value; set => _maLength.Value = value; }
-	public MovingAverageTypeEnum MaType { get => _maType.Value; set => _maType.Value = value; }
+	public MovingAverageTypes MaType { get => _maType.Value; set => _maType.Value = value; }
 	public bool UseMaRiskManagement { get => _useMaRisk.Value; set => _useMaRisk.Value = value; }
 	public int MaRiskExitCandles { get => _maRiskExitCandles.Value; set => _maRiskExitCandles.Value = value; }
 	public DataType CandleType { get => _candleType.Value; set => _candleType.Value = value; }
@@ -89,7 +89,7 @@ public class AdxCciMaStrategy : Strategy
 		_maLength = Param(nameof(MaLength), 200)
 			.SetDisplay("MA Length", "Length of moving average", "MA Trend")
 			.SetCanOptimize(true);
-		_maType = Param(nameof(MaType), MovingAverageTypeEnum.Simple)
+		_maType = Param(nameof(MaType), MovingAverageTypes.Simple)
 			.SetDisplay("MA Type", "Type of moving average", "MA Trend");
 		_useMaRisk = Param(nameof(UseMaRiskManagement), false)
 			.SetDisplay("Use MA Risk Management", "Exit after candles against MA", "Risk Management");
@@ -126,11 +126,11 @@ public class AdxCciMaStrategy : Strategy
 		_adx = new() { Length = AdxLength };
 		_ma = MaType switch
 		{
-			MovingAverageTypeEnum.Hull => new HullMovingAverage(),
-			MovingAverageTypeEnum.Exponential => new ExponentialMovingAverage(),
-			MovingAverageTypeEnum.Smoothed => new SmoothedMovingAverage(),
-			MovingAverageTypeEnum.Weighted => new WeightedMovingAverage(),
-			MovingAverageTypeEnum.VolumeWeighted => new VolumeWeightedMovingAverage(),
+			MovingAverageTypes.Hull => new HullMovingAverage(),
+			MovingAverageTypes.Exponential => new ExponentialMovingAverage(),
+			MovingAverageTypes.Smoothed => new SmoothedMovingAverage(),
+			MovingAverageTypes.Weighted => new WeightedMovingAverage(),
+			MovingAverageTypes.VolumeWeighted => new VolumeWeightedMovingAverage(),
 			_ => new SimpleMovingAverage()
 		};
 		_ma.Length = MaLength;
@@ -233,7 +233,7 @@ public class AdxCciMaStrategy : Strategy
 		_prevMinusDi = minusDi;
 	}
 
-	public enum MovingAverageTypeEnum
+	public enum MovingAverageTypes
 	{
 		Simple,
 		Hull,

--- a/API/0519_ALMA_Optimized/CS/AlmaOptimizedStrategy.cs
+++ b/API/0519_ALMA_Optimized/CS/AlmaOptimizedStrategy.cs
@@ -34,13 +34,13 @@ public class AlmaOptimizedStrategy : Strategy
 	private int _barIndex;
 	private int _lastBuyBar;
 	private int _entryBar;
-	private SignalType _lastSignal;
+	private SignalTypes _lastSignal;
 	private decimal _stopPrice;
 	private decimal _takePrice;
 	private decimal _prevClose;
 	private decimal _prevFastEma;
 
-	private enum SignalType
+	private enum SignalTypes
 	{
 		None,
 		Buy,
@@ -243,7 +243,7 @@ public class AlmaOptimizedStrategy : Strategy
 		_barIndex = 0;
 		_lastBuyBar = int.MinValue;
 		_entryBar = 0;
-		_lastSignal = SignalType.None;
+		_lastSignal = SignalTypes.None;
 		_stopPrice = 0m;
 		_takePrice = 0m;
 		_prevClose = 0m;
@@ -294,10 +294,10 @@ public class AlmaOptimizedStrategy : Strategy
 
 		if (_prevClose != 0m || _prevFastEma != 0m)
 		{
-			var buyCond = volatility && candle.ClosePrice > slowEmaValue && candle.ClosePrice > almaValue && rsiValue > 30m && adxValue > 30m && candle.ClosePrice < upperBand && (_barIndex - _lastBuyBar > CooldownBars) && _lastSignal != SignalType.Buy;
+			var buyCond = volatility && candle.ClosePrice > slowEmaValue && candle.ClosePrice > almaValue && rsiValue > 30m && adxValue > 30m && candle.ClosePrice < upperBand && (_barIndex - _lastBuyBar > CooldownBars) && _lastSignal != SignalTypes.Buy;
 
 			var crossUnder = _prevClose >= _prevFastEma && candle.ClosePrice < fastEmaValue;
-			var sellCond = volatility && crossUnder && _lastSignal != SignalType.Sell;
+			var sellCond = volatility && crossUnder && _lastSignal != SignalTypes.Sell;
 
 			if (buyCond && Position <= 0)
 			{
@@ -305,7 +305,7 @@ public class AlmaOptimizedStrategy : Strategy
 				BuyMarket(volume);
 				_lastBuyBar = _barIndex;
 				_entryBar = _barIndex;
-				_lastSignal = SignalType.Buy;
+				_lastSignal = SignalTypes.Buy;
 				_stopPrice = candle.ClosePrice - atrValue * SlAtrMultiplier;
 				_takePrice = candle.ClosePrice + atrValue * TpAtrMultiplier;
 			}
@@ -314,7 +314,7 @@ public class AlmaOptimizedStrategy : Strategy
 				var volume = Volume + Math.Abs(Position);
 				SellMarket(volume);
 				_entryBar = _barIndex;
-				_lastSignal = SignalType.Sell;
+				_lastSignal = SignalTypes.Sell;
 				_stopPrice = candle.ClosePrice + atrValue * SlAtrMultiplier;
 				_takePrice = candle.ClosePrice - atrValue * TpAtrMultiplier;
 			}
@@ -325,14 +325,14 @@ public class AlmaOptimizedStrategy : Strategy
 			if (candle.LowPrice <= _stopPrice || candle.HighPrice >= _takePrice || (TimeBasedExit > 0 && _barIndex - _entryBar >= TimeBasedExit))
 			{
 				SellMarket(Position);
-				_lastSignal = SignalType.Sell;
+				_lastSignal = SignalTypes.Sell;
 			}
 			else if (Position < 0)
 			{
 				if (candle.HighPrice >= _stopPrice || candle.LowPrice <= _takePrice || (TimeBasedExit > 0 && _barIndex - _entryBar >= TimeBasedExit))
 				{
 					BuyMarket(Math.Abs(Position));
-					_lastSignal = SignalType.Buy;
+					_lastSignal = SignalTypes.Buy;
 				}
 			}
 

--- a/API/0557_Bbtrend_Supertrend_Decision/CS/BbtrendSupertrendDecisionStrategy.cs
+++ b/API/0557_Bbtrend_Supertrend_Decision/CS/BbtrendSupertrendDecisionStrategy.cs
@@ -27,7 +27,7 @@ public class BbtrendSupertrendDecisionStrategy : Strategy
 	private readonly StrategyParam<int> _supertrendLength;
 	private readonly StrategyParam<decimal> _supertrendMultiplier;
 	private readonly StrategyParam<Sides?> _tradeDirection;
-	private readonly StrategyParam<TpSlMode> _tpSlCondition;
+	private readonly StrategyParam<TpSlModes> _tpSlCondition;
 	private readonly StrategyParam<decimal> _takeProfitPerc;
 	private readonly StrategyParam<decimal> _stopLossPerc;
 	private readonly StrategyParam<DataType> _candleType;
@@ -95,7 +95,7 @@ public class BbtrendSupertrendDecisionStrategy : Strategy
 	/// <summary>
 	/// Take profit / stop loss mode.
 	/// </summary>
-	public TpSlMode TpSlCondition
+	public TpSlModes TpSlCondition
 	{
 		get => _tpSlCondition.Value;
 		set => _tpSlCondition.Value = value;
@@ -164,7 +164,7 @@ public class BbtrendSupertrendDecisionStrategy : Strategy
 		_tradeDirection = Param(nameof(TradeDirection), (Sides?)null)
 		.SetDisplay("Direction", "Allowed trading direction", "Trading");
 		
-		_tpSlCondition = Param(nameof(TpSlCondition), Strategies.TpSlMode.None)
+		_tpSlCondition = Param(nameof(TpSlCondition), Strategies.TpSlModes.None)
 		.SetDisplay("TP/SL Mode", "Protection mode", "Risk");
 		
 		_takeProfitPerc = Param(nameof(TakeProfitPerc), 30m)
@@ -209,9 +209,9 @@ public class BbtrendSupertrendDecisionStrategy : Strategy
 		
 		Unit tp = default;
 		Unit sl = default;
-		if (TpSlCondition == TpSlMode.TP || TpSlCondition == TpSlMode.Both)
+		if (TpSlCondition == TpSlModes.TP || TpSlCondition == TpSlModes.Both)
 		tp = TakeProfitPerc.Percents();
-		if (TpSlCondition == TpSlMode.SL || TpSlCondition == TpSlMode.Both)
+		if (TpSlCondition == TpSlModes.SL || TpSlCondition == TpSlModes.Both)
 		sl = StopLossPerc.Percents();
 		if (tp != default || sl != default)
 		StartProtection(tp, sl);
@@ -282,7 +282,7 @@ public class BbtrendSupertrendDecisionStrategy : Strategy
 /// <summary>
 /// Protection mode for take profit and stop loss.
 /// </summary>
-public enum TpSlMode
+public enum TpSlModes
 {
 	None,
 	TP,

--- a/API/0561_Breadth_Thrust_Volatility_Stop/CS/BreadthThrustVolatilityStopStrategy.cs
+++ b/API/0561_Breadth_Thrust_Volatility_Stop/CS/BreadthThrustVolatilityStopStrategy.cs
@@ -180,19 +180,19 @@ public class BreadthThrustVolatilityStopStrategy : Strategy
 		.Start();
 		
 		SubscribeCandles(CandleType, true, AdvancingStocks)
-		.Bind(c => ProcessBreadth(c, BreadthType.AdvancingStocks))
+		.Bind(c => ProcessBreadth(c, BreadthTypes.AdvancingStocks))
 		.Start();
 		
 		SubscribeCandles(CandleType, true, DecliningStocks)
-		.Bind(c => ProcessBreadth(c, BreadthType.DecliningStocks))
+		.Bind(c => ProcessBreadth(c, BreadthTypes.DecliningStocks))
 		.Start();
 		
 		SubscribeCandles(CandleType, true, AdvancingVolume)
-		.Bind(c => ProcessBreadth(c, BreadthType.AdvancingVolume))
+		.Bind(c => ProcessBreadth(c, BreadthTypes.AdvancingVolume))
 		.Start();
 		
 		SubscribeCandles(CandleType, true, DecliningVolume)
-		.Bind(c => ProcessBreadth(c, BreadthType.DecliningVolume))
+		.Bind(c => ProcessBreadth(c, BreadthTypes.DecliningVolume))
 		.Start();
 		
 		var area = CreateChartArea();
@@ -204,7 +204,7 @@ public class BreadthThrustVolatilityStopStrategy : Strategy
 		}
 	}
 	
-	private enum BreadthType
+	private enum BreadthTypes
 	{
 		AdvancingStocks,
 		DecliningStocks,
@@ -212,23 +212,23 @@ public class BreadthThrustVolatilityStopStrategy : Strategy
 		DecliningVolume
 	}
 	
-	private void ProcessBreadth(ICandleMessage candle, BreadthType type)
+	private void ProcessBreadth(ICandleMessage candle, BreadthTypes type)
 	{
 		if (candle.State != CandleStates.Finished)
 		return;
 		
 		switch (type)
 		{
-		case BreadthType.AdvancingStocks:
+		case BreadthTypes.AdvancingStocks:
 		_advancingStocksValue = candle.ClosePrice;
 		break;
-	case BreadthType.DecliningStocks:
+	case BreadthTypes.DecliningStocks:
 	_decliningStocksValue = candle.ClosePrice;
 	break;
-case BreadthType.AdvancingVolume:
+case BreadthTypes.AdvancingVolume:
 _advancingVolumeValue = candle.ClosePrice;
 break;
-case BreadthType.DecliningVolume:
+case BreadthTypes.DecliningVolume:
 _decliningVolumeValue = candle.ClosePrice;
 break;
 }

--- a/API/0562_Breakouts_With_Timefilter/CS/BreakoutsWithTimeFilterStrategy.cs
+++ b/API/0562_Breakouts_With_Timefilter/CS/BreakoutsWithTimeFilterStrategy.cs
@@ -21,12 +21,12 @@ public class BreakoutsWithTimeFilterStrategy : Strategy
 	private readonly StrategyParam<int> _length;
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<bool> _useMaFilter;
-	private readonly StrategyParam<MaTypeEnum> _maType;
+	private readonly StrategyParam<MaTypes> _maType;
 	private readonly StrategyParam<int> _maLength;
 	private readonly StrategyParam<bool> _useTimeFilter;
 	private readonly StrategyParam<TimeSpan> _startTime;
 	private readonly StrategyParam<TimeSpan> _endTime;
-	private readonly StrategyParam<StopLossType> _slType;
+	private readonly StrategyParam<StopLossTypes> _slType;
 	private readonly StrategyParam<int> _slLength;
 	private readonly StrategyParam<int> _atrLength;
 	private readonly StrategyParam<decimal> _atrMultiplier;
@@ -40,12 +40,12 @@ public class BreakoutsWithTimeFilterStrategy : Strategy
 	public int Length { get => _length.Value; set => _length.Value = value; }
 	public DataType CandleType { get => _candleType.Value; set => _candleType.Value = value; }
 	public bool UseMaFilter { get => _useMaFilter.Value; set => _useMaFilter.Value = value; }
-	public MaTypeEnum MaType { get => _maType.Value; set => _maType.Value = value; }
+	public MaTypes MaType { get => _maType.Value; set => _maType.Value = value; }
 	public int MaLength { get => _maLength.Value; set => _maLength.Value = value; }
 	public bool UseTimeFilter { get => _useTimeFilter.Value; set => _useTimeFilter.Value = value; }
 	public TimeSpan StartTime { get => _startTime.Value; set => _startTime.Value = value; }
 	public TimeSpan EndTime { get => _endTime.Value; set => _endTime.Value = value; }
-	public StopLossType SlType { get => _slType.Value; set => _slType.Value = value; }
+	public StopLossTypes SlType { get => _slType.Value; set => _slType.Value = value; }
 	public int SlLength { get => _slLength.Value; set => _slLength.Value = value; }
 	public int AtrLength { get => _atrLength.Value; set => _atrLength.Value = value; }
 	public decimal AtrMultiplier { get => _atrMultiplier.Value; set => _atrMultiplier.Value = value; }
@@ -65,7 +65,7 @@ public class BreakoutsWithTimeFilterStrategy : Strategy
 		_useMaFilter = Param(nameof(UseMaFilter), false)
 			.SetDisplay("Use MA Filter", "Enable moving average filter", "MA Filter");
 
-		_maType = Param(nameof(MaType), MaTypeEnum.Hull)
+		_maType = Param(nameof(MaType), MaTypes.Hull)
 			.SetDisplay("MA Type", "Moving average type", "MA Filter");
 
 		_maLength = Param(nameof(MaLength), 99)
@@ -82,7 +82,7 @@ public class BreakoutsWithTimeFilterStrategy : Strategy
 		_endTime = Param(nameof(EndTime), new TimeSpan(15, 0, 0))
 			.SetDisplay("End Time", "End of trading window", "Time Filter");
 
-		_slType = Param(nameof(SlType), StopLossType.Atr)
+		_slType = Param(nameof(SlType), StopLossTypes.Atr)
 			.SetDisplay("Stop Loss Type", "Stop loss calculation", "Risk Management");
 
 		_slLength = Param(nameof(SlLength), 0)
@@ -123,10 +123,10 @@ public class BreakoutsWithTimeFilterStrategy : Strategy
 		var atr = new AverageTrueRange { Length = AtrLength };
 		var ma = MaType switch
 		{
-			MaTypeEnum.Sma => new SimpleMovingAverage { Length = MaLength },
-			MaTypeEnum.Ema => new ExponentialMovingAverage { Length = MaLength },
-			MaTypeEnum.Wma => new WeightedMovingAverage { Length = MaLength },
-			MaTypeEnum.Vwma => new VolumeWeightedMovingAverage { Length = MaLength },
+			MaTypes.Sma => new SimpleMovingAverage { Length = MaLength },
+			MaTypes.Ema => new ExponentialMovingAverage { Length = MaLength },
+			MaTypes.Wma => new WeightedMovingAverage { Length = MaLength },
+			MaTypes.Vwma => new VolumeWeightedMovingAverage { Length = MaLength },
 			_ => new HullMovingAverage { Length = MaLength }
 		};
 
@@ -180,9 +180,9 @@ public class BreakoutsWithTimeFilterStrategy : Strategy
 	{
 		_stopLevel = SlType switch
 		{
-			StopLossType.Atr => candle.ClosePrice - atrValue * AtrMultiplier,
-			StopLossType.Candle => GetCandleStop(false),
-			StopLossType.Points => candle.ClosePrice - PointsStop,
+			StopLossTypes.Atr => candle.ClosePrice - atrValue * AtrMultiplier,
+			StopLossTypes.Candle => GetCandleStop(false),
+			StopLossTypes.Points => candle.ClosePrice - PointsStop,
 			_ => 0m
 		};
 
@@ -196,9 +196,9 @@ public class BreakoutsWithTimeFilterStrategy : Strategy
 	{
 		_stopLevel = SlType switch
 		{
-			StopLossType.Atr => candle.ClosePrice + atrValue * AtrMultiplier,
-			StopLossType.Candle => GetCandleStop(true),
-			StopLossType.Points => candle.ClosePrice + PointsStop,
+			StopLossTypes.Atr => candle.ClosePrice + atrValue * AtrMultiplier,
+			StopLossTypes.Candle => GetCandleStop(true),
+			StopLossTypes.Points => candle.ClosePrice + PointsStop,
 			_ => 0m
 		};
 
@@ -224,7 +224,7 @@ public class BreakoutsWithTimeFilterStrategy : Strategy
 		return StartTime <= EndTime ? t >= StartTime && t <= EndTime : t >= StartTime || t <= EndTime;
 	}
 
-	public enum MaTypeEnum
+	public enum MaTypes
 	{
 		Sma,
 		Ema,
@@ -233,7 +233,7 @@ public class BreakoutsWithTimeFilterStrategy : Strategy
 		Hull
 	}
 
-	public enum StopLossType
+	public enum StopLossTypes
 	{
 		Atr,
 		Candle,

--- a/API/0564_Best_Dollar_Cost_Average/CS/BestDollarCostAverageStrategy.cs
+++ b/API/0564_Best_Dollar_Cost_Average/CS/BestDollarCostAverageStrategy.cs
@@ -20,7 +20,7 @@ public class BestDollarCostAverageStrategy : Strategy
 {
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<decimal> _amountInvested;
-	private readonly StrategyParam<DcaInterval> _interval;
+	private readonly StrategyParam<DcaIntervals> _interval;
 	private readonly StrategyParam<DateTimeOffset> _startDate;
 	private readonly StrategyParam<DateTimeOffset> _endDate;
 
@@ -50,7 +50,7 @@ public class BestDollarCostAverageStrategy : Strategy
 	/// <summary>
 	/// Interval for dollar cost averaging.
 	/// </summary>
-	public DcaInterval Interval
+	public DcaIntervals Interval
 	{
 		get => _interval.Value;
 		set => _interval.Value = value;
@@ -77,7 +77,7 @@ public class BestDollarCostAverageStrategy : Strategy
 	/// <summary>
 	/// Period options for DCA.
 	/// </summary>
-	public enum DcaInterval
+	public enum DcaIntervals
 	{
 		Daily,
 		Weekly,
@@ -96,7 +96,7 @@ public class BestDollarCostAverageStrategy : Strategy
 			.SetRange(0.01m, 1000000m)
 			.SetDisplay("Amount", "Amount invested each period", "DCA");
 
-		_interval = Param(nameof(Interval), DcaInterval.Weekly)
+		_interval = Param(nameof(Interval), DcaIntervals.Weekly)
 			.SetDisplay("Interval", "Investment interval", "DCA");
 
 		_startDate = Param(nameof(StartDate), new DateTimeOffset(new DateTime(2018, 1, 1)))
@@ -163,9 +163,9 @@ public class BestDollarCostAverageStrategy : Strategy
 	{
 		return Interval switch
 		{
-			DcaInterval.Daily => current + TimeSpan.FromDays(1),
-			DcaInterval.Weekly => current + TimeSpan.FromDays(7),
-			DcaInterval.Monthly => current.AddMonths(1),
+			DcaIntervals.Daily => current + TimeSpan.FromDays(1),
+			DcaIntervals.Weekly => current + TimeSpan.FromDays(7),
+			DcaIntervals.Monthly => current.AddMonths(1),
 			_ => current,
 		};
 	}

--- a/API/0576_Bullish_Bs_Rsi_Divergence/CS/BullishBsRsiDivergenceStrategy.cs
+++ b/API/0576_Bullish_Bs_Rsi_Divergence/CS/BullishBsRsiDivergenceStrategy.cs
@@ -24,7 +24,7 @@ public class BullishBsRsiDivergenceStrategy : Strategy
 	private readonly StrategyParam<int> _takeProfit;
 	private readonly StrategyParam<int> _rangeUpper;
 	private readonly StrategyParam<int> _rangeLower;
-	private readonly StrategyParam<TrailingStopType> _stopType;
+	private readonly StrategyParam<TrailingStopTypes> _stopType;
 	private readonly StrategyParam<decimal> _stopLoss;
 	private readonly StrategyParam<int> _atrLength;
 	private readonly StrategyParam<decimal> _atrMultiplier;
@@ -60,7 +60,7 @@ public class BullishBsRsiDivergenceStrategy : Strategy
 	public int TakeProfitRsiLevel { get => _takeProfit.Value; set => _takeProfit.Value = value; }
 	public int RangeUpper { get => _rangeUpper.Value; set => _rangeUpper.Value = value; }
 	public int RangeLower { get => _rangeLower.Value; set => _rangeLower.Value = value; }
-	public TrailingStopType StopType { get => _stopType.Value; set => _stopType.Value = value; }
+	public TrailingStopTypes StopType { get => _stopType.Value; set => _stopType.Value = value; }
 	public decimal StopLoss { get => _stopLoss.Value; set => _stopLoss.Value = value; }
 	public int AtrLength { get => _atrLength.Value; set => _atrLength.Value = value; }
 	public decimal AtrMultiplier { get => _atrMultiplier.Value; set => _atrMultiplier.Value = value; }
@@ -73,7 +73,7 @@ public class BullishBsRsiDivergenceStrategy : Strategy
 		_takeProfit = Param(nameof(TakeProfitRsiLevel), 80).SetDisplay("RSI Take Profit", "RSI level", "Risk Management");
 		_rangeUpper = Param(nameof(RangeUpper), 60).SetDisplay("Range Upper", "Max bars between pivots", "General");
 		_rangeLower = Param(nameof(RangeLower), 5).SetDisplay("Range Lower", "Min bars between pivots", "General");
-		_stopType = Param(nameof(StopType), TrailingStopType.None).SetDisplay("Stop Type", "Trailing stop type", "Risk Management");
+		_stopType = Param(nameof(StopType), TrailingStopTypes.None).SetDisplay("Stop Type", "Trailing stop type", "Risk Management");
 		_stopLoss = Param(nameof(StopLoss), 5m).SetDisplay("Stop Loss %", "Percent stop", "Risk Management");
 		_atrLength = Param(nameof(AtrLength), 14).SetDisplay("ATR Length", "ATR period", "Indicators");
 		_atrMultiplier = Param(nameof(AtrMultiplier), 3.5m).SetDisplay("ATR Multiplier", "ATR multiplier", "Risk Management");
@@ -213,9 +213,9 @@ public class BullishBsRsiDivergenceStrategy : Strategy
 		}
 		else if (Position > 0)
 		{
-			if (StopType != TrailingStopType.None)
+			if (StopType != TrailingStopTypes.None)
 			{
-				var slVal = StopType == TrailingStopType.Atr ? atr * AtrMultiplier : candle.ClosePrice * StopLoss / 100m;
+				var slVal = StopType == TrailingStopTypes.Atr ? atr * AtrMultiplier : candle.ClosePrice * StopLoss / 100m;
 				var newStop = candle.LowPrice - slVal;
 				_trailingStop = _trailingStop is decimal prev ? Math.Max(prev, newStop) : newStop;
 				if (candle.ClosePrice < _trailingStop)
@@ -238,7 +238,7 @@ public class BullishBsRsiDivergenceStrategy : Strategy
 /// <summary>
 /// Trailing stop-loss types.
 /// </summary>
-public enum TrailingStopType
+public enum TrailingStopTypes
 {
 	/// <summary> No trailing stop. </summary>
 	None,

--- a/API/0584_Boilerplate_Configurable/CS/BoilerplateConfigurableStrategy.cs
+++ b/API/0584_Boilerplate_Configurable/CS/BoilerplateConfigurableStrategy.cs
@@ -18,26 +18,26 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class BoilerplateConfigurableStrategy : Strategy
 {
-	public enum StrategyMode
+	public enum StrategyModes
 	{
 		Squeeze,
 		SmaCross
 	}
 
-       public enum RrMode
+       public enum RrModes
        {
                Atr,
                Static
        }
 
-	private readonly StrategyParam<StrategyMode> _mode;
+	private readonly StrategyParam<StrategyModes> _mode;
 	private readonly StrategyParam<int> _length;
 	private readonly StrategyParam<decimal> _wideMultiplier;
 	private readonly StrategyParam<decimal> _narrowMultiplier;
        private readonly StrategyParam<Sides?> _direction;
 	private readonly StrategyParam<bool> _tradeInverse;
 	private readonly StrategyParam<decimal> _maxLossPerc;
-	private readonly StrategyParam<RrMode> _rrMode;
+	private readonly StrategyParam<RrModes> _rrMode;
 	private readonly StrategyParam<int> _atrLength;
 	private readonly StrategyParam<decimal> _atrMultiplier;
 	private readonly StrategyParam<decimal> _staticRr;
@@ -74,14 +74,14 @@ public class BoilerplateConfigurableStrategy : Strategy
 	private decimal _peakEquity;
 	private bool _drawdownBreached;
 
-	public StrategyMode Mode { get => _mode.Value; set => _mode.Value = value; }
+	public StrategyModes Mode { get => _mode.Value; set => _mode.Value = value; }
 	public int Length { get => _length.Value; set => _length.Value = value; }
 	public decimal WideMultiplier { get => _wideMultiplier.Value; set => _wideMultiplier.Value = value; }
 	public decimal NarrowMultiplier { get => _narrowMultiplier.Value; set => _narrowMultiplier.Value = value; }
 	public Sides? Direction { get => _direction.Value; set => _direction.Value = value; }
 	public bool TradeInverse { get => _tradeInverse.Value; set => _tradeInverse.Value = value; }
 	public decimal MaxLossPerc { get => _maxLossPerc.Value; set => _maxLossPerc.Value = value; }
-	public RrMode RiskRewardMode { get => _rrMode.Value; set => _rrMode.Value = value; }
+	public RrModes RiskRewardMode { get => _rrMode.Value; set => _rrMode.Value = value; }
 	public int AtrLength { get => _atrLength.Value; set => _atrLength.Value = value; }
 	public decimal AtrMultiplier { get => _atrMultiplier.Value; set => _atrMultiplier.Value = value; }
 	public decimal StaticRr { get => _staticRr.Value; set => _staticRr.Value = value; }
@@ -104,7 +104,7 @@ public class BoilerplateConfigurableStrategy : Strategy
 
 	public BoilerplateConfigurableStrategy()
 	{
-		_mode = Param(nameof(Mode), StrategyMode.Squeeze)
+		_mode = Param(nameof(Mode), StrategyModes.Squeeze)
 			.SetDisplay("Strategy Type", "Entry strategy mode", "General");
 
 		_length = Param(nameof(Length), 20)
@@ -129,7 +129,7 @@ public class BoilerplateConfigurableStrategy : Strategy
 			.SetRange(0.0001m, 1m)
 			.SetDisplay("Max Loss %", "Max loss per trade", "Risk");
 
-		_rrMode = Param(nameof(RiskRewardMode), RrMode.Atr)
+		_rrMode = Param(nameof(RiskRewardMode), RrModes.Atr)
 			.SetDisplay("RR Mode", "Risk reward mode", "Risk");
 
 		_atrLength = Param(nameof(AtrLength), 14)
@@ -276,11 +276,11 @@ public class BoilerplateConfigurableStrategy : Strategy
 
 		switch (Mode)
 		{
-			case StrategyMode.SmaCross:
+			case StrategyModes.SmaCross:
 				longCondition = _prevFast <= _prevSlow && fastVal > slowVal;
 				shortCondition = _prevFast >= _prevSlow && fastVal < slowVal;
 				break;
-			case StrategyMode.Squeeze:
+			case StrategyModes.Squeeze:
 				var squeeze = hlc3 < upper2 && hlc3 > lower2;
 				longCondition = _prevHlc3 <= upper1 && hlc3 > upper1 && squeeze;
 				shortCondition = _prevHlc3 >= lower1 && hlc3 < lower1 && squeeze;
@@ -317,7 +317,7 @@ public class BoilerplateConfigurableStrategy : Strategy
 		_entryPrice = price;
 		_isLong = isLong;
 
-		var stop = RiskRewardMode == RrMode.Atr ? atr * AtrMultiplier : price * MaxLossPerc;
+		var stop = RiskRewardMode == RrModes.Atr ? atr * AtrMultiplier : price * MaxLossPerc;
 		var take = stop * StaticRr;
 
 		if (isLong)

--- a/API/0585_BuySell_Bullish_Engulfing/CS/BuySellBullishEngulfingStrategy.cs
+++ b/API/0585_BuySell_Bullish_Engulfing/CS/BuySellBullishEngulfingStrategy.cs
@@ -24,7 +24,7 @@ public class BuySellBullishEngulfingStrategy : Strategy
 	private readonly StrategyParam<decimal> _takeProfitPercent;
 	private readonly StrategyParam<decimal> _stopLossPercent;
 	private readonly StrategyParam<decimal> _orderPercent;
-	private readonly StrategyParam<TrendMode> _trendMode;
+	private readonly StrategyParam<TrendModes> _trendMode;
 
 	private ICandleMessage _previousCandle;
 	private decimal _bodyEma;
@@ -68,7 +68,7 @@ public class BuySellBullishEngulfingStrategy : Strategy
 	/// <summary>
 	/// Trend detection rule.
 	/// </summary>
-	public TrendMode TrendMode
+	public TrendModes TrendMode
 	{
 		get => _trendMode.Value;
 		set => _trendMode.Value = value;
@@ -105,7 +105,7 @@ public class BuySellBullishEngulfingStrategy : Strategy
 			.SetRange(1m, 100m)
 			.SetDisplay("Order Size %", "Percent of equity per trade", "Risk Management");
 
-		_trendMode = Param(nameof(TrendMode), TrendMode.Sma50)
+		_trendMode = Param(nameof(TrendMode), TrendModes.Sma50)
 			.SetDisplay("Trend Rule", "How to detect trend", "Pattern");
 
 		_bodyEmaLength = Param(nameof(BodyEmaLength), 14)
@@ -177,10 +177,10 @@ public class BuySellBullishEngulfingStrategy : Strategy
 			var prevBear = _previousCandle.ClosePrice < _previousCandle.OpenPrice;
 			var currBull = candle.ClosePrice > candle.OpenPrice;
 
-			var downTrend = TrendMode switch
+			var downTrend = TrendModes switch
 			{
-				TrendMode.Sma50 => candle.ClosePrice < sma50,
-				TrendMode.Sma50And200 => candle.ClosePrice < sma50 && sma50 < sma200,
+				TrendModes.Sma50 => candle.ClosePrice < sma50,
+				TrendModes.Sma50And200 => candle.ClosePrice < sma50 && sma50 < sma200,
 				_ => true
 			};
 
@@ -210,7 +210,7 @@ public class BuySellBullishEngulfingStrategy : Strategy
 /// <summary>
 /// Trend detection modes.
 /// </summary>
-public enum TrendMode
+public enum TrendModes
 {
 	/// <summary>
 	/// Price below SMA50.

--- a/API/0604_CCI_Support_Resistance/CS/CciSupportResistanceStrategy.cs
+++ b/API/0604_CCI_Support_Resistance/CS/CciSupportResistanceStrategy.cs
@@ -18,7 +18,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class CciSupportResistanceStrategy : Strategy
 {
-private enum TrendMode
+private enum TrendModes
 {
 Cross,
 Slope
@@ -30,7 +30,7 @@ private readonly StrategyParam<int> _leftPivot;
 private readonly StrategyParam<int> _rightPivot;
 private readonly StrategyParam<decimal> _buffer;
 private readonly StrategyParam<bool> _trendMatter;
-private readonly StrategyParam<TrendMode> _trendType;
+private readonly StrategyParam<TrendModes> _trendType;
 private readonly StrategyParam<int> _slowMaLength;
 private readonly StrategyParam<int> _fastMaLength;
 private readonly StrategyParam<int> _slopeLength;
@@ -105,7 +105,7 @@ set => _trendMatter.Value = value;
 /// <summary>
 /// Trend detection mode.
 /// </summary>
-public TrendMode TrendType
+public TrendModes TrendType
 {
 get => _trendType.Value;
 set => _trendType.Value = value;
@@ -189,7 +189,7 @@ _buffer = Param(nameof(Buffer), 10m)
 _trendMatter = Param(nameof(TrendMatter), true)
 .SetDisplay("Trend Filter", "Use trend filter", "Trend");
 
-_trendType = Param(nameof(TrendType), TrendMode.Cross)
+_trendType = Param(nameof(TrendType), TrendModes.Cross)
 .SetDisplay("Trend Type", "Cross or slope", "Trend");
 
 _slowMaLength = Param(nameof(SlowMaLength), 100)
@@ -311,7 +311,7 @@ if (_slowValues.Count > SlopeLength)
 _slowValues.Dequeue();
 
 var trend = _trendState;
-if (TrendType == TrendMode.Cross)
+if (TrendType == TrendModes.Cross)
 {
 trend = emaFastValue > emaSlowValue ? 1 : emaFastValue < emaSlowValue ? -1 : _trendState;
 }

--- a/API/0611_Chande_Kroll_Trend/CS/ChandeKrollTrendStrategy.cs
+++ b/API/0611_Chande_Kroll_Trend/CS/ChandeKrollTrendStrategy.cs
@@ -23,7 +23,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class ChandeKrollTrendStrategy : Strategy
 {
-	private readonly StrategyParam<CalcMode> _calcMode;
+	private readonly StrategyParam<CalcModes> _calcMode;
 	private readonly StrategyParam<decimal> _riskMultiplier;
 	private readonly StrategyParam<int> _atrPeriod;
 	private readonly StrategyParam<decimal> _atrMultiplier;
@@ -44,7 +44,7 @@ public class ChandeKrollTrendStrategy : Strategy
 	/// <summary>
 	/// Position size calculation mode.
 	/// </summary>
-	public CalcMode CalcMode { get => _calcMode.Value; set => _calcMode.Value = value; }
+	public CalcModes CalcMode { get => _calcMode.Value; set => _calcMode.Value = value; }
 
 	/// <summary>
 	/// Risk multiplier for position sizing.
@@ -81,7 +81,7 @@ public class ChandeKrollTrendStrategy : Strategy
 	/// </summary>
 	public ChandeKrollTrendStrategy()
 	{
-		_calcMode = Param(nameof(CalcMode), CalcMode.Exponential)
+		_calcMode = Param(nameof(CalcMode), CalcModes.Exponential)
 			.SetDisplay("Calc Mode", "Position size calculation mode", "General");
 
 		_riskMultiplier = Param(nameof(RiskMultiplier), 5m)
@@ -194,7 +194,7 @@ public class ChandeKrollTrendStrategy : Strategy
 		if (longCondition && Position <= 0)
 		{
 			var qty = RiskMultiplier / lowestClose * 1000m;
-			if (CalcMode == CalcMode.Exponential && _initialCapital > 0m)
+			if (CalcMode == CalcModes.Exponential && _initialCapital > 0m)
 			{
 				var equity = Portfolio.CurrentValue ?? 0m;
 				qty *= equity / _initialCapital;
@@ -215,7 +215,7 @@ public class ChandeKrollTrendStrategy : Strategy
 /// <summary>
 /// Position size calculation modes.
 /// </summary>
-public enum CalcMode
+public enum CalcModes
 {
 	/// <summary>
 	/// Use fixed multiplier.

--- a/API/0616_Chart_Oscillator/CS/ChartOscillatorStrategy.cs
+++ b/API/0616_Chart_Oscillator/CS/ChartOscillatorStrategy.cs
@@ -18,14 +18,14 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class ChartOscillatorStrategy : Strategy
 {
-	public enum OscillatorChoice
+	public enum OscillatorChoices
 	{
 		Stochastic,
 		Rsi,
 		Mfi
 	}
 
-	private readonly StrategyParam<OscillatorChoice> _choice;
+	private readonly StrategyParam<OscillatorChoices> _choice;
 	private readonly StrategyParam<int> _length;
 	private readonly StrategyParam<int> _kPeriod;
 	private readonly StrategyParam<int> _dPeriod;
@@ -46,7 +46,7 @@ public class ChartOscillatorStrategy : Strategy
 	/// <summary>
 	/// Selected oscillator type.
 	/// </summary>
-	public OscillatorChoice Choice { get => _choice.Value; set => _choice.Value = value; }
+	public OscillatorChoices Choice { get => _choice.Value; set => _choice.Value = value; }
 
 	/// <summary>
 	/// Period for RSI or MFI.
@@ -93,7 +93,7 @@ public class ChartOscillatorStrategy : Strategy
 	/// </summary>
 	public ChartOscillatorStrategy()
 	{
-		_choice = Param(nameof(Choice), OscillatorChoice.Stochastic)
+		_choice = Param(nameof(Choice), OscillatorChoices.Stochastic)
 			.SetDisplay("Oscillator", "Type of oscillator to use", "General");
 
 		_length = Param(nameof(Length), 14)
@@ -146,7 +146,7 @@ public class ChartOscillatorStrategy : Strategy
 	{
 		base.OnStarted(time);
 
-		if (Choice == OscillatorChoice.Stochastic)
+		if (Choice == OscillatorChoices.Stochastic)
 		{
 			_stochastic = new StochasticOscillator
 			{
@@ -155,7 +155,7 @@ public class ChartOscillatorStrategy : Strategy
 				D = { Length = DPeriod }
 			};
 		}
-		else if (Choice == OscillatorChoice.Rsi)
+		else if (Choice == OscillatorChoices.Rsi)
 		{
 			_rsi = new RelativeStrengthIndex { Length = Length };
 		}
@@ -166,9 +166,9 @@ public class ChartOscillatorStrategy : Strategy
 
 		var subscription = SubscribeCandles(CandleType);
 
-		if (Choice == OscillatorChoice.Stochastic)
+		if (Choice == OscillatorChoices.Stochastic)
 			subscription.BindEx(_stochastic, ProcessStochastic).Start();
-		else if (Choice == OscillatorChoice.Rsi)
+		else if (Choice == OscillatorChoices.Rsi)
 			subscription.Bind(_rsi, ProcessRsi).Start();
 		else
 			subscription.Bind(_mfi, ProcessMfi).Start();
@@ -182,9 +182,9 @@ public class ChartOscillatorStrategy : Strategy
 		if (area != null)
 		{
 			DrawCandles(area, subscription);
-			if (Choice == OscillatorChoice.Stochastic)
+			if (Choice == OscillatorChoices.Stochastic)
 				DrawIndicator(area, _stochastic);
-			else if (Choice == OscillatorChoice.Rsi)
+			else if (Choice == OscillatorChoices.Rsi)
 				DrawIndicator(area, _rsi);
 			else
 				DrawIndicator(area, _mfi);

--- a/API/0622_Cnagda_Fixed_Swing/CS/CnagdaFixedSwingStrategy.cs
+++ b/API/0622_Cnagda_Fixed_Swing/CS/CnagdaFixedSwingStrategy.cs
@@ -18,7 +18,7 @@ namespace StockSharp.Samples.Strategies;
 public class CnagdaFixedSwingStrategy : Strategy
 {
 private readonly StrategyParam<DataType> _candleType;
-private readonly StrategyParam<TradeLogic> _tradeLogic;
+private readonly StrategyParam<TradeLogics> _tradeLogic;
 private readonly StrategyParam<int> _swingLookback;
 private readonly StrategyParam<int> _riskReward;
 
@@ -44,14 +44,14 @@ private bool _prevHighVol;
 
 private decimal? _refHigh;
 private decimal? _refLow;
-private ScalpState _scalpState;
-private ScalpState _prevScalpState;
+private ScalpStates _scalpState;
+private ScalpStates _prevScalpState;
 
 private decimal? _rsiSignalHigh;
 private decimal? _rsiSignalLow;
 private int? _rsiSignalBar;
-private RsiEntryState _rsiEntryState;
-private RsiEntryState _prevRsiEntryState;
+private RsiEntryStates _rsiEntryState;
+private RsiEntryStates _prevRsiEntryState;
 
 private decimal? _slLong;
 private decimal? _tgLong;
@@ -63,7 +63,7 @@ public CnagdaFixedSwingStrategy()
 _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(1).TimeFrame())
 .SetDisplay("Candle Type", "Type of candles for calculations", "General");
 
-_tradeLogic = Param(nameof(Logic), TradeLogic.Rsi)
+_tradeLogic = Param(nameof(Logic), TradeLogics.Rsi)
 .SetDisplay("Trade Logic", "RSI or Scalp entry logic", "General");
 
 _swingLookback = Param(nameof(SwingLookback), 34)
@@ -81,7 +81,7 @@ get => _candleType.Value;
 set => _candleType.Value = value;
 }
 
-public TradeLogic Logic
+public TradeLogics Logic
 {
 get => _tradeLogic.Value;
 set => _tradeLogic.Value = value;
@@ -124,13 +124,13 @@ _prevRsiEma10 = 0;
 _prevHighVol = false;
 _refHigh = null;
 _refLow = null;
-_scalpState = ScalpState.Neutral;
-_prevScalpState = ScalpState.Neutral;
+_scalpState = ScalpStates.Neutral;
+_prevScalpState = ScalpStates.Neutral;
 _rsiSignalHigh = null;
 _rsiSignalLow = null;
 _rsiSignalBar = null;
-_rsiEntryState = RsiEntryState.None;
-_prevRsiEntryState = RsiEntryState.None;
+_rsiEntryState = RsiEntryStates.None;
+_prevRsiEntryState = RsiEntryStates.None;
 _slLong = null;
 _tgLong = null;
 _slShort = null;
@@ -190,24 +190,24 @@ if (buySignal || sellSignal)
 {
 _refHigh = haHigh;
 _refLow = haLow;
-_scalpState = ScalpState.WaitEntry;
+_scalpState = ScalpStates.WaitEntry;
 }
 
-if ((_scalpState == ScalpState.WaitEntry || _scalpState == ScalpState.Sell) && _refHigh != null && haClose > _refHigh)
-_scalpState = ScalpState.Buy;
+if ((_scalpState == ScalpStates.WaitEntry || _scalpState == ScalpStates.Sell) && _refHigh != null && haClose > _refHigh)
+_scalpState = ScalpStates.Buy;
 
-if ((_scalpState == ScalpState.WaitEntry || _scalpState == ScalpState.Buy) && _refLow != null && haClose < _refLow)
-_scalpState = ScalpState.Sell;
+if ((_scalpState == ScalpStates.WaitEntry || _scalpState == ScalpStates.Buy) && _refLow != null && haClose < _refLow)
+_scalpState = ScalpStates.Sell;
 
-if (_scalpState == ScalpState.Buy && haClose < maAvg)
+if (_scalpState == ScalpStates.Buy && haClose < maAvg)
 {
-_scalpState = ScalpState.Neutral;
+_scalpState = ScalpStates.Neutral;
 _refHigh = null;
 _refLow = null;
 }
-if (_scalpState == ScalpState.Sell && haClose > maAvg)
+if (_scalpState == ScalpStates.Sell && haClose > maAvg)
 {
-_scalpState = ScalpState.Neutral;
+_scalpState = ScalpStates.Neutral;
 _refHigh = null;
 _refLow = null;
 }
@@ -224,14 +224,14 @@ if (rsiCrossBull)
 _rsiSignalHigh = candle.HighPrice;
 _rsiSignalLow = null;
 _rsiSignalBar = _barIndex;
-_rsiEntryState = RsiEntryState.WaitEntry;
+_rsiEntryState = RsiEntryStates.WaitEntry;
 }
 else if (rsiCrossBear)
 {
 _rsiSignalLow = candle.LowPrice;
 _rsiSignalHigh = null;
 _rsiSignalBar = _barIndex;
-_rsiEntryState = RsiEntryState.WaitEntry;
+_rsiEntryState = RsiEntryStates.WaitEntry;
 }
 else if (_rsiSignalBar != null)
 {
@@ -239,49 +239,49 @@ if (_rsiSignalHigh != null)
 {
 if (candle.ClosePrice > _rsiSignalHigh && _barIndex > _rsiSignalBar)
 {
-_rsiEntryState = RsiEntryState.Buy;
+_rsiEntryState = RsiEntryStates.Buy;
 _rsiSignalHigh = null;
 _rsiSignalBar = null;
 }
 else
-_rsiEntryState = RsiEntryState.WaitEntry;
+_rsiEntryState = RsiEntryStates.WaitEntry;
 }
 else if (_rsiSignalLow != null)
 {
 if (candle.ClosePrice < _rsiSignalLow && _barIndex > _rsiSignalBar)
 {
-_rsiEntryState = RsiEntryState.Sell;
+_rsiEntryState = RsiEntryStates.Sell;
 _rsiSignalLow = null;
 _rsiSignalBar = null;
 }
 else
-_rsiEntryState = RsiEntryState.WaitEntry;
+_rsiEntryState = RsiEntryStates.WaitEntry;
 }
 else
 {
-_rsiEntryState = RsiEntryState.None;
+_rsiEntryState = RsiEntryStates.None;
 }
 }
 else
 {
-_rsiEntryState = RsiEntryState.None;
+_rsiEntryState = RsiEntryStates.None;
 }
 
-var longCondition = Logic == TradeLogic.Rsi
-? _rsiEntryState == RsiEntryState.Buy && _prevRsiEntryState != RsiEntryState.Buy
-: _scalpState == ScalpState.Buy && _prevScalpState != ScalpState.Buy;
+var longCondition = Logic == TradeLogics.Rsi
+? _rsiEntryState == RsiEntryStates.Buy && _prevRsiEntryState != RsiEntryStates.Buy
+: _scalpState == ScalpStates.Buy && _prevScalpState != ScalpStates.Buy;
 
-var shortCondition = Logic == TradeLogic.Rsi
-? _rsiEntryState == RsiEntryState.Sell && _prevRsiEntryState != RsiEntryState.Sell
-: _scalpState == ScalpState.Sell && _prevScalpState != ScalpState.Sell;
+var shortCondition = Logic == TradeLogics.Rsi
+? _rsiEntryState == RsiEntryStates.Sell && _prevRsiEntryState != RsiEntryStates.Sell
+: _scalpState == ScalpStates.Sell && _prevScalpState != ScalpStates.Sell;
 
-var exitLongCondition = Logic == TradeLogic.Rsi
-? _rsiEntryState == RsiEntryState.Sell && _prevRsiEntryState != RsiEntryState.Sell
-: _scalpState == ScalpState.Sell && _prevScalpState != ScalpState.Sell;
+var exitLongCondition = Logic == TradeLogics.Rsi
+? _rsiEntryState == RsiEntryStates.Sell && _prevRsiEntryState != RsiEntryStates.Sell
+: _scalpState == ScalpStates.Sell && _prevScalpState != ScalpStates.Sell;
 
-var exitShortCondition = Logic == TradeLogic.Rsi
-? _rsiEntryState == RsiEntryState.Buy && _prevRsiEntryState != RsiEntryState.Buy
-: _scalpState == ScalpState.Buy && _prevScalpState != ScalpState.Buy;
+var exitShortCondition = Logic == TradeLogics.Rsi
+? _rsiEntryState == RsiEntryStates.Buy && _prevRsiEntryState != RsiEntryStates.Buy
+: _scalpState == ScalpStates.Buy && _prevScalpState != ScalpStates.Buy;
 
 if (longCondition && swingLow != null)
 {
@@ -355,7 +355,7 @@ _prevScalpState = _scalpState;
 _prevRsiEntryState = _rsiEntryState;
 }
 
-private enum ScalpState
+private enum ScalpStates
 {
 Neutral,
 WaitEntry,
@@ -363,7 +363,7 @@ Buy,
 Sell
 }
 
-private enum RsiEntryState
+private enum RsiEntryStates
 {
 None,
 WaitEntry,
@@ -371,7 +371,7 @@ Buy,
 Sell
 }
 
-public enum TradeLogic
+public enum TradeLogics
 {
 Rsi,
 Scalp

--- a/API/0623_Color_Code_Overlay/CS/ColorCodeOverlayStrategy.cs
+++ b/API/0623_Color_Code_Overlay/CS/ColorCodeOverlayStrategy.cs
@@ -22,14 +22,14 @@ public class ColorCodeOverlayStrategy : Strategy
 	/// <summary>
 	/// Trade direction options.
 	/// </summary>
-	public enum TradeType
+	public enum TradeTypes
 	{
 		Both,
 		LongOnly,
 		ShortOnly
 	}
 
-	private readonly StrategyParam<TradeType> _tradeType;
+	private readonly StrategyParam<TradeTypes> _tradeType;
 	private readonly StrategyParam<int> _stopLossPips;
 	private readonly StrategyParam<int> _takeProfitPips;
 	private readonly StrategyParam<TimeSpan> _startTime;
@@ -45,7 +45,7 @@ public class ColorCodeOverlayStrategy : Strategy
 	/// <summary>
 	/// Trade type.
 	/// </summary>
-	public TradeType Mode { get => _tradeType.Value; set => _tradeType.Value = value; }
+	public TradeTypes Mode { get => _tradeType.Value; set => _tradeType.Value = value; }
 
 	/// <summary>
 	/// Stop loss in pips.
@@ -82,7 +82,7 @@ public class ColorCodeOverlayStrategy : Strategy
 	/// </summary>
 	public ColorCodeOverlayStrategy()
 	{
-		_tradeType = Param(nameof(Mode), TradeType.Both)
+		_tradeType = Param(nameof(Mode), TradeTypes.Both)
 			.SetDisplay("Trade Type", "Trading mode", "General");
 
 		_stopLossPips = Param(nameof(StopLossPips), 20)
@@ -168,16 +168,16 @@ public class ColorCodeOverlayStrategy : Strategy
 		{
 			if (changeRedToGreen)
 			{
-				if ((Mode == TradeType.Both || Mode == TradeType.ShortOnly) && Position < 0)
+				if ((Mode == TradeTypes.Both || Mode == TradeTypes.ShortOnly) && Position < 0)
 					BuyMarket(-Position);
-				if ((Mode == TradeType.Both || Mode == TradeType.LongOnly) && Position <= 0)
+				if ((Mode == TradeTypes.Both || Mode == TradeTypes.LongOnly) && Position <= 0)
 					BuyMarket();
 			}
 			else if (changeGreenToRed)
 			{
-				if ((Mode == TradeType.Both || Mode == TradeType.LongOnly) && Position > 0)
+				if ((Mode == TradeTypes.Both || Mode == TradeTypes.LongOnly) && Position > 0)
 					SellMarket(Position);
-				if ((Mode == TradeType.Both || Mode == TradeType.ShortOnly) && Position >= 0)
+				if ((Mode == TradeTypes.Both || Mode == TradeTypes.ShortOnly) && Position >= 0)
 					SellMarket();
 			}
 		}

--- a/API/0661_Daytrading_ES_Wick_Length/CS/DaytradingESWickLengthStrategy.cs
+++ b/API/0661_Daytrading_ES_Wick_Length/CS/DaytradingESWickLengthStrategy.cs
@@ -21,7 +21,7 @@ namespace StockSharp.Samples.Strategies;
 public class DaytradingESWickLengthStrategy : Strategy
 {
 	private readonly StrategyParam<int> _maLength;
-	private readonly StrategyParam<MovingAverageTypeEnum> _maType;
+	private readonly StrategyParam<MovingAverageTypes> _maType;
 	private readonly StrategyParam<decimal> _maOffset;
 	private readonly StrategyParam<int> _holdPeriods;
 	private readonly StrategyParam<DataType> _candleType;
@@ -41,7 +41,7 @@ public class DaytradingESWickLengthStrategy : Strategy
 	/// <summary>
 	/// Type of moving average.
 	/// </summary>
-	public MovingAverageTypeEnum MaType
+	public MovingAverageTypes MaType
 	{
 		get => _maType.Value;
 		set => _maType.Value = value;
@@ -85,7 +85,7 @@ public class DaytradingESWickLengthStrategy : Strategy
 			.SetCanOptimize(true)
 			.SetOptimize(10, 40, 5);
 
-		_maType = Param(nameof(MaType), MovingAverageTypeEnum.VolumeWeighted)
+		_maType = Param(nameof(MaType), MovingAverageTypes.VolumeWeighted)
 			.SetDisplay("MA Type", "Type of moving average", "General");
 
 		_maOffset = Param(nameof(MaOffset), 10m)
@@ -173,14 +173,14 @@ public class DaytradingESWickLengthStrategy : Strategy
 		}
 	}
 
-	private static IIndicator CreateMa(MovingAverageTypeEnum type, int length)
+	private static IIndicator CreateMa(MovingAverageTypes type, int length)
 	{
 		return type switch
 		{
-			MovingAverageTypeEnum.Simple => new SimpleMovingAverage { Length = length },
-			MovingAverageTypeEnum.Exponential => new ExponentialMovingAverage { Length = length },
-			MovingAverageTypeEnum.Weighted => new WeightedMovingAverage { Length = length },
-			MovingAverageTypeEnum.VolumeWeighted => new VolumeWeightedMovingAverage { Length = length },
+			MovingAverageTypes.Simple => new SimpleMovingAverage { Length = length },
+			MovingAverageTypes.Exponential => new ExponentialMovingAverage { Length = length },
+			MovingAverageTypes.Weighted => new WeightedMovingAverage { Length = length },
+			MovingAverageTypes.VolumeWeighted => new VolumeWeightedMovingAverage { Length = length },
 			_ => new SimpleMovingAverage { Length = length },
 		};
 	}
@@ -188,7 +188,7 @@ public class DaytradingESWickLengthStrategy : Strategy
 	/// <summary>
 	/// Available moving average types.
 	/// </summary>
-	public enum MovingAverageTypeEnum
+	public enum MovingAverageTypes
 	{
 		/// <summary>Simple moving average.</summary>
 		Simple,

--- a/API/0672_Delta_RSI_Oscillator/CS/DeltaRsiOscillatorStrategy.cs
+++ b/API/0672_Delta_RSI_Oscillator/CS/DeltaRsiOscillatorStrategy.cs
@@ -13,7 +13,7 @@ namespace StockSharp.Samples.Strategies;
 
 
 
-public enum SignalCondition
+public enum SignalConditions
 {
 	ZeroCrossing,
 	SignalLineCrossing,
@@ -28,9 +28,9 @@ public class DeltaRsiOscillatorStrategy : Strategy
 	private readonly StrategyParam<DataType> _candleTypeParam;
 	private readonly StrategyParam<int> _rsiLength;
 	private readonly StrategyParam<int> _signalLength;
-	private readonly StrategyParam<SignalCondition> _buyCondition;
-	private readonly StrategyParam<SignalCondition> _sellCondition;
-	private readonly StrategyParam<SignalCondition> _exitCondition;
+	private readonly StrategyParam<SignalConditions> _buyCondition;
+	private readonly StrategyParam<SignalConditions> _sellCondition;
+	private readonly StrategyParam<SignalConditions> _exitCondition;
 	private readonly StrategyParam<bool> _useLong;
 	private readonly StrategyParam<bool> _useShort;
 
@@ -60,19 +60,19 @@ public class DeltaRsiOscillatorStrategy : Strategy
 		set => _signalLength.Value = value;
 	}
 
-	public SignalCondition BuyCondition
+	public SignalConditions BuyCondition
 	{
 		get => _buyCondition.Value;
 		set => _buyCondition.Value = value;
 	}
 
-	public SignalCondition SellCondition
+	public SignalConditions SellCondition
 	{
 		get => _sellCondition.Value;
 		set => _sellCondition.Value = value;
 	}
 
-	public SignalCondition ExitCondition
+	public SignalConditions ExitCondition
 	{
 		get => _exitCondition.Value;
 		set => _exitCondition.Value = value;
@@ -95,9 +95,9 @@ public class DeltaRsiOscillatorStrategy : Strategy
 		_candleTypeParam = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame()).SetDisplay("Candle Type", "Type of candles", "General");
 		_rsiLength = Param(nameof(RsiLength), 21).SetRange(1, 100).SetDisplay("RSI Length", "RSI period", "Model Parameters").SetCanOptimize(true);
 		_signalLength = Param(nameof(SignalLength), 9).SetRange(1, 100).SetDisplay("Signal Length", "EMA period", "Model Parameters").SetCanOptimize(true);
-		_buyCondition = Param(nameof(BuyCondition), SignalCondition.ZeroCrossing).SetDisplay("Buy Condition", "Entry condition for longs", "Conditions");
-		_sellCondition = Param(nameof(SellCondition), SignalCondition.ZeroCrossing).SetDisplay("Sell Condition", "Entry condition for shorts", "Conditions");
-		_exitCondition = Param(nameof(ExitCondition), SignalCondition.ZeroCrossing).SetDisplay("Exit Condition", "Exit condition", "Conditions");
+		_buyCondition = Param(nameof(BuyCondition), SignalConditions.ZeroCrossing).SetDisplay("Buy Condition", "Entry condition for longs", "Conditions");
+		_sellCondition = Param(nameof(SellCondition), SignalConditions.ZeroCrossing).SetDisplay("Sell Condition", "Entry condition for shorts", "Conditions");
+		_exitCondition = Param(nameof(ExitCondition), SignalConditions.ZeroCrossing).SetDisplay("Exit Condition", "Exit condition", "Conditions");
 		_useLong = Param(nameof(UseLong), true).SetDisplay("Enable Long", "Allow long trades", "General");
 		_useShort = Param(nameof(UseShort), true).SetDisplay("Enable Short", "Allow short trades", "General");
 	}
@@ -182,29 +182,29 @@ public class DeltaRsiOscillatorStrategy : Strategy
 
 		var goLong = BuyCondition switch
 		{
-			SignalCondition.DirectionChange => dirChangeUp,
-			SignalCondition.SignalLineCrossing => crossSignalUp,
+			SignalConditions.DirectionChange => dirChangeUp,
+			SignalConditions.SignalLineCrossing => crossSignalUp,
 			_ => crossUp,
 		};
 
 		var goShort = SellCondition switch
 		{
-			SignalCondition.DirectionChange => dirChangeDown,
-			SignalCondition.SignalLineCrossing => crossSignalDown,
+			SignalConditions.DirectionChange => dirChangeDown,
+			SignalConditions.SignalLineCrossing => crossSignalDown,
 			_ => crossDown,
 		};
 
 		var exitLong = ExitCondition switch
 		{
-			SignalCondition.DirectionChange => dirChangeDown,
-			SignalCondition.SignalLineCrossing => crossSignalDown,
+			SignalConditions.DirectionChange => dirChangeDown,
+			SignalConditions.SignalLineCrossing => crossSignalDown,
 			_ => crossDown,
 		};
 
 		var exitShort = ExitCondition switch
 		{
-			SignalCondition.DirectionChange => dirChangeUp,
-			SignalCondition.SignalLineCrossing => crossSignalUp,
+			SignalConditions.DirectionChange => dirChangeUp,
+			SignalConditions.SignalLineCrossing => crossSignalUp,
 			_ => crossUp,
 		};
 

--- a/API/0695_Double_Macd/CS/DoubleMacdStrategy.cs
+++ b/API/0695_Double_Macd/CS/DoubleMacdStrategy.cs
@@ -21,12 +21,12 @@ public class DoubleMacdStrategy : Strategy
 	private readonly StrategyParam<int> _fastLength1;
 	private readonly StrategyParam<int> _slowLength1;
 	private readonly StrategyParam<int> _signalLength1;
-	private readonly StrategyParam<MaType> _maType1;
+	private readonly StrategyParam<MaTypes> _maType1;
 	
 	private readonly StrategyParam<int> _fastLength2;
 	private readonly StrategyParam<int> _slowLength2;
 	private readonly StrategyParam<int> _signalLength2;
-	private readonly StrategyParam<MaType> _maType2;
+	private readonly StrategyParam<MaTypes> _maType2;
 	
 	private readonly StrategyParam<decimal> _stopLossPercent;
 	private readonly StrategyParam<DataType> _candleType;
@@ -64,7 +64,7 @@ public class DoubleMacdStrategy : Strategy
 	/// <summary>
 	/// Moving average type for first MACD.
 	/// </summary>
-	public MaType MaType1
+	public MaTypes MaType1
 	{
 		get => _maType1.Value;
 		set => _maType1.Value = value;
@@ -100,7 +100,7 @@ public class DoubleMacdStrategy : Strategy
 	/// <summary>
 	/// Moving average type for second MACD.
 	/// </summary>
-	public MaType MaType2
+	public MaTypes MaType2
 	{
 		get => _maType2.Value;
 		set => _maType2.Value = value;
@@ -144,7 +144,7 @@ public class DoubleMacdStrategy : Strategy
 		.SetDisplay("Signal Length 1", "Signal length for first MACD", "MACD 1")
 		.SetCanOptimize(true);
 		
-		_maType1 = Param(nameof(MaType1), MaType.Ema)
+		_maType1 = Param(nameof(MaType1), MaTypes.Ema)
 		.SetDisplay("MA Type 1", "MA type for first MACD", "MACD 1");
 		
 		_fastLength2 = Param(nameof(FastLength2), 24)
@@ -162,7 +162,7 @@ public class DoubleMacdStrategy : Strategy
 		.SetDisplay("Signal Length 2", "Signal length for second MACD", "MACD 2")
 		.SetCanOptimize(true);
 		
-		_maType2 = Param(nameof(MaType2), MaType.Ema)
+		_maType2 = Param(nameof(MaType2), MaTypes.Ema)
 		.SetDisplay("MA Type 2", "MA type for second MACD", "MACD 2");
 		
 		_stopLossPercent = Param(nameof(StopLossPercent), 2m)
@@ -239,7 +239,7 @@ public class DoubleMacdStrategy : Strategy
 		}
 	}
 	
-	private static MovingAverageConvergenceDivergenceSignal CreateMacd(int fast, int slow, int signal, MaType type)
+	private static MovingAverageConvergenceDivergenceSignal CreateMacd(int fast, int slow, int signal, MaTypes type)
 	{
 		return new()
 		{
@@ -252,11 +252,11 @@ public class DoubleMacdStrategy : Strategy
 		};
 	}
 	
-	private static LengthIndicator<decimal> CreateMa(MaType type, int length)
+	private static LengthIndicator<decimal> CreateMa(MaTypes type, int length)
 	{
 		return type switch
 		{
-			MaType.Sma => new SimpleMovingAverage { Length = length },
+			MaTypes.Sma => new SimpleMovingAverage { Length = length },
 			_ => new ExponentialMovingAverage { Length = length },
 		};
 	}
@@ -264,7 +264,7 @@ public class DoubleMacdStrategy : Strategy
 	/// <summary>
 	/// Supported moving average types.
 	/// </summary>
-	public enum MaType
+	public enum MaTypes
 	{
 		/// <summary>
 		/// Exponential moving average.

--- a/API/0702_Dskyz_DAFE_MAtrix_ATR_Precision/CS/DskyzDafeMatrixAtrPrecisionStrategy.cs
+++ b/API/0702_Dskyz_DAFE_MAtrix_ATR_Precision/CS/DskyzDafeMatrixAtrPrecisionStrategy.cs
@@ -18,8 +18,8 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class DskyzDafeMatrixAtrPrecisionStrategy : Strategy
 {
-	private readonly StrategyParam<MovingAverageType> _fastMaType;
-	private readonly StrategyParam<MovingAverageType> _slowMaType;
+	private readonly StrategyParam<MovingAverageTypes> _fastMaType;
+	private readonly StrategyParam<MovingAverageTypes> _slowMaType;
 	private readonly StrategyParam<int> _fastLength;
 	private readonly StrategyParam<int> _slowLength;
 	private readonly StrategyParam<int> _atrPeriod;
@@ -49,7 +49,7 @@ public class DskyzDafeMatrixAtrPrecisionStrategy : Strategy
 	/// <summary>
 	/// Moving average type selection.
 	/// </summary>
-	public enum MovingAverageType
+	public enum MovingAverageTypes
 	{
 		SMA,
 		EMA,
@@ -69,10 +69,10 @@ public class DskyzDafeMatrixAtrPrecisionStrategy : Strategy
 	/// </summary>
 	public DskyzDafeMatrixAtrPrecisionStrategy()
 	{
-		_fastMaType = Param(nameof(FastMaType), MovingAverageType.SMA)
+		_fastMaType = Param(nameof(FastMaType), MovingAverageTypes.SMA)
 						  .SetDisplay("Fast MA Type", "Type of fast moving average", "Moving Averages");
 
-		_slowMaType = Param(nameof(SlowMaType), MovingAverageType.SMA)
+		_slowMaType = Param(nameof(SlowMaType), MovingAverageTypes.SMA)
 						  .SetDisplay("Slow MA Type", "Type of slow moving average", "Moving Averages");
 
 		_fastLength = Param(nameof(FastLength), 9)
@@ -130,7 +130,7 @@ public class DskyzDafeMatrixAtrPrecisionStrategy : Strategy
 	/// <summary>
 	/// Fast MA type.
 	/// </summary>
-	public MovingAverageType FastMaType
+	public MovingAverageTypes FastMaType
 	{
 		get => _fastMaType.Value;
 		set => _fastMaType.Value = value;
@@ -139,7 +139,7 @@ public class DskyzDafeMatrixAtrPrecisionStrategy : Strategy
 	/// <summary>
 	/// Slow MA type.
 	/// </summary>
-	public MovingAverageType SlowMaType
+	public MovingAverageTypes SlowMaType
 	{
 		get => _slowMaType.Value;
 		set => _slowMaType.Value = value;
@@ -315,19 +315,19 @@ public class DskyzDafeMatrixAtrPrecisionStrategy : Strategy
 		}
 	}
 
-	private static IIndicator CreateMovingAverage(MovingAverageType type, int length)
+	private static IIndicator CreateMovingAverage(MovingAverageTypes type, int length)
 	{
-		return type switch { MovingAverageType.SMA => new SimpleMovingAverage { Length = length },
-							 MovingAverageType.EMA => new ExponentialMovingAverage { Length = length },
-							 MovingAverageType.SMMA => new SmoothedMovingAverage { Length = length },
-							 MovingAverageType.HMA => new HullMovingAverage { Length = length },
-							 MovingAverageType.TEMA => new TripleExponentialMovingAverage { Length = length },
-							 MovingAverageType.WMA => new WeightedMovingAverage { Length = length },
-							 MovingAverageType.VWMA => new VolumeWeightedMovingAverage { Length = length },
-							 MovingAverageType.ZLEMA => new ZeroLagExponentialMovingAverage { Length = length },
-							 MovingAverageType.ALMA => new ArnaudLegouxMovingAverage { Length = length },
-							 MovingAverageType.KAMA => new KaufmanAdaptiveMovingAverage { Length = length },
-							 MovingAverageType.DEMA => new DoubleExponentialMovingAverage { Length = length },
+		return type switch { MovingAverageTypes.SMA => new SimpleMovingAverage { Length = length },
+							 MovingAverageTypes.EMA => new ExponentialMovingAverage { Length = length },
+							 MovingAverageTypes.SMMA => new SmoothedMovingAverage { Length = length },
+							 MovingAverageTypes.HMA => new HullMovingAverage { Length = length },
+							 MovingAverageTypes.TEMA => new TripleExponentialMovingAverage { Length = length },
+							 MovingAverageTypes.WMA => new WeightedMovingAverage { Length = length },
+							 MovingAverageTypes.VWMA => new VolumeWeightedMovingAverage { Length = length },
+							 MovingAverageTypes.ZLEMA => new ZeroLagExponentialMovingAverage { Length = length },
+							 MovingAverageTypes.ALMA => new ArnaudLegouxMovingAverage { Length = length },
+							 MovingAverageTypes.KAMA => new KaufmanAdaptiveMovingAverage { Length = length },
+							 MovingAverageTypes.DEMA => new DoubleExponentialMovingAverage { Length = length },
 							 _ => new SimpleMovingAverage { Length = length } };
 	}
 

--- a/API/0709_Dual_Rsi_Differential/CS/DualRsiDifferentialStrategy.cs
+++ b/API/0709_Dual_Rsi_Differential/CS/DualRsiDifferentialStrategy.cs
@@ -27,7 +27,7 @@ public class DualRsiDifferentialStrategy : Strategy
 	private readonly StrategyParam<decimal> _rsiDiffLevel;
 	private readonly StrategyParam<bool> _useHoldDays;
 	private readonly StrategyParam<int> _holdDays;
-	private readonly StrategyParam<TpslCondition> _condition;
+	private readonly StrategyParam<TpslConditions> _condition;
 	private readonly StrategyParam<decimal> _takeProfitPerc;
 	private readonly StrategyParam<decimal> _stopLossPerc;
 private readonly StrategyParam<Sides?> _direction;
@@ -41,7 +41,7 @@ private readonly StrategyParam<Sides?> _direction;
 /// <summary>
 /// Take profit and stop loss mode.
 /// </summary>
-public enum TpslCondition
+public enum TpslConditions
 	{
 		None,
 		TP,
@@ -82,7 +82,7 @@ public enum TpslCondition
 	/// <summary>
 	/// Take profit / stop loss mode.
 	/// </summary>
-	public TpslCondition Condition { get => _condition.Value; set => _condition.Value = value; }
+	public TpslConditions Condition { get => _condition.Value; set => _condition.Value = value; }
 
 	/// <summary>
 	/// Take profit percentage.
@@ -126,7 +126,7 @@ public Sides? Direction { get => _direction.Value; set => _direction.Value = val
 		.SetGreaterThanZero()
 		.SetDisplay("Hold Days", "Number of days to hold", "Risk");
 
-		_condition = Param(nameof(Condition), TpslCondition.None)
+		_condition = Param(nameof(Condition), TpslConditions.None)
 		.SetDisplay("TPSL Condition", "Take profit/stop loss mode", "Risk");
 
 		_takeProfitPerc = Param(nameof(TakeProfitPerc), 15m)
@@ -218,7 +218,7 @@ var allowShort = Direction is null or Sides.Sell;
 		return;
 		}
 
-		if (Condition is TpslCondition.TP or TpslCondition.Both)
+		if (Condition is TpslConditions.TP or TpslConditions.Both)
 		{
 		var takePrice = _entryPrice * (1 + TakeProfitPerc / 100m);
 		if (candle.ClosePrice >= takePrice)
@@ -230,7 +230,7 @@ var allowShort = Direction is null or Sides.Sell;
 		}
 		}
 
-		if (Condition is TpslCondition.SL or TpslCondition.Both)
+		if (Condition is TpslConditions.SL or TpslConditions.Both)
 		{
 		var stopPrice = _entryPrice * (1 - StopLossPerc / 100m);
 		if (candle.ClosePrice <= stopPrice)
@@ -261,7 +261,7 @@ var allowShort = Direction is null or Sides.Sell;
 		return;
 		}
 
-		if (Condition is TpslCondition.TP or TpslCondition.Both)
+		if (Condition is TpslConditions.TP or TpslConditions.Both)
 		{
 		var takePrice = _entryPrice * (1 - TakeProfitPerc / 100m);
 		if (candle.ClosePrice <= takePrice)
@@ -273,7 +273,7 @@ var allowShort = Direction is null or Sides.Sell;
 		}
 		}
 
-		if (Condition is TpslCondition.SL or TpslCondition.Both)
+		if (Condition is TpslConditions.SL or TpslConditions.Both)
 		{
 		var stopPrice = _entryPrice * (1 + StopLossPerc / 100m);
 		if (candle.ClosePrice >= stopPrice)

--- a/API/0712_Dual_Phase_Trend_Regime/CS/DualPhaseTrendRegimeStrategy.cs
+++ b/API/0712_Dual_Phase_Trend_Regime/CS/DualPhaseTrendRegimeStrategy.cs
@@ -20,7 +20,7 @@ public class DualPhaseTrendRegimeStrategy : Strategy
 {
 private readonly StrategyParam<DataType> _candleType;
 private readonly StrategyParam<Sides?> _direction;
-private readonly StrategyParam<SignalSource> _signalSource;
+private readonly StrategyParam<SignalSources> _signalSource;
 private readonly StrategyParam<int> _lengthSlow;
 private readonly StrategyParam<int> _lengthFast;
 private readonly StrategyParam<int> _refitBars;
@@ -46,7 +46,7 @@ private LinearRegression _oscFast = null!;
 /// <summary>
 /// Signal source options.
 /// </summary>
-public enum SignalSource
+public enum SignalSources
 {
 RegimeShift,
 OscillatorCross
@@ -65,7 +65,7 @@ public Sides? Direction { get => _direction.Value; set => _direction.Value = val
 /// <summary>
 /// Source of entry signals.
 /// </summary>
-public SignalSource Source { get => _signalSource.Value; set => _signalSource.Value = value; }
+public SignalSources Source { get => _signalSource.Value; set => _signalSource.Value = value; }
 
 /// <summary>
 /// Slow oscillator period.
@@ -103,7 +103,7 @@ _candleType = Param(nameof(CandleType), TimeSpan.FromHours(1).TimeFrame())
 _direction = Param(nameof(Direction), (Sides?)null)
 .SetDisplay("Trade Direction", "Allowed trade direction", "General");
 
-_signalSource = Param(nameof(Source), SignalSource.RegimeShift)
+_signalSource = Param(nameof(Source), SignalSources.RegimeShift)
 .SetDisplay("Signal Source", "Entry signal type", "General");
 
 _lengthSlow = Param(nameof(LengthSlow), 36)
@@ -224,7 +224,7 @@ var crossUp = _prevFastOsc <= _prevSlowOsc && fastSlope > slowSlope;
 var crossDown = _prevFastOsc >= _prevSlowOsc && fastSlope < slowSlope;
 
 bool longE, shortE, longX, shortX;
-if (Source == SignalSource.RegimeShift)
+if (Source == SignalSources.RegimeShift)
 {
 longE = bullShift;
 shortE = bearShift;

--- a/API/0713_Dual_Supertrend_MACD/CS/DualSupertrendMacdStrategy.cs
+++ b/API/0713_Dual_Supertrend_MACD/CS/DualSupertrendMacdStrategy.cs
@@ -25,8 +25,8 @@ public class DualSupertrendMacdStrategy : Strategy
 	private readonly StrategyParam<int> _macdFast;
 	private readonly StrategyParam<int> _macdSlow;
 	private readonly StrategyParam<int> _macdSignal;
-	private readonly StrategyParam<MovingAverageTypeEnum> _oscillatorMaType;
-	private readonly StrategyParam<MovingAverageTypeEnum> _signalMaType;
+	private readonly StrategyParam<MovingAverageTypes> _oscillatorMaType;
+	private readonly StrategyParam<MovingAverageTypes> _signalMaType;
 	private readonly StrategyParam<int> _atrPeriod1;
 	private readonly StrategyParam<decimal> _factor1;
 	private readonly StrategyParam<int> _atrPeriod2;
@@ -50,10 +50,10 @@ private readonly StrategyParam<Sides?> _direction;
 		_macdSignal =
 			Param(nameof(MacdSignal), 9).SetCanOptimize(true).SetDisplay("Signal Length", "MACD signal length", "MACD");
 
-		_oscillatorMaType = Param(nameof(OscillatorMaType), MovingAverageTypeEnum.Exponential)
+		_oscillatorMaType = Param(nameof(OscillatorMaType), MovingAverageTypes.Exponential)
 								.SetDisplay("Oscillator MA Type", "Type of MA for MACD fast/slow lines", "MACD");
 
-		_signalMaType = Param(nameof(SignalMaType), MovingAverageTypeEnum.Exponential)
+		_signalMaType = Param(nameof(SignalMaType), MovingAverageTypes.Exponential)
 							.SetDisplay("Signal MA Type", "Type of MA for MACD signal line", "MACD");
 
 		_atrPeriod1 = Param(nameof(AtrPeriod1), 10)
@@ -115,7 +115,7 @@ _direction = Param(nameof(Direction), (Sides?)null)
 	/// <summary>
 	/// Type of MA for MACD fast/slow lines.
 	/// </summary>
-	public MovingAverageTypeEnum OscillatorMaType
+	public MovingAverageTypes OscillatorMaType
 	{
 		get => _oscillatorMaType.Value;
 		set => _oscillatorMaType.Value = value;
@@ -124,7 +124,7 @@ _direction = Param(nameof(Direction), (Sides?)null)
 	/// <summary>
 	/// Type of MA for MACD signal line.
 	/// </summary>
-	public MovingAverageTypeEnum SignalMaType
+	public MovingAverageTypes SignalMaType
 	{
 		get => _signalMaType.Value;
 		set => _signalMaType.Value = value;
@@ -243,16 +243,16 @@ else if (Position < 0 && exitShort)
 BuyMarket(Math.Abs(Position));
 	}
 
-	private MovingAverage CreateMa(MovingAverageTypeEnum type, int length)
+	private MovingAverage CreateMa(MovingAverageTypes type, int length)
 	{
-		return type switch { MovingAverageTypeEnum.Simple => new SimpleMovingAverage { Length = length },
+		return type switch { MovingAverageTypes.Simple => new SimpleMovingAverage { Length = length },
 							 _ => new ExponentialMovingAverage { Length = length } };
 	}
 
 	/// <summary>
 	/// Moving average type enumeration.
 	/// </summary>
-	public enum MovingAverageTypeEnum
+	public enum MovingAverageTypes
 	{
 		/// <summary>
 		/// Simple Moving Average.

--- a/API/0721_Earnings_Trading/CS/EarningsTradingStrategy.cs
+++ b/API/0721_Earnings_Trading/CS/EarningsTradingStrategy.cs
@@ -19,7 +19,7 @@ namespace StockSharp.Samples.Strategies;
 public class EarningsTradingStrategy : Strategy
 {
 	private readonly StrategyParam<DataType> _candleType;
-	private readonly StrategyParam<TradeSide> _direction;
+	private readonly StrategyParam<TradeSides> _direction;
 	private readonly StrategyParam<DateTimeOffset> _entryDate1;
 	private readonly StrategyParam<DateTimeOffset> _exitDate1;
 	private readonly StrategyParam<DateTimeOffset> _entryDate2;
@@ -29,7 +29,7 @@ public class EarningsTradingStrategy : Strategy
 	/// <summary>
 	/// Trade direction.
 	/// </summary>
-	public enum TradeSide
+	public enum TradeSides
 	{
 		Long,
 		Short
@@ -43,7 +43,7 @@ public class EarningsTradingStrategy : Strategy
 	/// <summary>
 	/// Trade direction.
 	/// </summary>
-	public TradeSide Direction { get => _direction.Value; set => _direction.Value = value; }
+	public TradeSides Direction { get => _direction.Value; set => _direction.Value = value; }
 
 	/// <summary>
 	/// First entry date.
@@ -78,7 +78,7 @@ public class EarningsTradingStrategy : Strategy
 		_candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
 			.SetDisplay("Candle Type", "Type of candles", "General");
 
-		_direction = Param(nameof(Direction), TradeSide.Long)
+		_direction = Param(nameof(Direction), TradeSides.Long)
 			.SetDisplay("Direction", "Trade direction", "General");
 
 		_entryDate1 = Param(nameof(EntryDate1), new DateTimeOffset(2025, 3, 13, 0, 0, 0, TimeSpan.Zero))
@@ -124,7 +124,7 @@ public class EarningsTradingStrategy : Strategy
 		var isEntry = date == EntryDate1.Date || date == EntryDate2.Date;
 		var isExit = date == ExitDate1.Date || date == ExitDate2.Date;
 
-		if (Direction == TradeSide.Long)
+		if (Direction == TradeSides.Long)
 		{
 			if (isEntry && Position <= 0)
 			{

--- a/API/0741_EMA_Crossover_RSI_Distance/CS/EmaCrossoverRsiDistanceStrategy.cs
+++ b/API/0741_EMA_Crossover_RSI_Distance/CS/EmaCrossoverRsiDistanceStrategy.cs
@@ -39,8 +39,8 @@ public class EmaCrossoverRsiDistanceStrategy : Strategy
 	private SimpleMovingAverage _distanceAverage;
 	private decimal? _prevDistance4013;
 
-	private SignalType _lastSignal;
-	private enum SignalType
+	private SignalTypes _lastSignal;
+	private enum SignalTypes
 	{
 		None,
 		Long,
@@ -228,28 +228,28 @@ public class EmaCrossoverRsiDistanceStrategy : Strategy
 		if (candle.ClosePrice > ema5)
 		{
 		if (longCond && distanceCondition)
-		_lastSignal = SignalType.Long;
+		_lastSignal = SignalTypes.Long;
 		else if (shortCond && distanceCondition)
-		_lastSignal = SignalType.Short;
+		_lastSignal = SignalTypes.Short;
 		else if (neutralCond)
-		_lastSignal = SignalType.Neutral;
+		_lastSignal = SignalTypes.Neutral;
 		else if (greenCond)
-		_lastSignal = SignalType.Green;
+		_lastSignal = SignalTypes.Green;
 		else if (redCond)
-		_lastSignal = SignalType.Red;
+		_lastSignal = SignalTypes.Red;
 		}
 		else
 		{
 		if (longCond)
-		_lastSignal = SignalType.Long;
+		_lastSignal = SignalTypes.Long;
 		else if (shortCond)
-		_lastSignal = SignalType.Short;
+		_lastSignal = SignalTypes.Short;
 		else if (greenCond)
-		_lastSignal = SignalType.Green;
+		_lastSignal = SignalTypes.Green;
 		else if (redCond)
-		_lastSignal = SignalType.Red;
+		_lastSignal = SignalTypes.Red;
 		else
-		_lastSignal = SignalType.Neutral;
+		_lastSignal = SignalTypes.Neutral;
 		}
 
 		ExecuteSignal();
@@ -261,11 +261,11 @@ public class EmaCrossoverRsiDistanceStrategy : Strategy
 
 		switch (_lastSignal)
 		{
-		case SignalType.Long:
+		case SignalTypes.Long:
 		if (Position <= 0)
 		BuyMarket(volume);
 		break;
-		case SignalType.Short:
+		case SignalTypes.Short:
 		if (Position >= 0)
 		SellMarket(volume);
 		break;

--- a/API/0752_Engulfing_Candlestick/CS/EngulfingCandlestickStrategy.cs
+++ b/API/0752_Engulfing_Candlestick/CS/EngulfingCandlestickStrategy.cs
@@ -23,8 +23,8 @@ public class EngulfingCandlestickStrategy : Strategy
 {
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<int> _holdPeriods;
-	private readonly StrategyParam<PatternType> _pattern;
-	private readonly StrategyParam<TradeSide> _side;
+	private readonly StrategyParam<PatternTypes> _pattern;
+	private readonly StrategyParam<TradeSides> _side;
 
 	private ICandleMessage _previousCandle;
 	private int _barsInPosition;
@@ -32,7 +32,7 @@ public class EngulfingCandlestickStrategy : Strategy
 	/// <summary>
 	/// Engulfing pattern type.
 	/// </summary>
-	public enum PatternType
+	public enum PatternTypes
 	{
 		Bullish,
 		Bearish
@@ -41,7 +41,7 @@ public class EngulfingCandlestickStrategy : Strategy
 	/// <summary>
 	/// Trade direction.
 	/// </summary>
-	public enum TradeSide
+	public enum TradeSides
 	{
 		Long,
 		Short
@@ -68,7 +68,7 @@ public class EngulfingCandlestickStrategy : Strategy
 	/// <summary>
 	/// Selected engulfing pattern.
 	/// </summary>
-	public PatternType Pattern
+	public PatternTypes Pattern
 	{
 		get => _pattern.Value;
 		set => _pattern.Value = value;
@@ -77,7 +77,7 @@ public class EngulfingCandlestickStrategy : Strategy
 	/// <summary>
 	/// Trade side when pattern triggers.
 	/// </summary>
-	public TradeSide Side
+	public TradeSides Side
 	{
 		get => _side.Value;
 		set => _side.Value = value;
@@ -96,10 +96,10 @@ public class EngulfingCandlestickStrategy : Strategy
 			.SetDisplay("Hold Periods", "Bars to hold open position", "General")
 			.SetCanOptimize(true);
 
-		_pattern = Param(nameof(Pattern), PatternType.Bullish)
+		_pattern = Param(nameof(Pattern), PatternTypes.Bullish)
 			.SetDisplay("Pattern", "Engulfing pattern type", "General");
 
-		_side = Param(nameof(Side), TradeSide.Long)
+		_side = Param(nameof(Side), TradeSides.Long)
 			.SetDisplay("Trade Side", "Direction of entry", "General");
 	}
 
@@ -166,11 +166,11 @@ public class EngulfingCandlestickStrategy : Strategy
 				candle.OpenPrice > _previousCandle.ClosePrice &&
 				candle.ClosePrice < _previousCandle.OpenPrice;
 
-			var patternDetected = Pattern == PatternType.Bullish ? bullish : bearish;
+			var patternDetected = Pattern == PatternTypes.Bullish ? bullish : bearish;
 
 			if (patternDetected)
 			{
-				if (Side == TradeSide.Long)
+				if (Side == TradeSides.Long)
 					BuyMarket();
 				else
 					SellMarket();

--- a/API/0757_Enhanced_Ichimoku_Cloud/CS/EnhancedIchimokuCloudStrategy.cs
+++ b/API/0757_Enhanced_Ichimoku_Cloud/CS/EnhancedIchimokuCloudStrategy.cs
@@ -19,7 +19,7 @@ namespace StockSharp.Samples.Strategies;
 /// the high 25 bars ago, Tenkan-sen above Kijun-sen and close above EMA.
 /// Exits when Tenkan-sen crosses below Kijun-sen.
 /// </summary>
-public enum TradeMode
+public enum TradeModes
 {
 	Ichi,
 	Cloud
@@ -32,7 +32,7 @@ public class EnhancedIchimokuCloudStrategy : Strategy
 	private readonly StrategyParam<int> _laggingSpan2Periods;
 	private readonly StrategyParam<int> _displacement;
 	private readonly StrategyParam<int> _emaPeriod;
-	private readonly StrategyParam<TradeMode> _modeParam;
+	private readonly StrategyParam<TradeModes> _modeParam;
 	private readonly StrategyParam<DateTimeOffset> _startDate;
 	private readonly StrategyParam<DateTimeOffset> _endDate;
 	private readonly StrategyParam<DataType> _candleType;
@@ -51,7 +51,7 @@ public class EnhancedIchimokuCloudStrategy : Strategy
 	public int LaggingSpan2Periods { get => _laggingSpan2Periods.Value; set => _laggingSpan2Periods.Value = value; }
 	public int Displacement { get => _displacement.Value; set => _displacement.Value = value; }
 	public int EmaPeriod { get => _emaPeriod.Value; set => _emaPeriod.Value = value; }
-	public TradeMode Mode { get => _modeParam.Value; set => _modeParam.Value = value; }
+	public TradeModes Mode { get => _modeParam.Value; set => _modeParam.Value = value; }
 	public DateTimeOffset StartDate { get => _startDate.Value; set => _startDate.Value = value; }
 	public DateTimeOffset EndDate { get => _endDate.Value; set => _endDate.Value = value; }
 	public DataType CandleType { get => _candleType.Value; set => _candleType.Value = value; }
@@ -81,7 +81,7 @@ public class EnhancedIchimokuCloudStrategy : Strategy
 			.SetCanOptimize(true)
 			.SetOptimize(150, 200, 5);
 
-		_modeParam = Param(nameof(Mode), TradeMode.Ichi)
+		_modeParam = Param(nameof(Mode), TradeModes.Ichi)
 			.SetDisplay("Trade Setup", "Trading logic", "General");
 
 		_startDate = Param(nameof(StartDate), new DateTimeOffset(2018, 1, 1, 0, 0, 0, TimeSpan.Zero))
@@ -212,7 +212,7 @@ public class EnhancedIchimokuCloudStrategy : Strategy
 		bool buySignal;
 		bool sellSignal;
 
-		if (Mode == TradeMode.Ichi)
+		if (Mode == TradeModes.Ichi)
 		{
 			buySignal = longCond;
 			sellSignal = shortCond;

--- a/API/0807_Forex_Fire_EMA_MA_RSI/CS/ForexFireEmaMaRsiStrategy.cs
+++ b/API/0807_Forex_Fire_EMA_MA_RSI/CS/ForexFireEmaMaRsiStrategy.cs
@@ -24,7 +24,7 @@ public class ForexFireEmaMaRsiStrategy : Strategy
 	private readonly StrategyParam<int> _emaShortLength;
 	private readonly StrategyParam<int> _emaLongLength;
 	private readonly StrategyParam<int> _maLength;
-	private readonly StrategyParam<MovingAverageTypeEnum> _maType;
+	private readonly StrategyParam<MovingAverageTypes> _maType;
 	private readonly StrategyParam<int> _rsiSlowLength;
 	private readonly StrategyParam<int> _rsiFastLength;
 	private readonly StrategyParam<decimal> _rsiOverbought;
@@ -85,7 +85,7 @@ public class ForexFireEmaMaRsiStrategy : Strategy
 			.SetDisplay("MA Length", string.Empty, "General")
 			.SetCanOptimize(true);
 
-		_maType = Param(nameof(MaType), MovingAverageTypeEnum.Simple)
+		_maType = Param(nameof(MaType), MovingAverageTypes.Simple)
 			.SetDisplay("MA Type", string.Empty, "General");
 
 		_rsiSlowLength = Param(nameof(RsiSlowLength), 28)
@@ -167,7 +167,7 @@ public class ForexFireEmaMaRsiStrategy : Strategy
 	/// <summary>
 	/// Moving average type.
 	/// </summary>
-	public MovingAverageTypeEnum MaType
+	public MovingAverageTypes MaType
 	{
 		get => _maType.Value;
 		set => _maType.Value = value;
@@ -472,14 +472,14 @@ public class ForexFireEmaMaRsiStrategy : Strategy
 		_prevMa = ma;
 	}
 
-	private static IIndicator CreateMa(MovingAverageTypeEnum type, int length)
+	private static IIndicator CreateMa(MovingAverageTypes type, int length)
 	{
 		return type switch
 		{
-			MovingAverageTypeEnum.Simple => new SimpleMovingAverage { Length = length },
-			MovingAverageTypeEnum.Exponential => new ExponentialMovingAverage { Length = length },
-			MovingAverageTypeEnum.Weighted => new WeightedMovingAverage { Length = length },
-			MovingAverageTypeEnum.VolumeWeighted => new VolumeWeightedMovingAverage { Length = length },
+			MovingAverageTypes.Simple => new SimpleMovingAverage { Length = length },
+			MovingAverageTypes.Exponential => new ExponentialMovingAverage { Length = length },
+			MovingAverageTypes.Weighted => new WeightedMovingAverage { Length = length },
+			MovingAverageTypes.VolumeWeighted => new VolumeWeightedMovingAverage { Length = length },
 			_ => new SimpleMovingAverage { Length = length },
 		};
 	}
@@ -487,7 +487,7 @@ public class ForexFireEmaMaRsiStrategy : Strategy
 	/// <summary>
 	/// Available moving average types.
 	/// </summary>
-	public enum MovingAverageTypeEnum
+	public enum MovingAverageTypes
 	{
 		/// <summary>Simple moving average.</summary>
 		Simple,

--- a/API/0810_Four_WMA_TP_and_SL/CS/FourWmaTpSlStrategy.cs
+++ b/API/0810_Four_WMA_TP_and_SL/CS/FourWmaTpSlStrategy.cs
@@ -18,7 +18,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class FourWmaTpSlStrategy : Strategy
 {
-public enum MaMode
+public enum MaModes
 {
 Sma,
 Ema,
@@ -27,7 +27,7 @@ Vwma,
 Rma
 }
 
-public enum AltExitMa
+public enum AltExitMas
 {
 LongMa1,
 LongMa2,
@@ -39,13 +39,13 @@ private readonly StrategyParam<int> _longMa1Length;
 private readonly StrategyParam<int> _longMa2Length;
 private readonly StrategyParam<int> _shortMa1Length;
 private readonly StrategyParam<int> _shortMa2Length;
-private readonly StrategyParam<MaMode> _maType;
+private readonly StrategyParam<MaModes> _maType;
 private readonly StrategyParam<bool> _enableTpSl;
 private readonly StrategyParam<decimal> _takeProfitPercent;
 private readonly StrategyParam<decimal> _stopLossPercent;
 private readonly StrategyParam<Sides?> _direction;
 private readonly StrategyParam<bool> _enableAltExit;
-private readonly StrategyParam<AltExitMa> _altExitMa;
+private readonly StrategyParam<AltExitMas> _altExitMa;
 private readonly StrategyParam<DataType> _candleType;
 
 private decimal? _prevLongMa1;
@@ -76,7 +76,7 @@ public int ShortMa2Length { get => _shortMa2Length.Value; set => _shortMa2Length
 /// <summary>
 /// Type of moving average.
 /// </summary>
-public MaMode MaType { get => _maType.Value; set => _maType.Value = value; }
+public MaModes MaType { get => _maType.Value; set => _maType.Value = value; }
 
 /// <summary>
 /// Enable take profit and stop loss protection.
@@ -106,7 +106,7 @@ public bool EnableAltExit { get => _enableAltExit.Value; set => _enableAltExit.V
 /// <summary>
 /// Moving average used for alternate exit.
 /// </summary>
-public AltExitMa AltExitMaOption { get => _altExitMa.Value; set => _altExitMa.Value = value; }
+public AltExitMas AltExitMaOption { get => _altExitMa.Value; set => _altExitMa.Value = value; }
 
 /// <summary>
 /// Candle type.
@@ -138,7 +138,7 @@ _shortMa2Length = Param(nameof(ShortMa2Length), 40)
 .SetDisplay("Short MA2", "Length for second short MA", "Indicators")
 .SetCanOptimize(true);
 
-_maType = Param(nameof(MaType), MaMode.Wma)
+_maType = Param(nameof(MaType), MaModes.Wma)
 .SetDisplay("MA Type", "Type of moving average", "Indicators");
 
 _enableTpSl = Param(nameof(EnableTpSl), true)
@@ -158,7 +158,7 @@ _direction = Param(nameof(Direction), (Sides?)null)
 _enableAltExit = Param(nameof(EnableAltExit), false)
 .SetDisplay("Enable Alt Exit", "Enable alternate exit", "Risk");
 
-_altExitMa = Param(nameof(AltExitMaOption), AltExitMa.LongMa1)
+_altExitMa = Param(nameof(AltExitMaOption), AltExitMas.LongMa1)
 .SetDisplay("Alt Exit MA", "MA used for alternate exit", "Risk");
 
 _candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(1).TimeFrame())
@@ -212,15 +212,15 @@ stopLoss: new Unit(StopLossPercent, UnitTypes.Percent));
 }
 }
 
-private static LengthIndicator<decimal> CreateMa(MaMode type, int length)
+private static LengthIndicator<decimal> CreateMa(MaModes type, int length)
 {
 return type switch
 {
-MaMode.Sma => new SimpleMovingAverage { Length = length },
-MaMode.Ema => new ExponentialMovingAverage { Length = length },
-MaMode.Wma => new WeightedMovingAverage { Length = length },
-MaMode.Vwma => new VolumeWeightedMovingAverage { Length = length },
-MaMode.Rma => new SmoothedMovingAverage { Length = length },
+MaModes.Sma => new SimpleMovingAverage { Length = length },
+MaModes.Ema => new ExponentialMovingAverage { Length = length },
+MaModes.Wma => new WeightedMovingAverage { Length = length },
+MaModes.Vwma => new VolumeWeightedMovingAverage { Length = length },
+MaModes.Rma => new SmoothedMovingAverage { Length = length },
 _ => throw new ArgumentOutOfRangeException(nameof(type))
 };
 }
@@ -239,16 +239,16 @@ if (EnableAltExit)
 decimal altValue;
 switch (AltExitMaOption)
 {
-case AltExitMa.LongMa1:
+case AltExitMas.LongMa1:
 altValue = longMa1;
 break;
-case AltExitMa.LongMa2:
+case AltExitMas.LongMa2:
 altValue = longMa2;
 break;
-case AltExitMa.ShortMa1:
+case AltExitMas.ShortMa1:
 altValue = shortMa1;
 break;
-case AltExitMa.ShortMa2:
+case AltExitMas.ShortMa2:
 altValue = shortMa2;
 break;
 default:

--- a/API/0812_FreedX_Grid_Backtest/CS/FreedxGridBacktestStrategy.cs
+++ b/API/0812_FreedX_Grid_Backtest/CS/FreedxGridBacktestStrategy.cs
@@ -19,7 +19,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class FreedxGridBacktestStrategy : Strategy
 {
-	public enum GridMode
+	public enum GridModes
 	{
 		Neutral,
 		Long,
@@ -29,7 +29,7 @@ public class FreedxGridBacktestStrategy : Strategy
 	private readonly StrategyParam<decimal> _topLevel;
 	private readonly StrategyParam<decimal> _bottomLevel;
 	private readonly StrategyParam<int> _gridLevels;
-	private readonly StrategyParam<GridMode> _mode;
+	private readonly StrategyParam<GridModes> _mode;
 	private readonly StrategyParam<DataType> _candleType;
 
 	private decimal _reference;
@@ -67,7 +67,7 @@ public class FreedxGridBacktestStrategy : Strategy
 	/// <summary>
 	/// Trading mode for the grid.
 	/// </summary>
-	public GridMode Mode
+	public GridModes Mode
 	{
 		get => _mode.Value;
 		set => _mode.Value = value;
@@ -97,7 +97,7 @@ public class FreedxGridBacktestStrategy : Strategy
 			.SetGreaterThanZero()
 			.SetDisplay("Grid Levels", "Number of grid levels", "Grid Settings");
 
-		_mode = Param(nameof(Mode), GridMode.Neutral)
+		_mode = Param(nameof(Mode), GridModes.Neutral)
 			.SetDisplay("Mode", "Trading direction", "Grid Settings");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(1).TimeFrame())
@@ -148,7 +148,7 @@ public class FreedxGridBacktestStrategy : Strategy
 			return;
 
 		// Long side
-		if (Mode == GridMode.Neutral || Mode == GridMode.Long)
+		if (Mode == GridModes.Neutral || Mode == GridModes.Long)
 		{
 			while (candle.LowPrice <= _reference - _step * (_longIndex + 1))
 			{
@@ -164,7 +164,7 @@ public class FreedxGridBacktestStrategy : Strategy
 		}
 
 		// Short side
-		if (Mode == GridMode.Neutral || Mode == GridMode.Short)
+		if (Mode == GridModes.Neutral || Mode == GridModes.Short)
 		{
 			while (candle.HighPrice >= _reference + _step * (_shortIndex + 1))
 			{

--- a/API/0832_Gap_Filling/CS/GapFillingStrategy.cs
+++ b/API/0832_Gap_Filling/CS/GapFillingStrategy.cs
@@ -18,7 +18,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class GapFillingStrategy : Strategy
 {
-	public enum CloseWhenOption
+	public enum CloseWhenOptions
 	{
 		NewSession,
 		NewGap,
@@ -27,7 +27,7 @@ public class GapFillingStrategy : Strategy
 
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<bool> _invert;
-	private readonly StrategyParam<CloseWhenOption> _closeWhen;
+	private readonly StrategyParam<CloseWhenOptions> _closeWhen;
 
 	private decimal _prevOpen;
 	private decimal _prevClose;
@@ -39,7 +39,7 @@ public class GapFillingStrategy : Strategy
 
 	public DataType CandleType { get => _candleType.Value; set => _candleType.Value = value; }
 	public bool Invert { get => _invert.Value; set => _invert.Value = value; }
-	public CloseWhenOption CloseWhen { get => _closeWhen.Value; set => _closeWhen.Value = value; }
+	public CloseWhenOptions CloseWhen { get => _closeWhen.Value; set => _closeWhen.Value = value; }
 
 	public GapFillingStrategy()
 	{
@@ -49,7 +49,7 @@ public class GapFillingStrategy : Strategy
 		_invert = Param(nameof(Invert), false)
 			.SetDisplay("Invert", "Trade with gap direction", "Strategy");
 
-		_closeWhen = Param(nameof(CloseWhen), CloseWhenOption.NewSession)
+		_closeWhen = Param(nameof(CloseWhen), CloseWhenOptions.NewSession)
 			.SetDisplay("Close when", "Condition to close open positions", "Strategy");
 	}
 
@@ -106,8 +106,8 @@ public class GapFillingStrategy : Strategy
 		if (isNewSession && (upGap || dnGap))
 			_limitPrice = upGap ? Math.Max(_prevClose, _prevOpen) : Math.Min(_prevClose, _prevOpen);
 
-		if (CloseWhen == CloseWhenOption.NewSession && isNewSession ||
-			CloseWhen == CloseWhenOption.NewGap && isNewSession && (upGap || dnGap))
+		if (CloseWhen == CloseWhenOptions.NewSession && isNewSession ||
+			CloseWhen == CloseWhenOptions.NewGap && isNewSession && (upGap || dnGap))
 		{
 			CloseAll();
 		}

--- a/API/0834_Gaussian_Channel/CS/GaussianChannelStrategy.cs
+++ b/API/0834_Gaussian_Channel/CS/GaussianChannelStrategy.cs
@@ -14,14 +14,14 @@ namespace StockSharp.Samples.Strategies;
 
 
 
-public enum LineSelection
+public enum LineSelections
 {
 	Filter,
 	Upper,
 	Lower
 }
 
-public enum CrossDirection
+public enum CrossDirections
 {
 	CrossUp,
 	CrossDown
@@ -35,10 +35,10 @@ public class GaussianChannelStrategy : Strategy
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<int> _period;
 	private readonly StrategyParam<decimal> _multiplier;
-	private readonly StrategyParam<LineSelection> _longLine;
-	private readonly StrategyParam<LineSelection> _shortLine;
-	private readonly StrategyParam<CrossDirection> _longDirection;
-	private readonly StrategyParam<CrossDirection> _shortDirection;
+	private readonly StrategyParam<LineSelections> _longLine;
+	private readonly StrategyParam<LineSelections> _shortLine;
+	private readonly StrategyParam<CrossDirections> _longDirection;
+	private readonly StrategyParam<CrossDirections> _shortDirection;
 	private readonly StrategyParam<bool> _tradeLong;
 	private readonly StrategyParam<bool> _tradeShort;
 	private readonly StrategyParam<bool> _reverseOnOpp;
@@ -67,14 +67,14 @@ public class GaussianChannelStrategy : Strategy
 		_multiplier = Param(nameof(Multiplier), 1.414m)
 		.SetDisplay("ATR Mult", "ATR multiplier", "Channel");
 
-		_longLine = Param(nameof(LongLine), LineSelection.Filter)
+		_longLine = Param(nameof(LongLine), LineSelections.Filter)
 		.SetDisplay("Long line", "Line used for long entries", "Signals");
-		_shortLine = Param(nameof(ShortLine), LineSelection.Filter)
+		_shortLine = Param(nameof(ShortLine), LineSelections.Filter)
 		.SetDisplay("Short line", "Line used for short entries", "Signals");
 
-		_longDirection = Param(nameof(LongDirection), CrossDirection.CrossUp)
+		_longDirection = Param(nameof(LongDirection), CrossDirections.CrossUp)
 		.SetDisplay("Long direction", "Price cross direction for long entry", "Signals");
-		_shortDirection = Param(nameof(ShortDirection), CrossDirection.CrossDown)
+		_shortDirection = Param(nameof(ShortDirection), CrossDirections.CrossDown)
 		.SetDisplay("Short direction", "Price cross direction for short entry", "Signals");
 
 		_tradeLong = Param(nameof(TradeLong), true)
@@ -107,25 +107,25 @@ public class GaussianChannelStrategy : Strategy
 		set => _multiplier.Value = value;
 	}
 
-	public LineSelection LongLine
+	public LineSelections LongLine
 	{
 		get => _longLine.Value;
 		set => _longLine.Value = value;
 	}
 
-	public LineSelection ShortLine
+	public LineSelections ShortLine
 	{
 		get => _shortLine.Value;
 		set => _shortLine.Value = value;
 	}
 
-	public CrossDirection LongDirection
+	public CrossDirections LongDirection
 	{
 		get => _longDirection.Value;
 		set => _longDirection.Value = value;
 	}
 
-	public CrossDirection ShortDirection
+	public CrossDirections ShortDirection
 	{
 		get => _shortDirection.Value;
 		set => _shortDirection.Value = value;
@@ -175,12 +175,12 @@ public class GaussianChannelStrategy : Strategy
 		StartProtection();
 	}
 
-	private static decimal SelectLine(LineSelection type, decimal mid, decimal upper, decimal lower)
+	private static decimal SelectLine(LineSelections type, decimal mid, decimal upper, decimal lower)
 	{
 		return type switch
 		{
-			LineSelection.Upper => upper,
-			LineSelection.Lower => lower,
+			LineSelections.Upper => upper,
+			LineSelections.Lower => lower,
 			_ => mid,
 		};
 	}
@@ -228,11 +228,11 @@ public class GaussianChannelStrategy : Strategy
 		else if (_barsSinceShortDown != int.MaxValue)
 			_barsSinceShortDown++;
 
-		var longCond = LongDirection == CrossDirection.CrossUp
+		var longCond = LongDirection == CrossDirections.CrossUp
 		? longUp || (price > longLine && _barsSinceLongUp <= Lookback)
 		: longDown || (price < longLine && _barsSinceLongDown <= Lookback);
 
-		var shortCond = ShortDirection == CrossDirection.CrossUp
+		var shortCond = ShortDirection == CrossDirections.CrossUp
 		? shortUp || (price > shortLine && _barsSinceShortUp <= Lookback)
 		: shortDown || (price < shortLine && _barsSinceShortDown <= Lookback);
 

--- a/API/0880_High_Yield_Spread_SMA_Filter/CS/HighYieldSpreadSmaFilterStrategy.cs
+++ b/API/0880_High_Yield_Spread_SMA_Filter/CS/HighYieldSpreadSmaFilterStrategy.cs
@@ -13,7 +13,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-public enum SpreadBasis
+public enum SpreadBases
 {
 	HighYieldSpread,
 	Vix
@@ -27,7 +27,7 @@ public enum SpreadBasis
 /// </summary>
 public class HighYieldSpreadSmaFilterStrategy : Strategy
 {
-	private readonly StrategyParam<SpreadBasis> _basis;
+	private readonly StrategyParam<SpreadBases> _basis;
 	private readonly StrategyParam<decimal> _threshold;
 	private readonly StrategyParam<bool> _isLong;
 	private readonly StrategyParam<int> _holdingPeriod;
@@ -43,7 +43,7 @@ public class HighYieldSpreadSmaFilterStrategy : Strategy
 	/// <summary>
 	/// Spread source selection.
 	/// </summary>
-	public SpreadBasis Basis
+	public SpreadBases Basis
 	{
 		get => _basis.Value;
 		set => _basis.Value = value;
@@ -108,7 +108,7 @@ public class HighYieldSpreadSmaFilterStrategy : Strategy
 	/// </summary>
 	public HighYieldSpreadSmaFilterStrategy()
 	{
-		_basis = Param(nameof(Basis), SpreadBasis.HighYieldSpread)
+		_basis = Param(nameof(Basis), SpreadBases.HighYieldSpread)
 			.SetDisplay("Basis", "Spread source", "General");
 
 		_threshold = Param(nameof(Threshold), 5m)
@@ -186,7 +186,7 @@ public class HighYieldSpreadSmaFilterStrategy : Strategy
 
 	private Security CreateSpreadSecurity()
 	{
-		var id = Basis == SpreadBasis.HighYieldSpread ? "BAMLH0A0HYM2@FRED" : "VIX@CBOE";
+		var id = Basis == SpreadBases.HighYieldSpread ? "BAMLH0A0HYM2@FRED" : "VIX@CBOE";
 		return new Security { Id = id };
 	}
 

--- a/API/0880_High_Yield_Spread_with_SMA_Filter/CS/HighYieldSpreadWithSmaFilterStrategy.cs
+++ b/API/0880_High_Yield_Spread_with_SMA_Filter/CS/HighYieldSpreadWithSmaFilterStrategy.cs
@@ -20,7 +20,7 @@ namespace StockSharp.Samples.Strategies;
 public class HighYieldSpreadWithSmaFilterStrategy : Strategy
 {
 	private readonly StrategyParam<DataType> _candleType;
-	private readonly StrategyParam<Basis> _basis;
+	private readonly StrategyParam<Bases> _basis;
 	private readonly StrategyParam<decimal> _threshold;
 	private readonly StrategyParam<Sides> _direction;
 	private readonly StrategyParam<int> _holdingPeriod;
@@ -42,9 +42,9 @@ public class HighYieldSpreadWithSmaFilterStrategy : Strategy
 	}
 
 	/// <summary>
-	/// Basis selection.
+	/// Bases selection.
 	/// </summary>
-	public Basis BasisSelection
+	public Bases BasisSelection
 	{
 		get => _basis.Value;
 		set => _basis.Value = value;
@@ -103,8 +103,8 @@ public class HighYieldSpreadWithSmaFilterStrategy : Strategy
 		_candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
 			.SetDisplay("Candle Type", "Type of candles to use", "General");
 
-		_basis = Param(nameof(BasisSelection), Basis.HighYieldSpread)
-			.SetDisplay("Basis", "Spread basis", "General");
+		_basis = Param(nameof(BasisSelection), Bases.HighYieldSpread)
+			.SetDisplay("Bases", "Spread basis", "General");
 
 		_threshold = Param(nameof(Threshold), 5m)
 			.SetDisplay("Threshold", "Spread threshold", "Parameters")
@@ -133,7 +133,7 @@ public class HighYieldSpreadWithSmaFilterStrategy : Strategy
 	/// <inheritdoc />
 	public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
 	{
-		_basisSecurity = BasisSelection == Basis.HighYieldSpread
+		_basisSecurity = BasisSelection == Bases.HighYieldSpread
 			? new Security { Id = "FRED:BAMLH0A0HYM2" }
 			: new Security { Id = "CBOE:VIX" };
 
@@ -231,7 +231,7 @@ public class HighYieldSpreadWithSmaFilterStrategy : Strategy
 	/// <summary>
 	/// Spread basis options.
 	/// </summary>
-	public enum Basis
+	public enum Bases
 	{
 		HighYieldSpread,
 		Vix

--- a/API/0898_Hull_Suite_by_MRS/CS/HullSuiteByMRSStrategy.cs
+++ b/API/0898_Hull_Suite_by_MRS/CS/HullSuiteByMRSStrategy.cs
@@ -20,7 +20,7 @@ public class HullSuiteByMRSStrategy : Strategy
 {
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<int> _length;
-	private readonly StrategyParam<HullMode> _mode;
+	private readonly StrategyParam<HullModes> _mode;
 
 	private IIndicator _finalMa;
 	private ExponentialMovingAverage _emaFast;
@@ -49,12 +49,12 @@ public class HullSuiteByMRSStrategy : Strategy
 	/// <summary>
 	/// Hull variation.
 	/// </summary>
-	public HullMode Mode { get => _mode.Value; set => _mode.Value = value; }
+	public HullModes Mode { get => _mode.Value; set => _mode.Value = value; }
 
 	/// <summary>
 	/// Hull variation options.
 	/// </summary>
-	public enum HullMode
+	public enum HullModes
 	{
 		Hma,
 		Ehma,
@@ -73,7 +73,7 @@ public class HullSuiteByMRSStrategy : Strategy
 			.SetGreaterThanZero()
 			.SetDisplay("Length", "MA length", "Parameters");
 
-		_mode = Param(nameof(Mode), HullMode.Hma)
+		_mode = Param(nameof(Mode), HullModes.Hma)
 			.SetDisplay("Mode", "Hull variation", "Parameters");
 	}
 
@@ -102,13 +102,13 @@ public class HullSuiteByMRSStrategy : Strategy
 
 		switch (Mode)
 		{
-			case HullMode.Hma:
+			case HullModes.Hma:
 			{
 				_finalMa = new HullMovingAverage { Length = Length };
 				subscription.Bind(_finalMa, ProcessHma).Start();
 				break;
 			}
-			case HullMode.Ehma:
+			case HullModes.Ehma:
 			{
 				_emaFast = new ExponentialMovingAverage { Length = Math.Max(1, Length / 2) };
 				_emaSlow = new ExponentialMovingAverage { Length = Length };
@@ -117,7 +117,7 @@ public class HullSuiteByMRSStrategy : Strategy
 				subscription.Bind(_emaFast, _emaSlow, ProcessEhma).Start();
 				break;
 			}
-			case HullMode.Thma:
+			case HullModes.Thma:
 			{
 				_wma1 = new WeightedMovingAverage { Length = Math.Max(1, Length / 3) };
 				_wma2 = new WeightedMovingAverage { Length = Math.Max(1, Length / 2) };

--- a/API/0899_Hull_Suite_1_Risk_No_SL_TP/CS/HullSuite1RiskNoSlTpStrategy.cs
+++ b/API/0899_Hull_Suite_1_Risk_No_SL_TP/CS/HullSuite1RiskNoSlTpStrategy.cs
@@ -19,7 +19,7 @@ namespace StockSharp.Samples.Strategies;
 public class HullSuite1RiskNoSlTpStrategy : Strategy
 {
 	private readonly StrategyParam<int> _hullLength;
-	private readonly StrategyParam<HullVariation> _mode;
+	private readonly StrategyParam<HullVariations> _mode;
 	private readonly StrategyParam<DataType> _candleType;
 
 	private HullMovingAverage _hma;
@@ -48,7 +48,7 @@ public class HullSuite1RiskNoSlTpStrategy : Strategy
 	/// <summary>
 	/// Hull variation.
 	/// </summary>
-	public HullVariation Mode
+	public HullVariations Mode
 	{
 		get => _mode.Value;
 		set => _mode.Value = value;
@@ -74,7 +74,7 @@ public class HullSuite1RiskNoSlTpStrategy : Strategy
 						  .SetCanOptimize(true)
 						  .SetOptimize(20, 80, 5);
 
-		_mode = Param(nameof(Mode), HullVariation.Hma)
+		_mode = Param(nameof(Mode), HullVariations.Hma)
 					.SetDisplay("Hull Variation", "Type of Hull moving average", "Indicators");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
@@ -104,17 +104,17 @@ public class HullSuite1RiskNoSlTpStrategy : Strategy
 
 		switch (Mode)
 		{
-		case HullVariation.Hma:
+		case HullVariations.Hma:
 			_hma = new HullMovingAverage { Length = HullLength };
 			_hullIndicator = _hma;
 			break;
-		case HullVariation.Ehma:
+		case HullVariations.Ehma:
 			_ehmaFull = new ExponentialMovingAverage { Length = HullLength };
 			_ehmaHalf = new ExponentialMovingAverage { Length = HullLength / 2 };
 			_ehmaResult = new ExponentialMovingAverage { Length = (int)Math.Round(Math.Sqrt(HullLength)) };
 			_hullIndicator = _ehmaResult;
 			break;
-		case HullVariation.Thma:
+		case HullVariations.Thma:
 			_thmaFull = new WeightedMovingAverage { Length = HullLength };
 			_thmaHalf = new WeightedMovingAverage { Length = HullLength / 2 };
 			_thmaThird = new WeightedMovingAverage { Length = Math.Max(1, HullLength / 3) };
@@ -169,11 +169,11 @@ public class HullSuite1RiskNoSlTpStrategy : Strategy
 	{
 		switch (Mode)
 		{
-			case HullVariation.Hma:
+			case HullVariations.Hma:
 			{
 				return _hma.Process(price).ToNullableDecimal();
 			}
-			case HullVariation.Ehma:
+			case HullVariations.Ehma:
 			{
 				var emaFull = _ehmaFull.Process(price).ToNullableDecimal();
 				var emaHalf = _ehmaHalf.Process(price).ToNullableDecimal();
@@ -182,7 +182,7 @@ public class HullSuite1RiskNoSlTpStrategy : Strategy
 				var diff = 2m * half - full;
 				return _ehmaResult.Process(diff).ToNullableDecimal();
 			}
-			case HullVariation.Thma:
+			case HullVariations.Thma:
 			{
 				var wmaFull = _thmaFull.Process(price).ToNullableDecimal();
 				var wmaHalf = _thmaHalf.Process(price).ToNullableDecimal();
@@ -199,7 +199,7 @@ public class HullSuite1RiskNoSlTpStrategy : Strategy
 	}
 }
 
-public enum HullVariation
+public enum HullVariations
 {
 	Hma,
 	Ehma,

--- a/API/0900_Hull_Suite_No_SL_TP/CS/HullSuiteNoSlTpStrategy.cs
+++ b/API/0900_Hull_Suite_No_SL_TP/CS/HullSuiteNoSlTpStrategy.cs
@@ -23,7 +23,7 @@ namespace StockSharp.Samples.Strategies;
 public class HullSuiteNoSlTpStrategy : Strategy
 {
 	private readonly StrategyParam<int> _length;
-	private readonly StrategyParam<HullMode> _mode;
+	private readonly StrategyParam<HullModes> _mode;
 	private readonly StrategyParam<DataType> _candleType;
 	
 	private HullMovingAverage _hma;
@@ -50,7 +50,7 @@ public class HullSuiteNoSlTpStrategy : Strategy
 	/// <summary>
 	/// Hull variation.
 	/// </summary>
-	public HullMode Mode
+	public HullModes Mode
 	{
 		get => _mode.Value;
 		set => _mode.Value = value;
@@ -75,7 +75,7 @@ public class HullSuiteNoSlTpStrategy : Strategy
 		.SetCanOptimize(true)
 		.SetOptimize(20, 100, 5);
 		
-		_mode = Param(nameof(Mode), HullMode.Hma)
+		_mode = Param(nameof(Mode), HullModes.Hma)
 		.SetDisplay("Hull Mode", "Hull variation", "Indicators");
 		
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(1).TimeFrame())
@@ -115,19 +115,19 @@ public class HullSuiteNoSlTpStrategy : Strategy
 		
 		switch (Mode)
 		{
-		case HullMode.Hma:
+		case HullModes.Hma:
 		_hma = new HullMovingAverage { Length = Length };
 		subscription.Bind(_hma, ProcessHma).Start();
 		break;
 		
-	case HullMode.Ehma:
+	case HullModes.Ehma:
 	_emaHalf = new ExponentialMovingAverage { Length = Math.Max(1, Length / 2) };
 	_emaFull = new ExponentialMovingAverage { Length = Length };
 	_emaFinal = new ExponentialMovingAverage { Length = (int)Math.Round(Math.Sqrt(Length)) };
 	subscription.BindEx(_emaHalf, _emaFull, ProcessEhma).Start();
 	break;
 	
-case HullMode.Thma:
+case HullModes.Thma:
 _wmaThird = new WeightedMovingAverage { Length = Math.Max(1, Length / 3) };
 _wmaHalf = new WeightedMovingAverage { Length = Math.Max(1, Length / 2) };
 _wmaFull = new WeightedMovingAverage { Length = Length };
@@ -220,7 +220,7 @@ private void ProcessHull(ICandleMessage candle, decimal hull)
 /// <summary>
 /// Hull modes.
 /// </summary>
-public enum HullMode
+public enum HullModes
 {
 	/// <summary>Traditional Hull Moving Average.</summary>
 	Hma,

--- a/API/0902_Hurst_Future_Lines_of_Demarcation/CS/HurstFutureLinesOfDemarcationStrategy.cs
+++ b/API/0902_Hurst_Future_Lines_of_Demarcation/CS/HurstFutureLinesOfDemarcationStrategy.cs
@@ -13,7 +13,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-public enum CloseTrigger
+public enum CloseTriggers
 {
 Price,
 Signal,
@@ -45,16 +45,16 @@ private StrategyParam<int> _fldSmoothing;
 private StrategyParam<int> _signalCycleLength;
 private StrategyParam<int> _tradeCycleLength;
 private StrategyParam<int> _trendCycleLength;
-private StrategyParam<CloseTrigger> _closeTrigger1;
-private StrategyParam<CloseTrigger> _closeTrigger2;
+private StrategyParam<CloseTriggers> _closeTrigger1;
+private StrategyParam<CloseTriggers> _closeTrigger2;
 
 public bool SmoothFld { get => _smoothFld.Value; set => _smoothFld.Value = value; }
 public int FldSmoothing { get => _fldSmoothing.Value; set => _fldSmoothing.Value = value; }
 public int SignalCycleLength { get => _signalCycleLength.Value; set => _signalCycleLength.Value = value; }
 public int TradeCycleLength { get => _tradeCycleLength.Value; set => _tradeCycleLength.Value = value; }
 public int TrendCycleLength { get => _trendCycleLength.Value; set => _trendCycleLength.Value = value; }
-public CloseTrigger CloseTrigger1 { get => _closeTrigger1.Value; set => _closeTrigger1.Value = value; }
-public CloseTrigger CloseTrigger2 { get => _closeTrigger2.Value; set => _closeTrigger2.Value = value; }
+public CloseTriggers CloseTrigger1 { get => _closeTrigger1.Value; set => _closeTrigger1.Value = value; }
+public CloseTriggers CloseTrigger2 { get => _closeTrigger2.Value; set => _closeTrigger2.Value = value; }
 
 public HurstFutureLinesOfDemarcationStrategy()
 {
@@ -68,9 +68,9 @@ _tradeCycleLength = Param(nameof(TradeCycleLength), 20)
 .SetDisplay("Trade Cycle Length", "Trade cycle length", "Cycles");
 _trendCycleLength = Param(nameof(TrendCycleLength), 80)
 .SetDisplay("Trend Cycle Length", "Trend cycle length", "Cycles");
-_closeTrigger1 = Param(nameof(CloseTrigger1), CloseTrigger.Price)
+_closeTrigger1 = Param(nameof(CloseTrigger1), CloseTriggers.Price)
 .SetDisplay("Close Trigger 1", "First value for exit cross", "Exit");
-_closeTrigger2 = Param(nameof(CloseTrigger2), CloseTrigger.Trade)
+_closeTrigger2 = Param(nameof(CloseTrigger2), CloseTriggers.Trade)
 .SetDisplay("Close Trigger 2", "Second value for exit cross", "Exit");
 }
 
@@ -159,14 +159,14 @@ _prevPrice = price;
 _prevSignal = _signal;
 }
 
-private static decimal? GetTriggerValue(CloseTrigger trigger, decimal price, decimal? signal, decimal? trade, decimal? trend)
+private static decimal? GetTriggerValue(CloseTriggers trigger, decimal price, decimal? signal, decimal? trade, decimal? trend)
 {
 return trigger switch
 {
-CloseTrigger.Price => price,
-CloseTrigger.Signal => signal,
-CloseTrigger.Trade => trade,
-CloseTrigger.Trend => trend,
+CloseTriggers.Price => price,
+CloseTriggers.Signal => signal,
+CloseTriggers.Trade => trade,
+CloseTriggers.Trend => trend,
 _ => null,
 };
 }

--- a/API/0903_Hybrid_RSI_Breakout_Dashboard/CS/HybridRsiBreakoutDashboardStrategy.cs
+++ b/API/0903_Hybrid_RSI_Breakout_Dashboard/CS/HybridRsiBreakoutDashboardStrategy.cs
@@ -18,7 +18,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class HybridRsiBreakoutDashboardStrategy : Strategy
 {
-	private enum TradeType
+	private enum TradeTypes
 	{
 		None,
 		Rsi,
@@ -48,7 +48,7 @@ public class HybridRsiBreakoutDashboardStrategy : Strategy
 	private decimal _prevHighest;
 	private decimal _prevLowest;
 	private decimal _breakoutStop;
-	private TradeType _currentTrade;
+	private TradeTypes _currentTrade;
 	private string _lastTradeType = "None";
 	private string _lastDirection = "None";
 	private int _barIndex;
@@ -185,7 +185,7 @@ public class HybridRsiBreakoutDashboardStrategy : Strategy
 		_prevHighest = 0m;
 		_prevLowest = 0m;
 		_breakoutStop = 0m;
-		_currentTrade = TradeType.None;
+		_currentTrade = TradeTypes.None;
 		_lastTradeType = "None";
 		_lastDirection = "None";
 		_barIndex = 0;
@@ -261,21 +261,21 @@ public class HybridRsiBreakoutDashboardStrategy : Strategy
 		if (rsiLong && Position <= 0)
 		{
 			BuyMarket(Volume + Math.Abs(Position));
-			_currentTrade = TradeType.Rsi;
+			_currentTrade = TradeTypes.Rsi;
 			_lastTradeType = "RSI";
 			_lastDirection = "Long";
 		}
 		else if (rsiShort && Position >= 0)
 		{
 			SellMarket(Volume + Math.Abs(Position));
-			_currentTrade = TradeType.Rsi;
+			_currentTrade = TradeTypes.Rsi;
 			_lastTradeType = "RSI";
 			_lastDirection = "Short";
 		}
 		else if (longBreak && Position <= 0)
 		{
 			BuyMarket(Volume + Math.Abs(Position));
-			_currentTrade = TradeType.Breakout;
+			_currentTrade = TradeTypes.Breakout;
 			_lastTradeType = "Breakout";
 			_lastDirection = "Long";
 			_breakoutStop = candle.ClosePrice - atrValue * AtrMultiplier;
@@ -283,26 +283,26 @@ public class HybridRsiBreakoutDashboardStrategy : Strategy
 		else if (shortBreak && Position >= 0)
 		{
 			SellMarket(Volume + Math.Abs(Position));
-			_currentTrade = TradeType.Breakout;
+			_currentTrade = TradeTypes.Breakout;
 			_lastTradeType = "Breakout";
 			_lastDirection = "Short";
 			_breakoutStop = candle.ClosePrice + atrValue * AtrMultiplier;
 		}
 
-		if (_currentTrade == TradeType.Rsi)
+		if (_currentTrade == TradeTypes.Rsi)
 		{
 			if (Position > 0 && rsiLongExit)
 			{
 				SellMarket(Position);
-				_currentTrade = TradeType.None;
+				_currentTrade = TradeTypes.None;
 			}
 			else if (Position < 0 && rsiShortExit)
 			{
 				BuyMarket(-Position);
-				_currentTrade = TradeType.None;
+				_currentTrade = TradeTypes.None;
 			}
 		}
-		else if (_currentTrade == TradeType.Breakout)
+		else if (_currentTrade == TradeTypes.Breakout)
 		{
 			if (Position > 0)
 			{
@@ -313,7 +313,7 @@ public class HybridRsiBreakoutDashboardStrategy : Strategy
 				if (candle.LowPrice <= _breakoutStop)
 				{
 					SellMarket(Position);
-					_currentTrade = TradeType.None;
+					_currentTrade = TradeTypes.None;
 				}
 			}
 			else if (Position < 0)
@@ -325,7 +325,7 @@ public class HybridRsiBreakoutDashboardStrategy : Strategy
 				if (candle.HighPrice >= _breakoutStop)
 				{
 					BuyMarket(-Position);
-					_currentTrade = TradeType.None;
+					_currentTrade = TradeTypes.None;
 				}
 			}
 		}

--- a/API/0904_Ibs_Internal_Bar_Strength/CS/IbsInternalBarStrengthStrategy.cs
+++ b/API/0904_Ibs_Internal_Bar_Strength/CS/IbsInternalBarStrengthStrategy.cs
@@ -13,7 +13,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-public enum TradeType
+public enum TradeTypes
 {
 	Long,
 	Short,
@@ -30,7 +30,7 @@ public class IbsInternalBarStrengthStrategy : Strategy
 	private readonly StrategyParam<int> _emaPeriod;
 	private readonly StrategyParam<decimal> _minEntryPct;
 	private readonly StrategyParam<int> _maxTradeDuration;
-	private readonly StrategyParam<TradeType> _entryType;
+	private readonly StrategyParam<TradeTypes> _entryType;
 	private readonly StrategyParam<DataType> _candleType;
 
 	private ICandleMessage _prevCandle;
@@ -85,7 +85,7 @@ public class IbsInternalBarStrengthStrategy : Strategy
 	/// <summary>
 	/// Allowed trade directions.
 	/// </summary>
-	public TradeType EntryType
+	public TradeTypes EntryType
 	{
 		get => _entryType.Value;
 		set => _entryType.Value = value;
@@ -123,7 +123,7 @@ public class IbsInternalBarStrengthStrategy : Strategy
 			.SetDisplay("Max Duration", "Maximum trade duration in days", "Risk")
 			.SetGreaterThanZero();
 
-		_entryType = Param(nameof(EntryType), TradeType.Long)
+		_entryType = Param(nameof(EntryType), TradeTypes.Long)
 			.SetDisplay("Entry Type", "Allowed trade directions", "General");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
@@ -224,8 +224,8 @@ public class IbsInternalBarStrengthStrategy : Strategy
 
 		var emaLong = EmaPeriod == 0 || candle.ClosePrice > ema;
 		var emaShort = EmaPeriod == 0 || candle.ClosePrice < ema;
-		var allowLong = EntryType == TradeType.Long || EntryType == TradeType.All;
-		var allowShort = EntryType == TradeType.Short || EntryType == TradeType.All;
+		var allowLong = EntryType == TradeTypes.Long || EntryType == TradeTypes.All;
+		var allowShort = EntryType == TradeTypes.Short || EntryType == TradeTypes.All;
 
 		var enterLong = ibs < IbsEntryThreshold && emaLong && allowLong;
 		var enterShort = ibs > IbsExitThreshold && emaShort && allowShort;

--- a/API/0911_Ichimoku_Clouds_Long_and_Short/CS/IchimokuCloudsLongAndShortStrategy.cs
+++ b/API/0911_Ichimoku_Clouds_Long_and_Short/CS/IchimokuCloudsLongAndShortStrategy.cs
@@ -215,14 +215,14 @@ public class IchimokuCloudsLongAndShortStrategy : Strategy
 		}
 	}
 
-	private enum SignalStrength
+	private enum SignalStrengths
 	{
 		Strong,
 		Neutral,
 		Weak
 	}
 
-	private static bool IsSignalAllowed(string option, SignalStrength strength, bool bullish)
+	private static bool IsSignalAllowed(string option, SignalStrengths strength, bool bullish)
 	{
 		if (option == "None")
 			return false;
@@ -231,12 +231,12 @@ public class IchimokuCloudsLongAndShortStrategy : Strategy
 		{
 			return option switch
 			{
-				"Bullish Strong" => strength == SignalStrength.Strong,
-				"Bullish Neutral" => strength == SignalStrength.Neutral,
-				"Bullish Weak" => strength == SignalStrength.Weak,
-				"Bullish Strong and Neutral" => strength is SignalStrength.Strong or SignalStrength.Neutral,
-				"Bullish Neutral and Weak" => strength is SignalStrength.Neutral or SignalStrength.Weak,
-				"Bullish Strong and Weak" => strength is SignalStrength.Strong or SignalStrength.Weak,
+				"Bullish Strong" => strength == SignalStrengths.Strong,
+				"Bullish Neutral" => strength == SignalStrengths.Neutral,
+				"Bullish Weak" => strength == SignalStrengths.Weak,
+				"Bullish Strong and Neutral" => strength is SignalStrengths.Strong or SignalStrengths.Neutral,
+				"Bullish Neutral and Weak" => strength is SignalStrengths.Neutral or SignalStrengths.Weak,
+				"Bullish Strong and Weak" => strength is SignalStrengths.Strong or SignalStrengths.Weak,
 				"Bullish All" => true,
 				_ => false
 			};
@@ -244,12 +244,12 @@ public class IchimokuCloudsLongAndShortStrategy : Strategy
 
 		return option switch
 		{
-			"Bearish Strong" => strength == SignalStrength.Strong,
-			"Bearish Neutral" => strength == SignalStrength.Neutral,
-			"Bearish Weak" => strength == SignalStrength.Weak,
-			"Bearish Strong and Neutral" => strength is SignalStrength.Strong or SignalStrength.Neutral,
-			"Bearish Neutral and Weak" => strength is SignalStrength.Neutral or SignalStrength.Weak,
-			"Bearish Strong and Weak" => strength is SignalStrength.Strong or SignalStrength.Weak,
+			"Bearish Strong" => strength == SignalStrengths.Strong,
+			"Bearish Neutral" => strength == SignalStrengths.Neutral,
+			"Bearish Weak" => strength == SignalStrengths.Weak,
+			"Bearish Strong and Neutral" => strength is SignalStrengths.Strong or SignalStrengths.Neutral,
+			"Bearish Neutral and Weak" => strength is SignalStrengths.Neutral or SignalStrengths.Weak,
+			"Bearish Strong and Weak" => strength is SignalStrengths.Strong or SignalStrengths.Weak,
 			"Bearish All" => true,
 			_ => false
 		};
@@ -285,7 +285,7 @@ public class IchimokuCloudsLongAndShortStrategy : Strategy
 
 		if (crossUp)
 		{
-			var strength = tenkan > upperCloud ? SignalStrength.Strong : tenkan < lowerCloud ? SignalStrength.Weak : SignalStrength.Neutral;
+			var strength = tenkan > upperCloud ? SignalStrengths.Strong : tenkan < lowerCloud ? SignalStrengths.Weak : SignalStrengths.Neutral;
 
 			if (TradingMode == "Long" && IsSignalAllowed(EntrySignalOptionsLong, strength, true) && Position <= 0)
 			{
@@ -299,7 +299,7 @@ public class IchimokuCloudsLongAndShortStrategy : Strategy
 		}
 		else if (crossDown)
 		{
-			var strength = tenkan < lowerCloud ? SignalStrength.Strong : tenkan > upperCloud ? SignalStrength.Weak : SignalStrength.Neutral;
+			var strength = tenkan < lowerCloud ? SignalStrengths.Strong : tenkan > upperCloud ? SignalStrengths.Weak : SignalStrengths.Neutral;
 
 			if (TradingMode == "Short" && IsSignalAllowed(EntrySignalOptionsShort, strength, false) && Position >= 0)
 			{

--- a/API/0932_InwCoin_Martingale/CS/InwCoinMartingaleStrategy.cs
+++ b/API/0932_InwCoin_Martingale/CS/InwCoinMartingaleStrategy.cs
@@ -17,9 +17,9 @@ namespace StockSharp.Samples.Strategies;
 /// Martingale strategy for Bitcoin with optional entry signals.
 /// </summary>
 public class InwCoinMartingaleStrategy : Strategy {
-	private enum StartLogic { MacdLine, StochasticRsi, AtrChannel }
+	private enum StartLogics { MacdLine, StochasticRsi, AtrChannel }
 
-	private readonly StrategyParam<StartLogic> _startLogic;
+	private readonly StrategyParam<StartLogics> _startLogic;
 	private readonly StrategyParam<decimal> _takeProfitPercent;
 	private readonly StrategyParam<decimal> _martingalePercent;
 	private readonly StrategyParam<decimal> _martingaleMultiplier;
@@ -34,7 +34,7 @@ public class InwCoinMartingaleStrategy : Strategy {
 	/// <summary>
 	/// Entry logic selector.
 	/// </summary>
-	public StartLogic EntryLogic {
+	public StartLogics EntryLogic {
 	  get => _startLogic.Value;
 	  set => _startLogic.Value = value;
 	}
@@ -76,7 +76,7 @@ public class InwCoinMartingaleStrategy : Strategy {
 	/// </summary>
 	public InwCoinMartingaleStrategy() {
 	  _startLogic =
-	Param(nameof(EntryLogic), StartLogic.MacdLine)
+	Param(nameof(EntryLogic), StartLogics.MacdLine)
 	    .SetDisplay("Start Logic", "Entry signal selector", "Parameters");
 
 	  _takeProfitPercent =
@@ -157,7 +157,7 @@ public class InwCoinMartingaleStrategy : Strategy {
 	  bool buySignal = false;
 
 	  switch (EntryLogic) {
-	  case StartLogic.MacdLine: {
+	  case StartLogics.MacdLine: {
 	    var macd = (MovingAverageConvergenceDivergenceSignalValue)macdVal;
 	    if (macd.Macd is decimal m && macd.Signal is decimal s) {
 	var hist = m - s;
@@ -166,7 +166,7 @@ public class InwCoinMartingaleStrategy : Strategy {
 	    }
 	    break;
 	  }
-	  case StartLogic.StochasticRsi: {
+	  case StartLogics.StochasticRsi: {
 	    var stoch = (StochasticOscillatorValue)stochVal;
 	    if (stoch.D is decimal d && stoch.K is decimal k) {
 	if (_isFirst) {
@@ -178,7 +178,7 @@ public class InwCoinMartingaleStrategy : Strategy {
 	    }
 	    break;
 	  }
-	  case StartLogic.AtrChannel: {
+	  case StartLogics.AtrChannel: {
 	    if (emaVal.GetValue<decimal>() is decimal e && atrVal.GetValue<decimal>()
 							 is decimal a) {
 	var upper = e + a;

--- a/API/0937_IU_Bigger_Than_Range/CS/IuBiggerThanRangeStrategy.cs
+++ b/API/0937_IU_Bigger_Than_Range/CS/IuBiggerThanRangeStrategy.cs
@@ -18,7 +18,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class IuBiggerThanRangeStrategy : Strategy
 {
-	private enum StopLossMethod
+	private enum StopLossMethods
 	{
 		PreviousHighLow,
 		Atr,
@@ -27,7 +27,7 @@ public class IuBiggerThanRangeStrategy : Strategy
 
 	private readonly StrategyParam<int> _lookbackPeriod;
 	private readonly StrategyParam<int> _riskToReward;
-	private readonly StrategyParam<StopLossMethod> _stopLossMethod;
+	private readonly StrategyParam<StopLossMethods> _stopLossMethod;
 	private readonly StrategyParam<int> _atrLength;
 	private readonly StrategyParam<decimal> _atrFactor;
 	private readonly StrategyParam<int> _swingLength;
@@ -68,7 +68,7 @@ public class IuBiggerThanRangeStrategy : Strategy
 	/// <summary>
 	/// Stop loss calculation method.
 	/// </summary>
-	public StopLossMethod StopLoss
+	public StopLossMethods StopLoss
 	{
 		get => _stopLossMethod.Value;
 		set => _stopLossMethod.Value = value;
@@ -125,7 +125,7 @@ public class IuBiggerThanRangeStrategy : Strategy
 			.SetDisplay("Risk To Reward", "Risk to reward ratio", "Parameters")
 			.SetCanOptimize(true);
 
-		_stopLossMethod = Param(nameof(StopLoss), StopLossMethod.PreviousHighLow)
+		_stopLossMethod = Param(nameof(StopLoss), StopLossMethods.PreviousHighLow)
 			.SetDisplay("Stop Loss Method", "Stop loss calculation method", "Risk Management");
 
 		_atrLength = Param(nameof(AtrLength), 14)
@@ -276,8 +276,8 @@ public class IuBiggerThanRangeStrategy : Strategy
 	{
 		return StopLoss switch
 		{
-			StopLossMethod.PreviousHighLow => isLong ? _prevCandleLow : _prevCandleHigh,
-			StopLossMethod.Atr => isLong ? _entryPrice - atrValue * AtrFactor : _entryPrice + atrValue * AtrFactor,
+			StopLossMethods.PreviousHighLow => isLong ? _prevCandleLow : _prevCandleHigh,
+			StopLossMethods.Atr => isLong ? _entryPrice - atrValue * AtrFactor : _entryPrice + atrValue * AtrFactor,
 			_ => isLong ? swingLow : swingHigh,
 		};
 	}

--- a/API/0941_IU_Higher_Timeframe_MA_Cross/CS/IUHigherTimeframeMACrossStrategy.cs
+++ b/API/0941_IU_Higher_Timeframe_MA_Cross/CS/IUHigherTimeframeMACrossStrategy.cs
@@ -19,10 +19,10 @@ public class IUHigherTimeframeMACrossStrategy : Strategy
 	private readonly StrategyParam<decimal> _riskToReward;
 	private readonly StrategyParam<DataType> _ma1CandleType;
 	private readonly StrategyParam<int> _ma1Length;
-	private readonly StrategyParam<MovingAverageTypeEnum> _ma1Type;
+	private readonly StrategyParam<MovingAverageTypes> _ma1Type;
 	private readonly StrategyParam<DataType> _ma2CandleType;
 	private readonly StrategyParam<int> _ma2Length;
-	private readonly StrategyParam<MovingAverageTypeEnum> _ma2Type;
+	private readonly StrategyParam<MovingAverageTypes> _ma2Type;
 
 	private decimal? _ma1;
 	private decimal? _ma2;
@@ -58,7 +58,7 @@ public class IUHigherTimeframeMACrossStrategy : Strategy
 		.SetCanOptimize(true)
 		.SetOptimize(5, 100, 5);
 
-		_ma1Type = Param(nameof(Ma1Type), MovingAverageTypeEnum.Exponential)
+		_ma1Type = Param(nameof(Ma1Type), MovingAverageTypes.Exponential)
 		.SetDisplay("MA1 Type", "Type of first MA", "Moving Averages");
 
 		_ma2CandleType = Param(nameof(Ma2CandleType), TimeSpan.FromMinutes(60).TimeFrame())
@@ -70,17 +70,17 @@ public class IUHigherTimeframeMACrossStrategy : Strategy
 		.SetCanOptimize(true)
 		.SetOptimize(10, 200, 5);
 
-		_ma2Type = Param(nameof(Ma2Type), MovingAverageTypeEnum.Exponential)
+		_ma2Type = Param(nameof(Ma2Type), MovingAverageTypes.Exponential)
 		.SetDisplay("MA2 Type", "Type of second MA", "Moving Averages");
 	}
 
 	public decimal RiskToReward { get => _riskToReward.Value; set => _riskToReward.Value = value; }
 	public DataType Ma1CandleType { get => _ma1CandleType.Value; set => _ma1CandleType.Value = value; }
 	public int Ma1Length { get => _ma1Length.Value; set => _ma1Length.Value = value; }
-	public MovingAverageTypeEnum Ma1Type { get => _ma1Type.Value; set => _ma1Type.Value = value; }
+	public MovingAverageTypes Ma1Type { get => _ma1Type.Value; set => _ma1Type.Value = value; }
 	public DataType Ma2CandleType { get => _ma2CandleType.Value; set => _ma2CandleType.Value = value; }
 	public int Ma2Length { get => _ma2Length.Value; set => _ma2Length.Value = value; }
-	public MovingAverageTypeEnum Ma2Type { get => _ma2Type.Value; set => _ma2Type.Value = value; }
+	public MovingAverageTypes Ma2Type { get => _ma2Type.Value; set => _ma2Type.Value = value; }
 
 	public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
 	=> [(Security, Ma1CandleType), (Security, Ma2CandleType)];
@@ -193,20 +193,20 @@ public class IUHigherTimeframeMACrossStrategy : Strategy
 		_takePrice = null;
 	}
 
-	private static LengthIndicator<decimal> CreateMa(MovingAverageTypeEnum type, int length)
+	private static LengthIndicator<decimal> CreateMa(MovingAverageTypes type, int length)
 	{
 		return type switch
 		{
-			MovingAverageTypeEnum.Simple => new SimpleMovingAverage { Length = length },
-			MovingAverageTypeEnum.Exponential => new ExponentialMovingAverage { Length = length },
-			MovingAverageTypeEnum.Smoothed => new SmoothedMovingAverage { Length = length },
-			MovingAverageTypeEnum.Weighted => new WeightedMovingAverage { Length = length },
-			MovingAverageTypeEnum.VolumeWeighted => new VolumeWeightedMovingAverage { Length = length },
+			MovingAverageTypes.Simple => new SimpleMovingAverage { Length = length },
+			MovingAverageTypes.Exponential => new ExponentialMovingAverage { Length = length },
+			MovingAverageTypes.Smoothed => new SmoothedMovingAverage { Length = length },
+			MovingAverageTypes.Weighted => new WeightedMovingAverage { Length = length },
+			MovingAverageTypes.VolumeWeighted => new VolumeWeightedMovingAverage { Length = length },
 			_ => new SimpleMovingAverage { Length = length },
 		};
 	}
 
-	public enum MovingAverageTypeEnum
+	public enum MovingAverageTypes
 	{
 		Simple,
 		Exponential,

--- a/API/0945_JLines_Ribbon_4_Cycle_Engine/CS/JLinesRibbon4CycleEngineStrategy.cs
+++ b/API/0945_JLines_Ribbon_4_Cycle_Engine/CS/JLinesRibbon4CycleEngineStrategy.cs
@@ -32,8 +32,8 @@ public class JLinesRibbon4CycleEngineStrategy : Strategy
 	private ExponentialMovingAverage _ema445;
 	private AverageDirectionalIndex _adx;
 
-	private enum CycleState { Chop, Long, Short }
-	private CycleState _cycle = CycleState.Chop;
+	private enum CycleStates { Chop, Long, Short }
+	private CycleStates _cycle = CycleStates.Chop;
 	private bool _newCycle;
 
 	private decimal _prevEma72;
@@ -125,19 +125,19 @@ public class JLinesRibbon4CycleEngineStrategy : Strategy
 		var trendLong = !inChop && ema72 > ema89;
 		var trendShort = !inChop && ema72 < ema89;
 
-		if (inChop && _cycle != CycleState.Chop)
+		if (inChop && _cycle != CycleStates.Chop)
 		{
-			_cycle = CycleState.Chop;
+			_cycle = CycleStates.Chop;
 			_newCycle = true;
 		}
-		else if (trendLong && _cycle != CycleState.Long)
+		else if (trendLong && _cycle != CycleStates.Long)
 		{
-			_cycle = CycleState.Long;
+			_cycle = CycleStates.Long;
 			_newCycle = true;
 		}
-		else if (trendShort && _cycle != CycleState.Short)
+		else if (trendShort && _cycle != CycleStates.Short)
 		{
-			_cycle = CycleState.Short;
+			_cycle = CycleStates.Short;
 			_newCycle = true;
 		}
 		else
@@ -145,14 +145,14 @@ public class JLinesRibbon4CycleEngineStrategy : Strategy
 			_newCycle = false;
 		}
 
-		if (_newCycle && _cycle == CycleState.Chop && Position != 0)
+		if (_newCycle && _cycle == CycleStates.Chop && Position != 0)
 			ClosePosition();
 
 		if (_newCycle)
 		{
-			if (_cycle == CycleState.Long && Position <= 0)
+			if (_cycle == CycleStates.Long && Position <= 0)
 				BuyMarket();
-			else if (_cycle == CycleState.Short && Position >= 0)
+			else if (_cycle == CycleStates.Short && Position >= 0)
 				SellMarket();
 		}
 
@@ -163,7 +163,7 @@ public class JLinesRibbon4CycleEngineStrategy : Strategy
 		var xAbove126 = _prevClose <= _prevEma126 && candle.ClosePrice > ema126;
 		var xBelow126 = _prevClose >= _prevEma126 && candle.ClosePrice < ema126;
 
-		if (_cycle == CycleState.Long)
+		if (_cycle == CycleStates.Long)
 		{
 			if (flipLongEvt)
 				BuyMarket();
@@ -191,7 +191,7 @@ public class JLinesRibbon4CycleEngineStrategy : Strategy
 			if (Position > 0 && candle.LowPrice <= _lastLow)
 				ClosePosition();
 		}
-		else if (_cycle == CycleState.Short)
+		else if (_cycle == CycleStates.Short)
 		{
 			if (Position == 0 && ema72 < ema89)
 				SellMarket();

--- a/API/0950_Kaufman_Adaptive_Moving_Average/CS/KaufmanAdaptiveMovingAverageStrategy.cs
+++ b/API/0950_Kaufman_Adaptive_Moving_Average/CS/KaufmanAdaptiveMovingAverageStrategy.cs
@@ -18,7 +18,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class KaufmanAdaptiveMovingAverageStrategy : Strategy
 {
-	public enum TradeSide
+	public enum TradeSides
 	{
 		Long,
 		Short,
@@ -30,7 +30,7 @@ public class KaufmanAdaptiveMovingAverageStrategy : Strategy
 	private readonly StrategyParam<int> _slow;
 	private readonly StrategyParam<int> _risingPeriod;
 	private readonly StrategyParam<int> _fallingPeriod;
-	private readonly StrategyParam<TradeSide> _orderDirection;
+	private readonly StrategyParam<TradeSides> _orderDirection;
 	private readonly StrategyParam<DataType> _candleType;
 
 	private decimal _prevKama;
@@ -43,7 +43,7 @@ public class KaufmanAdaptiveMovingAverageStrategy : Strategy
 	public int Slow { get => _slow.Value; set => _slow.Value = value; }
 	public int RisingPeriod { get => _risingPeriod.Value; set => _risingPeriod.Value = value; }
 	public int FallingPeriod { get => _fallingPeriod.Value; set => _fallingPeriod.Value = value; }
-	public TradeSide OrderDirection { get => _orderDirection.Value; set => _orderDirection.Value = value; }
+	public TradeSides OrderDirection { get => _orderDirection.Value; set => _orderDirection.Value = value; }
 	public DataType CandleType { get => _candleType.Value; set => _candleType.Value = value; }
 
 	public KaufmanAdaptiveMovingAverageStrategy()
@@ -78,7 +78,7 @@ public class KaufmanAdaptiveMovingAverageStrategy : Strategy
 			.SetCanOptimize(true)
 			.SetOptimize(5, 20, 5);
 
-		_orderDirection = Param(nameof(OrderDirection), TradeSide.Long)
+		_orderDirection = Param(nameof(OrderDirection), TradeSides.Long)
 			.SetDisplay("Order direction", "Allowed trade direction", "Strategy");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(1).TimeFrame())
@@ -162,7 +162,7 @@ public class KaufmanAdaptiveMovingAverageStrategy : Strategy
 			if (Position < 0)
 				BuyMarket(Math.Abs(Position));
 
-			var allowLong = OrderDirection == TradeSide.Long || OrderDirection == TradeSide.Both;
+			var allowLong = OrderDirection == TradeSides.Long || OrderDirection == TradeSides.Both;
 			if (allowLong && Position == 0)
 				BuyMarket(Volume);
 		}
@@ -171,7 +171,7 @@ public class KaufmanAdaptiveMovingAverageStrategy : Strategy
 			if (Position > 0)
 				SellMarket(Math.Abs(Position));
 
-			var allowShort = OrderDirection == TradeSide.Short || OrderDirection == TradeSide.Both;
+			var allowShort = OrderDirection == TradeSides.Short || OrderDirection == TradeSides.Both;
 			if (allowShort && Position == 0)
 				SellMarket(Volume);
 		}

--- a/API/0954_Keltner_Channel_Golden_Cross/CS/KeltnerChannelGoldenCrossStrategy.cs
+++ b/API/0954_Keltner_Channel_Golden_Cross/CS/KeltnerChannelGoldenCrossStrategy.cs
@@ -22,7 +22,7 @@ private readonly StrategyParam<int> _maLength;
 private readonly StrategyParam<decimal> _entryAtrMultiplier;
 private readonly StrategyParam<decimal> _profitAtrMultiplier;
 private readonly StrategyParam<decimal> _exitAtrMultiplier;
-private readonly StrategyParam<MovingAverageTypeEnum> _maType;
+private readonly StrategyParam<MovingAverageTypes> _maType;
 private readonly StrategyParam<int> _shortMaLength;
 private readonly StrategyParam<int> _longMaLength;
 private readonly StrategyParam<DataType> _candleType;
@@ -50,7 +50,7 @@ public decimal ExitAtrMultiplier { get => _exitAtrMultiplier.Value; set => _exit
 /// <summary>
 /// Basis MA type.
 /// </summary>
-public MovingAverageTypeEnum MaType { get => _maType.Value; set => _maType.Value = value; }
+public MovingAverageTypes MaType { get => _maType.Value; set => _maType.Value = value; }
 
 /// <summary>
 /// Short MA length for golden cross.
@@ -89,7 +89,7 @@ _exitAtrMultiplier = Param(nameof(ExitAtrMultiplier), -1m)
 .SetDisplay("Exit Mult", "ATR multiplier for stop", "Risk")
 .SetCanOptimize(true);
 
-_maType = Param(nameof(MaType), MovingAverageTypeEnum.Simple)
+_maType = Param(nameof(MaType), MovingAverageTypes.Simple)
 .SetDisplay("MA Type", "Type of basis moving average", "General");
 
 _shortMaLength = Param(nameof(ShortMaLength), 50)
@@ -135,12 +135,12 @@ DrawOwnTrades(area);
 }
 }
 
-private MovingAverage CreateMa(MovingAverageTypeEnum type, int length)
+private MovingAverage CreateMa(MovingAverageTypes type, int length)
 {
 return type switch
 {
-MovingAverageTypeEnum.Exponential => new ExponentialMovingAverage { Length = length },
-MovingAverageTypeEnum.Weighted => new WeightedMovingAverage { Length = length },
+MovingAverageTypes.Exponential => new ExponentialMovingAverage { Length = length },
+MovingAverageTypes.Weighted => new WeightedMovingAverage { Length = length },
 _ => new SimpleMovingAverage { Length = length },
 };
 }
@@ -188,7 +188,7 @@ SellMarket(Volume);
 /// <summary>
 /// Moving average type.
 /// </summary>
-public enum MovingAverageTypeEnum
+public enum MovingAverageTypes
 {
 /// <summary>
 /// Simple moving average.

--- a/API/0957_KST_Skyrexio/CS/KstSkyrexioStrategy.cs
+++ b/API/0957_KST_Skyrexio/CS/KstSkyrexioStrategy.cs
@@ -21,7 +21,7 @@ public class KstSkyrexioStrategy : Strategy
 {
 	private readonly StrategyParam<decimal> _atrStopLoss;
 	private readonly StrategyParam<decimal> _atrTakeProfit;
-	private readonly StrategyParam<MaType> _filterMaType;
+	private readonly StrategyParam<MaTypes> _filterMaType;
 	private readonly StrategyParam<int> _filterMaLength;
 	private readonly StrategyParam<bool> _enableChopFilter;
 	private readonly StrategyParam<decimal> _chopThreshold;
@@ -45,7 +45,7 @@ public class KstSkyrexioStrategy : Strategy
 	/// <summary>
 	/// Moving average type for filter.
 	/// </summary>
-	public enum MaType
+	public enum MaTypes
 	{
 		SMA,
 		EMA,
@@ -70,7 +70,7 @@ public class KstSkyrexioStrategy : Strategy
 	/// <summary>
 	/// Filter moving average type.
 	/// </summary>
-	public MaType FilterMaType { get => _filterMaType.Value; set => _filterMaType.Value = value; }
+	public MaTypes FilterMaType { get => _filterMaType.Value; set => _filterMaType.Value = value; }
 
 	/// <summary>
 	/// Filter moving average length.
@@ -155,7 +155,7 @@ public class KstSkyrexioStrategy : Strategy
 			.SetGreaterThanZero()
 			.SetDisplay("ATR Take Profit", "ATR take-profit multiplier", "Stops");
 
-		_filterMaType = Param(nameof(FilterMaType), MaType.LSMA)
+		_filterMaType = Param(nameof(FilterMaType), MaTypes.LSMA)
 			.SetDisplay("Filter MA Type", "Type of trend filter", "Filter");
 
 		_filterMaLength = Param(nameof(FilterMaLength), 200)
@@ -305,14 +305,14 @@ public class KstSkyrexioStrategy : Strategy
 	{
 		return FilterMaType switch
 		{
-			MaType.SMA => new SimpleMovingAverage { Length = FilterMaLength },
-			MaType.EMA => new ExponentialMovingAverage { Length = FilterMaLength },
-			MaType.WMA => new WeightedMovingAverage { Length = FilterMaLength },
-			MaType.HMA => new HullMovingAverage { Length = FilterMaLength },
-			MaType.SMMA => new SmoothedMovingAverage { Length = FilterMaLength },
-			MaType.ALMA => new ArnaudLegouxMovingAverage { Length = FilterMaLength },
-			MaType.LSMA => new LinearRegression { Length = FilterMaLength },
-			MaType.VWMA => new VolumeWeightedMovingAverage { Length = FilterMaLength },
+			MaTypes.SMA => new SimpleMovingAverage { Length = FilterMaLength },
+			MaTypes.EMA => new ExponentialMovingAverage { Length = FilterMaLength },
+			MaTypes.WMA => new WeightedMovingAverage { Length = FilterMaLength },
+			MaTypes.HMA => new HullMovingAverage { Length = FilterMaLength },
+			MaTypes.SMMA => new SmoothedMovingAverage { Length = FilterMaLength },
+			MaTypes.ALMA => new ArnaudLegouxMovingAverage { Length = FilterMaLength },
+			MaTypes.LSMA => new LinearRegression { Length = FilterMaLength },
+			MaTypes.VWMA => new VolumeWeightedMovingAverage { Length = FilterMaLength },
 			_ => new SimpleMovingAverage { Length = FilterMaLength }
 		};
 	}

--- a/API/0961_LANZ_2_0_Backtest/CS/Lanz20BacktestStrategy.cs
+++ b/API/0961_LANZ_2_0_Backtest/CS/Lanz20BacktestStrategy.cs
@@ -23,7 +23,7 @@ public class Lanz20BacktestStrategy : Strategy
 {
 	private readonly StrategyParam<decimal> _accountSizeUsd;
 	private readonly StrategyParam<decimal> _riskPercent;
-	private readonly StrategyParam<SlProtectionModeOption> _slProtectionMode;
+	private readonly StrategyParam<SlProtectionModeOptions> _slProtectionMode;
 	private readonly StrategyParam<int> _fullCoveragePips;
 	private readonly StrategyParam<decimal> _minBosBreakPips;
 	private readonly StrategyParam<decimal> _rrMultiplier;
@@ -71,7 +71,7 @@ public class Lanz20BacktestStrategy : Strategy
 	/// <summary>
 	/// Stop-loss protection mode.
 	/// </summary>
-	public SlProtectionModeOption SlProtectionMode
+	public SlProtectionModeOptions SlProtectionMode
 	{
 		get => _slProtectionMode.Value;
 		set => _slProtectionMode.Value = value;
@@ -125,7 +125,7 @@ public class Lanz20BacktestStrategy : Strategy
 		.SetGreaterThanZero()
 		.SetDisplay("Risk %", "Risk percentage", "Risk");
 		
-		_slProtectionMode = Param(nameof(SlProtectionMode), SlProtectionModeOption.FullCoverage)
+		_slProtectionMode = Param(nameof(SlProtectionMode), SlProtectionModeOptions.FullCoverage)
 		.SetDisplay("SL Mode", "Stop-loss protection mode", "Risk");
 		
 		_fullCoveragePips = Param(nameof(FullCoveragePips), 12)
@@ -324,9 +324,9 @@ public class Lanz20BacktestStrategy : Strategy
 			var fallbackSl = entryPrice - 5m * _pipSize;
 			var slBase = SlProtectionMode switch
 			{
-				SlProtectionModeOption.FirstSwing => _lastSwingLow ?? fallbackSl,
-				SlProtectionModeOption.SecondSwing => _prevLow ?? fallbackSl,
-				SlProtectionModeOption.FullCoverage => (_olderSwingLow == null || _prevLow == null || _lastSwingLow == null)
+				SlProtectionModeOptions.FirstSwing => _lastSwingLow ?? fallbackSl,
+				SlProtectionModeOptions.SecondSwing => _prevLow ?? fallbackSl,
+				SlProtectionModeOptions.FullCoverage => (_olderSwingLow == null || _prevLow == null || _lastSwingLow == null)
 				? fallbackSl
 				: Math.Min((decimal)_olderSwingLow, Math.Min((decimal)_prevLow, (decimal)_lastSwingLow)) - FullCoveragePips * _pipSize,
 				_ => fallbackSl
@@ -347,9 +347,9 @@ public class Lanz20BacktestStrategy : Strategy
 			var fallbackSl = entryPrice + 5m * _pipSize;
 			var slBase = SlProtectionMode switch
 			{
-				SlProtectionModeOption.FirstSwing => _lastSwingHigh ?? fallbackSl,
-				SlProtectionModeOption.SecondSwing => _prevHigh ?? fallbackSl,
-				SlProtectionModeOption.FullCoverage => (_olderSwingHigh == null || _prevHigh == null || _lastSwingHigh == null)
+				SlProtectionModeOptions.FirstSwing => _lastSwingHigh ?? fallbackSl,
+				SlProtectionModeOptions.SecondSwing => _prevHigh ?? fallbackSl,
+				SlProtectionModeOptions.FullCoverage => (_olderSwingHigh == null || _prevHigh == null || _lastSwingHigh == null)
 				? fallbackSl
 				: Math.Max((decimal)_olderSwingHigh, Math.Max((decimal)_prevHigh, (decimal)_lastSwingHigh)) + FullCoveragePips * _pipSize,
 				_ => fallbackSl
@@ -371,7 +371,7 @@ public class Lanz20BacktestStrategy : Strategy
 /// <summary>
 /// Modes of stop-loss protection.
 /// </summary>
-public enum SlProtectionModeOption
+public enum SlProtectionModeOptions
 {
 	/// <summary>Use last swing.</summary>
 	FirstSwing,

--- a/API/0973_Linear_Continuation/CS/LinearContinuationStrategy.cs
+++ b/API/0973_Linear_Continuation/CS/LinearContinuationStrategy.cs
@@ -19,7 +19,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class LinearContinuationStrategy : Strategy
 {
-	private readonly StrategyParam<MovingAverageTypeEnum> _maType;
+	private readonly StrategyParam<MovingAverageTypes> _maType;
 	private readonly StrategyParam<int> _ma1Period;
 	private readonly StrategyParam<int> _ma2Period;
 	private readonly StrategyParam<int> _ma3Period;
@@ -29,7 +29,7 @@ public class LinearContinuationStrategy : Strategy
 	/// <summary>
 	/// Moving average type (SMA or EMA).
 	/// </summary>
-	public MovingAverageTypeEnum MaType
+	public MovingAverageTypes MaType
 	{
 		get => _maType.Value;
 		set => _maType.Value = value;
@@ -85,7 +85,7 @@ public class LinearContinuationStrategy : Strategy
 	/// </summary>
 	public LinearContinuationStrategy()
 	{
-		_maType = Param(nameof(MaType), MovingAverageTypeEnum.Simple)
+		_maType = Param(nameof(MaType), MovingAverageTypes.Simple)
 			.SetDisplay("MA Type", "Moving average type", "General");
 
 		_ma1Period = Param(nameof(Ma1Period), 200)
@@ -161,12 +161,12 @@ public class LinearContinuationStrategy : Strategy
 		return AggressiveMode ? 1 : (int)Math.Round(period / 4.669m) + 1;
 	}
 
-	private static IIndicator CreateMa(MovingAverageTypeEnum type, int length)
+	private static IIndicator CreateMa(MovingAverageTypes type, int length)
 	{
 		return type switch
 		{
-			MovingAverageTypeEnum.Simple => new SimpleMovingAverage { Length = length },
-			MovingAverageTypeEnum.Exponential => new ExponentialMovingAverage { Length = length },
+			MovingAverageTypes.Simple => new SimpleMovingAverage { Length = length },
+			MovingAverageTypes.Exponential => new ExponentialMovingAverage { Length = length },
 			_ => throw new ArgumentOutOfRangeException(nameof(type), type, null),
 		};
 	}
@@ -174,7 +174,7 @@ public class LinearContinuationStrategy : Strategy
 	/// <summary>
 	/// Moving average types.
 	/// </summary>
-	public enum MovingAverageTypeEnum
+	public enum MovingAverageTypes
 	{
 		/// <summary>Simple moving average.</summary>
 		Simple,

--- a/API/0980_Liquid_Pulse/CS/LiquidPulseStrategy.cs
+++ b/API/0980_Liquid_Pulse/CS/LiquidPulseStrategy.cs
@@ -20,11 +20,11 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class LiquidPulseStrategy : Strategy
 {
-	public enum VolumeSensitivityLevel { Low, Medium, High }
-	public enum MacdSpeedOption { Fast, Medium, Slow }
+	public enum VolumeSensitivityLevels { Low, Medium, High }
+	public enum MacdSpeedOptions { Fast, Medium, Slow }
 	
-	private readonly StrategyParam<VolumeSensitivityLevel> _volumeSensitivity;
-	private readonly StrategyParam<MacdSpeedOption> _macdSpeed;
+	private readonly StrategyParam<VolumeSensitivityLevels> _volumeSensitivity;
+	private readonly StrategyParam<MacdSpeedOptions> _macdSpeed;
 	private readonly StrategyParam<int> _dailyTradeLimit;
 	private readonly StrategyParam<int> _adxTrendThreshold;
 	private readonly StrategyParam<int> _atrPeriod;
@@ -39,8 +39,8 @@ public class LiquidPulseStrategy : Strategy
 	private DateTime _day;
 	private int _trades;
 	
-	public VolumeSensitivityLevel VolumeSensitivity { get => _volumeSensitivity.Value; set => _volumeSensitivity.Value = value; }
-	public MacdSpeedOption MacdSpeed { get => _macdSpeed.Value; set => _macdSpeed.Value = value; }
+	public VolumeSensitivityLevels VolumeSensitivity { get => _volumeSensitivity.Value; set => _volumeSensitivity.Value = value; }
+	public MacdSpeedOptions MacdSpeed { get => _macdSpeed.Value; set => _macdSpeed.Value = value; }
 	public int DailyTradeLimit { get => _dailyTradeLimit.Value; set => _dailyTradeLimit.Value = value; }
 	public int AdxTrendThreshold { get => _adxTrendThreshold.Value; set => _adxTrendThreshold.Value = value; }
 	public int AtrPeriod { get => _atrPeriod.Value; set => _atrPeriod.Value = value; }
@@ -48,9 +48,9 @@ public class LiquidPulseStrategy : Strategy
 	
 	public LiquidPulseStrategy()
 	{
-		_volumeSensitivity = Param(nameof(VolumeSensitivity), VolumeSensitivityLevel.Medium)
+		_volumeSensitivity = Param(nameof(VolumeSensitivity), VolumeSensitivityLevels.Medium)
 		.SetDisplay("Volume Sensitivity", "Volume sensitivity", "General");
-		_macdSpeed = Param(nameof(MacdSpeed), MacdSpeedOption.Medium)
+		_macdSpeed = Param(nameof(MacdSpeed), MacdSpeedOptions.Medium)
 		.SetDisplay("MACD Speed", "MACD speed", "General");
 		_dailyTradeLimit = Param(nameof(DailyTradeLimit), 20)
 		.SetDisplay("Daily Trade Limit", "Max trades per day", "Risk");
@@ -82,16 +82,16 @@ public class LiquidPulseStrategy : Strategy
 		
 		var (lookback, threshold) = VolumeSensitivity switch
 		{
-			VolumeSensitivityLevel.Low => (30, 1.5m),
-			VolumeSensitivityLevel.Medium => (20, 1.8m),
+			VolumeSensitivityLevels.Low => (30, 1.5m),
+			VolumeSensitivityLevels.Medium => (20, 1.8m),
 			_ => (11, 2m)
 		};
 		_volSma = new SimpleMovingAverage { Length = lookback };
 		
 		var (fast, slow, signal) = MacdSpeed switch
 		{
-			MacdSpeedOption.Fast => (2, 7, 5),
-			MacdSpeedOption.Medium => (5, 13, 9),
+			MacdSpeedOptions.Fast => (2, 7, 5),
+			MacdSpeedOptions.Medium => (5, 13, 9),
 			_ => (12, 26, 9)
 		};
 		_macd = new()

--- a/API/0981_Liquidity_Engulfment/CS/LiquidityEngulfmentStrategy.cs
+++ b/API/0981_Liquidity_Engulfment/CS/LiquidityEngulfmentStrategy.cs
@@ -18,14 +18,14 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class LiquidityEngulfmentStrategy : Strategy
 {
-	public enum TradeMode
+	public enum TradeModes
 	{
 		Both,
 		BullishOnly,
 		BearishOnly
 	}
 
-	private readonly StrategyParam<TradeMode> _mode;
+	private readonly StrategyParam<TradeModes> _mode;
 	private readonly StrategyParam<int> _upperLookback;
 	private readonly StrategyParam<int> _lowerLookback;
 	private readonly StrategyParam<int> _stopLossPips;
@@ -53,7 +53,7 @@ public class LiquidityEngulfmentStrategy : Strategy
 	private DateTimeOffset _entryTime;
 	private int _index;
 
-	public TradeMode Mode { get => _mode.Value; set => _mode.Value = value; }
+	public TradeModes Mode { get => _mode.Value; set => _mode.Value = value; }
 	public int UpperLookback { get => _upperLookback.Value; set => _upperLookback.Value = value; }
 	public int LowerLookback { get => _lowerLookback.Value; set => _lowerLookback.Value = value; }
 	public int StopLossPips { get => _stopLossPips.Value; set => _stopLossPips.Value = value; }
@@ -65,7 +65,7 @@ public class LiquidityEngulfmentStrategy : Strategy
 
 	public LiquidityEngulfmentStrategy()
 	{
-		_mode = Param(nameof(Mode), TradeMode.Both).SetDisplay("Mode", "Trading mode", "General");
+		_mode = Param(nameof(Mode), TradeModes.Both).SetDisplay("Mode", "Trading mode", "General");
 		_upperLookback = Param(nameof(UpperLookback), 10).SetGreaterThanZero().SetDisplay("Upper Lookback", "Upper liquidity", "Indicators").SetCanOptimize(true).SetOptimize(5, 20, 1);
 		_lowerLookback = Param(nameof(LowerLookback), 10).SetGreaterThanZero().SetDisplay("Lower Lookback", "Lower liquidity", "Indicators").SetCanOptimize(true).SetOptimize(5, 20, 1);
 		_stopLossPips = Param(nameof(StopLossPips), 10).SetGreaterThanZero().SetDisplay("Stop Loss", "Stop in pips", "Risk");
@@ -189,8 +189,8 @@ public class LiquidityEngulfmentStrategy : Strategy
 
 		var inRange = candle.OpenTime >= StartDate && candle.OpenTime <= EndDate;
 		var step = Security.PriceStep ?? 1m;
-		var canLong = Mode != TradeMode.BearishOnly;
-		var canShort = Mode != TradeMode.BullishOnly;
+		var canLong = Mode != TradeModes.BearishOnly;
+		var canShort = Mode != TradeModes.BullishOnly;
 
 		if (inRange && canShort && bearSignal && Position >= 0)
 		{

--- a/API/0982_Liquidity_Internal_Market_Shift/CS/LiquidityInternalMarketShiftStrategy.cs
+++ b/API/0982_Liquidity_Internal_Market_Shift/CS/LiquidityInternalMarketShiftStrategy.cs
@@ -19,14 +19,14 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class LiquidityInternalMarketShiftStrategy : Strategy
 {
-public enum TradeMode
+public enum TradeModes
 {
 Both,
 BullishOnly,
 BearishOnly
 }
 
-private readonly StrategyParam<TradeMode> _mode;
+private readonly StrategyParam<TradeModes> _mode;
 private readonly StrategyParam<DateTimeOffset> _startDate;
 private readonly StrategyParam<DateTimeOffset> _endDate;
 private readonly StrategyParam<bool> _enableTakeProfit;
@@ -57,7 +57,7 @@ private decimal? _entryPrice;
 private DateTimeOffset _entryTime;
 private bool _isLongPosition;
 
-public TradeMode Mode { get => _mode.Value; set => _mode.Value = value; }
+public TradeModes Mode { get => _mode.Value; set => _mode.Value = value; }
 public DateTimeOffset StartDate { get => _startDate.Value; set => _startDate.Value = value; }
 public DateTimeOffset EndDate { get => _endDate.Value; set => _endDate.Value = value; }
 public bool EnableTakeProfit { get => _enableTakeProfit.Value; set => _enableTakeProfit.Value = value; }
@@ -69,7 +69,7 @@ public DataType CandleType { get => _candleType.Value; set => _candleType.Value 
 
 public LiquidityInternalMarketShiftStrategy()
 {
-_mode = Param(nameof(Mode), TradeMode.Both)
+_mode = Param(nameof(Mode), TradeModes.Both)
 .SetDisplay("Mode", "Trading mode", "General");
 
 _startDate = Param(nameof(StartDate), new DateTimeOffset(new DateTime(2024, 1, 1), TimeSpan.Zero))
@@ -244,7 +244,7 @@ _lockedBearish = false;
 
 bool inTimeRange = candle.OpenTime >= StartDate && candle.OpenTime <= EndDate;
 
-if (Mode != TradeMode.BearishOnly && bullishSignal && inTimeRange && _entryPrice is null)
+if (Mode != TradeModes.BearishOnly && bullishSignal && inTimeRange && _entryPrice is null)
 {
 BuyMarket();
 _entryPrice = candle.ClosePrice;
@@ -252,7 +252,7 @@ _entryTime = candle.OpenTime;
 _isLongPosition = true;
 }
 
-if (Mode != TradeMode.BullishOnly && bearishSignal && inTimeRange && _entryPrice is null)
+if (Mode != TradeModes.BullishOnly && bearishSignal && inTimeRange && _entryPrice is null)
 {
 SellMarket();
 _entryPrice = candle.ClosePrice;

--- a/API/0988_Logistic_RSI_STOCH_ROC_AO/CS/LogisticRsiStochRocAoStrategy.cs
+++ b/API/0988_Logistic_RSI_STOCH_ROC_AO/CS/LogisticRsiStochRocAoStrategy.cs
@@ -22,7 +22,7 @@ public class LogisticRsiStochRocAoStrategy : Strategy
 	/// <summary>
 	/// Indicator source options.
 	/// </summary>
-	public enum IndicatorSource
+	public enum IndicatorSources
 	{
 		AwesomeOscillator,
 		LogisticDominance,
@@ -31,7 +31,7 @@ public class LogisticRsiStochRocAoStrategy : Strategy
 		Stochastic
 	}
 
-	private readonly StrategyParam<IndicatorSource> _indicator;
+	private readonly StrategyParam<IndicatorSources> _indicator;
 	private readonly StrategyParam<int> _length;
 	private readonly StrategyParam<int> _lenLd;
 	private readonly StrategyParam<int> _lenRoc;
@@ -54,7 +54,7 @@ public class LogisticRsiStochRocAoStrategy : Strategy
 	/// <summary>
 	/// Selected indicator source.
 	/// </summary>
-	public IndicatorSource Indicator
+	public IndicatorSources Indicator
 	{
 		get => _indicator.Value;
 		set => _indicator.Value = value;
@@ -119,7 +119,7 @@ public class LogisticRsiStochRocAoStrategy : Strategy
 	/// </summary>
 	public LogisticRsiStochRocAoStrategy()
 	{
-		_indicator = Param(nameof(Indicator), IndicatorSource.LogisticDominance)
+		_indicator = Param(nameof(Indicator), IndicatorSources.LogisticDominance)
 						 .SetDisplay("Indicator", "Source indicator", "General");
 
 		_length = Param(nameof(Length), 13).SetDisplay("Length", "Logistic map length", "General").SetCanOptimize(true);
@@ -180,12 +180,12 @@ public class LogisticRsiStochRocAoStrategy : Strategy
 		decimal r;
 		switch (Indicator)
 		{
-		case IndicatorSource.AwesomeOscillator:
+		case IndicatorSources.AwesomeOscillator:
 			if (!aoValue.IsFinal)
 				return;
 			r = aoValue.ToDecimal();
 			break;
-		case IndicatorSource.LogisticDominance:
+		case IndicatorSources.LogisticDominance:
 			if (!rocLdValue.IsFinal)
 				return;
 			var ld = rocLdValue.ToDecimal();
@@ -193,17 +193,17 @@ public class LogisticRsiStochRocAoStrategy : Strategy
 			var pos = LogisticMap(candle.ClosePrice, ld, highest);
 			r = -neg - pos;
 			break;
-		case IndicatorSource.RateOfChange:
+		case IndicatorSources.RateOfChange:
 			if (!rocValue.IsFinal)
 				return;
 			r = rocValue.ToDecimal();
 			break;
-		case IndicatorSource.RelativeStrengthIndex:
+		case IndicatorSources.RelativeStrengthIndex:
 			if (!rsiValue.IsFinal)
 				return;
 			r = rsiValue.ToDecimal() / 100m - 0.5m;
 			break;
-		case IndicatorSource.Stochastic:
+		case IndicatorSources.Stochastic:
 			if (!stochValue.IsFinal)
 				return;
 			var st = (StochasticOscillatorValue)stochValue;

--- a/API/0990_Long_and_Short_with_Multi_Indicators/CS/LongAndShortWithMultiIndicatorsStrategy.cs
+++ b/API/0990_Long_and_Short_with_Multi_Indicators/CS/LongAndShortWithMultiIndicatorsStrategy.cs
@@ -23,7 +23,7 @@ public class LongAndShortWithMultiIndicatorsStrategy : Strategy
 	private readonly StrategyParam<int> _rsiOversold;
 	private readonly StrategyParam<int> _rocLength;
 	private readonly StrategyParam<int> _maLength;
-	private readonly StrategyParam<MaType> _maType;
+	private readonly StrategyParam<MaTypes> _maType;
 	private readonly StrategyParam<int> _atrLength;
 	private readonly StrategyParam<decimal> _atrMultiplier;
 	private readonly StrategyParam<int> _bearishMaLength;
@@ -66,7 +66,7 @@ public class LongAndShortWithMultiIndicatorsStrategy : Strategy
 	/// <summary>
 	/// Moving average type.
 	/// </summary>
-	public MaType MaTypeParam { get => _maType.Value; set => _maType.Value = value; }
+	public MaTypes MaTypeParam { get => _maType.Value; set => _maType.Value = value; }
 
 	/// <summary>
 	/// ATR length.
@@ -128,7 +128,7 @@ public class LongAndShortWithMultiIndicatorsStrategy : Strategy
 			.SetDisplay("MA Length", "Length of moving average", "Indicators")
 			.SetGreaterThanZero();
 
-		_maType = Param(nameof(MaTypeParam), MaType.Tema)
+		_maType = Param(nameof(MaTypeParam), MaTypes.Tema)
 			.SetDisplay("MA Type", "Type of moving average", "Indicators");
 
 		_atrLength = Param(nameof(AtrLength), 14)
@@ -236,17 +236,17 @@ public class LongAndShortWithMultiIndicatorsStrategy : Strategy
 		}
 	}
 
-	private static IIndicator CreateMa(MaType type, int length)
+	private static IIndicator CreateMa(MaTypes type, int length)
 	{
 		return type switch
 		{
-			MaType.Sma => new SimpleMovingAverage { Length = length },
-			MaType.Ema => new ExponentialMovingAverage { Length = length },
-			MaType.Wma => new WeightedMovingAverage { Length = length },
-			MaType.Hma => new HullMovingAverage { Length = length },
-			MaType.Vwma => new VolumeWeightedMovingAverage { Length = length },
-			MaType.Rma => new SmoothedMovingAverage { Length = length },
-			MaType.Tema => new TripleExponentialMovingAverage { Length = length },
+			MaTypes.Sma => new SimpleMovingAverage { Length = length },
+			MaTypes.Ema => new ExponentialMovingAverage { Length = length },
+			MaTypes.Wma => new WeightedMovingAverage { Length = length },
+			MaTypes.Hma => new HullMovingAverage { Length = length },
+			MaTypes.Vwma => new VolumeWeightedMovingAverage { Length = length },
+			MaTypes.Rma => new SmoothedMovingAverage { Length = length },
+			MaTypes.Tema => new TripleExponentialMovingAverage { Length = length },
 			_ => new SimpleMovingAverage { Length = length }
 		};
 	}
@@ -254,7 +254,7 @@ public class LongAndShortWithMultiIndicatorsStrategy : Strategy
 	/// <summary>
 	/// Moving average types.
 	/// </summary>
-	public enum MaType
+	public enum MaTypes
 	{
 		Sma = 1,
 		Ema,

--- a/API/0993_Long_Short_Exit_Risk_Management/CS/LongShortExitRiskManagementStrategy.cs
+++ b/API/0993_Long_Short_Exit_Risk_Management/CS/LongShortExitRiskManagementStrategy.cs
@@ -14,7 +14,7 @@ namespace StockSharp.Samples.Strategies;
 
 
 
-public enum TradingDirection
+public enum TradingDirections
 {
 	LongOnly,
 	ShortOnly,
@@ -27,7 +27,7 @@ public enum TradingDirection
 /// </summary>
 public class LongShortExitRiskManagementStrategy : Strategy
 {
-	private readonly StrategyParam<TradingDirection> _tradingDirection;
+	private readonly StrategyParam<TradingDirections> _tradingDirection;
 	private readonly StrategyParam<decimal> _stopLossPercent;
 	private readonly StrategyParam<decimal> _takeProfitPercent;
 	private readonly StrategyParam<int> _exitBars;
@@ -48,7 +48,7 @@ public class LongShortExitRiskManagementStrategy : Strategy
 	/// <summary>
 	/// Allowed trading direction.
 	/// </summary>
-	public TradingDirection TradingDirection
+	public TradingDirections TradingDirection
 	{
 		get => _tradingDirection.Value;
 		set => _tradingDirection.Value = value;
@@ -149,7 +149,7 @@ public class LongShortExitRiskManagementStrategy : Strategy
 	/// </summary>
 	public LongShortExitRiskManagementStrategy()
 	{
-		_tradingDirection = Param(nameof(TradingDirection), TradingDirection.All)
+		_tradingDirection = Param(nameof(TradingDirection), TradingDirections.All)
 			.SetDisplay("Trading Direction", "Allowed trading direction", "General");
 
 		_stopLossPercent = Param(nameof(StopLossPercent), 2m)
@@ -252,8 +252,8 @@ public class LongShortExitRiskManagementStrategy : Strategy
 			if (_tradesToday >= MaxTradesPerDay)
 				return;
 
-			var allowLong = TradingDirection == TradingDirection.All || TradingDirection == TradingDirection.LongOnly;
-			var allowShort = TradingDirection == TradingDirection.All || TradingDirection == TradingDirection.ShortOnly;
+			var allowLong = TradingDirection == TradingDirections.All || TradingDirection == TradingDirections.LongOnly;
+			var allowShort = TradingDirection == TradingDirections.All || TradingDirection == TradingDirections.ShortOnly;
 
 			var longSignal = candle.ClosePrice == LongValue;
 			var shortSignal = candle.ClosePrice == ShortValue;

--- a/API/0997_Long_Only_Opening_Range_Breakout_ORB_with_Pivot_Points/CS/LongOnlyOpeningRangeBreakoutWithPivotPointsStrategy.cs
+++ b/API/0997_Long_Only_Opening_Range_Breakout_ORB_with_Pivot_Points/CS/LongOnlyOpeningRangeBreakoutWithPivotPointsStrategy.cs
@@ -13,7 +13,7 @@ namespace StockSharp.Samples.Strategies;
 
 
 
-public enum SlType
+public enum SlTypes
 {
 	Percentage,
 	PreviousLow
@@ -29,7 +29,7 @@ public class LongOnlyOpeningRangeBreakoutWithPivotPointsStrategy : Strategy
 	private readonly StrategyParam<int> _rangeMinutes;
 	private readonly StrategyParam<int> _maxTrades;
 	private readonly StrategyParam<decimal> _stopLossPercent;
-	private readonly StrategyParam<SlType> _initialSlType;
+	private readonly StrategyParam<SlTypes> _initialSlType;
 
 	private DateTimeOffset _sessionStartTime;
 	private DateTimeOffset _sessionEndTime;
@@ -73,7 +73,7 @@ public class LongOnlyOpeningRangeBreakoutWithPivotPointsStrategy : Strategy
 		_stopLossPercent = Param(nameof(StopLossPercent), 3m)
 		.SetDisplay("Stop Loss %", "Initial stop loss percent", "Risk");
 
-		_initialSlType = Param(nameof(InitialSlType), SlType.Percentage)
+		_initialSlType = Param(nameof(InitialSlType), SlTypes.Percentage)
 		.SetDisplay("Initial SL Type", "Initial stop loss type", "Risk");
 	}
 
@@ -125,7 +125,7 @@ public class LongOnlyOpeningRangeBreakoutWithPivotPointsStrategy : Strategy
 	/// <summary>
 	/// Initial stop loss type.
 	/// </summary>
-	public SlType InitialSlType
+	public SlTypes InitialSlType
 	{
 		get => _initialSlType.Value;
 		set => _initialSlType.Value = value;
@@ -235,7 +235,7 @@ public class LongOnlyOpeningRangeBreakoutWithPivotPointsStrategy : Strategy
 			{
 				_entryPrice = _openingHigh.Value;
 				var slPercent = StopLossPercent / 100m;
-				_slLong0 = InitialSlType == SlType.Percentage ? _entryPrice * (1m - slPercent) : prevLow;
+				_slLong0 = InitialSlType == SlTypes.Percentage ? _entryPrice * (1m - slPercent) : prevLow;
 				BuyMarket(Volume + Math.Abs(Position));
 				_tradesCounter++;
 				_trailLong = 0m;


### PR DESCRIPTION
## Summary
- rename enum declarations in API strategies 0501-0997 so their names are pluralized
- update all related references (properties, parameters, nameof calls, etc.) to match the new enum names

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d83771591c8323a05cb7e04a4e3339