### PR TITLE
Move strategy enums inside class definitions

### DIFF
--- a/API/0557_Bbtrend_Supertrend_Decision/CS/BbtrendSupertrendDecisionStrategy.cs
+++ b/API/0557_Bbtrend_Supertrend_Decision/CS/BbtrendSupertrendDecisionStrategy.cs
@@ -21,6 +21,17 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class BbtrendSupertrendDecisionStrategy : Strategy
 {
+	/// <summary>
+	/// Protection mode for take profit and stop loss.
+	/// </summary>
+	public enum TpSlModes
+	{
+		None,
+		TP,
+		SL,
+		Both
+	}
+
 	private readonly StrategyParam<int> _shortBbLength;
 	private readonly StrategyParam<int> _longBbLength;
 	private readonly StrategyParam<decimal> _stdDev;
@@ -277,15 +288,4 @@ public class BbtrendSupertrendDecisionStrategy : Strategy
 		_prevDn = dn;
 		_prevSt = st;
 	}
-}
-
-/// <summary>
-/// Protection mode for take profit and stop loss.
-/// </summary>
-public enum TpSlModes
-{
-	None,
-	TP,
-	SL,
-	Both
 }

--- a/API/0576_Bullish_Bs_Rsi_Divergence/CS/BullishBsRsiDivergenceStrategy.cs
+++ b/API/0576_Bullish_Bs_Rsi_Divergence/CS/BullishBsRsiDivergenceStrategy.cs
@@ -18,6 +18,19 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class BullishBsRsiDivergenceStrategy : Strategy
 {
+	/// <summary>
+	/// Trailing stop-loss types.
+	/// </summary>
+	public enum TrailingStopTypes
+	{
+		/// <summary> No trailing stop. </summary>
+		None,
+		/// <summary> ATR based trailing stop. </summary>
+		Atr,
+		/// <summary> Percent based trailing stop. </summary>
+		Percent
+	}
+
 	private readonly StrategyParam<int> _rsiPeriod;
 	private readonly StrategyParam<int> _pivotRight;
 	private readonly StrategyParam<int> _pivotLeft;
@@ -233,17 +246,4 @@ public class BullishBsRsiDivergenceStrategy : Strategy
 		}
 	}
 
-}
-
-/// <summary>
-/// Trailing stop-loss types.
-/// </summary>
-public enum TrailingStopTypes
-{
-	/// <summary> No trailing stop. </summary>
-	None,
-	/// <summary> ATR based trailing stop. </summary>
-	Atr,
-	/// <summary> Percent based trailing stop. </summary>
-	Percent
 }

--- a/API/0585_BuySell_Bullish_Engulfing/CS/BuySellBullishEngulfingStrategy.cs
+++ b/API/0585_BuySell_Bullish_Engulfing/CS/BuySellBullishEngulfingStrategy.cs
@@ -18,6 +18,27 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class BuySellBullishEngulfingStrategy : Strategy
 {
+	/// <summary>
+	/// Trend detection modes.
+	/// </summary>
+	public enum TrendModes
+	{
+		/// <summary>
+		/// Price below SMA50.
+		/// </summary>
+		Sma50,
+
+		/// <summary>
+		/// Price below SMA50 and SMA50 below SMA200.
+		/// </summary>
+		Sma50And200,
+
+		/// <summary>
+		/// No trend check.
+		/// </summary>
+		None
+	}
+
 	private readonly StrategyParam<int> _bodyEmaLength;
 
 	private readonly StrategyParam<DataType> _candleType;
@@ -205,25 +226,4 @@ public class BuySellBullishEngulfingStrategy : Strategy
 		var size = portfolioValue * (OrderPercent / 100m) / price;
 		return size > 0 ? size : Volume;
 	}
