### PR TITLE
Pluralize API strategy enum names

### DIFF
--- a/API/1004_MA_MACD_BB_BackTester/CS/MaMacdBbBackTesterStrategy.cs
+++ b/API/1004_MA_MACD_BB_BackTester/CS/MaMacdBbBackTesterStrategy.cs
@@ -18,7 +18,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class MaMacdBbBackTesterStrategy : Strategy
 {
-	public enum IndicatorType
+	public enum IndicatorTypes
 	{
 		MA,
 		MACD,
@@ -26,7 +26,7 @@ public class MaMacdBbBackTesterStrategy : Strategy
 	}
 
 private readonly StrategyParam<DataType> _candleType;
-private readonly StrategyParam<IndicatorType> _indicator;
+private readonly StrategyParam<IndicatorTypes> _indicator;
 private readonly StrategyParam<Sides?> _direction;
 	private readonly StrategyParam<int> _maLength;
 	private readonly StrategyParam<int> _fastLength;
@@ -47,7 +47,7 @@ private readonly StrategyParam<Sides?> _direction;
 	private decimal? _prevSignal;
 
 	public DataType CandleType { get => _candleType.Value; set => _candleType.Value = value; }
-	public IndicatorType Indicator { get => _indicator.Value; set => _indicator.Value = value; }
+	public IndicatorTypes Indicator { get => _indicator.Value; set => _indicator.Value = value; }
 public Sides? Direction { get => _direction.Value; set => _direction.Value = value; }
 	public int MaLength { get => _maLength.Value; set => _maLength.Value = value; }
 	public int FastLength { get => _fastLength.Value; set => _fastLength.Value = value; }
@@ -63,7 +63,7 @@ public Sides? Direction { get => _direction.Value; set => _direction.Value = val
 		_candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
 			.SetDisplay("Candle Type", "Time frame", "General");
 
-		_indicator = Param(nameof(Indicator), IndicatorType.MA)
+		_indicator = Param(nameof(Indicator), IndicatorTypes.MA)
 			.SetDisplay("Indicator", "Trading indicator", "General");
 	 _direction = Param(nameof(Direction), Sides.Buy)
 	        .SetDisplay("Direction", "Trade direction", "General");
@@ -108,11 +108,11 @@ public Sides? Direction { get => _direction.Value; set => _direction.Value = val
 
 		switch (Indicator)
 		{
-			case IndicatorType.MA:
+			case IndicatorTypes.MA:
 				_ma = new SimpleMovingAverage { Length = MaLength };
 				subscription.Bind(_ma, ProcessMa).Start();
 				break;
-			case IndicatorType.MACD:
+			case IndicatorTypes.MACD:
 				_macd = new MovingAverageConvergenceDivergenceSignal
 				{
 					Macd =
@@ -124,7 +124,7 @@ public Sides? Direction { get => _direction.Value; set => _direction.Value = val
 				};
 				subscription.BindEx(_macd, ProcessMacd).Start();
 				break;
-			case IndicatorType.BB:
+			case IndicatorTypes.BB:
 				_bollinger = new BollingerBands { Length = BbLength, Width = BbMultiplier };
 				subscription.Bind(_bollinger, ProcessBb).Start();
 				break;

--- a/API/1005_MA_With_Logistic/CS/MaWithLogisticStrategy.cs
+++ b/API/1005_MA_With_Logistic/CS/MaWithLogisticStrategy.cs
@@ -20,8 +20,8 @@ public class MaWithLogisticStrategy : Strategy
 {
 	private readonly StrategyParam<int> _fastLength;
 	private readonly StrategyParam<int> _slowLength;
-	private readonly StrategyParam<MaTypeEnum> _maType;
-	private readonly StrategyParam<ExitTypeEnum> _exitType;
+	private readonly StrategyParam<MaTypes> _maType;
+	private readonly StrategyParam<ExitTypes> _exitType;
 	private readonly StrategyParam<decimal> _takeProfitPercent;
 	private readonly StrategyParam<decimal> _stopLossPercent;
 	private readonly StrategyParam<decimal> _logisticSlope;
@@ -51,7 +51,7 @@ public class MaWithLogisticStrategy : Strategy
 	/// <summary>
 	/// Moving average type.
 	/// </summary>
-	public MaTypeEnum MaType
+	public MaTypes MaType
 	{
 		get => _maType.Value;
 		set => _maType.Value = value;
@@ -60,7 +60,7 @@ public class MaWithLogisticStrategy : Strategy
 	/// <summary>
 	/// Exit mode.
 	/// </summary>
-	public ExitTypeEnum ExitType
+	public ExitTypes ExitType
 	{
 		get => _exitType.Value;
 		set => _exitType.Value = value;
@@ -138,8 +138,8 @@ public class MaWithLogisticStrategy : Strategy
 			Param(nameof(FastLength), 9).SetDisplay("Fast MA", "Fast MA period", "Indicators").SetGreaterThanZero();
 		_slowLength =
 			Param(nameof(SlowLength), 21).SetDisplay("Slow MA", "Slow MA period", "Indicators").SetGreaterThanZero();
-		_maType = Param(nameof(MaType), MaTypeEnum.EMA).SetDisplay("MA Type", "Moving average type", "Indicators");
-		_exitType = Param(nameof(ExitType), ExitTypeEnum.Percent).SetDisplay("Exit Type", "Exit method", "General");
+		_maType = Param(nameof(MaType), MaTypes.EMA).SetDisplay("MA Type", "Moving average type", "Indicators");
+		_exitType = Param(nameof(ExitType), ExitTypes.Percent).SetDisplay("Exit Type", "Exit method", "General");
 		_takeProfitPercent = Param(nameof(TakeProfitPercent), 20m)
 								 .SetDisplay("TP %", "Take profit percent", "Percent")
 								 .SetGreaterThanZero();
@@ -203,7 +203,7 @@ public class MaWithLogisticStrategy : Strategy
 
 		if (Position > 0)
 		{
-			if (ExitType == ExitTypeEnum.Percent)
+			if (ExitType == ExitTypes.Percent)
 			{
 				var tpPrice = PositionAvgPrice * (1m + TakeProfitPercent / 100m);
 				var slPrice = PositionAvgPrice * (1m - StopLossPercent / 100m);
@@ -211,7 +211,7 @@ public class MaWithLogisticStrategy : Strategy
 				if (close >= tpPrice || close <= slPrice)
 					SellMarket(Math.Abs(Position));
 			}
-			else if (ExitType == ExitTypeEnum.Logistic)
+			else if (ExitType == ExitTypes.Logistic)
 			{
 				var profitPct = (close - PositionAvgPrice) / PositionAvgPrice;
 				var prob = 1m / (1m + (decimal)Math.Exp((double)(-LogisticSlope * (profitPct - LogisticMidpoint))));
@@ -221,7 +221,7 @@ public class MaWithLogisticStrategy : Strategy
 		}
 		else if (Position < 0)
 		{
-			if (ExitType == ExitTypeEnum.Percent)
+			if (ExitType == ExitTypes.Percent)
 			{
 				var tpPrice = PositionAvgPrice * (1m - TakeProfitPercent / 100m);
 				var slPrice = PositionAvgPrice * (1m + StopLossPercent / 100m);
@@ -229,7 +229,7 @@ public class MaWithLogisticStrategy : Strategy
 				if (close <= tpPrice || close >= slPrice)
 					BuyMarket(Math.Abs(Position));
 			}
-			else if (ExitType == ExitTypeEnum.Logistic)
+			else if (ExitType == ExitTypes.Logistic)
 			{
 				var profitPct = (PositionAvgPrice - close) / PositionAvgPrice;
 				var prob = 1m / (1m + (decimal)Math.Exp((double)(-LogisticSlope * (profitPct - LogisticMidpoint))));
@@ -239,11 +239,11 @@ public class MaWithLogisticStrategy : Strategy
 		}
 	}
 
-	private MovingAverage CreateMa(MaTypeEnum type, int length)
+	private MovingAverage CreateMa(MaTypes type, int length)
 	{
 		return type switch {
-			MaTypeEnum.EMA => new ExponentialMovingAverage { Length = length },
-			MaTypeEnum.WMA => new WeightedMovingAverage { Length = length },
+			MaTypes.EMA => new ExponentialMovingAverage { Length = length },
+			MaTypes.WMA => new WeightedMovingAverage { Length = length },
 			_ => new SimpleMovingAverage { Length = length },
 		};
 	}
@@ -251,7 +251,7 @@ public class MaWithLogisticStrategy : Strategy
 	/// <summary>
 	/// Moving average types.
 	/// </summary>
-	public enum MaTypeEnum
+	public enum MaTypes
 	{
 		EMA,
 		SMA,
@@ -261,7 +261,7 @@ public class MaWithLogisticStrategy : Strategy
 	/// <summary>
 	/// Exit modes.
 	/// </summary>
-	public enum ExitTypeEnum
+	public enum ExitTypes
 	{
 		None,
 		Percent,

--- a/API/1010_MACD_Liquidity_Tracker/CS/MacdLiquidityTrackerStrategy.cs
+++ b/API/1010_MACD_Liquidity_Tracker/CS/MacdLiquidityTrackerStrategy.cs
@@ -24,7 +24,7 @@ public class MacdLiquidityTrackerStrategy : Strategy
 	private readonly StrategyParam<int> _slowLength;
 	private readonly StrategyParam<int> _signalLength;
 	private readonly StrategyParam<bool> _allowShort;
-	private readonly StrategyParam<SystemType> _systemType;
+	private readonly StrategyParam<SystemTypes> _systemType;
 	private readonly StrategyParam<bool> _useStopLoss;
 	private readonly StrategyParam<decimal> _stopLossPercent;
 	private readonly StrategyParam<bool> _useTakeProfit;
@@ -62,7 +62,7 @@ public class MacdLiquidityTrackerStrategy : Strategy
 	/// <summary>
 	/// System logic selection.
 	/// </summary>
-	public SystemType SystemLogic { get => _systemType.Value; set => _systemType.Value = value; }
+	public SystemTypes SystemLogic { get => _systemType.Value; set => _systemType.Value = value; }
 
 	/// <summary>
 	/// Enable stop loss.
@@ -119,7 +119,7 @@ public class MacdLiquidityTrackerStrategy : Strategy
 		_allowShort = Param(nameof(AllowShortTrades), false)
 			.SetDisplay("Allow Short Trades", "Enable short trades", "General");
 
-		_systemType = Param(nameof(SystemLogic), SystemType.Normal)
+		_systemType = Param(nameof(SystemLogic), SystemTypes.Normal)
 			.SetDisplay("System Type", "Logic for signals", "System");
 
 		_useStopLoss = Param(nameof(UseStopLoss), false)
@@ -210,19 +210,19 @@ public class MacdLiquidityTrackerStrategy : Strategy
 
 		switch (SystemLogic)
 		{
-			case SystemType.Fast:
+			case SystemTypes.Fast:
 				longSignal = isBrightBlue || isDarkMagenta;
 				shortSignal = isDarkBlue || isBrightMagenta;
 				break;
-			case SystemType.Normal:
+			case SystemTypes.Normal:
 				longSignal = macd > signal;
 				shortSignal = macd < signal;
 				break;
-			case SystemType.Safe:
+			case SystemTypes.Safe:
 				longSignal = isBrightBlue;
 				shortSignal = isDarkBlue || isBrightMagenta || isDarkMagenta;
 				break;
-			case SystemType.Crossover:
+			case SystemTypes.Crossover:
 				longSignal = macd > signal && (_prevMacd <= _prevSignal);
 				shortSignal = macd < signal && (_prevMacd >= _prevSignal);
 				break;
@@ -264,7 +264,7 @@ public class MacdLiquidityTrackerStrategy : Strategy
 	/// <summary>
 	/// Types of system logic.
 	/// </summary>
-	public enum SystemType
+	public enum SystemTypes
 	{
 		/// <summary>
 		/// Uses MACD momentum colour states.

--- a/API/1041_Mean_Reversion_Pro/CS/MeanReversionProStrategy.cs
+++ b/API/1041_Mean_Reversion_Pro/CS/MeanReversionProStrategy.cs
@@ -17,7 +17,7 @@ public class MeanReversionProStrategy : Strategy
 {
 	private readonly StrategyParam<int> _fastLength;
 	private readonly StrategyParam<int> _slowLength;
-	private readonly StrategyParam<TradingMode> _tradingMode;
+	private readonly StrategyParam<TradingModes> _tradingMode;
 	private readonly StrategyParam<DataType> _candleType;
 
 	public int FastLength
@@ -32,7 +32,7 @@ public class MeanReversionProStrategy : Strategy
 		set => _slowLength.Value = value;
 	}
 
-	public TradingMode Mode
+	public TradingModes Mode
 	{
 		get => _tradingMode.Value;
 		set => _tradingMode.Value = value;
@@ -58,7 +58,7 @@ public class MeanReversionProStrategy : Strategy
 			.SetCanOptimize(true)
 			.SetOptimize(100, 200, 50);
 
-		_tradingMode = Param(nameof(Mode), TradingMode.LongOnly)
+		_tradingMode = Param(nameof(Mode), TradingModes.LongOnly)
 			.SetDisplay("Trading Direction", "Allowed trading direction", "Parameters");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromDays(1).TimeFrame())
@@ -107,8 +107,8 @@ public class MeanReversionProStrategy : Strategy
 		var longThreshold = candle.LowPrice + 0.2m * range;
 		var shortThreshold = candle.HighPrice - 0.2m * range;
 
-		var longAllowed = Mode is TradingMode.LongOnly or TradingMode.Both;
-		var shortAllowed = Mode is TradingMode.ShortOnly or TradingMode.Both;
+		var longAllowed = Mode is TradingModes.LongOnly or TradingModes.Both;
+		var shortAllowed = Mode is TradingModes.ShortOnly or TradingModes.Both;
 
 		var longSignal = candle.ClosePrice < fast &&
 			candle.ClosePrice < longThreshold &&
@@ -143,7 +143,7 @@ public class MeanReversionProStrategy : Strategy
 		}
 	}
 
-	public enum TradingMode
+	public enum TradingModes
 	{
 		LongOnly,
 		ShortOnly,

--- a/API/1042_Mean_Reversion_V_F/CS/MeanReversionVFStrategy.cs
+++ b/API/1042_Mean_Reversion_V_F/CS/MeanReversionVFStrategy.cs
@@ -15,7 +15,7 @@ namespace StockSharp.Samples.Strategies;
 
 public class MeanReversionVFStrategy : Strategy
 {
-	public enum MaType
+	public enum MaTypes
 	{
 		Wma,
 		Sma,
@@ -24,7 +24,7 @@ public class MeanReversionVFStrategy : Strategy
 		Hma
 	}
 
-	private readonly StrategyParam<MaType> _maType;
+	private readonly StrategyParam<MaTypes> _maType;
 	private readonly StrategyParam<int> _maLength;
 	private readonly StrategyParam<decimal> _deviation1;
 	private readonly StrategyParam<decimal> _deviation2;
@@ -51,7 +51,7 @@ public class MeanReversionVFStrategy : Strategy
 	private decimal _trailPrice;
 	private decimal _extremePrice;
 
-	public MaType MovingAverageType { get => _maType.Value; set => _maType.Value = value; }
+	public MaTypes MovingAverageType { get => _maType.Value; set => _maType.Value = value; }
 	public int MaLength { get => _maLength.Value; set => _maLength.Value = value; }
 	public decimal Deviation1 { get => _deviation1.Value; set => _deviation1.Value = value; }
 	public decimal Deviation2 { get => _deviation2.Value; set => _deviation2.Value = value; }
@@ -71,7 +71,7 @@ public class MeanReversionVFStrategy : Strategy
 
 	public MeanReversionVFStrategy()
 	{
-		_maType = Param(nameof(MovingAverageType), MaType.Wma)
+		_maType = Param(nameof(MovingAverageType), MaTypes.Wma)
 			.SetDisplay("MA Type", "Type of moving average", "General");
 
 		_maLength = Param(nameof(MaLength), 20)
@@ -267,15 +267,15 @@ public class MeanReversionVFStrategy : Strategy
 		_extremePrice = 0m;
 	}
 
-	private static LengthIndicator<decimal> CreateMa(MaType type, int length)
+	private static LengthIndicator<decimal> CreateMa(MaTypes type, int length)
 	{
 		return type switch
 		{
-			MaType.Sma => new SimpleMovingAverage { Length = length },
-			MaType.Ema => new ExponentialMovingAverage { Length = length },
-			MaType.Wma => new WeightedMovingAverage { Length = length },
-			MaType.Rma => new SmoothedMovingAverage { Length = length },
-			MaType.Hma => new HullMovingAverage { Length = length },
+			MaTypes.Sma => new SimpleMovingAverage { Length = length },
+			MaTypes.Ema => new ExponentialMovingAverage { Length = length },
+			MaTypes.Wma => new WeightedMovingAverage { Length = length },
+			MaTypes.Rma => new SmoothedMovingAverage { Length = length },
+			MaTypes.Hma => new HullMovingAverage { Length = length },
 			_ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
 		};
 	}

--- a/API/1053_Mikuls_Ichimoku_Cloud_v2/CS/MikulsIchimokuCloudV2Strategy.cs
+++ b/API/1053_Mikuls_Ichimoku_Cloud_v2/CS/MikulsIchimokuCloudV2Strategy.cs
@@ -22,8 +22,8 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class MikulsIchimokuCloudV2Strategy : Strategy
 {
-	private readonly StrategyParam<TrailSource> _trailSource;
-	private readonly StrategyParam<TrailMethod> _trailMethod;
+	private readonly StrategyParam<TrailSources> _trailSource;
+	private readonly StrategyParam<TrailMethods> _trailMethod;
 	private readonly StrategyParam<decimal> _trailPercent;
 	private readonly StrategyParam<int> _swingLookback;
 	private readonly StrategyParam<int> _atrPeriod;
@@ -32,7 +32,7 @@ public class MikulsIchimokuCloudV2Strategy : Strategy
 	private readonly StrategyParam<bool> _useTakeProfit;
 	private readonly StrategyParam<decimal> _takeProfitPercent;
 	private readonly StrategyParam<bool> _useMaFilter;
-	private readonly StrategyParam<MovingAverageType> _maType;
+	private readonly StrategyParam<MovingAverageTypes> _maType;
 	private readonly StrategyParam<int> _maLength;
 	private readonly StrategyParam<int> _tenkanPeriod;
 	private readonly StrategyParam<int> _kijunPeriod;
@@ -52,12 +52,12 @@ public class MikulsIchimokuCloudV2Strategy : Strategy
 	/// <summary>
 	/// Source for trailing stop.
 	/// </summary>
-	public TrailSource TrailSource { get => _trailSource.Value; set => _trailSource.Value = value; }
+	public TrailSources TrailSource { get => _trailSource.Value; set => _trailSource.Value = value; }
 
 	/// <summary>
 	/// Trailing calculation method.
 	/// </summary>
-	public TrailMethod TrailMethod { get => _trailMethod.Value; set => _trailMethod.Value = value; }
+	public TrailMethods TrailMethod { get => _trailMethod.Value; set => _trailMethod.Value = value; }
 
 	/// <summary>
 	/// Percent for trailing stop.
@@ -102,7 +102,7 @@ public class MikulsIchimokuCloudV2Strategy : Strategy
 	/// <summary>
 	/// Moving average type.
 	/// </summary>
-	public MovingAverageType MaType { get => _maType.Value; set => _maType.Value = value; }
+	public MovingAverageTypes MaType { get => _maType.Value; set => _maType.Value = value; }
 
 	/// <summary>
 	/// Moving average length.
@@ -139,10 +139,10 @@ public class MikulsIchimokuCloudV2Strategy : Strategy
 	/// </summary>
 	public MikulsIchimokuCloudV2Strategy()
 	{
-		_trailSource = Param(nameof(TrailSource), Strategies.TrailSource.LowsHighs)
+		_trailSource = Param(nameof(TrailSource), Strategies.TrailSources.LowsHighs)
 			.SetDisplay("Trail Source", "Source for trailing stop", "Trailing");
 
-		_trailMethod = Param(nameof(TrailMethod), Strategies.TrailMethod.Atr)
+		_trailMethod = Param(nameof(TrailMethod), Strategies.TrailMethods.Atr)
 			.SetDisplay("Trail Method", "Trailing calculation method", "Trailing");
 
 		_trailPercent = Param(nameof(TrailPercent), 10m)
@@ -174,7 +174,7 @@ public class MikulsIchimokuCloudV2Strategy : Strategy
 		_useMaFilter = Param(nameof(UseMaFilter), false)
 			.SetDisplay("Use MA Filter", "Enable moving average filter", "MA Filter");
 
-		_maType = Param(nameof(MaType), Strategies.MovingAverageType.Ema)
+		_maType = Param(nameof(MaType), Strategies.MovingAverageTypes.Ema)
 			.SetDisplay("MA Type", "Moving average type", "MA Filter");
 
 		_maLength = Param(nameof(MaLength), 200)
@@ -242,15 +242,15 @@ public class MikulsIchimokuCloudV2Strategy : Strategy
 		}
 	}
 
-	private static IIndicator CreateMa(MovingAverageType type, int length)
+	private static IIndicator CreateMa(MovingAverageTypes type, int length)
 	{
 		return type switch
 		{
-			MovingAverageType.Sma => new SMA { Length = length },
-			MovingAverageType.Wma => new WMA { Length = length },
-			MovingAverageType.Hma => new HMA { Length = length },
-			MovingAverageType.Vwma => new VWMA { Length = length },
-			MovingAverageType.Vwap => new VWAP { Length = length },
+			MovingAverageTypes.Sma => new SMA { Length = length },
+			MovingAverageTypes.Wma => new WMA { Length = length },
+			MovingAverageTypes.Hma => new HMA { Length = length },
+			MovingAverageTypes.Vwma => new VWMA { Length = length },
+			MovingAverageTypes.Vwap => new VWAP { Length = length },
 			_ => new EMA { Length = length }
 		};
 	}
@@ -292,23 +292,23 @@ public class MikulsIchimokuCloudV2Strategy : Strategy
 
 		decimal? nextTrail = null;
 
-		if (TrailMethod == TrailMethod.Atr)
+		if (TrailMethods == TrailMethods.Atr)
 		{
 			var atrValue = atr * AtrMultiplier;
-			nextTrail = TrailSource switch
+			nextTrail = TrailSources switch
 			{
-				TrailSource.Close => close - atrValue,
-				TrailSource.Open => open - atrValue,
+				TrailSources.Close => close - atrValue,
+				TrailSources.Open => open - atrValue,
 				_ => swingLow - atrValue
 			};
 		}
-		else if (TrailMethod == TrailMethod.Percent)
+		else if (TrailMethods == TrailMethods.Percent)
 		{
 			var percentMulti = (100m - TrailPercent) / 100m;
-			var basis = TrailSource switch
+			var basis = TrailSources switch
 			{
-				TrailSource.Close => close,
-				TrailSource.Open => open,
+				TrailSources.Close => close,
+				TrailSources.Open => open,
 				_ => swingLow
 			};
 			nextTrail = basis * percentMulti;
@@ -351,7 +351,7 @@ public class MikulsIchimokuCloudV2Strategy : Strategy
 	/// <summary>
 	/// Trailing stop source options.
 	/// </summary>
-	public enum TrailSource
+	public enum TrailSources
 	{
 		LowsHighs,
 		Close,
@@ -361,7 +361,7 @@ public class MikulsIchimokuCloudV2Strategy : Strategy
 	/// <summary>
 	/// Trailing stop methods.
 	/// </summary>
-	public enum TrailMethod
+	public enum TrailMethods
 	{
 		Atr,
 		Percent,
@@ -371,7 +371,7 @@ public class MikulsIchimokuCloudV2Strategy : Strategy
 	/// <summary>
 	/// Moving average types.
 	/// </summary>
-	public enum MovingAverageType
+	public enum MovingAverageTypes
 	{
 		Ema,
 		Sma,

--- a/API/1060_Modified_OBV_With_Divergence_Detection/CS/ModifiedObvWithDivergenceDetectionStrategy.cs
+++ b/API/1060_Modified_OBV_With_Divergence_Detection/CS/ModifiedObvWithDivergenceDetectionStrategy.cs
@@ -21,7 +21,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class ModifiedObvWithDivergenceDetectionStrategy : Strategy
 {
-	private readonly StrategyParam<MovingAverageTypeEnum> _maType;
+	private readonly StrategyParam<MovingAverageTypes> _maType;
 	private readonly StrategyParam<int> _obvMaLength;
 	private readonly StrategyParam<int> _signalLength;
 	private readonly StrategyParam<DataType> _candleType;
@@ -42,7 +42,7 @@ public class ModifiedObvWithDivergenceDetectionStrategy : Strategy
 	/// <summary>
 	/// Type of moving average used for OBV smoothing.
 	/// </summary>
-	public MovingAverageTypeEnum MaType
+	public MovingAverageTypes MaType
 	{
 		get => _maType.Value;
 		set => _maType.Value = value;
@@ -80,7 +80,7 @@ public class ModifiedObvWithDivergenceDetectionStrategy : Strategy
 	/// </summary>
 	public ModifiedObvWithDivergenceDetectionStrategy()
 	{
-		_maType = Param(nameof(MaType), MovingAverageTypeEnum.Exponential)
+		_maType = Param(nameof(MaType), MovingAverageTypes.Exponential)
 			.SetDisplay("MA Type", "Moving average type for OBV", "General");
 
 		_obvMaLength = Param(nameof(ObvMaLength), 7)
@@ -129,18 +129,18 @@ public class ModifiedObvWithDivergenceDetectionStrategy : Strategy
 
 		IIndicator obvMa = MaType switch
 		{
-			MovingAverageTypeEnum.Simple => new SimpleMovingAverage(),
-			MovingAverageTypeEnum.VolumeWeighted => new VolumeWeightedMovingAverage(),
-			MovingAverageTypeEnum.Weighted => new WeightedMovingAverage(),
+			MovingAverageTypes.Simple => new SimpleMovingAverage(),
+			MovingAverageTypes.VolumeWeighted => new VolumeWeightedMovingAverage(),
+			MovingAverageTypes.Weighted => new WeightedMovingAverage(),
 			_ => new ExponentialMovingAverage(),
 		};
 		obvMa.Length = ObvMaLength;
 
 		IIndicator signalMa = MaType switch
 		{
-			MovingAverageTypeEnum.Simple => new SimpleMovingAverage(),
-			MovingAverageTypeEnum.VolumeWeighted => new VolumeWeightedMovingAverage(),
-			MovingAverageTypeEnum.Weighted => new WeightedMovingAverage(),
+			MovingAverageTypes.Simple => new SimpleMovingAverage(),
+			MovingAverageTypes.VolumeWeighted => new VolumeWeightedMovingAverage(),
+			MovingAverageTypes.Weighted => new WeightedMovingAverage(),
 			_ => new ExponentialMovingAverage(),
 		};
 		signalMa.Length = SignalLength;
@@ -253,7 +253,7 @@ public class ModifiedObvWithDivergenceDetectionStrategy : Strategy
 	/// <summary>
 	/// Moving average types.
 	/// </summary>
-	public enum MovingAverageTypeEnum
+	public enum MovingAverageTypes
 	{
 		/// <summary>
 		/// Exponential moving average.

--- a/API/1079_Moving_Average_Entanglement/CS/MovingAverageEntanglementStrategy.cs
+++ b/API/1079_Moving_Average_Entanglement/CS/MovingAverageEntanglementStrategy.cs
@@ -21,7 +21,7 @@ public class MovingAverageEntanglementStrategy : Strategy
 	private readonly StrategyParam<int> _volatilityPeriod;
 	private readonly StrategyParam<decimal> _deadZonePercentage;
 	private readonly StrategyParam<decimal> _deviationMultiplier;
-	private readonly StrategyParam<MaType> _maType;
+	private readonly StrategyParam<MaTypes> _maType;
 	private readonly StrategyParam<DataType> _candleType;
 
 	private MovingAverage _fastMa = null!;
@@ -67,7 +67,7 @@ public class MovingAverageEntanglementStrategy : Strategy
 		set => _deviationMultiplier.Value = value;
 	}
 
-	public MaType MaTypeParam
+	public MaTypes MaTypeParam
 	{
 		get => _maType.Value;
 		set => _maType.Value = value;
@@ -104,7 +104,7 @@ public class MovingAverageEntanglementStrategy : Strategy
 		_deviationMultiplier = Param(nameof(DeviationMultiplier), 2.5m)
 			.SetDisplay("Deviation Multiplier", "Std dev multiplier", "Trading");
 
-		_maType = Param(nameof(MaTypeParam), MaType.Sma)
+		_maType = Param(nameof(MaTypeParam), MaTypes.Sma)
 			.SetDisplay("MA Type", "Type of moving average", "Indicators");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
@@ -176,16 +176,16 @@ public class MovingAverageEntanglementStrategy : Strategy
 		_prevSellCondition = sellCondition;
 	}
 
-	private static MovingAverage CreateMa(MaType type, int length)
+	private static MovingAverage CreateMa(MaTypes type, int length)
 	{
 		return type switch
 		{
-		MaType.Ema => new ExponentialMovingAverage { Length = length },
+		MaTypes.Ema => new ExponentialMovingAverage { Length = length },
 		_ => new SimpleMovingAverage { Length = length },
 		};
 	}
 
-	public enum MaType
+	public enum MaTypes
 	{
 		Sma = 1,
 		Ema

--- a/API/1080_Moving_Average_Rainbow_Stormer/CS/MovingAverageRainbowStormerStrategy.cs
+++ b/API/1080_Moving_Average_Rainbow_Stormer/CS/MovingAverageRainbowStormerStrategy.cs
@@ -23,7 +23,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class MovingAverageRainbowStormerStrategy : Strategy
 {
-	private readonly StrategyParam<MovingAverageTypeEnum> _maType;
+	private readonly StrategyParam<MovingAverageTypes> _maType;
 	private readonly StrategyParam<int> _maLengthFirst;
 	private readonly StrategyParam<int> _maLengthSecond;
 	private readonly StrategyParam<int> _maLengthThird;
@@ -59,7 +59,7 @@ public class MovingAverageRainbowStormerStrategy : Strategy
 	/// <summary>
 	/// Moving average type.
 	/// </summary>
-	public MovingAverageTypeEnum MaType
+	public MovingAverageTypes MaType
 	{
 		get => _maType.Value;
 		set => _maType.Value = value;
@@ -223,7 +223,7 @@ public class MovingAverageRainbowStormerStrategy : Strategy
 	/// </summary>
 	public MovingAverageRainbowStormerStrategy()
 	{
-		_maType = Param(nameof(MaType), MovingAverageTypeEnum.Exponential)
+		_maType = Param(nameof(MaType), MovingAverageTypes.Exponential)
 		.SetDisplay("MA Type", string.Empty, "Moving Averages");
 
 		_maLengthFirst = Param(nameof(MaLengthFirst), 3)
@@ -505,16 +505,16 @@ public class MovingAverageRainbowStormerStrategy : Strategy
 		else return null;
 	}
 
-	private static IIndicator CreateMa(MovingAverageTypeEnum type, int length)
+	private static IIndicator CreateMa(MovingAverageTypes type, int length)
 	{
 		return type switch
 		{
-			MovingAverageTypeEnum.Simple => new SimpleMovingAverage { Length = length },
-			MovingAverageTypeEnum.Exponential => new ExponentialMovingAverage { Length = length },
-			MovingAverageTypeEnum.Smoothed => new SmoothedMovingAverage { Length = length },
-			MovingAverageTypeEnum.Weighted => new WeightedMovingAverage { Length = length },
-			MovingAverageTypeEnum.Hull => new HullMovingAverage { Length = length },
-			MovingAverageTypeEnum.VolumeWeighted => new VolumeWeightedMovingAverage { Length = length },
+			MovingAverageTypes.Simple => new SimpleMovingAverage { Length = length },
+			MovingAverageTypes.Exponential => new ExponentialMovingAverage { Length = length },
+			MovingAverageTypes.Smoothed => new SmoothedMovingAverage { Length = length },
+			MovingAverageTypes.Weighted => new WeightedMovingAverage { Length = length },
+			MovingAverageTypes.Hull => new HullMovingAverage { Length = length },
+			MovingAverageTypes.VolumeWeighted => new VolumeWeightedMovingAverage { Length = length },
 			_ => new ExponentialMovingAverage { Length = length },
 		};
 	}
@@ -522,7 +522,7 @@ public class MovingAverageRainbowStormerStrategy : Strategy
 	/// <summary>
 	/// Available moving average types.
 	/// </summary>
-	public enum MovingAverageTypeEnum
+	public enum MovingAverageTypes
 	{
 		/// <summary>Simple moving average.</summary>
 		Simple,

--- a/API/1097_Multi_Step_FlexiMA/CS/MultiStepFlexiMaStrategy.cs
+++ b/API/1097_Multi_Step_FlexiMA/CS/MultiStepFlexiMaStrategy.cs
@@ -23,7 +23,7 @@ public class MultiStepFlexiMaStrategy : Strategy
 	private readonly StrategyParam<int> _indicatorLength;
 	private readonly StrategyParam<decimal> _startingFactor;
 	private readonly StrategyParam<decimal> _incrementFactor;
-	private readonly StrategyParam<NormalizeMethod> _normalizeMethod;
+	private readonly StrategyParam<NormalizeMethods> _normalizeMethod;
 	private readonly StrategyParam<int> _superTrendPeriod;
 private readonly StrategyParam<decimal> _superTrendMultiplier;
 private readonly StrategyParam<Sides?> _direction;
@@ -45,7 +45,7 @@ private readonly StrategyParam<decimal> _tpLevel1;
 	/// <summary>
 	/// Normalization method for oscillator.
 	/// </summary>
-	public enum NormalizeMethod
+	public enum NormalizeMethods
 	{
 		None,
 		MaxMin,
@@ -75,7 +75,7 @@ private readonly StrategyParam<decimal> _tpLevel1;
 	/// <summary>
 	/// Normalization method.
 	/// </summary>
-	public NormalizeMethod Normalization { get => _normalizeMethod.Value; set => _normalizeMethod.Value = value; }
+	public NormalizeMethods Normalization { get => _normalizeMethod.Value; set => _normalizeMethod.Value = value; }
 
 	/// <summary>
 	/// SuperTrend ATR period.
@@ -140,7 +140,7 @@ public Sides? Direction { get => _direction.Value; set => _direction.Value = val
 		_incrementFactor = Param(nameof(IncrementFactor), 2m)
 		.SetDisplay("Increment Factor", "Increment between steps", "FlexiMA");
 
-		_normalizeMethod = Param(nameof(Normalization), NormalizeMethod.None)
+		_normalizeMethod = Param(nameof(Normalization), NormalizeMethods.None)
 		.SetDisplay("Normalization", "Normalization method", "FlexiMA");
 
 		_superTrendPeriod = Param(nameof(SuperTrendPeriod), 10)
@@ -235,7 +235,7 @@ public Sides? Direction { get => _direction.Value; set => _direction.Value = val
 
 		switch (Normalization)
 		{
-			case NormalizeMethod.MaxMin:
+			case NormalizeMethods.MaxMin:
 			var min = decimal.MaxValue;
 			var max = decimal.MinValue;
 			for (var i = 0; i < diffs.Length; i++)
@@ -250,7 +250,7 @@ public Sides? Direction { get => _direction.Value; set => _direction.Value = val
 			for (var i = 0; i < diffs.Length; i++)
 			normalized[i] = range == 0m ? 0m : (diffs[i] - min) / range;
 			break;
-			case NormalizeMethod.AbsoluteSum:
+			case NormalizeMethods.AbsoluteSum:
 			for (var i = 0; i < diffs.Length; i++)
 			normalized[i] = denom == 0m ? 0m : diffs[i] / denom;
 			break;

--- a/API/1099_Multi-Step_Vegas_SuperTrend/CS/MultiStepVegasSuperTrendStrategy.cs
+++ b/API/1099_Multi-Step_Vegas_SuperTrend/CS/MultiStepVegasSuperTrendStrategy.cs
@@ -23,7 +23,7 @@ public class MultiStepVegasSuperTrendStrategy : Strategy
 	private readonly StrategyParam<int> _vegasWindow;
 	private readonly StrategyParam<decimal> _superTrendMultiplier;
 	private readonly StrategyParam<decimal> _volatilityAdjustment;
-private readonly StrategyParam<MaType> _maType;
+private readonly StrategyParam<MaTypes> _maType;
 private readonly StrategyParam<Sides?> _direction;
 	private readonly StrategyParam<bool> _useTakeProfit;
 	private readonly StrategyParam<decimal> _takeProfitPercent1;
@@ -44,7 +44,7 @@ private readonly StrategyParam<Sides?> _direction;
 	private decimal? _prevLower;
 	private int _trend = 1;
 
-	public enum MaType
+	public enum MaTypes
 	{
 		Simple,
 		Jurik
@@ -70,7 +70,7 @@ private readonly StrategyParam<Sides?> _direction;
 		_volatilityAdjustment = Param(nameof(VolatilityAdjustment), 5m)
 			.SetDisplay("Volatility Adjustment", "Multiplier adjustment factor", "Parameters");
 
-		_maType = Param(nameof(MaType), MaType.Simple)
+		_maType = Param(nameof(MaType), MaTypes.Simple)
 			.SetDisplay("MA Type", "Vegas moving average type", "Parameters");
 	 _direction = Param(nameof(Direction), null)
 	        .SetDisplay("Direction", "Trade direction", "Parameters");
@@ -106,7 +106,7 @@ private readonly StrategyParam<Sides?> _direction;
 	public int VegasWindow { get => _vegasWindow.Value; set => _vegasWindow.Value = value; }
 	public decimal SuperTrendMultiplier { get => _superTrendMultiplier.Value; set => _superTrendMultiplier.Value = value; }
 	public decimal VolatilityAdjustment { get => _volatilityAdjustment.Value; set => _volatilityAdjustment.Value = value; }
-	public MaType MaType { get => _maType.Value; set => _maType.Value = value; }
+	public MaTypes MaType { get => _maType.Value; set => _maType.Value = value; }
 public Sides? Direction { get => _direction.Value; set => _direction.Value = value; }
 	public bool UseTakeProfit { get => _useTakeProfit.Value; set => _useTakeProfit.Value = value; }
 	public decimal TakeProfitPercent1 { get => _takeProfitPercent1.Value; set => _takeProfitPercent1.Value = value; }
@@ -124,7 +124,7 @@ public Sides? Direction { get => _direction.Value; set => _direction.Value = val
 	{
 		base.OnStarted(time);
 
-		_vegasMa = CreateMa(MaType, VegasWindow);
+		_vegasMa = CreateMa(MaTypes, VegasWindow);
 		_std = new StandardDeviation { Length = VegasWindow };
 		_atr = new AverageTrueRange { Length = AtrPeriod };
 
@@ -220,11 +220,11 @@ public Sides? Direction { get => _direction.Value; set => _direction.Value = val
 		Place(4, TakeProfitPercent4, TakeProfitAmount4);
 	}
 
-	private static IIndicator CreateMa(MaType type, int length)
+	private static IIndicator CreateMa(MaTypes type, int length)
 	{
 		return type switch
 		{
-			MaType.Jurik => new JurikMovingAverage { Length = length },
+			MaTypes.Jurik => new JurikMovingAverage { Length = length },
 			_ => new SimpleMovingAverage { Length = length },
 		};
 	}

--- a/API/1101_Multi_Timeframe_MACD/CS/MultiTimeframeMacdStrategy.cs
+++ b/API/1101_Multi_Timeframe_MACD/CS/MultiTimeframeMacdStrategy.cs
@@ -25,7 +25,7 @@ public class MultiTimeframeMacdStrategy : Strategy
 	private readonly StrategyParam<DataType> _higherCandleType;
 	private readonly StrategyParam<bool> _showCurrentTf;
 	private readonly StrategyParam<bool> _showHigherTf;
-	private readonly StrategyParam<EntryType> _entryType;
+	private readonly StrategyParam<EntryTypes> _entryType;
 	private readonly StrategyParam<bool> _useTrailingStop;
 	private readonly StrategyParam<decimal> _trailingStopPercent;
 
@@ -112,7 +112,7 @@ public class MultiTimeframeMacdStrategy : Strategy
 	/// <summary>
 	/// Entry signal type.
 	/// </summary>
-	public EntryType Entry
+	public EntryTypes Entry
 	{
 		get => _entryType.Value;
 		set => _entryType.Value = value;
@@ -168,7 +168,7 @@ public class MultiTimeframeMacdStrategy : Strategy
 		_showHigherTf = Param(nameof(ShowHigherTimeframe), true)
 							.SetDisplay("Use Higher TF", "Include higher timeframe MACD", "Logic");
 
-		_entryType = Param(nameof(Entry), EntryType.Crossover).SetDisplay("Entry Type", "Signal type", "Logic");
+		_entryType = Param(nameof(Entry), EntryTypes.Crossover).SetDisplay("Entry Type", "Signal type", "Logic");
 
 		_useTrailingStop =
 			Param(nameof(UseTrailingStop), false).SetDisplay("Use Trailing", "Enable trailing stop", "Risk");
@@ -302,11 +302,11 @@ public class MultiTimeframeMacdStrategy : Strategy
 			shortZero = higherBelowZero && _prevHigherMacd >= 0m && _higherMacdValue < 0m;
 		}
 
-		var entryLong = (Entry == EntryType.Crossover && longCross) || (Entry == EntryType.ZeroCross && longZero) ||
-						(Entry == EntryType.Both && (longCross || longZero));
+		var entryLong = (Entry == EntryTypes.Crossover && longCross) || (Entry == EntryTypes.ZeroCross && longZero) ||
+						(Entry == EntryTypes.Both && (longCross || longZero));
 
-		var entryShort = (Entry == EntryType.Crossover && shortCross) || (Entry == EntryType.ZeroCross && shortZero) ||
-						 (Entry == EntryType.Both && (shortCross || shortZero));
+		var entryShort = (Entry == EntryTypes.Crossover && shortCross) || (Entry == EntryTypes.ZeroCross && shortZero) ||
+						 (Entry == EntryTypes.Both && (shortCross || shortZero));
 
 		if (entryLong && Position <= 0)
 		{
@@ -359,14 +359,14 @@ public class MultiTimeframeMacdStrategy : Strategy
 		}
 		else
 		{
-			var exitLong = ((Entry == EntryType.Crossover || Entry == EntryType.Both) &&
+			var exitLong = ((Entry == EntryTypes.Crossover || Entry == EntryTypes.Both) &&
 							_prevCurrentMacd >= _prevCurrentSignal && _currentMacdValue < _currentSignalValue) ||
-						   ((Entry == EntryType.ZeroCross || Entry == EntryType.Both) && _prevCurrentMacd >= 0m &&
+						   ((Entry == EntryTypes.ZeroCross || Entry == EntryTypes.Both) && _prevCurrentMacd >= 0m &&
 							_currentMacdValue < 0m);
 
-			var exitShort = ((Entry == EntryType.Crossover || Entry == EntryType.Both) &&
+			var exitShort = ((Entry == EntryTypes.Crossover || Entry == EntryTypes.Both) &&
 							 _prevCurrentMacd <= _prevCurrentSignal && _currentMacdValue > _currentSignalValue) ||
-							((Entry == EntryType.ZeroCross || Entry == EntryType.Both) && _prevCurrentMacd <= 0m &&
+							((Entry == EntryTypes.ZeroCross || Entry == EntryTypes.Both) && _prevCurrentMacd <= 0m &&
 							 _currentMacdValue > 0m);
 
 			if (Position > 0 && exitLong)
@@ -383,7 +383,7 @@ public class MultiTimeframeMacdStrategy : Strategy
 	/// <summary>
 	/// Entry types.
 	/// </summary>
-	public enum EntryType
+	public enum EntryTypes
 	{
 		/// <summary>
 		/// MACD line crossing signal line.

--- a/API/1107_Mutanabby_AI_Algo_Pro/CS/MutanabbyAiAlgoProStrategy.cs
+++ b/API/1107_Mutanabby_AI_Algo_Pro/CS/MutanabbyAiAlgoProStrategy.cs
@@ -16,7 +16,7 @@ namespace StockSharp.Samples.Strategies;
 /// <summary>
 /// Defines stop loss calculation modes.
 /// </summary>
-public enum StopLossMode
+public enum StopLossModes
 {
 /// <summary>
 /// Stop loss is calculated from entry price.
@@ -40,7 +40,7 @@ private readonly StrategyParam<int> _rsiIndex;
 private readonly StrategyParam<int> _candleDeltaLength;
 private readonly StrategyParam<bool> _disableRepeatingSignals;
 private readonly StrategyParam<bool> _enableStopLoss;
-private readonly StrategyParam<StopLossMode> _stopLossMethod;
+private readonly StrategyParam<StopLossModes> _stopLossMethod;
 private readonly StrategyParam<decimal> _entryStopLossPercent;
 private readonly StrategyParam<int> _lookbackPeriod;
 private readonly StrategyParam<decimal> _stopLossBufferPercent;
@@ -103,7 +103,7 @@ set => _enableStopLoss.Value = value;
 /// <summary>
 /// Stop loss calculation method.
 /// </summary>
-public StopLossMode StopLossMethod
+public StopLossModes StopLossMethod
 {
 get => _stopLossMethod.Value;
 set => _stopLossMethod.Value = value;
@@ -172,7 +172,7 @@ _disableRepeatingSignals = Param(nameof(DisableRepeatingSignals), false)
 _enableStopLoss = Param(nameof(EnableStopLoss), true)
 .SetDisplay("Enable Stop Loss", "Activate stop loss", "Risk Management");
 
-_stopLossMethod = Param(nameof(StopLossMethod), StopLossMode.EntryPriceBased)
+_stopLossMethod = Param(nameof(StopLossMethod), StopLossModes.EntryPriceBased)
 .SetDisplay("Stop Loss Method", "Entry price or lowest low based", "Risk Management");
 
 _entryStopLossPercent = Param(nameof(EntryStopLossPercent), 2.0m)
@@ -279,7 +279,7 @@ BuyMarket(Volume + Math.Abs(Position));
 _entryPrice = candle.ClosePrice;
 if (EnableStopLoss)
 {
-_stopLossPrice = StopLossMethod == StopLossMode.EntryPriceBased
+_stopLossPrice = StopLossMethod == StopLossModes.EntryPriceBased
 ? _entryPrice * (1 - EntryStopLossPercent / 100m)
 : _lowestLow * (1 - StopLossBufferPercent / 100m);
 }

--- a/API/1138_Optimized_Heikin_Ashi_Buy_Sell/CS/OptimizedHeikinAshiBuySellStrategy.cs
+++ b/API/1138_Optimized_Heikin_Ashi_Buy_Sell/CS/OptimizedHeikinAshiBuySellStrategy.cs
@@ -19,7 +19,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class OptimizedHeikinAshiBuySellStrategy : Strategy
 {
-	public enum TradeType
+	public enum TradeTypes
 	{
 		BuyOnly,
 		SellOnly
@@ -28,7 +28,7 @@ public class OptimizedHeikinAshiBuySellStrategy : Strategy
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<DateTimeOffset> _startDate;
 	private readonly StrategyParam<DateTimeOffset> _endDate;
-	private readonly StrategyParam<TradeType> _tradeType;
+	private readonly StrategyParam<TradeTypes> _tradeType;
 	private readonly StrategyParam<bool> _useStopLoss;
 	private readonly StrategyParam<decimal> _stopLossPercent;
 	private readonly StrategyParam<bool> _useTakeProfit;
@@ -48,7 +48,7 @@ public class OptimizedHeikinAshiBuySellStrategy : Strategy
 		_endDate = Param(nameof(EndDate), new DateTimeOffset(new DateTime(2024, 1, 1), TimeSpan.Zero))
 			.SetDisplay("End Date", "Backtest end date", "General");
 
-		_tradeType = Param(nameof(TradeMode), TradeType.BuyOnly)
+		_tradeType = Param(nameof(TradeMode), TradeTypes.BuyOnly)
 			.SetDisplay("Trade Type", "Choose buy or sell mode", "General");
 
 		_useStopLoss = Param(nameof(UseStopLoss), true)
@@ -82,7 +82,7 @@ public class OptimizedHeikinAshiBuySellStrategy : Strategy
 		set => _endDate.Value = value;
 	}
 
-	public TradeType TradeMode
+	public TradeTypes TradeMode
 	{
 		get => _tradeType.Value;
 		set => _tradeType.Value = value;
@@ -177,7 +177,7 @@ public class OptimizedHeikinAshiBuySellStrategy : Strategy
 		var isBullish = haClose > haOpen;
 		var isBearish = haClose < haOpen;
 
-		if (TradeMode == TradeType.BuyOnly)
+		if (TradeMode == TradeTypes.BuyOnly)
 		{
 			if (isBullish && Position <= 0)
 				BuyMarket(Volume + Math.Abs(Position));

--- a/API/1140_Options_V13/CS/OptionsV13Strategy.cs
+++ b/API/1140_Options_V13/CS/OptionsV13Strategy.cs
@@ -13,7 +13,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-public enum SignalDirection
+public enum SignalDirections
 {
 	Long,
 	Short,
@@ -35,7 +35,7 @@ public class OptionsV13Strategy : Strategy
 	private readonly StrategyParam<decimal> _tpSlRatio;
 	private readonly StrategyParam<bool> _enableOrBreakout;
 	private readonly StrategyParam<bool> _enableEodClose;
-	private readonly StrategyParam<SignalDirection> _signalDirection;
+	private readonly StrategyParam<SignalDirections> _signalDirection;
 	private readonly StrategyParam<int> _volumeMaLength;
 	private readonly StrategyParam<TimeSpan> _noTradeStart;
 	private readonly StrategyParam<TimeSpan> _noTradeEnd;
@@ -63,7 +63,7 @@ public class OptionsV13Strategy : Strategy
 	public decimal TpSlRatio { get => _tpSlRatio.Value; set => _tpSlRatio.Value = value; }
 	public bool EnableOrBreakout { get => _enableOrBreakout.Value; set => _enableOrBreakout.Value = value; }
 	public bool EnableEodClose { get => _enableEodClose.Value; set => _enableEodClose.Value = value; }
-	public SignalDirection SignalDirection { get => _signalDirection.Value; set => _signalDirection.Value = value; }
+	public SignalDirections SignalDirection { get => _signalDirection.Value; set => _signalDirection.Value = value; }
 	public int VolumeMaLength { get => _volumeMaLength.Value; set => _volumeMaLength.Value = value; }
 	public TimeSpan NoTradeStart { get => _noTradeStart.Value; set => _noTradeStart.Value = value; }
 	public TimeSpan NoTradeEnd { get => _noTradeEnd.Value; set => _noTradeEnd.Value = value; }
@@ -97,7 +97,7 @@ public class OptionsV13Strategy : Strategy
 			.SetDisplay("Require OR Breakout", "Require price to break opening range", "Signals");
 		_enableEodClose = Param(nameof(EnableEodClose), true)
 			.SetDisplay("Auto Close at 15:55", "Close positions at 15:55 NY time", "Session");
-		_signalDirection = Param(nameof(SignalDirection), SignalDirection.Both)
+		_signalDirection = Param(nameof(SignalDirection), SignalDirections.Both)
 			.SetDisplay("Signal Direction", "Allowed trade direction", "Signals");
 		_volumeMaLength = Param(nameof(VolumeMaLength), 20)
 			.SetGreaterThanZero()
@@ -214,8 +214,8 @@ public class OptionsV13Strategy : Strategy
 
 		if (!blockedSession && volOk && Position == 0)
 		{
-			var allowLong = SignalDirection == SignalDirection.Both || SignalDirection == SignalDirection.Long;
-			var allowShort = SignalDirection == SignalDirection.Both || SignalDirection == SignalDirection.Short;
+			var allowLong = SignalDirections == SignalDirections.Both || SignalDirections == SignalDirections.Long;
+			var allowShort = SignalDirections == SignalDirections.Both || SignalDirections == SignalDirections.Short;
 
 			if (allowLong && _readyLong && rsiValue >= RsiLongThreshold && (!EnableOrBreakout || (candle.ClosePrice > _orHigh && _orHigh > 0)))
 			{

--- a/API/1151_Overnight_Positioning_EMA/CS/OvernightPositioningEmaStrategy.cs
+++ b/API/1151_Overnight_Positioning_EMA/CS/OvernightPositioningEmaStrategy.cs
@@ -20,7 +20,7 @@ public class OvernightPositioningEmaStrategy : Strategy
 	private readonly StrategyParam<int> _emaLen;
 	private readonly StrategyParam<bool> _useEma;
 	private readonly StrategyParam<DataType> _candle;
-	private readonly StrategyParam<Market> _market;
+	private readonly StrategyParam<Markets> _market;
 
 	private TimeZoneInfo _tz = TimeZoneInfo.Utc;
 	private TimeSpan _open;
@@ -31,9 +31,9 @@ public class OvernightPositioningEmaStrategy : Strategy
 	public int EmaLength { get => _emaLen.Value; set => _emaLen.Value = value; }
 	public bool UseEma { get => _useEma.Value; set => _useEma.Value = value; }
 	public DataType CandleType { get => _candle.Value; set => _candle.Value = value; }
-	public Market MarketSelection { get => _market.Value; set => _market.Value = value; }
+	public Markets MarketSelection { get => _market.Value; set => _market.Value = value; }
 
-	public enum Market { US, Asia, Europe }
+	public enum Markets { US, Asia, Europe }
 
 	public OvernightPositioningEmaStrategy()
 	{
@@ -42,7 +42,7 @@ public class OvernightPositioningEmaStrategy : Strategy
 		_emaLen = Param(nameof(EmaLength), 100).SetGreaterThanZero();
 		_useEma = Param(nameof(UseEma), true);
 		_candle = Param(nameof(CandleType), TimeSpan.FromMinutes(1).TimeFrame());
-		_market = Param(nameof(MarketSelection), Market.US);
+		_market = Param(nameof(MarketSelection), Markets.US);
 	}
 
 	public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities() => [(Security, CandleType)];
@@ -61,17 +61,17 @@ public class OvernightPositioningEmaStrategy : Strategy
 	{
 		switch (MarketSelection)
 		{
-			case Market.US:
+			case Markets.US:
 				_tz = TimeZoneInfo.FindSystemTimeZoneById("America/New_York");
 				_open = new(9, 30, 0);
 				_close = new(16, 0, 0);
 				break;
-			case Market.Asia:
+			case Markets.Asia:
 				_tz = TimeZoneInfo.FindSystemTimeZoneById("Asia/Tokyo");
 				_open = new(9, 0, 0);
 				_close = new(15, 0, 0);
 				break;
-			case Market.Europe:
+			case Markets.Europe:
 				_tz = TimeZoneInfo.FindSystemTimeZoneById("Europe/London");
 				_open = new(8, 0, 0);
 				_close = new(16, 30, 0);

--- a/API/1163_PercentX_Trend_Follower/CS/PercentXTrendFollowerStrategy.cs
+++ b/API/1163_PercentX_Trend_Follower/CS/PercentXTrendFollowerStrategy.cs
@@ -18,13 +18,13 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class PercentXTrendFollowerStrategy : Strategy
 {
-	public enum BandMode
+	public enum BandModes
 	{
 		Keltner,
 		Bollinger,
 	}
 
-	private readonly StrategyParam<BandMode> _bandType;
+	private readonly StrategyParam<BandModes> _bandType;
 	private readonly StrategyParam<int> _maLength;
 	private readonly StrategyParam<int> _loopbackPeriod;
 	private readonly StrategyParam<int> _outerLoopback;
@@ -50,7 +50,7 @@ public class PercentXTrendFollowerStrategy : Strategy
 	/// <summary>
 	/// Band type.
 	/// </summary>
-	public BandMode BandType { get => _bandType.Value; set => _bandType.Value = value; }
+	public BandModes BandType { get => _bandType.Value; set => _bandType.Value = value; }
 
 	/// <summary>
 	/// Moving average length.
@@ -97,7 +97,7 @@ public class PercentXTrendFollowerStrategy : Strategy
 	/// </summary>
 	public PercentXTrendFollowerStrategy()
 	{
-		_bandType = Param(nameof(BandType), BandMode.Keltner)
+		_bandType = Param(nameof(BandType), BandModes.Keltner)
 			.SetDisplay("Band Type", "Indicator for band calculation", "Parameters");
 
 		_maLength = Param(nameof(MaLength), 40)
@@ -174,7 +174,7 @@ public class PercentXTrendFollowerStrategy : Strategy
 		decimal upper;
 		decimal lower;
 
-		if (BandType == BandMode.Bollinger)
+		if (BandType == BandModes.Bollinger)
 		{
 			var bb = (BollingerBandsValue)bollingerValue;
 			if (bb.UpBand is not decimal up || bb.LowBand is not decimal low || bb.MovingAverage is not decimal mid)

--- a/API/1176_Power_Hour_Money/CS/PowerHourMoneyStrategy.cs
+++ b/API/1176_Power_Hour_Money/CS/PowerHourMoneyStrategy.cs
@@ -21,7 +21,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class PowerHourMoneyStrategy : Strategy
 {
-	private readonly StrategyParam<TradingSession> _session;
+	private readonly StrategyParam<TradingSessions> _session;
 	private readonly StrategyParam<bool> _useTrail;
 	private readonly StrategyParam<decimal> _longTrail;
 	private readonly StrategyParam<decimal> _shortTrail;
@@ -38,7 +38,7 @@ public class PowerHourMoneyStrategy : Strategy
 	/// <summary>
 	/// Trading session filter.
 	/// </summary>
-	public TradingSession Session
+	public TradingSessions Session
 	{
 		get => _session.Value;
 		set => _session.Value = value;
@@ -94,7 +94,7 @@ public class PowerHourMoneyStrategy : Strategy
 	/// </summary>
 	public PowerHourMoneyStrategy()
 	{
-		_session = Param(nameof(Session), TradingSession.NySession)
+		_session = Param(nameof(Session), TradingSessions.NySession)
 			.SetDisplay("Session", "Trading session", "Core");
 
 		_useTrail = Param(nameof(UseTrail), true)
@@ -195,8 +195,8 @@ public class PowerHourMoneyStrategy : Strategy
 
 		var tradeable = Session switch
 		{
-			TradingSession.NySession => local >= new TimeSpan(9, 30, 0) && local <= new TimeSpan(11, 30, 0),
-			TradingSession.ExtendedNy => local >= new TimeSpan(8, 0, 0) && local <= new TimeSpan(16, 0, 0),
+			TradingSessions.NySession => local >= new TimeSpan(9, 30, 0) && local <= new TimeSpan(11, 30, 0),
+			TradingSessions.ExtendedNy => local >= new TimeSpan(8, 0, 0) && local <= new TimeSpan(16, 0, 0),
 			_ => true,
 		};
 
@@ -260,7 +260,7 @@ public class PowerHourMoneyStrategy : Strategy
 /// <summary>
 /// Trading sessions.
 /// </summary>
-public enum TradingSession
+public enum TradingSessions
 {
 	/// <summary>
 	/// NY Session 9:30-11:30.

--- a/API/1192_Professional_ORB/CS/ProfessionalOrbStrategy.cs
+++ b/API/1192_Professional_ORB/CS/ProfessionalOrbStrategy.cs
@@ -27,7 +27,7 @@ public class ProfessionalOrbStrategy : Strategy
 	private decimal _orbRange;
 	private bool _orbFormed;
 	private int _tradesToday;
-	private PositionSide _positionSide;
+	private PositionSides _positionSide;
 	private decimal _entryPrice;
 	private decimal _profitTargetLevel;
 	private decimal _breakoutCandleHigh;
@@ -36,7 +36,7 @@ public class ProfessionalOrbStrategy : Strategy
 	private decimal _prevClose;
 	private DateTime _currentDate;
 
-	private enum PositionSide
+	private enum PositionSides
 	{
 		None,
 		Long,
@@ -193,7 +193,7 @@ public class ProfessionalOrbStrategy : Strategy
 
 		var validRange = _orbFormed && _orbRange >= MinOrbRange;
 		var afterOrb = _orbFormed && currentMinutes > orbEnd;
-		var canTrade = validRange && _tradesToday < MaxTrades && _positionSide == PositionSide.None;
+		var canTrade = validRange && _tradesToday < MaxTrades && _positionSide == PositionSides.None;
 
 		var bullBreak = afterOrb && _prevClose <= _orbHigh && candle.ClosePrice > _orbHigh;
 		var bearBreak = afterOrb && _prevClose >= _orbLow && candle.ClosePrice < _orbLow;
@@ -202,7 +202,7 @@ public class ProfessionalOrbStrategy : Strategy
 		{
 			var volume = Volume + Math.Abs(Position);
 			BuyMarket(volume);
-			_positionSide = PositionSide.Long;
+			_positionSide = PositionSides.Long;
 			_tradesToday++;
 			_entryPrice = candle.ClosePrice;
 			_profitTargetLevel = _entryPrice + ProfitTargetPoints;
@@ -213,7 +213,7 @@ public class ProfessionalOrbStrategy : Strategy
 		{
 			var volume = Volume + Math.Abs(Position);
 			SellMarket(volume);
-			_positionSide = PositionSide.Short;
+			_positionSide = PositionSides.Short;
 			_tradesToday++;
 			_entryPrice = candle.ClosePrice;
 			_profitTargetLevel = _entryPrice - ProfitTargetPoints;
@@ -221,22 +221,22 @@ public class ProfessionalOrbStrategy : Strategy
 			_breakoutCandleLow = candle.LowPrice;
 		}
 
-		if (_positionSide == PositionSide.Long && (candle.LowPrice <= _breakoutCandleLow || candle.ClosePrice <= _breakoutCandleLow))
+		if (_positionSide == PositionSides.Long && (candle.LowPrice <= _breakoutCandleLow || candle.ClosePrice <= _breakoutCandleLow))
 		{
 			SellMarket(Position);
 			ResetPositionState();
 		}
-		else if (_positionSide == PositionSide.Short && (candle.HighPrice >= _breakoutCandleHigh || candle.ClosePrice >= _breakoutCandleHigh))
+		else if (_positionSide == PositionSides.Short && (candle.HighPrice >= _breakoutCandleHigh || candle.ClosePrice >= _breakoutCandleHigh))
 		{
 			BuyMarket(-Position);
 			ResetPositionState();
 		}
 		else
 		{
-			var longStop = _positionSide == PositionSide.Long && candle.ClosePrice < (_orbHigh - atrValue * StopLossAtr);
-			var shortStop = _positionSide == PositionSide.Short && candle.ClosePrice > (_orbLow + atrValue * StopLossAtr);
-			var longProfit = _positionSide == PositionSide.Long && candle.ClosePrice >= _profitTargetLevel;
-			var shortProfit = _positionSide == PositionSide.Short && candle.ClosePrice <= _profitTargetLevel;
+			var longStop = _positionSide == PositionSides.Long && candle.ClosePrice < (_orbHigh - atrValue * StopLossAtr);
+			var shortStop = _positionSide == PositionSides.Short && candle.ClosePrice > (_orbLow + atrValue * StopLossAtr);
+			var longProfit = _positionSide == PositionSides.Long && candle.ClosePrice >= _profitTargetLevel;
+			var shortProfit = _positionSide == PositionSides.Short && candle.ClosePrice <= _profitTargetLevel;
 			var endDay = time.Hour >= 15 && time.Minute >= 15;
 
 			if (longStop || shortStop || endDay)
@@ -263,7 +263,7 @@ public class ProfessionalOrbStrategy : Strategy
 
 	private void ResetPositionState()
 	{
-		_positionSide = PositionSide.None;
+		_positionSide = PositionSides.None;
 		_entryPrice = 0m;
 		_profitTargetLevel = 0m;
 		_breakoutCandleHigh = 0m;

--- a/API/1195_ProfitView_Template/CS/ProfitViewTemplateStrategy.cs
+++ b/API/1195_ProfitView_Template/CS/ProfitViewTemplateStrategy.cs
@@ -18,9 +18,9 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class ProfitViewTemplateStrategy : Strategy
 {
-	private readonly StrategyParam<MaType> _ma1Type;
+	private readonly StrategyParam<MaTypes> _ma1Type;
 	private readonly StrategyParam<int> _ma1Length;
-	private readonly StrategyParam<MaType> _ma2Type;
+	private readonly StrategyParam<MaTypes> _ma2Type;
 	private readonly StrategyParam<int> _ma2Length;
 	private readonly StrategyParam<DataType> _candleType;
 
@@ -31,7 +31,7 @@ public class ProfitViewTemplateStrategy : Strategy
 	/// <summary>
 	/// Moving average type.
 	/// </summary>
-	public enum MaType
+	public enum MaTypes
 	{
 		SMA,
 		EMA,
@@ -41,7 +41,7 @@ public class ProfitViewTemplateStrategy : Strategy
 	/// <summary>
 	/// Type of MA1.
 	/// </summary>
-	public MaType Ma1Type
+	public MaTypes Ma1Type
 	{
 		get => _ma1Type.Value;
 		set => _ma1Type.Value = value;
@@ -59,7 +59,7 @@ public class ProfitViewTemplateStrategy : Strategy
 	/// <summary>
 	/// Type of MA2.
 	/// </summary>
-	public MaType Ma2Type
+	public MaTypes Ma2Type
 	{
 		get => _ma2Type.Value;
 		set => _ma2Type.Value = value;
@@ -88,14 +88,14 @@ public class ProfitViewTemplateStrategy : Strategy
 	/// </summary>
 	public ProfitViewTemplateStrategy()
 	{
-		_ma1Type = Param(nameof(Ma1Type), MaType.SMA)
+		_ma1Type = Param(nameof(Ma1Type), MaTypes.SMA)
 			.SetDisplay("MA1 Type", "Type of first moving average", "Moving Averages");
 		_ma1Length = Param(nameof(Ma1Length), 10)
 			.SetGreaterThanZero()
 			.SetDisplay("MA1 Length", "Length of first moving average", "Moving Averages")
 			.SetCanOptimize(true)
 			.SetOptimize(5, 50, 5);
-		_ma2Type = Param(nameof(Ma2Type), MaType.SMA)
+		_ma2Type = Param(nameof(Ma2Type), MaTypes.SMA)
 			.SetDisplay("MA2 Type", "Type of second moving average", "Moving Averages");
 		_ma2Length = Param(nameof(Ma2Length), 100)
 			.SetGreaterThanZero()
@@ -135,13 +135,13 @@ public class ProfitViewTemplateStrategy : Strategy
 		}
 	}
 
-	private IIndicator CreateMa(MaType type, int length)
+	private IIndicator CreateMa(MaTypes type, int length)
 	{
 		return type switch
 		{
-			MaType.SMA => new SimpleMovingAverage { Length = length },
-			MaType.EMA => new ExponentialMovingAverage { Length = length },
-			MaType.RMA => new SmoothedMovingAverage { Length = length },
+			MaTypes.SMA => new SimpleMovingAverage { Length = length },
+			MaTypes.EMA => new ExponentialMovingAverage { Length = length },
+			MaTypes.RMA => new SmoothedMovingAverage { Length = length },
 			_ => throw new ArgumentOutOfRangeException(nameof(type))
 		};
 	}

--- a/API/1200_Bollinger_Bands_Trailing_Stop/CS/BollingerBandsTrailingStopStrategy.cs
+++ b/API/1200_Bollinger_Bands_Trailing_Stop/CS/BollingerBandsTrailingStopStrategy.cs
@@ -22,7 +22,7 @@ public class BollingerBandsTrailingStopStrategy : Strategy
 	private readonly StrategyParam<decimal> _bbDeviation;
 	private readonly StrategyParam<int> _atrPeriod;
 	private readonly StrategyParam<decimal> _atrMultiplier;
-	private readonly StrategyParam<MovingAverageTypeEnum> _maType;
+	private readonly StrategyParam<MovingAverageTypes> _maType;
 	private readonly StrategyParam<DataType> _candleType;
 
 	private decimal _highestPrice;
@@ -51,7 +51,7 @@ public class BollingerBandsTrailingStopStrategy : Strategy
 	/// <summary>
 	/// Moving average type for Bollinger basis.
 	/// </summary>
-	public MovingAverageTypeEnum MaType { get => _maType.Value; set => _maType.Value = value; }
+	public MovingAverageTypes MaType { get => _maType.Value; set => _maType.Value = value; }
 
 	/// <summary>
 	/// Candle type.
@@ -83,7 +83,7 @@ public class BollingerBandsTrailingStopStrategy : Strategy
 			.SetDisplay("ATR Multiplier", "ATR trailing stop multiplier", "Risk")
 			.SetCanOptimize(true);
 
-		_maType = Param(nameof(MaType), MovingAverageTypeEnum.Simple)
+		_maType = Param(nameof(MaType), MovingAverageTypes.Simple)
 			.SetDisplay("MA Type", "Moving average for Bollinger basis", "Indicators");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
@@ -167,14 +167,14 @@ public class BollingerBandsTrailingStopStrategy : Strategy
 		}
 	}
 
-	private static MovingAverage CreateMa(MovingAverageTypeEnum type, int length)
+	private static MovingAverage CreateMa(MovingAverageTypes type, int length)
 	{
 		return type switch
 		{
-			MovingAverageTypeEnum.Exponential => new ExponentialMovingAverage { Length = length },
-			MovingAverageTypeEnum.Smoothed => new SmoothedMovingAverage { Length = length },
-			MovingAverageTypeEnum.Weighted => new WeightedMovingAverage { Length = length },
-			MovingAverageTypeEnum.VolumeWeighted => new VolumeWeightedMovingAverage { Length = length },
+			MovingAverageTypes.Exponential => new ExponentialMovingAverage { Length = length },
+			MovingAverageTypes.Smoothed => new SmoothedMovingAverage { Length = length },
+			MovingAverageTypes.Weighted => new WeightedMovingAverage { Length = length },
+			MovingAverageTypes.VolumeWeighted => new VolumeWeightedMovingAverage { Length = length },
 			_ => new SimpleMovingAverage { Length = length },
 		};
 	}
@@ -182,7 +182,7 @@ public class BollingerBandsTrailingStopStrategy : Strategy
 	/// <summary>
 	/// Moving average types.
 	/// </summary>
-	public enum MovingAverageTypeEnum
+	public enum MovingAverageTypes
 	{
 		/// <summary>
 		/// Simple moving average.

--- a/API/1215_Rally_Base_Drop_SND_Pivots/CS/RallyBaseDropSndPivotsStrategy.cs
+++ b/API/1215_Rally_Base_Drop_SND_Pivots/CS/RallyBaseDropSndPivotsStrategy.cs
@@ -19,7 +19,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class RallyBaseDropSndPivotsStrategy : Strategy
 {
-	public enum TradeMode
+	public enum TradeModes
 	{
 		LongAndShort,
 		LongOnly,
@@ -31,7 +31,7 @@ public class RallyBaseDropSndPivotsStrategy : Strategy
 	private readonly StrategyParam<decimal> _mult;
 	private readonly StrategyParam<decimal> _riskReward;
 	private readonly StrategyParam<bool> _reverseConditions;
-	private readonly StrategyParam<TradeMode> _mode;
+	private readonly StrategyParam<TradeModes> _mode;
 
 	private readonly List<ICandleMessage> _candles = [];
 	private readonly AverageTrueRange _atr = new() { Length = 14 };
@@ -68,7 +68,7 @@ public class RallyBaseDropSndPivotsStrategy : Strategy
 		_reverseConditions = Param(nameof(ReverseConditions), false)
 			.SetDisplay("Reverse Conditions", "Swap long/short levels", "General");
 
-		_mode = Param(nameof(Mode), TradeMode.LongAndShort)
+		_mode = Param(nameof(Mode), TradeModes.LongAndShort)
 			.SetDisplay("Trade Mode", "Allowed trade direction", "General");
 	}
 
@@ -100,7 +100,7 @@ public class RallyBaseDropSndPivotsStrategy : Strategy
 	/// <summary>
 	/// Trading mode.
 	/// </summary>
-	public TradeMode Mode { get => _mode.Value; set => _mode.Value = value; }
+	public TradeModes Mode { get => _mode.Value; set => _mode.Value = value; }
 
 	/// <inheritdoc />
 	public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
@@ -161,7 +161,7 @@ public class RallyBaseDropSndPivotsStrategy : Strategy
 
 		if (!ReverseConditions)
 		{
-			if (Mode != TradeMode.ShortOnly && _up is decimal upLvl && _prevClose is decimal pc1 && pc1 <= upLvl && candle.ClosePrice > upLvl && (_lastLongLevel != upLvl))
+			if (Mode != TradeModes.ShortOnly && _up is decimal upLvl && _prevClose is decimal pc1 && pc1 <= upLvl && candle.ClosePrice > upLvl && (_lastLongLevel != upLvl))
 			{
 				_lastLongLevel = upLvl;
 				_lastLongEntryPrice = candle.ClosePrice;
@@ -169,7 +169,7 @@ public class RallyBaseDropSndPivotsStrategy : Strategy
 				BuyMarket();
 			}
 
-			if (Mode != TradeMode.LongOnly && _down is decimal dnLvl && _prevClose is decimal pc2 && pc2 >= dnLvl && candle.ClosePrice < dnLvl && (_lastShortLevel != dnLvl))
+			if (Mode != TradeModes.LongOnly && _down is decimal dnLvl && _prevClose is decimal pc2 && pc2 >= dnLvl && candle.ClosePrice < dnLvl && (_lastShortLevel != dnLvl))
 			{
 				_lastShortLevel = dnLvl;
 				_lastShortEntryPrice = candle.ClosePrice;
@@ -179,7 +179,7 @@ public class RallyBaseDropSndPivotsStrategy : Strategy
 		}
 		else
 		{
-			if (Mode != TradeMode.ShortOnly && _down is decimal dnLvl && _prevClose is decimal pc1 && pc1 >= dnLvl && candle.ClosePrice < dnLvl && (_lastLongLevel != dnLvl))
+			if (Mode != TradeModes.ShortOnly && _down is decimal dnLvl && _prevClose is decimal pc1 && pc1 >= dnLvl && candle.ClosePrice < dnLvl && (_lastLongLevel != dnLvl))
 			{
 				_lastLongLevel = dnLvl;
 				_lastLongEntryPrice = candle.ClosePrice;
@@ -187,7 +187,7 @@ public class RallyBaseDropSndPivotsStrategy : Strategy
 				BuyMarket();
 			}
 
-			if (Mode != TradeMode.LongOnly && _up is decimal upLvl && _prevClose is decimal pc2 && pc2 <= upLvl && candle.ClosePrice > upLvl && (_lastShortLevel != upLvl))
+			if (Mode != TradeModes.LongOnly && _up is decimal upLvl && _prevClose is decimal pc2 && pc2 <= upLvl && candle.ClosePrice > upLvl && (_lastShortLevel != upLvl))
 			{
 				_lastShortLevel = upLvl;
 				_lastShortEntryPrice = candle.ClosePrice;

--- a/API/1219_Random_State_Machine/CS/RandomStateMachineStrategy.cs
+++ b/API/1219_Random_State_Machine/CS/RandomStateMachineStrategy.cs
@@ -20,7 +20,7 @@ public class RandomStateMachineStrategy : Strategy
 {
 	private readonly StrategyParam<int> _stateResetInterval;
 	private readonly StrategyParam<int> _maLength;
-	private readonly StrategyParam<MaType> _maType;
+	private readonly StrategyParam<MaTypes> _maType;
 	private readonly StrategyParam<bool> _enableLongs;
 	private readonly StrategyParam<bool> _enableShorts;
 	private readonly StrategyParam<bool> _useTpSlLong;
@@ -62,7 +62,7 @@ public class RandomStateMachineStrategy : Strategy
 	/// <summary>
 	/// Moving average type.
 	/// </summary>
-	public MaType MaTypeIndicator { get => _maType.Value; set => _maType.Value = value; }
+	public MaTypes MaTypeIndicator { get => _maType.Value; set => _maType.Value = value; }
 
 	/// <summary>
 	/// Enable long trades.
@@ -152,7 +152,7 @@ public class RandomStateMachineStrategy : Strategy
 			.SetDisplay("MA Length", "Moving average length", "Indicators")
 			.SetGreaterThanZero();
 
-		_maType = Param(nameof(MaTypeIndicator), MaType.Ema)
+		_maType = Param(nameof(MaTypeIndicator), MaTypes.Ema)
 			.SetDisplay("MA Type", "Moving average type", "Indicators");
 
 		_enableLongs = Param(nameof(EnableLongs), true)
@@ -239,12 +239,12 @@ public class RandomStateMachineStrategy : Strategy
 		subscription.Bind(_maIndicator, ProcessCandle).Start();
 	}
 
-	private MovingAverage CreateMa(MaType type, int length)
+	private MovingAverage CreateMa(MaTypes type, int length)
 	{
 		return type switch
 		{
-			MaType.Sma => new SimpleMovingAverage { Length = length },
-			MaType.Ema => new ExponentialMovingAverage { Length = length },
+			MaTypes.Sma => new SimpleMovingAverage { Length = length },
+			MaTypes.Ema => new ExponentialMovingAverage { Length = length },
 			_ => new SimpleMovingAverage { Length = length },
 		};
 	}
@@ -344,7 +344,7 @@ public class RandomStateMachineStrategy : Strategy
 	/// <summary>
 	/// Moving average types.
 	/// </summary>
-	public enum MaType
+	public enum MaTypes
 	{
 		/// <summary>
 		/// Simple moving average.

--- a/API/1220_Random_Synthetic_Asset_Generation/CS/RandomSyntheticAssetGenerationStrategy.cs
+++ b/API/1220_Random_Synthetic_Asset_Generation/CS/RandomSyntheticAssetGenerationStrategy.cs
@@ -21,7 +21,7 @@ public class RandomSyntheticAssetGenerationStrategy : Strategy
 	private readonly StrategyParam<int> _seed;
 	private readonly StrategyParam<decimal> _intrabarVolatility;
 	private readonly StrategyParam<decimal> _priceMultiplier;
-	private readonly StrategyParam<RandomMethod> _method;
+	private readonly StrategyParam<RandomMethods> _method;
 
 	private decimal _randomClose;
 	private int _barIndex;
@@ -33,7 +33,7 @@ public class RandomSyntheticAssetGenerationStrategy : Strategy
 	/// <summary>
 	/// The pseudo-random generation method.
 	/// </summary>
-	public enum RandomMethod
+	public enum RandomMethods
 	{
 		/// <summary>Ricardo Santos method.</summary>
 		Rs,
@@ -50,7 +50,7 @@ public class RandomSyntheticAssetGenerationStrategy : Strategy
 		_seed = Param(nameof(Seed), 123456).SetCanOptimize(true);
 		_intrabarVolatility = Param(nameof(IntrabarVolatility), 0.66m).SetDisplay("Intrabar Volatility").SetCanOptimize(true);
 		_priceMultiplier = Param(nameof(PriceMultiplier), 30m).SetDisplay("Price Multiplier").SetCanOptimize(true);
-		_method = Param(nameof(Method), RandomMethod.Rs).SetDisplay("Method").SetCanOptimize(true);
+		_method = Param(nameof(Method), RandomMethods.Rs).SetDisplay("Method").SetCanOptimize(true);
 	}
 
 	/// <summary>Seed [>= 0].</summary>
@@ -75,7 +75,7 @@ public class RandomSyntheticAssetGenerationStrategy : Strategy
 	}
 
 	/// <summary>Pseudo-random generation method.</summary>
-	public RandomMethod Method
+	public RandomMethods Method
 	{
 		get => _method.Value;
 		set => _method.Value = value;
@@ -130,9 +130,9 @@ public class RandomSyntheticAssetGenerationStrategy : Strategy
 		AddInfo($"O:{randomOpen:0.00} H:{randomHigh:0.00} L:{randomLow:0.00} C:{randomClose:0.00} V:{randomVolume:0.00} TR:{randomTr:0.00}");
 	}
 
-	private decimal Rand(RandomMethod method, decimal range, int seed)
+	private decimal Rand(RandomMethods method, decimal range, int seed)
 	{
-		if (method == RandomMethod.Rs)
+		if (method == RandomMethods.Rs)
 		{
 			var result = (decimal)Math.PI * (_rsState * _barIndex + seed);
 			result %= range;
@@ -147,7 +147,7 @@ public class RandomSyntheticAssetGenerationStrategy : Strategy
 		return (_s1 / 30269m + _s2 / 30307m + _s3 / 30323m) % range;
 	}
 
-	private decimal RandomValue(RandomMethod method, int seed)
+	private decimal RandomValue(RandomMethods method, int seed)
 	{
 		var rand1 = 0.1m + (decimal)Math.Pow(1 - Math.Log10(0.01 + (double)Rand(method, 10m, seed)), 2);
 		var rand2 = Rand(method, 1m, seed + 1) + 1m;
@@ -157,7 +157,7 @@ public class RandomSyntheticAssetGenerationStrategy : Strategy
 		return randNormal + (Rand(method, 0.1m, seed) - 0.05m);
 	}
 
-	private decimal RandomWick(RandomMethod method, decimal change, decimal intrabarVolatility, int seed)
+	private decimal RandomWick(RandomMethods method, decimal change, decimal intrabarVolatility, int seed)
 	{
 		var absChange = Math.Abs(change);
 		var randValue = Rand(method, 1m, seed);

--- a/API/1232_Refined_MA_Engulfing/CS/RefinedMaEngulfingStrategy.cs
+++ b/API/1232_Refined_MA_Engulfing/CS/RefinedMaEngulfingStrategy.cs
@@ -28,7 +28,7 @@ public class RefinedMaEngulfingStrategy : Strategy
 	private decimal _l1, _l2, _l3, _l4, _l5;
 	private decimal? _lastSwingHigh;
 	private decimal? _lastSwingLow;
-	private MarketStructure _marketStructure;
+	private MarketStructures _marketStructure;
 	private bool _structureConfirmed;
 	private decimal _prevClose;
 	private int _barIndex;
@@ -158,18 +158,18 @@ public class RefinedMaEngulfingStrategy : Strategy
 
 		if (bullBreakConfirmed)
 		{
-			_marketStructure = MarketStructure.Bullish;
+			_marketStructure = MarketStructures.Bullish;
 			_structureConfirmed = true;
 		}
 
 		if (bearBreakConfirmed)
 		{
-			_marketStructure = MarketStructure.Bearish;
+			_marketStructure = MarketStructures.Bearish;
 			_structureConfirmed = true;
 		}
 
-		var bullishStructure = _marketStructure == MarketStructure.Bullish && _structureConfirmed;
-		var bearishStructure = _marketStructure == MarketStructure.Bearish && _structureConfirmed;
+		var bullishStructure = _marketStructure == MarketStructures.Bullish && _structureConfirmed;
+		var bearishStructure = _marketStructure == MarketStructures.Bearish && _structureConfirmed;
 
 		var longConfluence = 1; // fib placeholder
 		if (bullEngulf)
@@ -214,7 +214,7 @@ public class RefinedMaEngulfingStrategy : Strategy
 		_barIndex++;
 	}
 
-	private enum MarketStructure
+	private enum MarketStructures
 	{
 		None,
 		Bullish,

--- a/API/1244_Resampling_Filter_Pack/CS/ResamplingFilterPackStrategy.cs
+++ b/API/1244_Resampling_Filter_Pack/CS/ResamplingFilterPackStrategy.cs
@@ -19,14 +19,14 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class ResamplingFilterPackStrategy : Strategy
 {
-	public enum FilterType
+	public enum FilterTypes
 	{
 		Sma,
 		Ema
 	}
 
 	private readonly StrategyParam<int> _barsPerSample;
-	private readonly StrategyParam<FilterType> _filterType;
+	private readonly StrategyParam<FilterTypes> _filterType;
 	private readonly StrategyParam<int> _maPeriod;
 	private readonly StrategyParam<DataType> _candleType;
 
@@ -48,7 +48,7 @@ public class ResamplingFilterPackStrategy : Strategy
 	/// <summary>
 	/// Moving average type.
 	/// </summary>
-	public FilterType MovingAverageType
+	public FilterTypes MovingAverageType
 	{
 		get => _filterType.Value;
 		set => _filterType.Value = value;
@@ -82,7 +82,7 @@ public class ResamplingFilterPackStrategy : Strategy
 			.SetCanOptimize(true)
 			.SetOptimize(3, 7, 1);
 
-		_filterType = Param(nameof(MovingAverageType), FilterType.Ema)
+		_filterType = Param(nameof(MovingAverageType), FilterTypes.Ema)
 			.SetDisplay("Filter Type", "Moving average type", "Filter");
 
 		_maPeriod = Param(nameof(MaPeriod), 9)
@@ -105,7 +105,7 @@ public class ResamplingFilterPackStrategy : Strategy
 	{
 		base.OnStarted(time);
 
-		_ma = MovingAverageType == FilterType.Sma
+		_ma = MovingAverageType == FilterTypes.Sma
 			? new SimpleMovingAverage { Length = MaPeriod }
 			: new ExponentialMovingAverage { Length = MaPeriod };
 

--- a/API/1254_Risk_Management_and_Positionsize_MACD_Example/CS/RiskManagementAndPositionsizeMacdExampleStrategy.cs
+++ b/API/1254_Risk_Management_and_Positionsize_MACD_Example/CS/RiskManagementAndPositionsizeMacdExampleStrategy.cs
@@ -23,12 +23,12 @@ public class RiskManagementAndPositionsizeMacdExampleStrategy : Strategy
 	private readonly StrategyParam<bool> _leverageEquity;
 	private readonly StrategyParam<decimal> _marginFactor;
 	private readonly StrategyParam<decimal> _quantity;
-	private readonly StrategyParam<MovingAverageTypeEnum> _macdMaType;
+	private readonly StrategyParam<MovingAverageTypes> _macdMaType;
 	private readonly StrategyParam<int> _fastMaLength;
 	private readonly StrategyParam<int> _slowMaLength;
 	private readonly StrategyParam<int> _signalMaLength;
 	private readonly StrategyParam<TimeSpan> _macdTimeFrame;
-	private readonly StrategyParam<MovingAverageTypeEnum> _trendMaType;
+	private readonly StrategyParam<MovingAverageTypes> _trendMaType;
 	private readonly StrategyParam<int> _trendMaLength;
 	private readonly StrategyParam<TimeSpan> _trendTimeFrame;
 	private readonly StrategyParam<DataType> _candleType;
@@ -84,7 +84,7 @@ public class RiskManagementAndPositionsizeMacdExampleStrategy : Strategy
 	/// <summary>
 	/// Moving average type for MACD.
 	/// </summary>
-	public MovingAverageTypeEnum MacdMaType
+	public MovingAverageTypes MacdMaType
 	{
 		get => _macdMaType.Value;
 		set => _macdMaType.Value = value;
@@ -129,7 +129,7 @@ public class RiskManagementAndPositionsizeMacdExampleStrategy : Strategy
 	/// <summary>
 	/// Moving average type for trend filter.
 	/// </summary>
-	public MovingAverageTypeEnum TrendMaType
+	public MovingAverageTypes TrendMaType
 	{
 		get => _trendMaType.Value;
 		set => _trendMaType.Value = value;
@@ -185,7 +185,7 @@ public class RiskManagementAndPositionsizeMacdExampleStrategy : Strategy
 						.SetCanOptimize(true)
 						.SetOptimize(1m, 5m, 1m);
 
-		_macdMaType = Param(nameof(MacdMaType), MovingAverageTypeEnum.EMA)
+		_macdMaType = Param(nameof(MacdMaType), MovingAverageTypes.EMA)
 						  .SetDisplay("MACD MA Type", "Moving average type for MACD", "MACD Settings");
 
 		_fastMaLength = Param(nameof(FastMaLength), 11)
@@ -206,7 +206,7 @@ public class RiskManagementAndPositionsizeMacdExampleStrategy : Strategy
 		_macdTimeFrame = Param(nameof(MacdTimeFrame), TimeSpan.FromMinutes(30))
 							 .SetDisplay("MACD Higher Time Frame", "Time frame for MACD", "MACD Settings");
 
-		_trendMaType = Param(nameof(TrendMaType), MovingAverageTypeEnum.EMA)
+		_trendMaType = Param(nameof(TrendMaType), MovingAverageTypes.EMA)
 						   .SetDisplay("Trend MA Type", "Moving average type for trend", "Trend Settings");
 
 		_trendMaLength = Param(nameof(TrendMaLength), 55)
@@ -347,18 +347,18 @@ public class RiskManagementAndPositionsizeMacdExampleStrategy : Strategy
 		return equity * (1 + MarginFactor) / price;
 	}
 
-	private static MovingAverage CreateMa(MovingAverageTypeEnum type, int length)
+	private static MovingAverage CreateMa(MovingAverageTypes type, int length)
 	{
-		return type switch { MovingAverageTypeEnum.SMA => new SimpleMovingAverage { Length = length },
-							 MovingAverageTypeEnum.EMA => new ExponentialMovingAverage { Length = length },
-							 MovingAverageTypeEnum.DEMA => new DoubleExponentialMovingAverage { Length = length },
-							 MovingAverageTypeEnum.TEMA => new TripleExponentialMovingAverage { Length = length },
-							 MovingAverageTypeEnum.WMA => new WeightedMovingAverage { Length = length },
-							 MovingAverageTypeEnum.HMA => new HullMovingAverage { Length = length },
+		return type switch { MovingAverageTypes.SMA => new SimpleMovingAverage { Length = length },
+							 MovingAverageTypes.EMA => new ExponentialMovingAverage { Length = length },
+							 MovingAverageTypes.DEMA => new DoubleExponentialMovingAverage { Length = length },
+							 MovingAverageTypes.TEMA => new TripleExponentialMovingAverage { Length = length },
+							 MovingAverageTypes.WMA => new WeightedMovingAverage { Length = length },
+							 MovingAverageTypes.HMA => new HullMovingAverage { Length = length },
 							 _ => throw new ArgumentOutOfRangeException(nameof(type), type, null) };
 	}
 
-	public enum MovingAverageTypeEnum
+	public enum MovingAverageTypes
 	{
 		SMA,
 		EMA,

--- a/API/1255_Risk_to_Reward_FIXED_SL_Backtester/CS/RiskToRewardFixedSlBacktesterStrategy.cs
+++ b/API/1255_Risk_to_Reward_FIXED_SL_Backtester/CS/RiskToRewardFixedSlBacktesterStrategy.cs
@@ -21,7 +21,7 @@ public class RiskToRewardFixedSlBacktesterStrategy : Strategy
 	private readonly StrategyParam<decimal> _dealStartValue;
 	private readonly StrategyParam<bool> _useRiskToReward;
 	private readonly StrategyParam<decimal> _riskToRewardRatio;
-	private readonly StrategyParam<StopMode> _stopLossType;
+	private readonly StrategyParam<StopModes> _stopLossType;
 	private readonly StrategyParam<decimal> _atrFactor;
 	private readonly StrategyParam<int> _pivotLookback;
 	private readonly StrategyParam<decimal> _fixedTp;
@@ -44,7 +44,7 @@ public class RiskToRewardFixedSlBacktesterStrategy : Strategy
 	public decimal DealStartValue { get => _dealStartValue.Value; set => _dealStartValue.Value = value; }
 	public bool UseRiskToReward { get => _useRiskToReward.Value; set => _useRiskToReward.Value = value; }
 	public decimal RiskToRewardRatio { get => _riskToRewardRatio.Value; set => _riskToRewardRatio.Value = value; }
-	public StopMode StopLossType { get => _stopLossType.Value; set => _stopLossType.Value = value; }
+	public StopModes StopLossType { get => _stopLossType.Value; set => _stopLossType.Value = value; }
 	public decimal AtrFactor { get => _atrFactor.Value; set => _atrFactor.Value = value; }
 	public int PivotLookback { get => _pivotLookback.Value; set => _pivotLookback.Value = value; }
 	public decimal FixedTp { get => _fixedTp.Value; set => _fixedTp.Value = value; }
@@ -65,7 +65,7 @@ public class RiskToRewardFixedSlBacktesterStrategy : Strategy
 		_riskToRewardRatio = Param(nameof(RiskToRewardRatio), 1.5m)
 			.SetDisplay("Risk To Reward Ratio", "Take profit ratio", "Risk Management");
 
-		_stopLossType = Param(nameof(StopLossType), StopMode.Atr)
+		_stopLossType = Param(nameof(StopLossType), StopModes.Atr)
 			.SetDisplay("Stop Loss Type", "ATR or Pivot", "Risk Management");
 
 		_atrFactor = Param(nameof(AtrFactor), 1.4m)
@@ -140,9 +140,9 @@ public class RiskToRewardFixedSlBacktesterStrategy : Strategy
 		if (!IsFormedAndOnlineAndAllowTrading())
 			return;
 
-		if (StopLossType == StopMode.Atr && !_atr.IsFormed)
+		if (StopLossType == StopModes.Atr && !_atr.IsFormed)
 			return;
-		if (StopLossType == StopMode.PivotLow && !_lowest.IsFormed)
+		if (StopLossType == StopModes.PivotLow && !_lowest.IsFormed)
 			return;
 
 		var dealStart = candle.ClosePrice == DealStartValue;
@@ -150,8 +150,8 @@ public class RiskToRewardFixedSlBacktesterStrategy : Strategy
 		var sl = UseRiskToReward
 		? StopLossType switch
 		{
-			StopMode.Atr => candle.LowPrice - atrValue * AtrFactor,
-			StopMode.PivotLow => lowestValue,
+			StopModes.Atr => candle.LowPrice - atrValue * AtrFactor,
+			StopModes.PivotLow => lowestValue,
 			_ => candle.LowPrice - atrValue * AtrFactor,
 		}
 		: candle.ClosePrice * (1m - FixedSl);
@@ -188,7 +188,7 @@ public class RiskToRewardFixedSlBacktesterStrategy : Strategy
 			SellMarket(Position);
 	}
 
-	public enum StopMode
+	public enum StopModes
 	{
 		Atr,
 		PivotLow

--- a/API/1259_RSI_Backed_Weighted_MA/CS/RsiBackedWeightedMaStrategy.cs
+++ b/API/1259_RSI_Backed_Weighted_MA/CS/RsiBackedWeightedMaStrategy.cs
@@ -22,7 +22,7 @@ namespace StockSharp.Samples.Strategies;
 public class RsiBackedWeightedMaStrategy : Strategy
 {
 	private readonly StrategyParam<int> _rsiLength;
-	private readonly StrategyParam<MaType> _maType;
+	private readonly StrategyParam<MaTypes> _maType;
 	private readonly StrategyParam<int> _maLength;
 	private readonly StrategyParam<decimal> _rsiLong;
 	private readonly StrategyParam<decimal> _rsiShort;
@@ -56,7 +56,7 @@ public class RsiBackedWeightedMaStrategy : Strategy
 	/// <summary>
 	/// Moving average type.
 	/// </summary>
-	public MaType MaType { get => _maType.Value; set => _maType.Value = value; }
+	public MaTypes MaType { get => _maType.Value; set => _maType.Value = value; }
 
 	/// <summary>
 	/// Moving average length.
@@ -132,7 +132,7 @@ public class RsiBackedWeightedMaStrategy : Strategy
 		.SetGreaterThanZero()
 		.SetDisplay("RSI Length", "RSI calculation period", "RSI Settings");
 
-		_maType = Param(nameof(MaType), MaType.RWMA)
+		_maType = Param(nameof(MaType), MaTypes.RWMA)
 		.SetDisplay("MA Type", "Moving average type", "MA Settings");
 
 		_maLength = Param(nameof(MaLength), 19)
@@ -214,9 +214,9 @@ public class RsiBackedWeightedMaStrategy : Strategy
 		_capitalRef = Portfolio?.CurrentValue ?? 0m;
 		_cashOrder = _capitalRef * 0.95m;
 
-		LengthIndicator<decimal> ma = MaType switch
+		LengthIndicator<decimal> ma = MaTypes switch
 		{
-			MaType.SMA => new SimpleMovingAverage { Length = MaLength },
+			MaTypes.SMA => new SimpleMovingAverage { Length = MaLength },
 			_ => new RetroWeightedMovingAverage { Length = MaLength }
 		};
 
@@ -388,7 +388,7 @@ public class RsiBackedWeightedMaStrategy : Strategy
 	/// <summary>
 	/// Types of moving averages.
 	/// </summary>
-	public enum MaType
+	public enum MaTypes
 	{
 		/// <summary>Simple moving average.</summary>
 		SMA,

--- a/API/1267_RSI_Divergence_AliferCrypto/CS/RsiDivergenceAliferCryptoStrategy.cs
+++ b/API/1267_RSI_Divergence_AliferCrypto/CS/RsiDivergenceAliferCryptoStrategy.cs
@@ -26,10 +26,10 @@ public class RsiDivergenceAliferCryptoStrategy : Strategy {
 	private readonly StrategyParam<int> _oversoldLevel;
 	private readonly StrategyParam<int> _overboughtLevel;
 	private readonly StrategyParam<bool> _enableTrendFilter;
-	private readonly StrategyParam<MaType> _maType;
+	private readonly StrategyParam<MaTypes> _maType;
 	private readonly StrategyParam<int> _maLength;
-	private readonly StrategyParam<SlTpMethod> _method;
-	private readonly StrategyParam<ExitMode> _exitMode;
+	private readonly StrategyParam<SlTpMethods> _method;
+	private readonly StrategyParam<ExitModes> _exitMode;
 	private readonly StrategyParam<int> _swingLook;
 	private readonly StrategyParam<decimal> _swingMarginPct;
 	private readonly StrategyParam<decimal> _rrSwing;
@@ -95,7 +95,7 @@ public class RsiDivergenceAliferCryptoStrategy : Strategy {
 		get => _enableTrendFilter.Value;
 		set => _enableTrendFilter.Value = value;
 	}
-	public MaType TrendMaType {
+	public MaTypes TrendMaType {
 		get => _maType.Value;
 		set => _maType.Value = value;
 	}
@@ -103,11 +103,11 @@ public class RsiDivergenceAliferCryptoStrategy : Strategy {
 		get => _maLength.Value;
 		set => _maLength.Value = value;
 	}
-	public SlTpMethod Method {
+	public SlTpMethods Method {
 		get => _method.Value;
 		set => _method.Value = value;
 	}
-	public ExitMode ExitMode {
+	public ExitModes ExitMode {
 		get => _exitMode.Value;
 		set => _exitMode.Value = value;
 	}
@@ -169,14 +169,14 @@ public class RsiDivergenceAliferCryptoStrategy : Strategy {
 		_enableTrendFilter =
 			Param(nameof(EnableTrendFilter), false)
 				.SetDisplay("Enable Trend Filter", "Use trend MA", "Filters");
-		_maType = Param(nameof(TrendMaType), MaType.Sma)
+		_maType = Param(nameof(TrendMaType), MaTypes.Sma)
 					  .SetDisplay("MA Type", "Trend MA type", "Filters");
 		_maLength = Param(nameof(TrendMaLength), 200)
 						.SetDisplay("MA Length", "Trend MA length", "Filters");
-		_method = Param(nameof(Method), SlTpMethod.Swing)
+		_method = Param(nameof(Method), SlTpMethods.Swing)
 					  .SetDisplay("SL/TP Method", "Stop/target method", "Risk");
 		_exitMode =
-			Param(nameof(ExitMode), Strategies.ExitMode.Dynamic)
+			Param(nameof(ExitMode), Strategies.ExitModes.Dynamic)
 				.SetDisplay("Exit Mode", "Dynamic or static exits", "Risk");
 		_swingLook = Param(nameof(SwingLook), 20)
 						 .SetDisplay("Swing Lookback",
@@ -345,7 +345,7 @@ public class RsiDivergenceAliferCryptoStrategy : Strategy {
 			decimal tpCalc;
 			decimal rr;
 
-			if (Method == SlTpMethod.Swing) {
+			if (Method == SlTpMethods.Swing) {
 				slCalc = swingLow * (1m - SwingMarginPct / 100m);
 				rr = RrSwing;
 			} else {
@@ -355,13 +355,13 @@ public class RsiDivergenceAliferCryptoStrategy : Strategy {
 			var risk = entryPrice - slCalc;
 			tpCalc = entryPrice + risk * rr;
 
-			if (ExitMode == ExitMode.Static && _entrySl is null) {
+			if (ExitModes == ExitModes.Static && _entrySl is null) {
 				_entrySl = slCalc;
 				_entryTp = tpCalc;
 			}
 
-			_slPrice = ExitMode == ExitMode.Dynamic ? slCalc : _entrySl;
-			_tpPrice = ExitMode == ExitMode.Dynamic ? tpCalc : _entryTp;
+			_slPrice = ExitModes == ExitModes.Dynamic ? slCalc : _entrySl;
+			_tpPrice = ExitModes == ExitModes.Dynamic ? tpCalc : _entryTp;
 
 			if (_slPrice is decimal sl && candle.LowPrice <= sl) {
 				SellMarket(Math.Abs(Position));
@@ -380,7 +380,7 @@ public class RsiDivergenceAliferCryptoStrategy : Strategy {
 			decimal tpCalc;
 			decimal rr;
 
-			if (Method == SlTpMethod.Swing) {
+			if (Method == SlTpMethods.Swing) {
 				slCalc = swingHigh * (1m + SwingMarginPct / 100m);
 				rr = RrSwing;
 			} else {
@@ -390,13 +390,13 @@ public class RsiDivergenceAliferCryptoStrategy : Strategy {
 			var risk = slCalc - entryPrice;
 			tpCalc = entryPrice - risk * rr;
 
-			if (ExitMode == ExitMode.Static && _entrySl is null) {
+			if (ExitModes == ExitModes.Static && _entrySl is null) {
 				_entrySl = slCalc;
 				_entryTp = tpCalc;
 			}
 
-			_slPrice = ExitMode == ExitMode.Dynamic ? slCalc : _entrySl;
-			_tpPrice = ExitMode == ExitMode.Dynamic ? tpCalc : _entryTp;
+			_slPrice = ExitModes == ExitModes.Dynamic ? slCalc : _entrySl;
+			_tpPrice = ExitModes == ExitModes.Dynamic ? tpCalc : _entryTp;
 
 			if (_slPrice is decimal sl && candle.HighPrice >= sl) {
 				BuyMarket(Math.Abs(Position));
@@ -412,13 +412,13 @@ public class RsiDivergenceAliferCryptoStrategy : Strategy {
 		}
 	}
 
-	private static MovingAverage CreateMa(MaType type, int length) {
+	private static MovingAverage CreateMa(MaTypes type, int length) {
 		return type switch {
-			MaType.Sma => new SimpleMovingAverage { Length = length },
-			MaType.Ema => new ExponentialMovingAverage { Length = length },
-			MaType.Smma => new SmoothedMovingAverage { Length = length },
-			MaType.Wma => new WeightedMovingAverage { Length = length },
-			MaType.Vwma => new VolumeWeightedMovingAverage { Length = length },
+			MaTypes.Sma => new SimpleMovingAverage { Length = length },
+			MaTypes.Ema => new ExponentialMovingAverage { Length = length },
+			MaTypes.Smma => new SmoothedMovingAverage { Length = length },
+			MaTypes.Wma => new WeightedMovingAverage { Length = length },
+			MaTypes.Vwma => new VolumeWeightedMovingAverage { Length = length },
 			_ => new SimpleMovingAverage { Length = length },
 		};
 	}
@@ -427,7 +427,7 @@ public class RsiDivergenceAliferCryptoStrategy : Strategy {
 /// <summary>
 /// Moving average types.
 /// </summary>
-public enum MaType {
+public enum MaTypes {
 	/// <summary> Simple moving average. </summary>
 	Sma,
 	/// <summary> Exponential moving average. </summary>
@@ -443,7 +443,7 @@ public enum MaType {
 /// <summary>
 /// Stop loss and take profit calculation method.
 /// </summary>
-public enum SlTpMethod {
+public enum SlTpMethods {
 	/// <summary> Use recent swing high/low. </summary>
 	Swing,
 	/// <summary> Use ATR based calculation. </summary>
@@ -453,7 +453,7 @@ public enum SlTpMethod {
 /// <summary>
 /// Exit levels mode.
 /// </summary>
-public enum ExitMode {
+public enum ExitModes {
 	/// <summary> Recalculate SL/TP each bar. </summary>
 	Dynamic,
 	/// <summary> Lock SL/TP at entry. </summary>

--- a/API/1294_Separated_Moving_Average/CS/SeparatedMovingAverageStrategy.cs
+++ b/API/1294_Separated_Moving_Average/CS/SeparatedMovingAverageStrategy.cs
@@ -13,7 +13,7 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-public enum MaType
+public enum MaTypes
 {
 	SMA,
 	EMA,
@@ -22,7 +22,7 @@ public enum MaType
 
 public class SeparatedMovingAverageStrategy : Strategy
 {
-	private readonly StrategyParam<MaType> _maType;
+	private readonly StrategyParam<MaTypes> _maType;
 	private readonly StrategyParam<int> _length;
 	private readonly StrategyParam<bool> _useHeikinAshi;
 	private readonly StrategyParam<DataType> _candleType;
@@ -36,7 +36,7 @@ public class SeparatedMovingAverageStrategy : Strategy
 
 	public SeparatedMovingAverageStrategy()
 	{
-		_maType = Param(nameof(MaType), MaType.SMA)
+		_maType = Param(nameof(MaType), MaTypes.SMA)
 			.SetDisplay("Type", "Moving average type", "General");
 		_length = Param(nameof(Length), 20)
 			.SetGreaterThanZero()
@@ -47,7 +47,7 @@ public class SeparatedMovingAverageStrategy : Strategy
 			.SetDisplay("Candle Type", "Type of candles", "General");
 	}
 
-	public MaType MaType
+	public MaTypes MaType
 	{
 		get => _maType.Value;
 		set => _maType.Value = value;
@@ -90,10 +90,10 @@ public class SeparatedMovingAverageStrategy : Strategy
 	}
 
 	private MovingAverage CreateMa()
-		=> MaType switch
+		=> MaTypes switch
 		{
-			MaType.EMA => new ExponentialMovingAverage { Length = Length },
-			MaType.HMA => new HullMovingAverage { Length = Length },
+			MaTypes.EMA => new ExponentialMovingAverage { Length = Length },
+			MaTypes.HMA => new HullMovingAverage { Length = Length },
 			_ => new SMA { Length = Length },
 		};
 

--- a/API/1304_Simple_Fibonacci_Retracement/CS/SimpleFibonacciRetracementStrategy.cs
+++ b/API/1304_Simple_Fibonacci_Retracement/CS/SimpleFibonacciRetracementStrategy.cs
@@ -20,13 +20,13 @@ namespace StockSharp.Samples.Strategies;
 public class SimpleFibonacciRetracementStrategy : Strategy
 {
 	private readonly StrategyParam<int> _lookbackPeriod;
-	private readonly StrategyParam<FibDirection> _fibDirection;
+	private readonly StrategyParam<FibDirections> _fibDirection;
 	private readonly StrategyParam<decimal> _fibLevel236;
 	private readonly StrategyParam<decimal> _fibLevel382;
 	private readonly StrategyParam<decimal> _fibLevel50;
 	private readonly StrategyParam<decimal> _fibLevel618;
-	private readonly StrategyParam<FibLevel> _buyEntryLevel;
-	private readonly StrategyParam<FibLevel> _sellEntryLevel;
+	private readonly StrategyParam<FibLevels> _buyEntryLevel;
+	private readonly StrategyParam<FibLevels> _sellEntryLevel;
 	private readonly StrategyParam<int> _takeProfitPips;
 	private readonly StrategyParam<int> _stopLossPips;
 	private readonly StrategyParam<DataType> _candleType;
@@ -45,7 +45,7 @@ public class SimpleFibonacciRetracementStrategy : Strategy
 	/// <summary>
 	/// Direction for Fibonacci calculation.
 	/// </summary>
-	public FibDirection Direction { get => _fibDirection.Value; set => _fibDirection.Value = value; }
+	public FibDirections Direction { get => _fibDirection.Value; set => _fibDirection.Value = value; }
 	
 	/// <summary>
 	/// 23.6% Fibonacci level.
@@ -70,12 +70,12 @@ public class SimpleFibonacciRetracementStrategy : Strategy
 	/// <summary>
 	/// Entry level for long positions.
 	/// </summary>
-	public FibLevel BuyEntryLevel { get => _buyEntryLevel.Value; set => _buyEntryLevel.Value = value; }
+	public FibLevels BuyEntryLevel { get => _buyEntryLevel.Value; set => _buyEntryLevel.Value = value; }
 	
 	/// <summary>
 	/// Entry level for short positions.
 	/// </summary>
-	public FibLevel SellEntryLevel { get => _sellEntryLevel.Value; set => _sellEntryLevel.Value = value; }
+	public FibLevels SellEntryLevel { get => _sellEntryLevel.Value; set => _sellEntryLevel.Value = value; }
 	
 	/// <summary>
 	/// Take profit in pips.
@@ -102,7 +102,7 @@ public class SimpleFibonacciRetracementStrategy : Strategy
 		.SetDisplay("Lookback Period", "Period for highest/lowest", "General")
 		.SetCanOptimize(true);
 		
-		_fibDirection = Param(nameof(Direction), FibDirection.TopToBottom)
+		_fibDirection = Param(nameof(Direction), FibDirections.TopToBottom)
 		.SetDisplay("Fibonacci Direction", "Direction of calculation", "General")
 		.SetCanOptimize(true);
 		
@@ -122,11 +122,11 @@ public class SimpleFibonacciRetracementStrategy : Strategy
 		.SetDisplay("Fib 61.8%", "Fibonacci 61.8% level", "Fibonacci")
 		.SetCanOptimize(true);
 		
-		_buyEntryLevel = Param(nameof(BuyEntryLevel), FibLevel.Fib618)
+		_buyEntryLevel = Param(nameof(BuyEntryLevel), FibLevels.Fib618)
 		.SetDisplay("Buy Entry Level", "Fibonacci level for longs", "Entries")
 		.SetCanOptimize(true);
 		
-		_sellEntryLevel = Param(nameof(SellEntryLevel), FibLevel.Fib382)
+		_sellEntryLevel = Param(nameof(SellEntryLevel), FibLevels.Fib382)
 		.SetDisplay("Sell Entry Level", "Fibonacci level for shorts", "Entries")
 		.SetCanOptimize(true);
 		
@@ -192,7 +192,7 @@ public class SimpleFibonacciRetracementStrategy : Strategy
 		decimal fib50;
 		decimal fib618;
 		
-		if (Direction == FibDirection.TopToBottom)
+		if (Direction == FibDirections.TopToBottom)
 		{
 			fib0 = high;
 			fib100 = low;
@@ -258,24 +258,24 @@ public class SimpleFibonacciRetracementStrategy : Strategy
 		}
 	}
 	
-	private static decimal GetLevel(FibLevel level, decimal fib236, decimal fib382, decimal fib50, decimal fib618)
+	private static decimal GetLevel(FibLevels level, decimal fib236, decimal fib382, decimal fib50, decimal fib618)
 	{
 		return level switch
 		{
-			FibLevel.Fib236 => fib236,
-			FibLevel.Fib382 => fib382,
-			FibLevel.Fib50 => fib50,
+			FibLevels.Fib236 => fib236,
+			FibLevels.Fib382 => fib382,
+			FibLevels.Fib50 => fib50,
 			_ => fib618,
 		};
 	}
 	
-	public enum FibDirection
+	public enum FibDirections
 	{
 		TopToBottom,
 		BottomToTop
 	}
 	
-	public enum FibLevel
+	public enum FibLevels
 	{
 		Fib236,
 		Fib382,

--- a/API/1339_Stochastic_Heat_Map/CS/StochasticHeatMapStrategy.cs
+++ b/API/1339_Stochastic_Heat_Map/CS/StochasticHeatMapStrategy.cs
@@ -24,7 +24,7 @@ public class StochasticHeatMapStrategy : Strategy
 	private readonly StrategyParam<int> _smoothSlow;
 	private readonly StrategyParam<int> _plotNumber;
 	private readonly StrategyParam<bool> _useWaves;
-	private readonly StrategyParam<MaType> _maType;
+	private readonly StrategyParam<MaTypes> _maType;
 	private readonly StrategyParam<DataType> _candleType;
 
 	private decimal _prevFast;
@@ -78,7 +78,7 @@ public class StochasticHeatMapStrategy : Strategy
 	/// <summary>
 	/// Moving average type used for smoothing.
 	/// </summary>
-	public MaType MaType
+	public MaTypes MaType
 	{
 		get => _maType.Value;
 		set => _maType.Value = value;
@@ -121,7 +121,7 @@ public class StochasticHeatMapStrategy : Strategy
 		_useWaves = Param(nameof(UseWaves), false)
 			.SetDisplay("Waves", "Increase smoothing for each Stochastic", "Parameters");
 
-		_maType = Param(nameof(MaType), MaType.EMA)
+		_maType = Param(nameof(MaType), MaTypes.EMA)
 			.SetDisplay("MA Type", "Type of moving average for smoothing", "Parameters");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(15).TimeFrame())
@@ -155,7 +155,7 @@ public class StochasticHeatMapStrategy : Strategy
 			SmoothSlow = SmoothSlow,
 			PlotNumber = PlotNumber,
 			UseWaves = UseWaves,
-			MaType = MaType
+			MaTypes = MaTypes
 		};
 
 		var subscription = SubscribeCandles(CandleType);
@@ -212,7 +212,7 @@ public class StochasticHeatMapIndicator : BaseIndicator<decimal>
 	public int SmoothSlow { get; set; } = 21;
 	public int PlotNumber { get; set; } = 28;
 	public bool UseWaves { get; set; }
-	public MaType MaType { get; set; } = MaType.EMA;
+	public MaTypes MaType { get; set; } = MaTypes.EMA;
 
 	private readonly List<(StochasticOscillator stoch, IIndicator ma)> _items = new();
 	private IIndicator _slowMa;
@@ -236,20 +236,20 @@ public class StochasticHeatMapIndicator : BaseIndicator<decimal>
 					D = { Length = 1 },
 				};
 
-				IIndicator ma = MaType switch
+				IIndicator ma = MaTypes switch
 				{
-					MaType.SMA => new SimpleMovingAverage { Length = smooth },
-					MaType.WMA => new WeightedMovingAverage { Length = smooth },
+					MaTypes.SMA => new SimpleMovingAverage { Length = smooth },
+					MaTypes.WMA => new WeightedMovingAverage { Length = smooth },
 					_ => new ExponentialMovingAverage { Length = smooth },
 				};
 
 				_items.Add((stoch, ma));
 			}
 
-			_slowMa = MaType switch
+			_slowMa = MaTypes switch
 			{
-				MaType.SMA => new SimpleMovingAverage { Length = SmoothSlow },
-				MaType.WMA => new WeightedMovingAverage { Length = SmoothSlow },
+				MaTypes.SMA => new SimpleMovingAverage { Length = SmoothSlow },
+				MaTypes.WMA => new WeightedMovingAverage { Length = SmoothSlow },
 				_ => new ExponentialMovingAverage { Length = SmoothSlow },
 			};
 		}
@@ -299,7 +299,7 @@ public class StochasticHeatMapValue : ComplexIndicatorValue
 /// <summary>
 /// Moving average type.
 /// </summary>
-public enum MaType
+public enum MaTypes
 {
 	/// <summary>
 	/// Simple moving average.

--- a/API/1359_Stx_Monthly_Trades_Profit/CS/StxMonthlyTradesProfitStrategy.cs
+++ b/API/1359_Stx_Monthly_Trades_Profit/CS/StxMonthlyTradesProfitStrategy.cs
@@ -20,7 +20,7 @@ public class StxMonthlyTradesProfitStrategy : Strategy
 {
 	private readonly StrategyParam<string> _testCase;
 	private readonly StrategyParam<DataType> _candleType;
-	private readonly StrategyParam<ProfitMode> _profitMode;
+	private readonly StrategyParam<ProfitModes> _profitMode;
 	private readonly StrategyParam<int> _leverage;
 	private readonly StrategyParam<bool> _showYearly;
 
@@ -41,7 +41,7 @@ public class StxMonthlyTradesProfitStrategy : Strategy
 	/// <summary>
 	/// Profit calculation modes.
 	/// </summary>
-	public enum ProfitMode
+	public enum ProfitModes
 	{
 		/// <summary>Disable profit calculation.</summary>
 		Disabled,
@@ -66,7 +66,7 @@ public class StxMonthlyTradesProfitStrategy : Strategy
 	}
 
 	/// <summary>Profit calculation mode.</summary>
-	public ProfitMode Mode
+	public ProfitModes Mode
 	{
 		get => _profitMode.Value;
 		set => _profitMode.Value = value;
@@ -97,7 +97,7 @@ public class StxMonthlyTradesProfitStrategy : Strategy
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(1).TimeFrame())
 			.SetDisplay("Candle Type", "Type of candles", "General");
 
-		_profitMode = Param(nameof(Mode), ProfitMode.MonthlyProfit)
+		_profitMode = Param(nameof(Mode), ProfitModes.MonthlyProfit)
 			.SetDisplay("Profit Mode", "Monthly calculation mode", "Trades Profit Table");
 
 		_leverage = Param(nameof(Leverage), 1)
@@ -235,7 +235,7 @@ public class StxMonthlyTradesProfitStrategy : Strategy
 
 	private void UpdateProfit(ICandleMessage candle)
 	{
-		if (Mode == ProfitMode.Disabled)
+		if (Mode == ProfitModes.Disabled)
 			return;
 
 		var month = candle.OpenTime.Month;
@@ -247,7 +247,7 @@ public class StxMonthlyTradesProfitStrategy : Strategy
 			_monthlyPnL[year] = arr;
 		}
 
-		if (Mode == ProfitMode.MonthlyEquity)
+		if (Mode == ProfitModes.MonthlyEquity)
 		{
 			var equity = 1m + PnL;
 			_monthlyProfit = equity / (1m + _startMonthPnL) - 1m;

--- a/API/1367_Supertrend_CCI_Scalp/CS/SupertrendCciScalpStrategy.cs
+++ b/API/1367_Supertrend_CCI_Scalp/CS/SupertrendCciScalpStrategy.cs
@@ -24,7 +24,7 @@ public class SupertrendCciScalpStrategy : Strategy
 	private readonly StrategyParam<decimal> _factor2;
 	private readonly StrategyParam<int> _cciLength;
 	private readonly StrategyParam<int> _smoothingLength;
-	private readonly StrategyParam<MovingAverageTypeEnum> _maType;
+	private readonly StrategyParam<MovingAverageTypes> _maType;
 	private readonly StrategyParam<decimal> _cciLevel;
 	private readonly StrategyParam<DataType> _candleType;
 
@@ -64,7 +64,7 @@ public class SupertrendCciScalpStrategy : Strategy
 	/// <summary>
 	/// Moving average type for smoothed CCI.
 	/// </summary>
-	public MovingAverageTypeEnum MaType { get => _maType.Value; set => _maType.Value = value; }
+	public MovingAverageTypes MaType { get => _maType.Value; set => _maType.Value = value; }
 
 	/// <summary>
 	/// CCI level for signals.
@@ -99,7 +99,7 @@ public class SupertrendCciScalpStrategy : Strategy
 	_smoothingLength = Param(nameof(SmoothingLength), 5)
 	    .SetDisplay("Smoothing Length", "Moving average length for CCI", "CCI");
 
-	_maType = Param(nameof(MaType), MovingAverageTypeEnum.Simple)
+	_maType = Param(nameof(MaType), MovingAverageTypes.Simple)
 	    .SetDisplay("MA Type", "Type of moving average", "CCI");
 
 	_cciLevel = Param(nameof(CciLevel), 100m)
@@ -197,20 +197,20 @@ public class SupertrendCciScalpStrategy : Strategy
 	}
 	}
 
-	private static IIndicator CreateMa(MovingAverageTypeEnum type, int length)
+	private static IIndicator CreateMa(MovingAverageTypes type, int length)
 	{
 	return type switch
 	{
-	    MovingAverageTypeEnum.Simple => new SimpleMovingAverage { Length = length },
-	    MovingAverageTypeEnum.Exponential => new ExponentialMovingAverage { Length = length },
-	    MovingAverageTypeEnum.Smoothed => new SmoothedMovingAverage { Length = length },
-	    MovingAverageTypeEnum.Weighted => new WeightedMovingAverage { Length = length },
-	    MovingAverageTypeEnum.VolumeWeighted => new VolumeWeightedMovingAverage { Length = length },
+	    MovingAverageTypes.Simple => new SimpleMovingAverage { Length = length },
+	    MovingAverageTypes.Exponential => new ExponentialMovingAverage { Length = length },
+	    MovingAverageTypes.Smoothed => new SmoothedMovingAverage { Length = length },
+	    MovingAverageTypes.Weighted => new WeightedMovingAverage { Length = length },
+	    MovingAverageTypes.VolumeWeighted => new VolumeWeightedMovingAverage { Length = length },
 	    _ => new SimpleMovingAverage { Length = length },
 	};
 	}
 
-	public enum MovingAverageTypeEnum
+	public enum MovingAverageTypes
 	{
 	Simple,
 	Exponential,

--- a/API/1376_Supertrend_Fixed_TP_Unified_with_Time_Filter_MSK/CS/SupertrendFixedTpUnifiedWithTimeFilterMskStrategy.cs
+++ b/API/1376_Supertrend_Fixed_TP_Unified_with_Time_Filter_MSK/CS/SupertrendFixedTpUnifiedWithTimeFilterMskStrategy.cs
@@ -21,7 +21,7 @@ public class SupertrendFixedTpUnifiedWithTimeFilterMskStrategy : Strategy
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<int> _atrPeriod;
 	private readonly StrategyParam<decimal> _factor;
-	private readonly StrategyParam<TradeMode> _tradeMode;
+	private readonly StrategyParam<TradeModes> _tradeMode;
 	private readonly StrategyParam<decimal> _takeProfitPercent;
 	private readonly StrategyParam<bool> _usePriceFilter;
 	private readonly StrategyParam<decimal> _priceFilter;
@@ -35,7 +35,7 @@ public class SupertrendFixedTpUnifiedWithTimeFilterMskStrategy : Strategy
 	public DataType CandleType { get => _candleType.Value; set => _candleType.Value = value; }
 	public int AtrPeriod { get => _atrPeriod.Value; set => _atrPeriod.Value = value; }
 	public decimal Factor { get => _factor.Value; set => _factor.Value = value; }
-	public TradeMode Mode { get => _tradeMode.Value; set => _tradeMode.Value = value; }
+	public TradeModes Mode { get => _tradeMode.Value; set => _tradeMode.Value = value; }
 	public decimal TakeProfitPercent { get => _takeProfitPercent.Value; set => _takeProfitPercent.Value = value; }
 	public bool UsePriceFilter { get => _usePriceFilter.Value; set => _usePriceFilter.Value = value; }
 	public decimal PriceFilter { get => _priceFilter.Value; set => _priceFilter.Value = value; }
@@ -51,7 +51,7 @@ public class SupertrendFixedTpUnifiedWithTimeFilterMskStrategy : Strategy
 			.SetDisplay("ATR Length", "ATR period", "Supertrend");
 		_factor = Param(nameof(Factor), 1.8m)
 			.SetDisplay("Factor", "ATR multiplier", "Supertrend");
-		_tradeMode = Param(nameof(Mode), TradeMode.Both)
+		_tradeMode = Param(nameof(Mode), TradeModes.Both)
 			.SetDisplay("Trade Mode", "Trading direction", "General");
 		_takeProfitPercent = Param(nameof(TakeProfitPercent), 1.5m)
 			.SetDisplay("Take Profit %", "Take profit percent", "Risk");
@@ -111,13 +111,13 @@ public class SupertrendFixedTpUnifiedWithTimeFilterMskStrategy : Strategy
 		var longEntry = isUp && _lastUp == false && inTime && (!UsePriceFilter || candle.ClosePrice > PriceFilter);
 		var shortEntry = !isUp && _lastUp == true && inTime && (!UsePriceFilter || candle.ClosePrice < PriceFilter);
 
-		if (longEntry && Mode != TradeMode.ShortOnly)
+		if (longEntry && Mode != TradeModes.ShortOnly)
 		{
 			var volume = Volume + Math.Abs(Position);
 			BuyMarket(volume);
 			_tpLevel = candle.ClosePrice * (1 + TakeProfitPercent / 100m);
 		}
-		else if (shortEntry && Mode != TradeMode.LongOnly)
+		else if (shortEntry && Mode != TradeModes.LongOnly)
 		{
 			var volume = Volume + Math.Abs(Position);
 			SellMarket(volume);
@@ -149,7 +149,7 @@ public class SupertrendFixedTpUnifiedWithTimeFilterMskStrategy : Strategy
 			: mskHour >= TimeFrom || mskHour < TimeTo;
 	}
 
-	public enum TradeMode
+	public enum TradeModes
 	{
 		Both,
 		LongOnly,

--- a/API/1405_Trading_The_Channel/CS/TradingTheChannelStrategy.cs
+++ b/API/1405_Trading_The_Channel/CS/TradingTheChannelStrategy.cs
@@ -18,14 +18,14 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class TradingTheChannelStrategy : Strategy
 {
-	private enum TradeRule
+	private enum TradeRules
 	{
 		TradeTrend,
 		TradeBreakouts,
 		TradeChannel
 	}
 
-	private enum RangeSource
+	private enum RangeSources
 	{
 		Close,
 		HighLow
@@ -33,8 +33,8 @@ public class TradingTheChannelStrategy : Strategy
 
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<int> _period;
-	private readonly StrategyParam<TradeRule> _rule;
-	private readonly StrategyParam<RangeSource> _rangeSource;
+	private readonly StrategyParam<TradeRules> _rule;
+	private readonly StrategyParam<RangeSources> _rangeSource;
 	private readonly StrategyParam<decimal> _zonePercent;
 	private readonly StrategyParam<bool> _longOnly;
 	private readonly StrategyParam<bool> _trendFilter;
@@ -57,12 +57,12 @@ public class TradingTheChannelStrategy : Strategy
 	/// <summary>
 	/// Trading mode.
 	/// </summary>
-	public TradeRule Rule { get => _rule.Value; set => _rule.Value = value; }
+	public TradeRules Rule { get => _rule.Value; set => _rule.Value = value; }
 
 	/// <summary>
 	/// Source for band calculation.
 	/// </summary>
-	public RangeSource Source { get => _rangeSource.Value; set => _rangeSource.Value = value; }
+	public RangeSources Source { get => _rangeSource.Value; set => _rangeSource.Value = value; }
 
 	/// <summary>
 	/// Zone width fraction for rule 3.
@@ -93,10 +93,10 @@ public class TradingTheChannelStrategy : Strategy
 			.SetCanOptimize(true)
 			.SetOptimize(20, 80, 20);
 
-		_rule = Param(nameof(Rule), TradeRule.TradeTrend)
+		_rule = Param(nameof(Rule), TradeRules.TradeTrend)
 			.SetDisplay("Trade Rule", "Trading mode", "Parameters");
 
-		_rangeSource = Param(nameof(Source), RangeSource.Close)
+		_rangeSource = Param(nameof(Source), RangeSources.Close)
 			.SetDisplay("Range Source", "Use close or high/low", "Parameters");
 
 		_zonePercent = Param(nameof(ZonePercent), 0.2m)
@@ -198,7 +198,7 @@ public class TradingTheChannelStrategy : Strategy
 		for (var i = 0; i < n; i++)
 		{
 			var predicted = intercept + slope * i;
-			if (Source == RangeSource.Close)
+			if (Source == RangeSources.Close)
 			{
 				b = Math.Max(b, predicted - closes[i]);
 				t = Math.Max(t, closes[i] - predicted);
@@ -215,7 +215,7 @@ public class TradingTheChannelStrategy : Strategy
 
 		switch (Rule)
 		{
-			case TradeRule.TradeTrend:
+			case TradeRules.TradeTrend:
 			if (signal != _prevSignal)
 			{
 			if (signal > 0 && Position <= 0)
@@ -225,14 +225,14 @@ public class TradingTheChannelStrategy : Strategy
 			}
 			break;
 
-			case TradeRule.TradeBreakouts:
+			case TradeRules.TradeBreakouts:
 			if (candle.ClosePrice > upper && Position <= 0)
 			BuyMarket();
 			else if (candle.ClosePrice < lower && Position >= 0 && !LongOnly)
 			SellMarket();
 			break;
 
-			case TradeRule.TradeChannel:
+			case TradeRules.TradeChannel:
 			var range = upper - lower;
 			var buyZone = lower + ZonePercent * range;
 			var sellZone = upper - ZonePercent * range;

--- a/API/1412_Text/CS/TextStrategy.cs
+++ b/API/1412_Text/CS/TextStrategy.cs
@@ -24,7 +24,7 @@ public class TextStrategy : Strategy
 	/// <summary>
 	/// Supported fonts.
 	/// </summary>
-	public enum EFont
+	public enum EFonts
 	{
 		BoldStrong,
 		Circled
@@ -36,14 +36,14 @@ public class TextStrategy : Strategy
 	/// <param name="fromText">Initial text.</param>
 	/// <param name="font">Desired font.</param>
 	/// <returns>Text transformed to the selected font.</returns>
-	public static string ToFont(string fromText, EFont font)
+	public static string ToFont(string fromText, EFonts font)
 	{
 		const string pine = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 		string[] map;
 
 		switch (font)
 		{
-			case EFont.BoldStrong:
+			case EFonts.BoldStrong:
 				map = new[]
 				{
 					"α","Ⴆ","ƈ","ԃ","ҽ","ϝ","ɠ","ԋ","ι","ʝ","ƙ","ʅ","ɱ","ɳ","σ","ρ","ϙ","ɾ","ʂ","ƚ","υ","ʋ","ɯ","𝐱","ყ","ȥ",
@@ -51,7 +51,7 @@ public class TextStrategy : Strategy
 					"𝟎","𝟏","𝟐","𝟑","𝟒","𝟓","𝟔","𝟕","𝟖","𝟗"
 				};
 				break;
-			case EFont.Circled:
+			case EFonts.Circled:
 				map = new[]
 				{
 					"🅐","🅑","🅒","🅓","🅔","🅕","🅖","🅗","🅘","🅙","🅚","🅛","🅜","🅝","🅞","🅟","🅠","🅡","🅢","🅣","🅤","🅥","🅦","🅧","🅨","🅩",

--- a/API/1417_Bar_Counter_Trend_Reversal/CS/BarCounterTrendReversalStrategy.cs
+++ b/API/1417_Bar_Counter_Trend_Reversal/CS/BarCounterTrendReversalStrategy.cs
@@ -23,7 +23,7 @@ public class BarCounterTrendReversalStrategy : Strategy
 	private readonly StrategyParam<int> _noOfFalls;
 	private readonly StrategyParam<bool> _volumeConfirm;
 	private readonly StrategyParam<bool> _channelConfirm;
-	private readonly StrategyParam<ChannelType> _channelType;
+	private readonly StrategyParam<ChannelTypes> _channelType;
 	private readonly StrategyParam<int> _channelLength;
 	private readonly StrategyParam<int> _channelMultiplier;
 	private readonly StrategyParam<DataType> _candleType;
@@ -42,7 +42,7 @@ public class BarCounterTrendReversalStrategy : Strategy
 	/// <summary>
 	/// Channel indicator type.
 	/// </summary>
-	public enum ChannelType
+	public enum ChannelTypes
 	{
 		/// <summary> Keltner Channel. </summary>
 		Kc,
@@ -59,7 +59,7 @@ public class BarCounterTrendReversalStrategy : Strategy
 	/// <summary>Require channel breakout confirmation.</summary>
 	public bool ChannelConfirm { get => _channelConfirm.Value; set => _channelConfirm.Value = value; }
 	/// <summary>Selected channel type.</summary>
-	public ChannelType Channel { get => _channelType.Value; set => _channelType.Value = value; }
+	public ChannelTypes Channel { get => _channelType.Value; set => _channelType.Value = value; }
 	/// <summary>Channel indicator length.</summary>
 	public int ChannelLength { get => _channelLength.Value; set => _channelLength.Value = value; }
 	/// <summary>Channel multiplier.</summary>
@@ -82,7 +82,7 @@ public class BarCounterTrendReversalStrategy : Strategy
 		.SetDisplay("Volume Confirm", "Require volume rising", "Parameters");
 		_channelConfirm = Param(nameof(ChannelConfirm), true)
 		.SetDisplay("Channel Confirm", "Use channel breakout", "Parameters");
-		_channelType = Param(nameof(Channel), ChannelType.Kc)
+		_channelType = Param(nameof(Channel), ChannelTypes.Kc)
 		.SetDisplay("Channel Type", "Channel indicator type", "Parameters");
 		_channelLength = Param(nameof(ChannelLength), 20)
 		.SetDisplay("Channel Length", "Length for channel indicator", "Parameters")
@@ -116,7 +116,7 @@ public class BarCounterTrendReversalStrategy : Strategy
 	{
 		base.OnStarted(time);
 
-		_channelIndicator = Channel == ChannelType.Kc
+		_channelIndicator = Channel == ChannelTypes.Kc
 		? new KeltnerChannels { Length = ChannelLength, Multiplier = ChannelMultiplier }
 		: new BollingerBands { Length = ChannelLength, Width = ChannelMultiplier };
 

--- a/API/1430_Tick_Delta_Volume/CS/TickDeltaVolumeStrategy.cs
+++ b/API/1430_Tick_Delta_Volume/CS/TickDeltaVolumeStrategy.cs
@@ -18,7 +18,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class TickDeltaVolumeStrategy : Strategy
 {
-	public enum DeltaMode
+	public enum DeltaModes
 	{
 		/// <summary>Use volume delta.</summary>
 		Volume,
@@ -28,7 +28,7 @@ public class TickDeltaVolumeStrategy : Strategy
 		PriceVolume
 	}
 
-	private readonly StrategyParam<DeltaMode> _mode;
+	private readonly StrategyParam<DeltaModes> _mode;
 	private readonly StrategyParam<int> _length;
 
 	private ExponentialMovingAverage _mean;
@@ -38,7 +38,7 @@ public class TickDeltaVolumeStrategy : Strategy
 	/// <summary>
 	/// Delta calculation mode.
 	/// </summary>
-	public DeltaMode Mode
+	public DeltaModes Mode
 	{
 		get => _mode.Value;
 		set => _mode.Value = value;
@@ -58,7 +58,7 @@ public class TickDeltaVolumeStrategy : Strategy
 	/// </summary>
 	public TickDeltaVolumeStrategy()
 	{
-		_mode = Param(nameof(Mode), DeltaMode.Volume)
+		_mode = Param(nameof(Mode), DeltaModes.Volume)
 		.SetDisplay("Mode", "Delta calculation mode", "General");
 
 		_length = Param(nameof(Length), 10)
@@ -103,8 +103,8 @@ public class TickDeltaVolumeStrategy : Strategy
 
 		var vpd = Mode switch
 		{
-			DeltaMode.Price => priceDelta,
-			DeltaMode.PriceVolume => priceDelta * volumeDelta,
+			DeltaModes.Price => priceDelta,
+			DeltaModes.PriceVolume => priceDelta * volumeDelta,
 			_ => volumeDelta
 		};
 

--- a/API/1476_TrendMaster_Pro_2_3_with_Alerts/CS/TrendMasterPro23WithAlertsStrategy.cs
+++ b/API/1476_TrendMaster_Pro_2_3_with_Alerts/CS/TrendMasterPro23WithAlertsStrategy.cs
@@ -18,17 +18,17 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class TrendMasterPro23WithAlertsStrategy : Strategy
 {
-	public enum MaType
+	public enum MaTypes
 	{
 		Ema,
 		Sma
 	}
 
-	private readonly StrategyParam<MaType> _maType;
+	private readonly StrategyParam<MaTypes> _maType;
 	private readonly StrategyParam<int> _shortLength;
 	private readonly StrategyParam<int> _longLength;
 	private readonly StrategyParam<bool> _enableTrendFilter;
-	private readonly StrategyParam<MaType> _trendMaType;
+	private readonly StrategyParam<MaTypes> _trendMaType;
 	private readonly StrategyParam<int> _trendMaLength;
 	private readonly StrategyParam<int> _rsiLength;
 	private readonly StrategyParam<decimal> _rsiLong;
@@ -43,7 +43,7 @@ public class TrendMasterPro23WithAlertsStrategy : Strategy
 	/// <summary>
 	/// Type of moving average for signals.
 	/// </summary>
-	public MaType MovingAverageType
+	public MaTypes MovingAverageType
 	{
 		get => _maType.Value;
 		set => _maType.Value = value;
@@ -79,7 +79,7 @@ public class TrendMasterPro23WithAlertsStrategy : Strategy
 	/// <summary>
 	/// Moving average type for trend filter.
 	/// </summary>
-	public MaType TrendMaType
+	public MaTypes TrendMaType
 	{
 		get => _trendMaType.Value;
 		set => _trendMaType.Value = value;
@@ -153,11 +153,11 @@ public class TrendMasterPro23WithAlertsStrategy : Strategy
 	/// </summary>
 	public TrendMasterPro23WithAlertsStrategy()
 	{
-		_maType = Param(nameof(MovingAverageType), MaType.Ema).SetDisplay("MA Type", "Moving average type", "Indicators");
+		_maType = Param(nameof(MovingAverageType), MaTypes.Ema).SetDisplay("MA Type", "Moving average type", "Indicators");
 		_shortLength = Param(nameof(ShortLength), 9).SetGreaterThanZero().SetDisplay("Short MA", "Short MA length", "Indicators");
 		_longLength = Param(nameof(LongLength), 21).SetGreaterThanZero().SetDisplay("Long MA", "Long MA length", "Indicators");
 		_enableTrendFilter = Param(nameof(EnableTrendFilter), false).SetDisplay("Enable Trend Filter", "Use higher timeframe trend", "Filter");
-		_trendMaType = Param(nameof(TrendMaType), MaType.Ema).SetDisplay("Trend MA Type", "Trend filter MA", "Filter");
+		_trendMaType = Param(nameof(TrendMaType), MaTypes.Ema).SetDisplay("Trend MA Type", "Trend filter MA", "Filter");
 		_trendMaLength = Param(nameof(TrendMaLength), 50).SetGreaterThanZero().SetDisplay("Trend MA Length", "Trend filter length", "Filter");
 		_rsiLength = Param(nameof(RsiLength), 14).SetGreaterThanZero().SetDisplay("RSI Length", "RSI period", "Indicators");
 		_rsiLong = Param(nameof(RsiLongThreshold), 55m).SetDisplay("RSI Long", "Long threshold", "Indicators");
@@ -173,9 +173,9 @@ public class TrendMasterPro23WithAlertsStrategy : Strategy
 		return [(Security, CandleType)];
 	}
 
-	private IIndicator CreateMa(MaType type, int length)
+	private IIndicator CreateMa(MaTypes type, int length)
 	{
-		return type == MaType.Sma ? new SimpleMovingAverage { Length = length } : new ExponentialMovingAverage { Length = length };
+		return type == MaTypes.Sma ? new SimpleMovingAverage { Length = length } : new ExponentialMovingAverage { Length = length };
 	}
 
 	/// <inheritdoc />

--- a/API/1483_Triangular_Hull_Moving_Average/CS/TriangularHullMovingAverageStrategy.cs
+++ b/API/1483_Triangular_Hull_Moving_Average/CS/TriangularHullMovingAverageStrategy.cs
@@ -20,7 +20,7 @@ public class TriangularHullMovingAverageStrategy : Strategy
 {
 	private readonly StrategyParam<int> _length;
 	private readonly StrategyParam<DataType> _candleType;
-	private readonly StrategyParam<EntryDirection> _entryMode;
+	private readonly StrategyParam<EntryDirections> _entryMode;
 
 	private decimal? _prev1;
 	private decimal? _prev2;
@@ -47,7 +47,7 @@ public class TriangularHullMovingAverageStrategy : Strategy
 	/// <summary>
 	/// Trade direction mode.
 	/// </summary>
-	public EntryDirection EntryMode
+	public EntryDirections EntryMode
 	{
 		get => _entryMode.Value;
 		set => _entryMode.Value = value;
@@ -66,7 +66,7 @@ public class TriangularHullMovingAverageStrategy : Strategy
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
 			.SetDisplay("Candle Type", "Type of candles to use", "General");
 
-		_entryMode = Param(nameof(EntryMode), EntryDirection.LongAndShort)
+		_entryMode = Param(nameof(EntryMode), EntryDirections.LongAndShort)
 			.SetDisplay("Entry Mode", "Trade direction", "General");
 	}
 
@@ -131,21 +131,21 @@ public class TriangularHullMovingAverageStrategy : Strategy
 
 		switch (EntryMode)
 		{
-			case EntryDirection.LongAndShort:
+			case EntryDirections.LongAndShort:
 				if (signalUp && Position <= 0)
 					BuyMarket(volume);
 				else if (signalDn && Position >= 0)
 					SellMarket(volume);
 				break;
 
-			case EntryDirection.OnlyLong:
+			case EntryDirections.OnlyLong:
 				if (signalUp && Position <= 0)
 					BuyMarket(volume);
 				else if (signalDn && Position > 0)
 					SellMarket(Position);
 				break;
 
-			case EntryDirection.OnlyShort:
+			case EntryDirections.OnlyShort:
 				if (signalDn && Position >= 0)
 					SellMarket(volume);
 				else if (signalUp && Position < 0)
@@ -161,7 +161,7 @@ public class TriangularHullMovingAverageStrategy : Strategy
 	/// <summary>
 	/// Trade direction options.
 	/// </summary>
-	public enum EntryDirection
+	public enum EntryDirections
 	{
 		/// <summary>
 		/// Only long trades.

--- a/API/1491_TSI_w_SuperTrend_decision_presentTrading/CS/TsiSuperTrendDecisionStrategy.cs
+++ b/API/1491_TSI_w_SuperTrend_decision_presentTrading/CS/TsiSuperTrendDecisionStrategy.cs
@@ -26,7 +26,7 @@ public class TsiSuperTrendDecisionStrategy : Strategy
 	private readonly StrategyParam<decimal> _stMultiplier;
 	private readonly StrategyParam<decimal> _threshold;
 	private readonly StrategyParam<Sides?> _direction;
-	private readonly StrategyParam<ProtectionType> _tpsl;
+	private readonly StrategyParam<ProtectionTypes> _tpsl;
 	private readonly StrategyParam<decimal> _takeProfit;
 	private readonly StrategyParam<decimal> _stopLoss;
 
@@ -34,7 +34,7 @@ public class TsiSuperTrendDecisionStrategy : Strategy
 	private decimal[] _prices;
 	private int _index;
 
-	public enum ProtectionType
+	public enum ProtectionTypes
 	{
 		None,
 		TP,
@@ -65,7 +65,7 @@ public class TsiSuperTrendDecisionStrategy : Strategy
 	public decimal StMultiplier { get => _stMultiplier.Value; set => _stMultiplier.Value = value; }
 	public decimal Threshold { get => _threshold.Value; set => _threshold.Value = value; }
 	public Sides? Direction { get => _direction.Value; set => _direction.Value = value; }
-	public ProtectionType Tpsl { get => _tpsl.Value; set => _tpsl.Value = value; }
+	public ProtectionTypes Tpsl { get => _tpsl.Value; set => _tpsl.Value = value; }
 	public decimal TakeProfit { get => _takeProfit.Value; set => _takeProfit.Value = value; }
 	public decimal StopLoss { get => _stopLoss.Value; set => _stopLoss.Value = value; }
 
@@ -83,7 +83,7 @@ public class TsiSuperTrendDecisionStrategy : Strategy
 		.SetDisplay("TSI Threshold", "Entry threshold", "Trading");
 		_direction = Param(nameof(Direction), (Sides?)null)
 		.SetDisplay("Direction", "Trade direction", "Trading");
-		_tpsl = Param(nameof(Tpsl), ProtectionType.None)
+		_tpsl = Param(nameof(Tpsl), ProtectionTypes.None)
 		.SetDisplay("TPSL", "Protection type", "Risk");
 		_takeProfit = Param(nameof(TakeProfit), 30m)
 		.SetDisplay("Take Profit %", "Take profit", "Risk");
@@ -100,13 +100,13 @@ public class TsiSuperTrendDecisionStrategy : Strategy
 
 		switch (Tpsl)
 		{
-			case ProtectionType.TP:
+			case ProtectionTypes.TP:
 				StartProtection(new Unit(TakeProfit, UnitTypes.Percent), new Unit(0));
 				break;
-			case ProtectionType.SL:
+			case ProtectionTypes.SL:
 				StartProtection(new Unit(0), new Unit(StopLoss, UnitTypes.Percent));
 				break;
-			case ProtectionType.Both:
+			case ProtectionTypes.Both:
 				StartProtection(new Unit(TakeProfit, UnitTypes.Percent), new Unit(StopLoss, UnitTypes.Percent));
 				break;
 			default:

--- a/API/1513_Uptrick_X_PineIndicators_Z_Score_Flow/CS/UptrickXPineIndicatorsZScoreFlowStrategy.cs
+++ b/API/1513_Uptrick_X_PineIndicators_Z_Score_Flow/CS/UptrickXPineIndicatorsZScoreFlowStrategy.cs
@@ -18,7 +18,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class UptrickXPineIndicatorsZScoreFlowStrategy : Strategy
 {
-public enum TradeMode
+public enum TradeModes
 {
 Standard,
 ZeroCross,
@@ -36,7 +36,7 @@ private readonly StrategyParam<int> _cooldownBars;
 private readonly StrategyParam<int> _slopeIndex;
 private readonly StrategyParam<bool> _enableLong;
 private readonly StrategyParam<bool> _enableShort;
-private readonly StrategyParam<TradeMode> _tradeMode;
+private readonly StrategyParam<TradeModes> _tradeMode;
 
 private SMA _basis;
 private StandardDeviation _stdev;
@@ -113,7 +113,7 @@ public bool EnableShort { get => _enableShort.Value; set => _enableShort.Value =
 /// <summary>
 /// Trade execution mode.
 /// </summary>
-public TradeMode Mode { get => _tradeMode.Value; set => _tradeMode.Value = value; }
+public TradeModes Mode { get => _tradeMode.Value; set => _tradeMode.Value = value; }
 
 public UptrickXPineIndicatorsZScoreFlowStrategy()
 {
@@ -156,7 +156,7 @@ _enableLong = Param(nameof(EnableLong), true)
 _enableShort = Param(nameof(EnableShort), true)
 .SetDisplay("Enable Short", "Allow short trades", "Trading");
 
-_tradeMode = Param(nameof(Mode), TradeMode.Standard)
+_tradeMode = Param(nameof(Mode), TradeModes.Standard)
 .SetDisplay("Trade Mode", "Execution mode", "Trading");
 }
 
@@ -248,13 +248,13 @@ _prevBearish = bearishCondition;
 
 switch (Mode)
 {
-case TradeMode.Standard:
+case TradeModes.Standard:
 StandardMode(buySignal, sellSignal);
 break;
-case TradeMode.ZeroCross:
+case TradeModes.ZeroCross:
 ZeroCrossMode(zscore);
 break;
-case TradeMode.TrendReversal:
+case TradeModes.TrendReversal:
 TrendReversalMode(trendBullishReversal, trendBearishReversal);
 break;
 }

--- a/API/1542_Vortex_Cross_MA_Confirmation/CS/VortexCrossMaConfirmationStrategy.cs
+++ b/API/1542_Vortex_Cross_MA_Confirmation/CS/VortexCrossMaConfirmationStrategy.cs
@@ -21,7 +21,7 @@ public class VortexCrossMaConfirmationStrategy : Strategy
 	private readonly StrategyParam<int> _vortexLength;
 	private readonly StrategyParam<int> _smaLength;
 	private readonly StrategyParam<int> _smoothingLength;
-	private readonly StrategyParam<MaTypeEnum> _maType;
+	private readonly StrategyParam<MaTypes> _maType;
 	private readonly StrategyParam<DataType> _candleType;
 
 	private SimpleMovingAverage _sma = null!;
@@ -66,7 +66,7 @@ public class VortexCrossMaConfirmationStrategy : Strategy
 	/// <summary>
 	/// Smoothing method.
 	/// </summary>
-	public MaTypeEnum MaType
+	public MaTypes MaType
 	{
 		get => _maType.Value;
 		set => _maType.Value = value;
@@ -84,7 +84,7 @@ public class VortexCrossMaConfirmationStrategy : Strategy
 	/// <summary>
 	/// Moving average types.
 	/// </summary>
-	public enum MaTypeEnum
+	public enum MaTypes
 	{
 		SMA,
 		EMA,
@@ -115,7 +115,7 @@ public class VortexCrossMaConfirmationStrategy : Strategy
 			.SetDisplay("Smoothing Length", "Length for additional smoothing", "General")
 			.SetCanOptimize(true);
 
-		_maType = Param(nameof(MaType), MaTypeEnum.SMA)
+		_maType = Param(nameof(MaType), MaTypes.SMA)
 			.SetDisplay("MA Type", "Smoothing method", "General")
 			.SetCanOptimize(true);
 
@@ -135,12 +135,12 @@ public class VortexCrossMaConfirmationStrategy : Strategy
 		_sma = new SimpleMovingAverage { Length = SmaLength };
 		_smoothMa = MaType switch
 		{
-			MaTypeEnum.EMA => new ExponentialMovingAverage { Length = SmoothingLength },
-			MaTypeEnum.RMA => new SmoothedMovingAverage { Length = SmoothingLength },
-			MaTypeEnum.WMA => new WeightedMovingAverage { Length = SmoothingLength },
-			MaTypeEnum.VWMA => new VolumeWeightedMovingAverage { Length = SmoothingLength },
-			MaTypeEnum.ALMA => new ArnaudLegouxMovingAverage { Length = SmoothingLength },
-			MaTypeEnum.HMA => new HullMovingAverage { Length = SmoothingLength },
+			MaTypes.EMA => new ExponentialMovingAverage { Length = SmoothingLength },
+			MaTypes.RMA => new SmoothedMovingAverage { Length = SmoothingLength },
+			MaTypes.WMA => new WeightedMovingAverage { Length = SmoothingLength },
+			MaTypes.VWMA => new VolumeWeightedMovingAverage { Length = SmoothingLength },
+			MaTypes.ALMA => new ArnaudLegouxMovingAverage { Length = SmoothingLength },
+			MaTypes.HMA => new HullMovingAverage { Length = SmoothingLength },
 			_ => new SimpleMovingAverage { Length = SmoothingLength }
 		};
 

--- a/API/1551_VWAP/CS/VwapStrategy.cs
+++ b/API/1551_VWAP/CS/VwapStrategy.cs
@@ -18,7 +18,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class VwapStrategy : Strategy
 {
-	public enum ExitMode
+	public enum ExitModes
 	{
 		Vwap,
 		Deviation,
@@ -26,8 +26,8 @@ public class VwapStrategy : Strategy
 	}
 
 	private readonly StrategyParam<decimal> _stopPoints;
-	private readonly StrategyParam<ExitMode> _exitModeLong;
-	private readonly StrategyParam<ExitMode> _exitModeShort;
+	private readonly StrategyParam<ExitModes> _exitModeLong;
+	private readonly StrategyParam<ExitModes> _exitModeShort;
 	private readonly StrategyParam<decimal> _targetLongDeviation;
 	private readonly StrategyParam<decimal> _targetShortDeviation;
 	private readonly StrategyParam<bool> _enableSafetyExit;
@@ -54,12 +54,12 @@ public class VwapStrategy : Strategy
 	/// <summary>
 	/// Long exit mode.
 	/// </summary>
-	public ExitMode ExitModeLong { get => _exitModeLong.Value; set => _exitModeLong.Value = value; }
+	public ExitModes ExitModeLong { get => _exitModeLong.Value; set => _exitModeLong.Value = value; }
 
 	/// <summary>
 	/// Short exit mode.
 	/// </summary>
-	public ExitMode ExitModeShort { get => _exitModeShort.Value; set => _exitModeShort.Value = value; }
+	public ExitModes ExitModeShort { get => _exitModeShort.Value; set => _exitModeShort.Value = value; }
 
 	/// <summary>
 	/// Deviation multiplier for long targets.
@@ -107,10 +107,10 @@ public class VwapStrategy : Strategy
 			.SetGreaterThanZero()
 			.SetDisplay("Stop Points", "Stop buffer from signal bar", "Parameters");
 
-		_exitModeLong = Param(nameof(ExitModeLong), ExitMode.Vwap)
+		_exitModeLong = Param(nameof(ExitModeLong), ExitModes.Vwap)
 			.SetDisplay("Long Exit Mode", string.Empty, "Parameters");
 
-		_exitModeShort = Param(nameof(ExitModeShort), ExitMode.Vwap)
+		_exitModeShort = Param(nameof(ExitModeShort), ExitModes.Vwap)
 			.SetDisplay("Short Exit Mode", string.Empty, "Parameters");
 
 		_targetLongDeviation = Param(nameof(TargetLongDeviation), 2m)
@@ -254,10 +254,10 @@ public class VwapStrategy : Strategy
 		if (Position > 0 && _signalLow.HasValue)
 		{
 			var stop = _signalLow.Value - StopPoints;
-			var exitVwap = ExitModeLong == ExitMode.Vwap && candle.HighPrice >= vwap;
-			var exitDev = ExitModeLong == ExitMode.Deviation && candle.HighPrice >= targetUpperLong;
+			var exitVwap = ExitModeLong == ExitModes.Vwap && candle.HighPrice >= vwap;
+			var exitDev = ExitModeLong == ExitModes.Deviation && candle.HighPrice >= targetUpperLong;
 
-			if (candle.LowPrice <= stop || (ExitModeLong != ExitMode.None && (exitVwap || exitDev)))
+			if (candle.LowPrice <= stop || (ExitModeLong != ExitModes.None && (exitVwap || exitDev)))
 				SellMarket();
 			else if (EnableSafetyExit && _bearCount >= NumOpposingBars)
 				SellMarket();
@@ -265,10 +265,10 @@ public class VwapStrategy : Strategy
 		else if (Position < 0 && _signalHigh.HasValue)
 		{
 			var stop = _signalHigh.Value + StopPoints;
-			var exitVwap = ExitModeShort == ExitMode.Vwap && candle.LowPrice <= vwap;
-			var exitDev = ExitModeShort == ExitMode.Deviation && candle.LowPrice <= targetLowerShort;
+			var exitVwap = ExitModeShort == ExitModes.Vwap && candle.LowPrice <= vwap;
+			var exitDev = ExitModeShort == ExitModes.Deviation && candle.LowPrice <= targetLowerShort;
 
-			if (candle.HighPrice >= stop || (ExitModeShort != ExitMode.None && (exitVwap || exitDev)))
+			if (candle.HighPrice >= stop || (ExitModeShort != ExitModes.None && (exitVwap || exitDev)))
 				BuyMarket();
 			else if (EnableSafetyExit && _bullCount >= NumOpposingBars)
 				BuyMarket();

--- a/API/1567_Yeong_RRG/CS/YeongRrgStrategy.cs
+++ b/API/1567_Yeong_RRG/CS/YeongRrgStrategy.cs
@@ -33,7 +33,7 @@ public class YeongRrgStrategy : Strategy
 	private StandardDeviation _rmRatioStd;
 
 	private decimal _lastIndexClose;
-	private State _state = State.None;
+        private States _state = States.None;
 
 	/// <summary>
 	/// Period used for calculations.
@@ -103,7 +103,7 @@ public class YeongRrgStrategy : Strategy
 		_rmRatioMean = null;
 		_rmRatioStd = null;
 		_lastIndexClose = 0m;
-		_state = State.None;
+                _state = States.None;
 	}
 
 	/// <inheritdoc />
@@ -191,17 +191,17 @@ public class YeongRrgStrategy : Strategy
 		var jdkRs = 100m + ((rsRatio - meanRsRatio) / stdRsRatio + 1m);
 		var jdkRm = 100m + ((rmRatio - meanRmRatio) / stdRmRatio + 1m);
 
-		if (jdkRs > 100m && jdkRm > 100m)
-			_state = State.Green;
-		else if (jdkRs > 100m && jdkRm < 100m)
-			_state = State.Yellow;
-		else if (jdkRs < 100m && jdkRm < 100m)
-			_state = State.Red;
-		else if (jdkRs < 100m && jdkRm > 100m)
-			_state = State.Blue;
+                if (jdkRs > 100m && jdkRm > 100m)
+                        _state = States.Green;
+                else if (jdkRs > 100m && jdkRm < 100m)
+                        _state = States.Yellow;
+                else if (jdkRs < 100m && jdkRm < 100m)
+                        _state = States.Red;
+                else if (jdkRs < 100m && jdkRm > 100m)
+                        _state = States.Blue;
 
-		var buySignal = _state == State.Green && candle.ServerTime.Year >= 2010;
-		var sellSignal = _state == State.Red;
+                var buySignal = _state == States.Green && candle.ServerTime.Year >= 2010;
+                var sellSignal = _state == States.Red;
 
 		if (buySignal && Position <= 0)
 		{
@@ -214,7 +214,7 @@ public class YeongRrgStrategy : Strategy
 		}
 	}
 
-	private enum State
+        private enum States
 	{
 		None,
 		Green,

--- a/API/1569_YinYang_RSI_Volume_Trend/CS/YinYangRsiVolumeTrendStrategy.cs
+++ b/API/1569_YinYang_RSI_Volume_Trend/CS/YinYangRsiVolumeTrendStrategy.cs
@@ -25,7 +25,7 @@ public class YinYangRsiVolumeTrendStrategy : Strategy
 	private readonly StrategyParam<bool> _useTakeProfit;
 	private readonly StrategyParam<bool> _useStopLoss;
 	private readonly StrategyParam<decimal> _stopLossMultiplier;
-	private readonly StrategyParam<ResetCondition> _resetCondition;
+	private readonly StrategyParam<ResetConditions> _resetCondition;
 	private readonly StrategyParam<CandlePrice> _purchaseSource;
 	private readonly StrategyParam<CandlePrice> _exitSource;
 	private readonly StrategyParam<DataType> _candleType;
@@ -76,7 +76,7 @@ public class YinYangRsiVolumeTrendStrategy : Strategy
 	/// <summary>
 	/// Reset mode for purchase availability.
 	/// </summary>
-	public ResetCondition ResetCondition { get => _resetCondition.Value; set => _resetCondition.Value = value; }
+	public ResetConditions ResetCondition { get => _resetCondition.Value; set => _resetCondition.Value = value; }
 	
 	/// <summary>
 	/// Price source for purchase checks.
@@ -112,7 +112,7 @@ public class YinYangRsiVolumeTrendStrategy : Strategy
 		.SetGreaterThanZero()
 		.SetDisplay("Stoploss Multiplier %", "Distance from purchase lines", "Risk");
 		
-		_resetCondition = Param(nameof(ResetCondition), ResetCondition.Entry)
+		_resetCondition = Param(nameof(ResetCondition), ResetConditions.Entry)
 		.SetDisplay("Reset After", "When to reset purchase availability", "General");
 		
 		_purchaseSource = Param(nameof(PurchaseSource), CandlePrice.Close)
@@ -232,8 +232,8 @@ public class YinYangRsiVolumeTrendStrategy : Strategy
 		var longTakeProfit = CrossDown(_prevExitSrc, _prevZoneBasis, exitSrc, zoneBasis) && _longTakeProfitAvailable;
 		
 		var longAvailReset = CrossDown(_prevPurchaseSrc, _prevZoneHigh, purchaseSrc, zoneHigh)
-		|| (ResetCondition == ResetCondition.StopLoss && _longStopLoss)
-		|| (ResetCondition == ResetCondition.Entry && longEntry);
+		|| (ResetConditions == ResetConditions.StopLoss && _longStopLoss)
+		|| (ResetConditions == ResetConditions.Entry && longEntry);
 		if (longAvailReset)
 		_longAvailable = true;
 		else if (longStart)
@@ -251,8 +251,8 @@ public class YinYangRsiVolumeTrendStrategy : Strategy
 		var shortTakeProfit = CrossUp(_prevExitSrc, _prevZoneBasis, exitSrc, zoneBasis) && _shortTakeProfitAvailable;
 		
 		var shortAvailReset = CrossUp(_prevPurchaseSrc, _prevZoneLow, purchaseSrc, zoneLow)
-		|| (ResetCondition == ResetCondition.StopLoss && _shortStopLoss)
-		|| (ResetCondition == ResetCondition.Entry && shortEntry);
+		|| (ResetConditions == ResetConditions.StopLoss && _shortStopLoss)
+		|| (ResetConditions == ResetConditions.Entry && shortEntry);
 		if (shortAvailReset)
 		_shortAvailable = true;
 		else if (shortStart)
@@ -306,7 +306,7 @@ public class YinYangRsiVolumeTrendStrategy : Strategy
 /// <summary>
 /// Options for resetting purchase availability.
 /// </summary>
-public enum ResetCondition
+public enum ResetConditions
 {
 	/// <summary>
 	/// Reset after entry condition is met.

--- a/API/1630_EMA_WPR_Retracement/CS/EmaWprRetracementStrategy.cs
+++ b/API/1630_EMA_WPR_Retracement/CS/EmaWprRetracementStrategy.cs
@@ -142,17 +142,17 @@ trailingStop: UseTrailingStop ? new Unit(TrailingStop, UnitTypes.Price) : null);
 Volume = OrderVolume;
 }
 
-private enum TrendDir
+private enum TrendDirections
 {
 None,
 Up,
 Down
 }
 
-private TrendDir GetTrend()
+private TrendDirections GetTrend()
 {
 if (_emaValues.Count <= BarsInTrend)
-return TrendDir.None;
+return TrendDirections.None;
 
 var arr = _emaValues.ToArray();
 var count = 0;
@@ -167,10 +167,10 @@ count++;
 }
 
 if (count == BarsInTrend)
-return TrendDir.Up;
+return TrendDirections.Up;
 if (count == -BarsInTrend)
-return TrendDir.Down;
-return TrendDir.None;
+return TrendDirections.Down;
+return TrendDirections.None;
 }
 
 private void UpdateEntryPrice(decimal price, decimal volumeChange)
@@ -235,16 +235,16 @@ _avgEntryPrice = 0;
 }
 }
 
-var trend = UseEmaTrend ? GetTrend() : TrendDir.None;
+var trend = UseEmaTrend ? GetTrend() : TrendDirections.None;
 var maxPos = MaxTrades * OrderVolume;
 
-if (wpr <= -99.99m && _canBuy && (!UseEmaTrend || trend == TrendDir.Up) && Position < maxPos)
+if (wpr <= -99.99m && _canBuy && (!UseEmaTrend || trend == TrendDirections.Up) && Position < maxPos)
 {
 BuyMarket(OrderVolume);
 _canBuy = false;
 UpdateEntryPrice(candle.ClosePrice, OrderVolume);
 }
-else if (wpr >= -0.01m && _canSell && (!UseEmaTrend || trend == TrendDir.Down) && Position > -maxPos)
+else if (wpr >= -0.01m && _canSell && (!UseEmaTrend || trend == TrendDirections.Down) && Position > -maxPos)
 {
 SellMarket(OrderVolume);
 _canSell = false;

--- a/API/1632_VisualTrader_Simulator_Edition/CS/VisualTraderSimulatorEditionStrategy.cs
+++ b/API/1632_VisualTrader_Simulator_Edition/CS/VisualTraderSimulatorEditionStrategy.cs
@@ -19,19 +19,19 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class VisualTraderSimulatorEditionStrategy : Strategy
 {
-	public enum TradeDirection
+	public enum TradeDirections
 	{
 		Buy,
 		Sell
 	}
 
-	private readonly StrategyParam<TradeDirection> _tradeDirection;
+	private readonly StrategyParam<TradeDirections> _tradeDirection;
 	private readonly StrategyParam<decimal> _takeProfit;
 	private readonly StrategyParam<decimal> _stopLoss;
 
 	public VisualTraderSimulatorEditionStrategy()
 	{
-		_tradeDirection = Param(nameof(Direction), TradeDirection.Buy)
+		_tradeDirection = Param(nameof(Direction), TradeDirections.Buy)
 			.SetDisplay("Trade Direction", "Initial trade direction", "General");
 
 		_takeProfit = Param(nameof(TakeProfit), 0m)
@@ -48,7 +48,7 @@ public class VisualTraderSimulatorEditionStrategy : Strategy
 	/// <summary>
 	/// Direction of the initial trade.
 	/// </summary>
-	public TradeDirection Direction
+	public TradeDirections Direction
 	{
 		get => _tradeDirection.Value;
 		set => _tradeDirection.Value = value;
@@ -81,7 +81,7 @@ public class VisualTraderSimulatorEditionStrategy : Strategy
 			takeProfit: TakeProfit > 0 ? new Unit(TakeProfit, UnitTypes.Absolute) : default,
 			stopLoss: StopLoss > 0 ? new Unit(StopLoss, UnitTypes.Absolute) : default);
 
-		if (Direction == TradeDirection.Buy)
+		if (Direction == TradeDirections.Buy)
 			BuyMarket();
 		else
 			SellMarket();

--- a/API/1641_X_Trail_2/CS/XTrail2Strategy.cs
+++ b/API/1641_X_Trail_2/CS/XTrail2Strategy.cs
@@ -20,10 +20,10 @@ public class XTrail2Strategy : Strategy
 {
 	private readonly StrategyParam<int> _ma1Length;
 	private readonly StrategyParam<int> _ma2Length;
-	private readonly StrategyParam<MovingAverageTypeEnum> _ma1Type;
-	private readonly StrategyParam<MovingAverageTypeEnum> _ma2Type;
-	private readonly StrategyParam<AppliedPriceType> _ma1PriceType;
-	private readonly StrategyParam<AppliedPriceType> _ma2PriceType;
+	private readonly StrategyParam<MovingAverageTypes> _ma1Type;
+	private readonly StrategyParam<MovingAverageTypes> _ma2Type;
+	private readonly StrategyParam<AppliedPriceTypes> _ma1PriceType;
+	private readonly StrategyParam<AppliedPriceTypes> _ma2PriceType;
 	private readonly StrategyParam<DataType> _candleType;
 
 	private IIndicator _ma1;
@@ -47,22 +47,22 @@ public class XTrail2Strategy : Strategy
 	/// <summary>
 	/// Type of the first moving average.
 	/// </summary>
-	public MovingAverageTypeEnum Ma1Type { get => _ma1Type.Value; set => _ma1Type.Value = value; }
+	public MovingAverageTypes Ma1Type { get => _ma1Type.Value; set => _ma1Type.Value = value; }
 
 	/// <summary>
 	/// Type of the second moving average.
 	/// </summary>
-	public MovingAverageTypeEnum Ma2Type { get => _ma2Type.Value; set => _ma2Type.Value = value; }
+	public MovingAverageTypes Ma2Type { get => _ma2Type.Value; set => _ma2Type.Value = value; }
 
 	/// <summary>
 	/// Applied price for the first moving average.
 	/// </summary>
-	public AppliedPriceType Ma1PriceType { get => _ma1PriceType.Value; set => _ma1PriceType.Value = value; }
+	public AppliedPriceTypes Ma1PriceType { get => _ma1PriceType.Value; set => _ma1PriceType.Value = value; }
 
 	/// <summary>
 	/// Applied price for the second moving average.
 	/// </summary>
-	public AppliedPriceType Ma2PriceType { get => _ma2PriceType.Value; set => _ma2PriceType.Value = value; }
+	public AppliedPriceTypes Ma2PriceType { get => _ma2PriceType.Value; set => _ma2PriceType.Value = value; }
 
 	/// <summary>
 	/// Candle type to process.
@@ -82,16 +82,16 @@ public class XTrail2Strategy : Strategy
 			.SetGreaterThanZero()
 			.SetDisplay("MA2 Length", "Length of the second MA", "Moving Averages");
 
-		_ma1Type = Param(nameof(Ma1Type), MovingAverageTypeEnum.Simple)
+		_ma1Type = Param(nameof(Ma1Type), MovingAverageTypes.Simple)
 			.SetDisplay("MA1 Type", "Type of the first MA", "Moving Averages");
 
-		_ma2Type = Param(nameof(Ma2Type), MovingAverageTypeEnum.Simple)
+		_ma2Type = Param(nameof(Ma2Type), MovingAverageTypes.Simple)
 			.SetDisplay("MA2 Type", "Type of the second MA", "Moving Averages");
 
-		_ma1PriceType = Param(nameof(Ma1PriceType), AppliedPriceType.Median)
+		_ma1PriceType = Param(nameof(Ma1PriceType), AppliedPriceTypes.Median)
 			.SetDisplay("MA1 Price", "Applied price for the first MA", "Moving Averages");
 
-		_ma2PriceType = Param(nameof(Ma2PriceType), AppliedPriceType.Median)
+		_ma2PriceType = Param(nameof(Ma2PriceType), AppliedPriceTypes.Median)
 			.SetDisplay("MA2 Price", "Applied price for the second MA", "Moving Averages");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(1).TimeFrame())
@@ -160,27 +160,27 @@ public class XTrail2Strategy : Strategy
 		_ma2Prev = ma2;
 	}
 
-	private static IIndicator CreateMa(MovingAverageTypeEnum type, int length)
+	private static IIndicator CreateMa(MovingAverageTypes type, int length)
 	{
 		return type switch
 		{
-			MovingAverageTypeEnum.Exponential => new ExponentialMovingAverage { Length = length },
-			MovingAverageTypeEnum.Smoothed => new SmoothedMovingAverage { Length = length },
-			MovingAverageTypeEnum.Weighted => new WeightedMovingAverage { Length = length },
+			MovingAverageTypes.Exponential => new ExponentialMovingAverage { Length = length },
+			MovingAverageTypes.Smoothed => new SmoothedMovingAverage { Length = length },
+			MovingAverageTypes.Weighted => new WeightedMovingAverage { Length = length },
 			_ => new SimpleMovingAverage { Length = length },
 		};
 	}
 
-	private static decimal GetPrice(ICandleMessage candle, AppliedPriceType priceType)
+	private static decimal GetPrice(ICandleMessage candle, AppliedPriceTypes priceType)
 	{
 		return priceType switch
 		{
-			AppliedPriceType.Open => candle.OpenPrice,
-			AppliedPriceType.High => candle.HighPrice,
-			AppliedPriceType.Low => candle.LowPrice,
-			AppliedPriceType.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-			AppliedPriceType.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-			AppliedPriceType.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice * 2m) / 4m,
+			AppliedPriceTypes.Open => candle.OpenPrice,
+			AppliedPriceTypes.High => candle.HighPrice,
+			AppliedPriceTypes.Low => candle.LowPrice,
+			AppliedPriceTypes.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+			AppliedPriceTypes.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+			AppliedPriceTypes.Weighted => (candle.HighPrice + candle.LowPrice + candle.ClosePrice * 2m) / 4m,
 			_ => candle.ClosePrice,
 		};
 	}
@@ -189,7 +189,7 @@ public class XTrail2Strategy : Strategy
 /// <summary>
 /// Moving average calculation method.
 /// </summary>
-public enum MovingAverageTypeEnum
+public enum MovingAverageTypes
 {
 	/// <summary>Simple moving average.</summary>
 	Simple,
@@ -204,7 +204,7 @@ public enum MovingAverageTypeEnum
 /// <summary>
 /// Price type used for indicator calculations.
 /// </summary>
-public enum AppliedPriceType
+public enum AppliedPriceTypes
 {
 	/// <summary>Close price.</summary>
 	Close,

--- a/API/1662_Live_RSI/CS/LiveRSIStrategy.cs
+++ b/API/1662_Live_RSI/CS/LiveRSIStrategy.cs
@@ -35,7 +35,7 @@ public class LiveRSIStrategy : Strategy
 	private RelativeStrengthIndex _rsiOpen = null!;
 	private ParabolicSar _sar = null!;
 
-	private TrendDirection _lastTrend;
+	private TrendDirections _lastTrend;
 
 	/// <summary>
 	/// RSI calculation period.
@@ -147,7 +147,7 @@ public class LiveRSIStrategy : Strategy
 
 		StartProtection(default, new Unit(StopLoss, UnitTypes.Absolute));
 
-		_lastTrend = TrendDirection.None;
+		_lastTrend = TrendDirections.None;
 	}
 
 	private void ProcessCandle(ICandleMessage candle)
@@ -172,21 +172,21 @@ public class LiveRSIStrategy : Strategy
 
 		var trend = DetectTrend(candle, rsiClose, rsiWeighted, rsiTypical, rsiMedian, rsiOpen, sar);
 
-		if (_lastTrend == TrendDirection.None)
+		if (_lastTrend == TrendDirections.None)
 		{
 			_lastTrend = trend;
 			return;
 		}
 
-		if (trend == TrendDirection.Bull && _lastTrend == TrendDirection.Bear && Position <= 0)
+		if (trend == TrendDirections.Bull && _lastTrend == TrendDirections.Bear && Position <= 0)
 		{
 			BuyMarket();
-			_lastTrend = TrendDirection.Bull;
+			_lastTrend = TrendDirections.Bull;
 		}
-		else if (trend == TrendDirection.Bear && _lastTrend == TrendDirection.Bull && Position >= 0)
+		else if (trend == TrendDirections.Bear && _lastTrend == TrendDirections.Bull && Position >= 0)
 		{
 			SellMarket();
-			_lastTrend = TrendDirection.Bear;
+			_lastTrend = TrendDirections.Bear;
 		}
 
 		if (Position > 0)
@@ -199,7 +199,7 @@ public class LiveRSIStrategy : Strategy
 		}
 	}
 
-	private TrendDirection DetectTrend(ICandleMessage candle, decimal rsiClose, decimal rsiWeighted,
+	private TrendDirections DetectTrend(ICandleMessage candle, decimal rsiClose, decimal rsiWeighted,
 		decimal rsiTypical, decimal rsiMedian, decimal rsiOpen, decimal sar)
 	{
 		var hourOk = !CheckHour || (candle.OpenTime.Hour > StartHour && candle.OpenTime.Hour < EndHour);
@@ -207,19 +207,19 @@ public class LiveRSIStrategy : Strategy
 		if (hourOk && rsiClose > rsiWeighted && rsiWeighted > rsiTypical && rsiTypical > rsiMedian &&
 			rsiMedian > rsiOpen && candle.ClosePrice > sar && rsiClose > 50m)
 		{
-			return TrendDirection.Bull;
+			return TrendDirections.Bull;
 		}
 
 		if (hourOk && rsiClose < rsiWeighted && rsiWeighted < rsiTypical && rsiTypical < rsiMedian &&
 			rsiMedian < rsiOpen && candle.ClosePrice < sar && rsiClose < 50m)
 		{
-			return TrendDirection.Bear;
+			return TrendDirections.Bear;
 		}
 
-		return TrendDirection.None;
+		return TrendDirections.None;
 	}
 
-	private enum TrendDirection
+	private enum TrendDirections
 	{
 		None,
 		Bull,

--- a/API/1673_Ride_Alligator/CS/RideAlligatorStrategy.cs
+++ b/API/1673_Ride_Alligator/CS/RideAlligatorStrategy.cs
@@ -22,7 +22,7 @@ namespace StockSharp.Samples.Strategies;
 public class RideAlligatorStrategy : Strategy
 {
 	private readonly StrategyParam<int> _alligatorPeriod;
-	private readonly StrategyParam<MovingAverageTypeEnum> _maType;
+	private readonly StrategyParam<MovingAverageTypes> _maType;
 	private readonly StrategyParam<DataType> _candleType;
 
 	private LengthIndicator<decimal> _jaw;
@@ -44,7 +44,7 @@ public class RideAlligatorStrategy : Strategy
 	/// <summary>
 	/// Moving average type for Alligator lines.
 	/// </summary>
-	public MovingAverageTypeEnum MaType
+	public MovingAverageTypes MaType
 	{
 		get => _maType.Value;
 		set => _maType.Value = value;
@@ -68,7 +68,7 @@ public class RideAlligatorStrategy : Strategy
 		.SetGreaterThanZero()
 		.SetDisplay("Alligator Period", "Base period for Alligator", "Alligator");
 
-		_maType = Param(nameof(MaType), MovingAverageTypeEnum.Weighted)
+		_maType = Param(nameof(MaType), MovingAverageTypes.Weighted)
 		.SetDisplay("MA Type", "Moving average type", "Alligator");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(1).TimeFrame())
@@ -154,14 +154,14 @@ public class RideAlligatorStrategy : Strategy
 		}
 	}
 
-	private static LengthIndicator<decimal> CreateMa(MovingAverageTypeEnum type, int length)
+	private static LengthIndicator<decimal> CreateMa(MovingAverageTypes type, int length)
 	{
 		return type switch
 		{
-			MovingAverageTypeEnum.Simple => new SimpleMovingAverage { Length = length },
-			MovingAverageTypeEnum.Exponential => new ExponentialMovingAverage { Length = length },
-			MovingAverageTypeEnum.Smoothed => new SmoothedMovingAverage { Length = length },
-			MovingAverageTypeEnum.Weighted => new WeightedMovingAverage { Length = length },
+			MovingAverageTypes.Simple => new SimpleMovingAverage { Length = length },
+			MovingAverageTypes.Exponential => new ExponentialMovingAverage { Length = length },
+			MovingAverageTypes.Smoothed => new SmoothedMovingAverage { Length = length },
+			MovingAverageTypes.Weighted => new WeightedMovingAverage { Length = length },
 			_ => throw new ArgumentOutOfRangeException(nameof(type), type, null),
 		};
 	}
@@ -169,7 +169,7 @@ public class RideAlligatorStrategy : Strategy
 	/// <summary>
 	/// Moving average types supported by the strategy.
 	/// </summary>
-	public enum MovingAverageTypeEnum
+	public enum MovingAverageTypes
 	{
 		Simple,
 		Exponential,

--- a/API/1682_X_Alert_3/CS/XAlert3Strategy.cs
+++ b/API/1682_X_Alert_3/CS/XAlert3Strategy.cs
@@ -20,10 +20,10 @@ namespace StockSharp.Samples.Strategies;
 public class XAlert3Strategy : Strategy
 {
 	private readonly StrategyParam<int> _ma1Period;
-	private readonly StrategyParam<MovingAverageTypeEnum> _ma1Type;
+	private readonly StrategyParam<MovingAverageTypes> _ma1Type;
 	private readonly StrategyParam<int> _ma2Period;
-	private readonly StrategyParam<MovingAverageTypeEnum> _ma2Type;
-	private readonly StrategyParam<PriceTypeEnum> _priceType;
+	private readonly StrategyParam<MovingAverageTypes> _ma2Type;
+	private readonly StrategyParam<PriceTypes> _priceType;
 	private readonly StrategyParam<DataType> _candleType;
 
 	private IIndicator _ma1;
@@ -43,7 +43,7 @@ public class XAlert3Strategy : Strategy
 	/// <summary>
 	/// Type of the first moving average.
 	/// </summary>
-	public MovingAverageTypeEnum Ma1Type
+	public MovingAverageTypes Ma1Type
 	{
 		get => _ma1Type.Value;
 		set => _ma1Type.Value = value;
@@ -61,7 +61,7 @@ public class XAlert3Strategy : Strategy
 	/// <summary>
 	/// Type of the second moving average.
 	/// </summary>
-	public MovingAverageTypeEnum Ma2Type
+	public MovingAverageTypes Ma2Type
 	{
 		get => _ma2Type.Value;
 		set => _ma2Type.Value = value;
@@ -70,7 +70,7 @@ public class XAlert3Strategy : Strategy
 	/// <summary>
 	/// Source price used for calculations.
 	/// </summary>
-	public PriceTypeEnum PriceType
+	public PriceTypes PriceType
 	{
 		get => _priceType.Value;
 		set => _priceType.Value = value;
@@ -95,7 +95,7 @@ public class XAlert3Strategy : Strategy
 			.SetDisplay("MA1 Period", "Length of the first moving average", "MA1")
 			.SetCanOptimize(true);
 
-		_ma1Type = Param(nameof(Ma1Type), MovingAverageTypeEnum.Simple)
+		_ma1Type = Param(nameof(Ma1Type), MovingAverageTypes.Simple)
 			.SetDisplay("MA1 Type", "Type of the first moving average", "MA1");
 
 		_ma2Period = Param(nameof(Ma2Period), 14)
@@ -103,10 +103,10 @@ public class XAlert3Strategy : Strategy
 			.SetDisplay("MA2 Period", "Length of the second moving average", "MA2")
 			.SetCanOptimize(true);
 
-		_ma2Type = Param(nameof(Ma2Type), MovingAverageTypeEnum.Simple)
+		_ma2Type = Param(nameof(Ma2Type), MovingAverageTypes.Simple)
 			.SetDisplay("MA2 Type", "Type of the second moving average", "MA2");
 
-		_priceType = Param(nameof(PriceType), PriceTypeEnum.Median)
+		_priceType = Param(nameof(PriceType), PriceTypes.Median)
 			.SetDisplay("Price Type", "Source price for calculations", "General");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(1).TimeFrame())
@@ -173,33 +173,33 @@ public class XAlert3Strategy : Strategy
 		_prevDiff1 = diff;
 	}
 
-	private static IIndicator CreateMovingAverage(MovingAverageTypeEnum type, int length)
+	private static IIndicator CreateMovingAverage(MovingAverageTypes type, int length)
 	{
 		return type switch
 		{
-			MovingAverageTypeEnum.Exponential => new ExponentialMovingAverage { Length = length },
-			MovingAverageTypeEnum.Smoothed => new SmoothedMovingAverage { Length = length },
-			MovingAverageTypeEnum.Weighted => new WeightedMovingAverage { Length = length },
+			MovingAverageTypes.Exponential => new ExponentialMovingAverage { Length = length },
+			MovingAverageTypes.Smoothed => new SmoothedMovingAverage { Length = length },
+			MovingAverageTypes.Weighted => new WeightedMovingAverage { Length = length },
 			_ => new SimpleMovingAverage { Length = length }
 		};
 	}
 
-	private static decimal GetPrice(ICandleMessage candle, PriceTypeEnum type)
+	private static decimal GetPrice(ICandleMessage candle, PriceTypes type)
 	{
 		return type switch
 		{
-			PriceTypeEnum.Open => candle.OpenPrice,
-			PriceTypeEnum.High => candle.HighPrice,
-			PriceTypeEnum.Low => candle.LowPrice,
-			PriceTypeEnum.Median => (candle.HighPrice + candle.LowPrice) / 2m,
-			PriceTypeEnum.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
-			PriceTypeEnum.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
+			PriceTypes.Open => candle.OpenPrice,
+			PriceTypes.High => candle.HighPrice,
+			PriceTypes.Low => candle.LowPrice,
+			PriceTypes.Median => (candle.HighPrice + candle.LowPrice) / 2m,
+			PriceTypes.Typical => (candle.HighPrice + candle.LowPrice + candle.ClosePrice) / 3m,
+			PriceTypes.Weighted => (candle.HighPrice + candle.LowPrice + 2m * candle.ClosePrice) / 4m,
 			_ => candle.ClosePrice
 		};
 	}
 }
 
-public enum MovingAverageTypeEnum
+public enum MovingAverageTypes
 {
 	/// <summary>Simple Moving Average.</summary>
 	Simple,
@@ -211,7 +211,7 @@ public enum MovingAverageTypeEnum
 	Weighted
 }
 
-public enum PriceTypeEnum
+public enum PriceTypes
 {
 	/// <summary>Close price.</summary>
 	Close,

--- a/API/1691_Lego_4_Beta/CS/Lego4BetaStrategy.cs
+++ b/API/1691_Lego_4_Beta/CS/Lego4BetaStrategy.cs
@@ -22,7 +22,7 @@ public class Lego4BetaStrategy : Strategy
 	private readonly StrategyParam<bool> _useMaOpen;
 	private readonly StrategyParam<int> _fastMaLength;
 	private readonly StrategyParam<int> _slowMaLength;
-	private readonly StrategyParam<MaType> _maType;
+	private readonly StrategyParam<MaTypes> _maType;
 	private readonly StrategyParam<bool> _useStochasticOpen;
 	private readonly StrategyParam<int> _stochLength;
 	private readonly StrategyParam<int> _stochKPeriod;
@@ -73,7 +73,7 @@ public class Lego4BetaStrategy : Strategy
 	/// <summary>
 	/// Moving average type.
 	/// </summary>
-	public MaType MaType
+	public MaTypes MaType
 	{
 		get => _maType.Value;
 		set => _maType.Value = value;
@@ -196,7 +196,7 @@ public class Lego4BetaStrategy : Strategy
 		.SetDisplay("Slow MA Length", "Length of slow MA", "Moving Average")
 		.SetCanOptimize(true);
 
-		_maType = Param(nameof(MaType), MaType.EMA)
+		_maType = Param(nameof(MaType), MaTypes.EMA)
 		.SetDisplay("MA Type", "Moving average type", "Moving Average");
 
 		_useStochasticOpen = Param(nameof(UseStochasticOpen), false)
@@ -267,8 +267,8 @@ public class Lego4BetaStrategy : Strategy
 
 		StartProtection();
 
-		_fastMa = CreateMa(MaType, FastMaLength);
-		_slowMa = CreateMa(MaType, SlowMaLength);
+		_fastMa = CreateMa(MaTypes, FastMaLength);
+		_slowMa = CreateMa(MaTypes, SlowMaLength);
 		_stochastic = new StochasticOscillator
 		{
 			Length = StochLength,
@@ -338,12 +338,12 @@ public class Lego4BetaStrategy : Strategy
 		_prevSlow = slow;
 	}
 
-	private MovingAverage CreateMa(MaType type, int length)
+	private MovingAverage CreateMa(MaTypes type, int length)
 	{
 		return type switch
 		{
-			MaType.SMA => new SimpleMovingAverage { Length = length },
-			MaType.WMA => new WeightedMovingAverage { Length = length },
+			MaTypes.SMA => new SimpleMovingAverage { Length = length },
+			MaTypes.WMA => new WeightedMovingAverage { Length = length },
 			_ => new ExponentialMovingAverage { Length = length },
 		};
 	}
@@ -352,7 +352,7 @@ public class Lego4BetaStrategy : Strategy
 /// <summary>
 /// Moving average type.
 /// </summary>
-public enum MaType
+public enum MaTypes
 {
 	/// <summary>
 	/// Simple moving average.

--- a/API/1777_Binary_Wave/CS/BinaryWaveStrategy.cs
+++ b/API/1777_Binary_Wave/CS/BinaryWaveStrategy.cs
@@ -22,7 +22,7 @@ public class BinaryWaveStrategy : Strategy
 	/// <summary>
 	/// Mode for generating entry signals.
 	/// </summary>
-	public enum EntryMode
+	public enum EntryModes
 	{
 		/// <summary>
 		/// Enter when the wave crosses zero.
@@ -35,7 +35,7 @@ public class BinaryWaveStrategy : Strategy
 		Twist
 	}
 
-	private readonly StrategyParam<EntryMode> _mode;
+	private readonly StrategyParam<EntryModes> _mode;
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<int> _maPeriod;
 	private readonly StrategyParam<int> _fastMacd;
@@ -73,7 +73,7 @@ public class BinaryWaveStrategy : Strategy
 	/// <summary>
 	/// Mode for generating entry signals.
 	/// </summary>
-	public EntryMode Mode
+	public EntryModes Mode
 	{
 		get => _mode.Value;
 		set => _mode.Value = value;
@@ -282,7 +282,7 @@ public class BinaryWaveStrategy : Strategy
 	/// </summary>
 	public BinaryWaveStrategy()
 	{
-		_mode = Param(nameof(Mode), EntryMode.Breakdown)
+		_mode = Param(nameof(Mode), EntryModes.Breakdown)
 		.SetDisplay("Mode", "Entry signal mode", "General");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(5).TimeFrame())
@@ -467,7 +467,7 @@ public class BinaryWaveStrategy : Strategy
 	var buyClose = false;
 	var sellClose = false;
 
-	if (Mode == EntryMode.Breakdown)
+	if (Mode == EntryModes.Breakdown)
 	{
 	if (_prevWave <= 0 && wave > 0)
 	{

--- a/API/1781_Xmacd_Modes/CS/XmacdModesStrategy.cs
+++ b/API/1781_Xmacd_Modes/CS/XmacdModesStrategy.cs
@@ -22,7 +22,7 @@ public class XmacdModesStrategy : Strategy
 	private readonly StrategyParam<int> _slowEmaPeriod;
 	private readonly StrategyParam<int> _signalPeriod;
 	private readonly StrategyParam<DataType> _candleType;
-	private readonly StrategyParam<XmacdMode> _mode;
+	private readonly StrategyParam<XmacdModes> _mode;
 	private readonly StrategyParam<decimal> _stopLossPercent;
 	private readonly StrategyParam<decimal> _takeProfitPercent;
 
@@ -35,7 +35,7 @@ public class XmacdModesStrategy : Strategy
 	public int SlowEmaPeriod { get => _slowEmaPeriod.Value; set => _slowEmaPeriod.Value = value; }
 	public int SignalPeriod { get => _signalPeriod.Value; set => _signalPeriod.Value = value; }
 	public DataType CandleType { get => _candleType.Value; set => _candleType.Value = value; }
-	public XmacdMode Mode { get => _mode.Value; set => _mode.Value = value; }
+	public XmacdModes Mode { get => _mode.Value; set => _mode.Value = value; }
 	public decimal StopLossPercent { get => _stopLossPercent.Value; set => _stopLossPercent.Value = value; }
 	public decimal TakeProfitPercent { get => _takeProfitPercent.Value; set => _takeProfitPercent.Value = value; }
 
@@ -59,7 +59,7 @@ public class XmacdModesStrategy : Strategy
 		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(4).TimeFrame())
 			.SetDisplay("Candle Type", "Type of candles to use", "General");
 
-		_mode = Param(nameof(Mode), XmacdMode.MacdDisposition)
+		_mode = Param(nameof(Mode), XmacdModes.MacdDisposition)
 			.SetDisplay("Mode", "Trading mode", "General");
 
 		_stopLossPercent = Param(nameof(StopLossPercent), 2m)
@@ -142,14 +142,14 @@ public class XmacdModesStrategy : Strategy
 
 		switch (Mode)
 		{
-			case XmacdMode.Breakdown:
+			case XmacdModes.Breakdown:
 				var crossUp = macd > 0m && _prevMacd <= 0m;
 				var crossDown = macd < 0m && _prevMacd >= 0m;
 				buy = crossUp;
 				sell = crossDown;
 				break;
 
-			case XmacdMode.MacdTwist:
+			case XmacdModes.MacdTwist:
 				var wasDecreasing = _prevMacd < _prevMacd2;
 				var nowIncreasing = macd > _prevMacd;
 				var wasIncreasing = _prevMacd > _prevMacd2;
@@ -158,7 +158,7 @@ public class XmacdModesStrategy : Strategy
 				sell = wasIncreasing && nowDecreasing;
 				break;
 
-			case XmacdMode.SignalTwist:
+			case XmacdModes.SignalTwist:
 				var sigWasDecreasing = _prevSignal < _prevSignal2;
 				var sigNowIncreasing = signal > _prevSignal;
 				var sigWasIncreasing = _prevSignal > _prevSignal2;
@@ -167,7 +167,7 @@ public class XmacdModesStrategy : Strategy
 				sell = sigWasIncreasing && sigNowDecreasing;
 				break;
 
-			case XmacdMode.MacdDisposition:
+			case XmacdModes.MacdDisposition:
 				var crossAbove = macd > signal && _prevMacd <= _prevSignal;
 				var crossBelow = macd < signal && _prevMacd >= _prevSignal;
 				buy = crossAbove;
@@ -187,7 +187,7 @@ public class XmacdModesStrategy : Strategy
 	}
 }
 
-public enum XmacdMode
+public enum XmacdModes
 {
 	Breakdown,
 	MacdTwist,

--- a/API/1820_Price_Action/CS/PriceActionStrategy.cs
+++ b/API/1820_Price_Action/CS/PriceActionStrategy.cs
@@ -23,10 +23,10 @@ public class PriceActionStrategy : Strategy
 	private readonly StrategyParam<decimal> _leverage;
 	private readonly StrategyParam<decimal> _trailingStop;
 	private readonly StrategyParam<decimal> _trailingStep;
-	private readonly StrategyParam<TradeDirection> _initialDirection;
+	private readonly StrategyParam<TradeDirections> _initialDirection;
 	private readonly StrategyParam<DataType> _candleType;
 
-	private TradeDirection _nextDirection;
+	private TradeDirections _nextDirection;
 	private decimal _stopPrice;
 	private decimal _takeProfitPrice;
 
@@ -54,7 +54,7 @@ public class PriceActionStrategy : Strategy
 	/// <summary>
 	/// Direction of the first trade.
 	/// </summary>
-	public TradeDirection InitialDirection { get => _initialDirection.Value; set => _initialDirection.Value = value; }
+	public TradeDirections InitialDirection { get => _initialDirection.Value; set => _initialDirection.Value = value; }
 
 	/// <summary>
 	/// Candle type for processing.
@@ -76,7 +76,7 @@ public class PriceActionStrategy : Strategy
 		_trailingStep = Param(nameof(TrailingStep), 0m)
 			.SetDisplay("Trailing Step", "Minimal move to trail", "Risk");
 
-		_initialDirection = Param(nameof(InitialDirection), TradeDirection.Buy)
+		_initialDirection = Param(nameof(InitialDirection), TradeDirections.Buy)
 			.SetDisplay("Initial Direction", "First trade side", "General");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(1).TimeFrame())
@@ -112,19 +112,19 @@ public class PriceActionStrategy : Strategy
 
 		if (Position == 0)
 		{
-			if (_nextDirection == TradeDirection.Buy)
+			if (_nextDirection == TradeDirections.Buy)
 			{
 				BuyMarket(Volume);
 				_stopPrice = candle.ClosePrice - TP;
 				_takeProfitPrice = candle.ClosePrice + Leverage * TP;
-				_nextDirection = TradeDirection.Sell;
+				_nextDirection = TradeDirections.Sell;
 			}
 			else
 			{
 				SellMarket(Volume);
 				_stopPrice = candle.ClosePrice + TP;
 				_takeProfitPrice = candle.ClosePrice - Leverage * TP;
-				_nextDirection = TradeDirection.Buy;
+				_nextDirection = TradeDirections.Buy;
 			}
 		}
 		else if (Position > 0)
@@ -154,7 +154,7 @@ public class PriceActionStrategy : Strategy
 	}
 }
 
-public enum TradeDirection
+public enum TradeDirections
 {
 	Buy = 1,
 	Sell = 2

--- a/API/1824_VR_Overturn/CS/VROverturnStrategy.cs
+++ b/API/1824_VR_Overturn/CS/VROverturnStrategy.cs
@@ -18,13 +18,13 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class VROverturnStrategy : Strategy
 {
-	private enum TradeMode
+	private enum TradeModes
 	{
 		Martingale,
 		AntiMartingale
 	}
 
-	private readonly StrategyParam<TradeMode> _tradeMode;
+	private readonly StrategyParam<TradeModes> _tradeMode;
 	private readonly StrategyParam<Sides> _startSide;
 	private readonly StrategyParam<int> _takePoints;
 	private readonly StrategyParam<int> _stopPoints;
@@ -40,7 +40,7 @@ public class VROverturnStrategy : Strategy
 	/// <summary>
 	/// Trade mode selection.
 	/// </summary>
-	public TradeMode Mode { get => _tradeMode.Value; set => _tradeMode.Value = value; }
+	public TradeModes Mode { get => _tradeMode.Value; set => _tradeMode.Value = value; }
 
 	/// <summary>
 	/// Initial trade side.
@@ -72,7 +72,7 @@ public class VROverturnStrategy : Strategy
 	/// </summary>
 	public VROverturnStrategy()
 	{
-		_tradeMode = Param(nameof(Mode), TradeMode.Martingale)
+		_tradeMode = Param(nameof(Mode), TradeModes.Martingale)
 			.SetDisplay("Trade Mode", "Martingale or AntiMartingale", "General");
 
 		_startSide = Param(nameof(StartSide), Sides.Buy)
@@ -146,7 +146,7 @@ public class VROverturnStrategy : Strategy
 			var exitPrice = trade.Trade.Price;
 			var profit = (_currentSide == Sides.Buy ? exitPrice - _entryPrice : _entryPrice - exitPrice) * _currentVolume;
 
-			if (Mode == TradeMode.Martingale)
+			if (Mode == TradeModes.Martingale)
 			{
 				_currentVolume = profit > 0m ? StartVolume : _currentVolume * Multiplier;
 			}

--- a/API/1828_SwingCyborg/CS/SwingCyborgStrategy.cs
+++ b/API/1828_SwingCyborg/CS/SwingCyborgStrategy.cs
@@ -18,8 +18,8 @@ namespace StockSharp.Samples.Strategies;
 
 public class SwingCyborgStrategy : Strategy
 {
-	private readonly StrategyParam<TrendType> _trendPrediction;
-	private readonly StrategyParam<TrendTimeframe> _trendTimeframe;
+	private readonly StrategyParam<TrendTypes> _trendPrediction;
+	private readonly StrategyParam<TrendTimeframes> _trendTimeframe;
 	private readonly StrategyParam<DateTimeOffset> _trendStart;
 	private readonly StrategyParam<DateTimeOffset> _trendEnd;
 	private readonly StrategyParam<Aggressiveness> _aggressiveness;
@@ -32,7 +32,7 @@ public class SwingCyborgStrategy : Strategy
 	/// <summary>
 	/// Expected trend direction.
 	/// </summary>
-	public TrendType TrendPrediction
+	public TrendTypes TrendPrediction
 	{
 	get => _trendPrediction.Value;
 	set => _trendPrediction.Value = value;
@@ -41,7 +41,7 @@ public class SwingCyborgStrategy : Strategy
 	/// <summary>
 	/// Timeframe of expected trend.
 	/// </summary>
-	public TrendTimeframe TrendTimeframe
+	public TrendTimeframes TrendTimeframe
 	{
 	get => _trendTimeframe.Value;
 	set => _trendTimeframe.Value = value;
@@ -80,10 +80,10 @@ public class SwingCyborgStrategy : Strategy
 	public SwingCyborgStrategy()
 	{
 	
-	_trendPrediction = Param(nameof(TrendPrediction), TrendType.Uptrend)
+	_trendPrediction = Param(nameof(TrendPrediction), TrendTypes.Uptrend)
 	.SetDisplay("Trend Prediction", "Expected trend direction", "General");
 	
-	_trendTimeframe = Param(nameof(TrendTimeframe), TrendTimeframe.H1)
+	_trendTimeframe = Param(nameof(TrendTimeframe), TrendTimeframes.H1)
 	.SetDisplay("Trend Timeframe", "Timeframe of expected trend", "General");
 	
 	_trendStart = Param(nameof(TrendStart), new DateTimeOffset(2023, 1, 1, 0, 0, 0, TimeSpan.Zero))
@@ -99,11 +99,11 @@ public class SwingCyborgStrategy : Strategy
 	/// <inheritdoc />
 	public override IEnumerable<(Security sec, DataType dt)> GetWorkingSecurities()
 	{
-	_candleType = TrendTimeframe switch
+	_candleType = TrendTimeframes switch
 	{
-	TrendTimeframe.M30 => TimeSpan.FromMinutes(30).TimeFrame(),
-	TrendTimeframe.H1 => TimeSpan.FromHours(1).TimeFrame(),
-	TrendTimeframe.H4 => TimeSpan.FromHours(4).TimeFrame(),
+	TrendTimeframes.M30 => TimeSpan.FromMinutes(30).TimeFrame(),
+	TrendTimeframes.H1 => TimeSpan.FromHours(1).TimeFrame(),
+	TrendTimeframes.H4 => TimeSpan.FromHours(4).TimeFrame(),
 	_ => TimeSpan.FromHours(1).TimeFrame()
 	};
 	return [(Security, _candleType)];
@@ -152,11 +152,11 @@ public class SwingCyborgStrategy : Strategy
 	
 	if (Position == 0)
 	{
-	if (TrendPrediction == TrendType.Uptrend && rsiValue <= 65m)
+	if (TrendPrediction == TrendTypes.Uptrend && rsiValue <= 65m)
 	{
 	BuyMarket(Volume);
 	}
-	else if (TrendPrediction == TrendType.Downtrend && rsiValue >= 35m)
+	else if (TrendPrediction == TrendTypes.Downtrend && rsiValue >= 35m)
 	{
 	SellMarket(Volume);
 	}
@@ -166,7 +166,7 @@ public class SwingCyborgStrategy : Strategy
 	/// <summary>
 	/// Expected trend direction.
 	/// </summary>
-	public enum TrendType
+	public enum TrendTypes
 	{
 	Uptrend,
 	Downtrend
@@ -175,7 +175,7 @@ public class SwingCyborgStrategy : Strategy
 	/// <summary>
 	/// Timeframe of expected trend.
 	/// </summary>
-	public enum TrendTimeframe
+	public enum TrendTimeframes
 	{
 	M30,
 	H1,

--- a/API/1862_Bulls_vs_Bears_Crossover/CS/BullsVsBearsCrossoverStrategy.cs
+++ b/API/1862_Bulls_vs_Bears_Crossover/CS/BullsVsBearsCrossoverStrategy.cs
@@ -19,7 +19,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class BullsVsBearsCrossoverStrategy : Strategy
 {
-	private readonly StrategyParam<MovingAverageTypeEnum> _maType;
+	private readonly StrategyParam<MovingAverageTypes> _maType;
 	private readonly StrategyParam<int> _maLength;
 	private readonly StrategyParam<decimal> _stopLoss;
 	private readonly StrategyParam<decimal> _takeProfit;
@@ -37,7 +37,7 @@ public class BullsVsBearsCrossoverStrategy : Strategy
 	/// <summary>
 	/// Moving average calculation method.
 	/// </summary>
-	public MovingAverageTypeEnum MaType
+	public MovingAverageTypes MaType
 	{
 		get => _maType.Value;
 		set => _maType.Value = value;
@@ -120,7 +120,7 @@ public class BullsVsBearsCrossoverStrategy : Strategy
 	/// </summary>
 	public BullsVsBearsCrossoverStrategy()
 	{
-		_maType = Param(nameof(MaType), MovingAverageTypeEnum.SMA)
+		_maType = Param(nameof(MaType), MovingAverageTypes.SMA)
 			.SetDisplay("MA Type", "Moving average type", "General")
 			.SetCanOptimize(true);
 
@@ -255,14 +255,14 @@ public class BullsVsBearsCrossoverStrategy : Strategy
 		_prevBear = bear;
 	}
 
-	private static IIndicator CreateMovingAverage(MovingAverageTypeEnum type, int length)
+	private static IIndicator CreateMovingAverage(MovingAverageTypes type, int length)
 	{
 		return type switch
 		{
-			MovingAverageTypeEnum.SMA => new SimpleMovingAverage { Length = length },
-			MovingAverageTypeEnum.EMA => new ExponentialMovingAverage { Length = length },
-			MovingAverageTypeEnum.SMMA => new SmoothedMovingAverage { Length = length },
-			MovingAverageTypeEnum.WMA => new WeightedMovingAverage { Length = length },
+			MovingAverageTypes.SMA => new SimpleMovingAverage { Length = length },
+			MovingAverageTypes.EMA => new ExponentialMovingAverage { Length = length },
+			MovingAverageTypes.SMMA => new SmoothedMovingAverage { Length = length },
+			MovingAverageTypes.WMA => new WeightedMovingAverage { Length = length },
 			_ => new SimpleMovingAverage { Length = length },
 		};
 	}
@@ -271,7 +271,7 @@ public class BullsVsBearsCrossoverStrategy : Strategy
 /// <summary>
 /// Moving average types.
 /// </summary>
-public enum MovingAverageTypeEnum
+public enum MovingAverageTypes
 {
 	/// <summary>
 	/// Simple moving average.

--- a/API/1874_Color_BB_Candles/CS/ColorBbCandlesStrategy.cs
+++ b/API/1874_Color_BB_Candles/CS/ColorBbCandlesStrategy.cs
@@ -21,7 +21,7 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class ColorBbCandlesStrategy : Strategy
 {
-	private enum BandState
+	private enum BandStates
 	{
 		Neutral,
 		Above,
@@ -32,7 +32,7 @@ public class ColorBbCandlesStrategy : Strategy
 	private readonly StrategyParam<decimal> _bollingerDeviation;
 	private readonly StrategyParam<DataType> _candleType;
 	
-	private BandState _previousState = BandState.Neutral;
+	private BandStates _previousState = BandStates.Neutral;
 	private decimal _entryPrice;
 	
 	/// <summary>
@@ -93,7 +93,7 @@ public class ColorBbCandlesStrategy : Strategy
 	protected override void OnReseted()
 	{
 		base.OnReseted();
-		_previousState = BandState.Neutral;
+		_previousState = BandStates.Neutral;
 		_entryPrice = 0m;
 	}
 	
@@ -131,14 +131,14 @@ public class ColorBbCandlesStrategy : Strategy
 		if (!IsFormedAndOnlineAndAllowTrading())
 		return;
 		
-		var state = BandState.Neutral;
+		var state = BandStates.Neutral;
 		
 		if (candle.ClosePrice > upperBand)
-		state = BandState.Above;
+		state = BandStates.Above;
 		else if (candle.ClosePrice < lowerBand)
-		state = BandState.Below;
+		state = BandStates.Below;
 		
-		if (state == BandState.Above && _previousState != BandState.Above)
+		if (state == BandStates.Above && _previousState != BandStates.Above)
 		{
 			var volume = Volume + (Position < 0 ? Math.Abs(Position) : 0);
 			if (volume > 0)
@@ -147,7 +147,7 @@ public class ColorBbCandlesStrategy : Strategy
 				_entryPrice = candle.ClosePrice;
 			}
 		}
-		else if (state == BandState.Below && _previousState != BandState.Below)
+		else if (state == BandStates.Below && _previousState != BandStates.Below)
 		{
 			var volume = Volume + (Position > 0 ? Math.Abs(Position) : 0);
 			if (volume > 0)
@@ -156,7 +156,7 @@ public class ColorBbCandlesStrategy : Strategy
 				_entryPrice = candle.ClosePrice;
 			}
 		}
-		else if (state == BandState.Neutral && _previousState != BandState.Neutral)
+		else if (state == BandStates.Neutral && _previousState != BandStates.Neutral)
 		{
 			if (Position > 0)
 			{

--- a/API/1896_Double_Trading/CS/DoubleTradingStrategy.cs
+++ b/API/1896_Double_Trading/CS/DoubleTradingStrategy.cs
@@ -18,14 +18,14 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class DoubleTradingStrategy : Strategy
 {
-	public enum TradeDirection { Auto, Buy, Sell }
+	public enum TradeDirections { Auto, Buy, Sell }
 
 	private readonly StrategyParam<decimal> _volume1;
 	private readonly StrategyParam<decimal> _volume2;
 	private readonly StrategyParam<decimal> _profitTarget;
 	private readonly StrategyParam<Security> _secondSecurity;
-	private readonly StrategyParam<TradeDirection> _direction1;
-	private readonly StrategyParam<TradeDirection> _direction2;
+	private readonly StrategyParam<TradeDirections> _direction1;
+	private readonly StrategyParam<TradeDirections> _direction2;
 	private readonly StrategyParam<DataType> _candleType;
 
 	private Sides _side1;
@@ -39,8 +39,8 @@ public class DoubleTradingStrategy : Strategy
 	public decimal Volume2 { get => _volume2.Value; set => _volume2.Value = value; }
 	public decimal ProfitTarget { get => _profitTarget.Value; set => _profitTarget.Value = value; }
 	public Security SecondSecurity { get => _secondSecurity.Value; set => _secondSecurity.Value = value; }
-	public TradeDirection Direction1 { get => _direction1.Value; set => _direction1.Value = value; }
-	public TradeDirection Direction2 { get => _direction2.Value; set => _direction2.Value = value; }
+	public TradeDirections Direction1 { get => _direction1.Value; set => _direction1.Value = value; }
+	public TradeDirections Direction2 { get => _direction2.Value; set => _direction2.Value = value; }
 	public DataType CandleType { get => _candleType.Value; set => _candleType.Value = value; }
 
 	public DoubleTradingStrategy()
@@ -49,8 +49,8 @@ public class DoubleTradingStrategy : Strategy
 		_volume2 = Param(nameof(Volume2), 1.3m).SetDisplay("Volume2", "Second volume", "Parameters");
 		_profitTarget = Param(nameof(ProfitTarget), 20m).SetDisplay("Profit Target", "Exit profit", "Risk");
 		_secondSecurity = Param<Security>(nameof(SecondSecurity)).SetDisplay("Second Security", "Hedged instrument", "Parameters").SetRequired();
-		_direction1 = Param(nameof(Direction1), TradeDirection.Auto).SetDisplay("Direction1", "First side", "Parameters");
-		_direction2 = Param(nameof(Direction2), TradeDirection.Auto).SetDisplay("Direction2", "Second side", "Parameters");
+		_direction1 = Param(nameof(Direction1), TradeDirections.Auto).SetDisplay("Direction1", "First side", "Parameters");
+		_direction2 = Param(nameof(Direction2), TradeDirections.Auto).SetDisplay("Direction2", "Second side", "Parameters");
 		_candleType = Param(nameof(CandleType), TimeSpan.FromMinutes(1).TimeFrame()).SetDisplay("Candle Type", "Candles", "Data");
 	}
 
@@ -68,8 +68,8 @@ public class DoubleTradingStrategy : Strategy
 		SubscribeCandles(CandleType).Bind(ProcessFirst).Start();
 		SubscribeCandles(CandleType, security: SecondSecurity).Bind(ProcessSecond).Start();
 
-		_side1 = Direction1 == TradeDirection.Sell ? Sides.Sell : Sides.Buy;
-		_side2 = Direction2 == TradeDirection.Buy ? Sides.Buy : Sides.Sell;
+		_side1 = Direction1 == TradeDirections.Sell ? Sides.Sell : Sides.Buy;
+		_side2 = Direction2 == TradeDirections.Buy ? Sides.Buy : Sides.Sell;
 
 		if (_side1 == Sides.Buy)
 			BuyMarket(Volume1);

--- a/API/1897_ExpOracle/CS/ExpOracleStrategy.cs
+++ b/API/1897_ExpOracle/CS/ExpOracleStrategy.cs
@@ -22,7 +22,7 @@ public class ExpOracleStrategy : Strategy
 {
 	private readonly StrategyParam<int> _oraclePeriod;
 	private readonly StrategyParam<int> _smooth;
-	private readonly StrategyParam<AlgorithmMode> _mode;
+	private readonly StrategyParam<AlgorithmModes> _mode;
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<bool> _allowBuy;
 	private readonly StrategyParam<bool> _allowSell;
@@ -52,7 +52,7 @@ public class ExpOracleStrategy : Strategy
 	/// <summary>
 	/// Selected trading algorithm.
 	/// </summary>
-	public AlgorithmMode Mode
+	public AlgorithmModes Mode
 	{
 		get => _mode.Value;
 		set => _mode.Value = value;
@@ -102,7 +102,7 @@ public class ExpOracleStrategy : Strategy
 			.SetCanOptimize(true)
 			.SetOptimize(2, 20, 2);
 
-		_mode = Param(nameof(Mode), AlgorithmMode.Twist)
+		_mode = Param(nameof(Mode), AlgorithmModes.Twist)
 			.SetDisplay("Mode", "Signal algorithm", "Parameters");
 
 		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(4).TimeFrame())
@@ -144,7 +144,7 @@ public class ExpOracleStrategy : Strategy
 
 		switch (Mode)
 		{
-			case AlgorithmMode.Breakdown:
+			case AlgorithmModes.Breakdown:
 				if (AllowBuy && _prevSignal <= 0m && signal > 0m)
 				{
 					var volume = Volume + Math.Abs(Position);
@@ -157,7 +157,7 @@ public class ExpOracleStrategy : Strategy
 				}
 				break;
 
-			case AlgorithmMode.Twist:
+			case AlgorithmModes.Twist:
 				if (AllowBuy && _prevPrevSignal < _prevSignal && signal >= _prevSignal)
 				{
 					var volume = Volume + Math.Abs(Position);
@@ -170,7 +170,7 @@ public class ExpOracleStrategy : Strategy
 				}
 				break;
 
-			case AlgorithmMode.Disposition:
+			case AlgorithmModes.Disposition:
 				if (AllowBuy && _prevSignal < _prevOracle && signal >= oracle)
 				{
 					var volume = Volume + Math.Abs(Position);
@@ -193,7 +193,7 @@ public class ExpOracleStrategy : Strategy
 /// <summary>
 /// Trading algorithm modes.
 /// </summary>
-public enum AlgorithmMode
+public enum AlgorithmModes
 {
 	/// <summary>
 	/// Signal line crossing zero.

--- a/API/1900_JBrainUltraRsi/CS/JBrainUltraRsiStrategy.cs
+++ b/API/1900_JBrainUltraRsi/CS/JBrainUltraRsiStrategy.cs
@@ -22,7 +22,7 @@ public class JBrainUltraRsiStrategy : Strategy
 	private readonly StrategyParam<int> _rsiPeriod;
 	private readonly StrategyParam<int> _stochLength;
 	private readonly StrategyParam<int> _signalLength;
-	private readonly StrategyParam<AlgorithmMode> _mode;
+	private readonly StrategyParam<AlgorithmModes> _mode;
 	private readonly StrategyParam<bool> _allowLongEntry;
 	private readonly StrategyParam<bool> _allowShortEntry;
 	private readonly StrategyParam<bool> _allowLongExit;
@@ -66,7 +66,7 @@ public class JBrainUltraRsiStrategy : Strategy
 	/// <summary>
 	/// Mode combining indicators.
 	/// </summary>
-	public AlgorithmMode Mode
+	public AlgorithmModes Mode
 	{
 		get => _mode.Value;
 		set => _mode.Value = value;
@@ -137,7 +137,7 @@ public class JBrainUltraRsiStrategy : Strategy
 		.SetDisplay("Stochastic %D", "Period for %D line", "Indicators")
 		.SetCanOptimize(true);
 		
-		_mode = Param(nameof(Mode), AlgorithmMode.Composition)
+		_mode = Param(nameof(Mode), AlgorithmModes.Composition)
 		.SetDisplay("Mode", "Algorithm to enter the market", "General");
 		
 		_allowLongEntry = Param(nameof(AllowLongEntry), true)
@@ -254,15 +254,15 @@ public class JBrainUltraRsiStrategy : Strategy
 		
 		switch (Mode)
 		{
-			case AlgorithmMode.JBrainSig1Filter:
+			case AlgorithmModes.JBrainSig1Filter:
 			buySignal = rsiUp && k > d;
 			sellSignal = rsiDown && k < d;
 			break;
-			case AlgorithmMode.UltraRsiFilter:
+			case AlgorithmModes.UltraRsiFilter:
 			buySignal = stochUp && rsi > 50m;
 			sellSignal = stochDown && rsi < 50m;
 			break;
-			case AlgorithmMode.Composition:
+			case AlgorithmModes.Composition:
 			buySignal = rsiUp && stochUp;
 			sellSignal = rsiDown && stochDown;
 			break;
@@ -292,7 +292,7 @@ public class JBrainUltraRsiStrategy : Strategy
 /// <summary>
 /// Combination modes for indicators.
 /// </summary>
-public enum AlgorithmMode
+public enum AlgorithmModes
 {
 	JBrainSig1Filter,
 	UltraRsiFilter,

--- a/API/1914_RMACD_Reversal/CS/RmacdReversalStrategy.cs
+++ b/API/1914_RMACD_Reversal/CS/RmacdReversalStrategy.cs
@@ -22,7 +22,7 @@ public class RmacdReversalStrategy : Strategy
 	private readonly StrategyParam<int> _slowLength;
 	private readonly StrategyParam<int> _signalLength;
 	private readonly StrategyParam<DataType> _candleType;
-	private readonly StrategyParam<AlgMode> _mode;
+        private readonly StrategyParam<AlgModes> _mode;
 
 	private decimal _prevMacd;
 	private decimal _prevMacd2;
@@ -69,7 +69,7 @@ public class RmacdReversalStrategy : Strategy
 	/// <summary>
 	/// Entry mode selection.
 	/// </summary>
-	public AlgMode Mode
+        public AlgModes Mode
 	{
 		get => _mode.Value;
 		set => _mode.Value = value;
@@ -95,7 +95,7 @@ public class RmacdReversalStrategy : Strategy
 		_candleType = Param(nameof(CandleType), TimeSpan.FromHours(4).TimeFrame())
 			.SetDisplay("Candle Type", "Timeframe for analysis", "General");
 
-		_mode = Param(nameof(Mode), AlgMode.MacdDisposition)
+                _mode = Param(nameof(Mode), AlgModes.MacdDisposition)
 			.SetDisplay("Mode", "Entry algorithm", "Trading");
 	}
 
@@ -171,24 +171,24 @@ public class RmacdReversalStrategy : Strategy
 		var buy = false;
 		var sell = false;
 
-		switch (Mode)
-		{
-			case AlgMode.Breakdown:
+                switch (Mode)
+                {
+                        case AlgModes.Breakdown:
 				buy = _prevMacd > 0m && macd <= 0m;
 				sell = _prevMacd < 0m && macd >= 0m;
 				break;
 
-			case AlgMode.MacdTwist:
+                        case AlgModes.MacdTwist:
 				buy = _prevMacd < _prevMacd2 && macd > _prevMacd;
 				sell = _prevMacd > _prevMacd2 && macd < _prevMacd;
 				break;
 
-			case AlgMode.SignalTwist:
+                        case AlgModes.SignalTwist:
 				buy = _prevSignal < _prevSignal2 && signal > _prevSignal;
 				sell = _prevSignal > _prevSignal2 && signal < _prevSignal;
 				break;
 
-			case AlgMode.MacdDisposition:
+                        case AlgModes.MacdDisposition:
 				buy = _prevMacd > _prevSignal && macd <= signal;
 				sell = _prevMacd < _prevSignal && macd >= signal;
 				break;
@@ -214,7 +214,7 @@ public class RmacdReversalStrategy : Strategy
 	/// <summary>
 	/// Entry modes for RMACD strategy.
 	/// </summary>
-	public enum AlgMode
+        public enum AlgModes
 	{
 		/// <summary>
 		/// MACD histogram crossing the zero line.

--- a/API/1948_GG_RSI_CCI/CS/GgRsiCciStrategy.cs
+++ b/API/1948_GG_RSI_CCI/CS/GgRsiCciStrategy.cs
@@ -27,7 +27,7 @@ public class GgRsiCciStrategy : Strategy
 	private readonly StrategyParam<bool> _allowSellOpen;
 	private readonly StrategyParam<bool> _allowBuyClose;
 	private readonly StrategyParam<bool> _allowSellClose;
-	private readonly StrategyParam<SignalMode> _mode;
+	private readonly StrategyParam<SignalModes> _mode;
 
 	private SimpleMovingAverage _rsiFast = null!;
 	private SimpleMovingAverage _rsiSlow = null!;
@@ -38,7 +38,7 @@ public class GgRsiCciStrategy : Strategy
 	/// <summary>
 	/// Defines how positions are closed.
 	/// </summary>
-	public enum SignalMode
+	public enum SignalModes
 	{
 		/// <summary>Position is closed only on opposite signal.</summary>
 		Trend,
@@ -76,7 +76,7 @@ public class GgRsiCciStrategy : Strategy
 		_allowSellClose = Param(nameof(AllowSellClose), true)
 			.SetDisplay("Close Long", "Permit closing long positions.", "Permissions");
 
-		_mode = Param(nameof(Mode), SignalMode.Flat)
+		_mode = Param(nameof(Mode), SignalModes.Flat)
 			.SetDisplay("Mode", "Closing style.", "Trading");
 	}
 
@@ -129,7 +129,7 @@ public class GgRsiCciStrategy : Strategy
 		set => _allowSellClose.Value = value;
 	}
 
-	public SignalMode Mode
+	public SignalModes Mode
 	{
 		get => _mode.Value;
 		set => _mode.Value = value;
@@ -196,7 +196,7 @@ public class GgRsiCciStrategy : Strategy
 			if (AllowSellOpen && Position >= 0 && _prevSignal != 0)
 				SellMarket(Volume + Math.Abs(Position));
 		}
-		else if (Mode == SignalMode.Flat)
+		else if (Mode == SignalModes.Flat)
 		{
 			if (AllowBuyClose && Position > 0)
 				SellMarket(Position);

--- a/API/1955_Exp_HLRSign/CS/ExpHlrSignStrategy.cs
+++ b/API/1955_Exp_HLRSign/CS/ExpHlrSignStrategy.cs
@@ -18,13 +18,13 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class ExpHlrSignStrategy : Strategy
 {
-	private enum AlgMethod
+	private enum AlgMethods
 	{
 		ModeIn,
 		ModeOut,
 	}
 
-	private readonly StrategyParam<AlgMethod> _mode;
+	private readonly StrategyParam<AlgMethods> _mode;
 	private readonly StrategyParam<int> _range;
 	private readonly StrategyParam<decimal> _upLevel;
 	private readonly StrategyParam<decimal> _dnLevel;
@@ -40,7 +40,7 @@ public class ExpHlrSignStrategy : Strategy
 	/// <summary>
 	/// Indicator mode.
 	/// </summary>
-	public AlgMethod Mode
+	public AlgMethods Mode
 	{
 		get => _mode.Value;
 		set => _mode.Value = value;
@@ -123,7 +123,7 @@ public class ExpHlrSignStrategy : Strategy
 	/// </summary>
 	public ExpHlrSignStrategy()
 	{
-		_mode = Param(nameof(Mode), AlgMethod.ModeOut)
+		_mode = Param(nameof(Mode), AlgMethods.ModeOut)
 			.SetDisplay("Mode", "Indicator operation mode", "General");
 
 		_range = Param(nameof(Range), 40)
@@ -221,7 +221,7 @@ public class ExpHlrSignStrategy : Strategy
 			return;
 		}
 
-		if (Mode == AlgMethod.ModeIn)
+		if (Mode == AlgMethods.ModeIn)
 		{
 			if (hlr > UpLevel && _previousHlr <= UpLevel)
 				buySignal = true;

--- a/API/1959_NRatio_Sign/CS/NRatioSignStrategy.cs
+++ b/API/1959_NRatio_Sign/CS/NRatioSignStrategy.cs
@@ -27,7 +27,7 @@ public class NRatioSignStrategy : Strategy
 	private readonly StrategyParam<decimal> _sharp;
 	private readonly StrategyParam<decimal> _upLevel;
 	private readonly StrategyParam<decimal> _downLevel;
-	private readonly StrategyParam<StrategyMode> _mode;
+	private readonly StrategyParam<StrategyModes> _mode;
 	private readonly StrategyParam<decimal> _takeProfit;
 	private readonly StrategyParam<decimal> _stopLoss;
 
@@ -41,7 +41,7 @@ public class NRatioSignStrategy : Strategy
 	/// <summary>
 	/// NRatio calculation mode.
 	/// </summary>
-	public enum StrategyMode
+	public enum StrategyModes
 	{
 		ModeIn,
 		ModeOut,
@@ -113,7 +113,7 @@ public class NRatioSignStrategy : Strategy
 	/// <summary>
 	/// Signal generation mode.
 	/// </summary>
-	public StrategyMode Mode
+	public StrategyModes Mode
 	{
 		get => _mode.Value;
 		set => _mode.Value = value;
@@ -166,7 +166,7 @@ public class NRatioSignStrategy : Strategy
 		_downLevel = Param(nameof(DownLevel), 20m)
 		.SetDisplay("Down Level", "Lower NRatio threshold", "Indicator");
 
-		_mode = Param(nameof(Mode), StrategyMode.ModeOut)
+		_mode = Param(nameof(Mode), StrategyModes.ModeOut)
 		.SetDisplay("Mode", "Signal generation mode", "Indicator");
 
 		_takeProfit = Param(nameof(TakeProfitPercent), 2m)
@@ -284,7 +284,7 @@ public class NRatioSignStrategy : Strategy
 	var buySignal = false;
 	var sellSignal = false;
 
-	if (Mode == StrategyMode.ModeIn)
+	if (Mode == StrategyModes.ModeIn)
 	{
 	if (nratio > UpLevel && _nratioPrev <= UpLevel)
 	buySignal = true;

--- a/API/1981_ColorNonLagDotMACD/CS/ColorNonLagDotMacdStrategy.cs
+++ b/API/1981_ColorNonLagDotMACD/CS/ColorNonLagDotMacdStrategy.cs
@@ -22,7 +22,7 @@ public class ColorNonLagDotMacdStrategy : Strategy
 	/// <summary>
 	/// Algorithm mode for generating signals.
 	/// </summary>
-	public enum AlgorithmMode
+	public enum AlgorithmModes
 	{
 	    /// <summary>
 	    /// Trade on zero line breakout of MACD histogram.
@@ -48,7 +48,7 @@ public class ColorNonLagDotMacdStrategy : Strategy
 	private readonly StrategyParam<int> _fastLength;
 	private readonly StrategyParam<int> _slowLength;
 	private readonly StrategyParam<int> _signalLength;
-	private readonly StrategyParam<AlgorithmMode> _mode;
+	private readonly StrategyParam<AlgorithmModes> _mode;
 	private readonly StrategyParam<bool> _buyOpen;
 	private readonly StrategyParam<bool> _sellOpen;
 	private readonly StrategyParam<bool> _buyClose;
@@ -92,7 +92,7 @@ public class ColorNonLagDotMacdStrategy : Strategy
 	/// <summary>
 	/// Mode that defines how signals are detected.
 	/// </summary>
-	public AlgorithmMode Mode
+	public AlgorithmModes Mode
 	{
 	    get => _mode.Value;
 	    set => _mode.Value = value;
@@ -184,7 +184,7 @@ public class ColorNonLagDotMacdStrategy : Strategy
 	        .SetCanOptimize(true)
 	        .SetOptimize(5, 15, 2);
 
-	    _mode = Param(nameof(Mode), AlgorithmMode.MacdDisposition)
+	    _mode = Param(nameof(Mode), AlgorithmModes.MacdDisposition)
 	        .SetDisplay("Mode", "Signal detection mode", "General");
 
 	    _buyOpen = Param(nameof(BuyPosOpen), true)
@@ -273,19 +273,19 @@ public class ColorNonLagDotMacdStrategy : Strategy
 
 	    switch (Mode)
 	    {
-	        case AlgorithmMode.Breakdown:
+	        case AlgorithmModes.Breakdown:
 	            buySignal = _prevMacd <= 0 && macd > 0;
 	            sellSignal = _prevMacd >= 0 && macd < 0;
 	            break;
-	        case AlgorithmMode.MacdTwist:
+	        case AlgorithmModes.MacdTwist:
 	            buySignal = _prevMacd < _prevMacd2 && macd > _prevMacd;
 	            sellSignal = _prevMacd > _prevMacd2 && macd < _prevMacd;
 	            break;
-	        case AlgorithmMode.SignalTwist:
+	        case AlgorithmModes.SignalTwist:
 	            buySignal = _prevSignal < _prevSignal2 && signal > _prevSignal;
 	            sellSignal = _prevSignal > _prevSignal2 && signal < _prevSignal;
 	            break;
-	        case AlgorithmMode.MacdDisposition:
+	        case AlgorithmModes.MacdDisposition:
 	            buySignal = _prevMacd <= _prevSignal && macd > signal;
 	            sellSignal = _prevMacd >= _prevSignal && macd < signal;
 	            break;


### PR DESCRIPTION
## Summary
- rename enums across the API 1001-2000 strategy range so identifiers end with plural forms
- drop leftover `Enum` suffixes from the affected strategy enums

## Testing
- `dotnet build AlgoTrading.sln` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8377c5a8883238d98d39f0f642866