-}
-
-/// <summary>
-/// Trend detection modes.
-/// </summary>
-public enum TrendModes
-{
-	/// <summary>
-	/// Price below SMA50.
-	/// </summary>
-	Sma50,
-
-	/// <summary>
-	/// Price below SMA50 and SMA50 below SMA200.
-	/// </summary>
-	Sma50And200,
-
-	/// <summary>
-	/// No trend check.
-	/// </summary>
-	None
 }

--- a/API/0611_Chande_Kroll_Trend/CS/ChandeKrollTrendStrategy.cs
+++ b/API/0611_Chande_Kroll_Trend/CS/ChandeKrollTrendStrategy.cs
@@ -23,6 +23,21 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class ChandeKrollTrendStrategy : Strategy
 {
+	/// <summary>
+	/// Position size calculation modes.
+	/// </summary>
+	public enum CalcModes
+	{
+		/// <summary>
+		/// Use fixed multiplier.
+		/// </summary>
+		Linear,
+		/// <summary>
+		/// Scale by current equity.
+		/// </summary>
+		Exponential
+	}
+
 	private readonly StrategyParam<CalcModes> _calcMode;
 	private readonly StrategyParam<decimal> _riskMultiplier;
 	private readonly StrategyParam<int> _atrPeriod;
@@ -210,19 +225,4 @@ public class ChandeKrollTrendStrategy : Strategy
 		_prevClose = candle.ClosePrice;
 		_prevLowStop = lowStop;
 	}
-}
-
-/// <summary>
-/// Position size calculation modes.
-/// </summary>
-public enum CalcModes
-{
-	/// <summary>
-	/// Use fixed multiplier.
-	/// </summary>
-	Linear,
-	/// <summary>
-	/// Scale by current equity.
-	/// </summary>
-	Exponential
 }

--- a/API/0672_Delta_RSI_Oscillator/CS/DeltaRsiOscillatorStrategy.cs
+++ b/API/0672_Delta_RSI_Oscillator/CS/DeltaRsiOscillatorStrategy.cs
@@ -11,20 +11,18 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-
-
-public enum SignalConditions
-{
-	ZeroCrossing,
-	SignalLineCrossing,
-	DirectionChange,
-}
-
 /// <summary>
 /// Delta-RSI Oscillator Strategy
 /// </summary>
 public class DeltaRsiOscillatorStrategy : Strategy
 {
+	public enum SignalConditions
+	{
+		ZeroCrossing,
+		SignalLineCrossing,
+		DirectionChange,
+	}
+
 	private readonly StrategyParam<DataType> _candleTypeParam;
 	private readonly StrategyParam<int> _rsiLength;
 	private readonly StrategyParam<int> _signalLength;

--- a/API/0757_Enhanced_Ichimoku_Cloud/CS/EnhancedIchimokuCloudStrategy.cs
+++ b/API/0757_Enhanced_Ichimoku_Cloud/CS/EnhancedIchimokuCloudStrategy.cs
@@ -19,14 +19,17 @@ namespace StockSharp.Samples.Strategies;
 /// the high 25 bars ago, Tenkan-sen above Kijun-sen and close above EMA.
 /// Exits when Tenkan-sen crosses below Kijun-sen.
 /// </summary>
-public enum TradeModes
-{
-	Ichi,
-	Cloud
-}
-
 public class EnhancedIchimokuCloudStrategy : Strategy
 {
+	/// <summary>
+	/// Trade mode options for Ichimoku Cloud processing.
+	/// </summary>
+	public enum TradeModes
+	{
+		Ichi,
+		Cloud
+	}
+
 	private readonly StrategyParam<int> _conversionPeriods;
 	private readonly StrategyParam<int> _basePeriods;
 	private readonly StrategyParam<int> _laggingSpan2Periods;

--- a/API/0834_Gaussian_Channel/CS/GaussianChannelStrategy.cs
+++ b/API/0834_Gaussian_Channel/CS/GaussianChannelStrategy.cs
@@ -12,26 +12,24 @@ using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-
-
-public enum LineSelections
-{
-	Filter,
-	Upper,
-	Lower
-}
-
-public enum CrossDirections
-{
-	CrossUp,
-	CrossDown
-}
-
 /// <summary>
 /// Gaussian Channel Strategy
 /// </summary>
 public class GaussianChannelStrategy : Strategy
 {
+	public enum LineSelections
+	{
+		Filter,
+		Upper,
+		Lower
+	}
+
+	public enum CrossDirections
+	{
+		CrossUp,
+		CrossDown
+	}
+
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<int> _period;
 	private readonly StrategyParam<decimal> _multiplier;

--- a/API/0880_High_Yield_Spread_SMA_Filter/CS/HighYieldSpreadSmaFilterStrategy.cs
+++ b/API/0880_High_Yield_Spread_SMA_Filter/CS/HighYieldSpreadSmaFilterStrategy.cs
@@ -13,12 +13,6 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-public enum SpreadBases
-{
-	HighYieldSpread,
-	Vix
-}
-
 /// <summary>
 /// Strategy that trades based on high yield spread or VIX with optional SMA filter.
 /// Goes long when spread rises above threshold and price passes SMA filter.
@@ -27,6 +21,12 @@ public enum SpreadBases
 /// </summary>
 public class HighYieldSpreadSmaFilterStrategy : Strategy
 {
+	public enum SpreadBases
+	{
+		HighYieldSpread,
+		Vix
+	}
+
 	private readonly StrategyParam<SpreadBases> _basis;
 	private readonly StrategyParam<decimal> _threshold;
 	private readonly StrategyParam<bool> _isLong;

--- a/API/0899_Hull_Suite_1_Risk_No_SL_TP/CS/HullSuite1RiskNoSlTpStrategy.cs
+++ b/API/0899_Hull_Suite_1_Risk_No_SL_TP/CS/HullSuite1RiskNoSlTpStrategy.cs
@@ -18,6 +18,13 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class HullSuite1RiskNoSlTpStrategy : Strategy
 {
+	public enum HullVariations
+	{
+		Hma,
+		Ehma,
+		Thma
+	}
+
 	private readonly StrategyParam<int> _hullLength;
 	private readonly StrategyParam<HullVariations> _mode;
 	private readonly StrategyParam<DataType> _candleType;
@@ -197,11 +204,4 @@ public class HullSuite1RiskNoSlTpStrategy : Strategy
 				throw new InvalidOperationException(Mode.ToString());
 		}
 	}
-}
-
-public enum HullVariations
-{
-	Hma,
-	Ehma,
-	Thma
 }

--- a/API/0902_Hurst_Future_Lines_of_Demarcation/CS/HurstFutureLinesOfDemarcationStrategy.cs
+++ b/API/0902_Hurst_Future_Lines_of_Demarcation/CS/HurstFutureLinesOfDemarcationStrategy.cs
@@ -13,17 +13,17 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-public enum CloseTriggers
-{
-Price,
-Signal,
-Trade,
-Trend,
-None
-}
-
 public class HurstFutureLinesOfDemarcationStrategy : Strategy
 {
+	public enum CloseTriggers
+	{
+	Price,
+	Signal,
+	Trade,
+	Trend,
+	None
+	}
+
 private SimpleMovingAverage _sma;
 private readonly Queue<decimal> _signalQueue = new();
 private readonly Queue<decimal> _tradeQueue = new();

--- a/API/0904_Ibs_Internal_Bar_Strength/CS/IbsInternalBarStrengthStrategy.cs
+++ b/API/0904_Ibs_Internal_Bar_Strength/CS/IbsInternalBarStrengthStrategy.cs
@@ -13,18 +13,18 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-public enum TradeTypes
-{
-	Long,
-	Short,
-	All
-}
-
 /// <summary>
 /// Internal Bar Strength mean reversion strategy with optional EMA filter and dollar-cost averaging.
 /// </summary>
 public class IbsInternalBarStrengthStrategy : Strategy
 {
+	public enum TradeTypes
+	{
+		Long,
+		Short,
+		All
+	}
+
 	private readonly StrategyParam<decimal> _ibsEntryThreshold;
 	private readonly StrategyParam<decimal> _ibsExitThreshold;
 	private readonly StrategyParam<int> _emaPeriod;

--- a/API/0961_LANZ_2_0_Backtest/CS/Lanz20BacktestStrategy.cs
+++ b/API/0961_LANZ_2_0_Backtest/CS/Lanz20BacktestStrategy.cs
@@ -21,6 +21,19 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class Lanz20BacktestStrategy : Strategy
 {
+	/// <summary>
+	/// Modes of stop-loss protection.
+	/// </summary>
+	public enum SlProtectionModeOptions
+	{
+		/// <summary>Use last swing.</summary>
+		FirstSwing,
+		/// <summary>Use second swing.</summary>
+		SecondSwing,
+		/// <summary>Use full coverage of swings.</summary>
+		FullCoverage
+	}
+
 	private readonly StrategyParam<decimal> _accountSizeUsd;
 	private readonly StrategyParam<decimal> _riskPercent;
 	private readonly StrategyParam<SlProtectionModeOptions> _slProtectionMode;
@@ -366,18 +379,5 @@ public class Lanz20BacktestStrategy : Strategy
 			}
 		}
 	}
-}
-
-/// <summary>
-/// Modes of stop-loss protection.
-/// </summary>
-public enum SlProtectionModeOptions
-{
-	/// <summary>Use last swing.</summary>
-	FirstSwing,
-	/// <summary>Use second swing.</summary>
-	SecondSwing,
-	/// <summary>Use full coverage of swings.</summary>
-	FullCoverage
 }
 

--- a/API/0993_Long_Short_Exit_Risk_Management/CS/LongShortExitRiskManagementStrategy.cs
+++ b/API/0993_Long_Short_Exit_Risk_Management/CS/LongShortExitRiskManagementStrategy.cs
@@ -12,21 +12,19 @@ using StockSharp.Algo;
 
 namespace StockSharp.Samples.Strategies;
 
-
-
-public enum TradingDirections
-{
-	LongOnly,
-	ShortOnly,
-	All,
-}
-
 /// <summary>
 /// Basic strategy demonstrating long and short entries with
 /// percentage based risk management.
 /// </summary>
 public class LongShortExitRiskManagementStrategy : Strategy
 {
+	public enum TradingDirections
+	{
+		LongOnly,
+		ShortOnly,
+		All,
+	}
+
 	private readonly StrategyParam<TradingDirections> _tradingDirection;
 	private readonly StrategyParam<decimal> _stopLossPercent;
 	private readonly StrategyParam<decimal> _takeProfitPercent;

--- a/API/0997_Long_Only_Opening_Range_Breakout_ORB_with_Pivot_Points/CS/LongOnlyOpeningRangeBreakoutWithPivotPointsStrategy.cs
+++ b/API/0997_Long_Only_Opening_Range_Breakout_ORB_with_Pivot_Points/CS/LongOnlyOpeningRangeBreakoutWithPivotPointsStrategy.cs
@@ -11,19 +11,17 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-
-
-public enum SlTypes
-{
-	Percentage,
-	PreviousLow
-}
-
 /// <summary>
 /// Long-only opening range breakout with pivot point trailing stop.
 /// </summary>
 public class LongOnlyOpeningRangeBreakoutWithPivotPointsStrategy : Strategy
 {
+	public enum SlTypes
+	{
+		Percentage,
+		PreviousLow
+	}
+
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<TimeSpan> _sessionStart;
 	private readonly StrategyParam<int> _rangeMinutes;


### PR DESCRIPTION
## Summary
- nest the various strategy-specific enums directly inside their respective strategy classes across the API 0000-1000 range to keep enum scope local

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d83d4e72608323b4bbb7c57e2a67f9