### PR TITLE
Move strategy enums inside their classes

### DIFF
--- a/API/1107_Mutanabby_AI_Algo_Pro/CS/MutanabbyAiAlgoProStrategy.cs
+++ b/API/1107_Mutanabby_AI_Algo_Pro/CS/MutanabbyAiAlgoProStrategy.cs
@@ -14,27 +14,27 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies;
 
 /// <summary>
-/// Defines stop loss calculation modes.
-/// </summary>
-public enum StopLossModes
-{
-/// <summary>
-/// Stop loss is calculated from entry price.
-/// </summary>
-EntryPriceBased,
-
-/// <summary>
-/// Stop loss is based on the lowest low over a period.
-/// </summary>
-LowestLowBased
-}
-
-/// <summary>
 /// Mutanabby AI Algo Pro strategy.
 /// Enters long on bullish engulfing with RSI and price filters.
 /// </summary>
 public class MutanabbyAiAlgoProStrategy : Strategy
 {
+        /// <summary>
+        /// Defines stop loss calculation modes.
+        /// </summary>
+        public enum StopLossModes
+        {
+                /// <summary>
+                /// Stop loss is calculated from entry price.
+                /// </summary>
+                EntryPriceBased,
+
+                /// <summary>
+                /// Stop loss is based on the lowest low over a period.
+                /// </summary>
+                LowestLowBased
+        }
+
 private readonly StrategyParam<decimal> _candleStabilityIndex;
 private readonly StrategyParam<int> _rsiIndex;
 private readonly StrategyParam<int> _candleDeltaLength;

--- a/API/1127_NY_Opening_Range_Breakout_MA_Stop/CS/NyOpeningRangeBreakoutMaStopStrategy.cs
+++ b/API/1127_NY_Opening_Range_Breakout_MA_Stop/CS/NyOpeningRangeBreakoutMaStopStrategy.cs
@@ -18,20 +18,20 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class NyOpeningRangeBreakoutMaStopStrategy : Strategy
 {
-public enum TakeProfitOptions
-	{
-		FixedRiskReward,
-		MovingAverage,
-		Both
-	}
+        public enum TakeProfitOptions
+        {
+                FixedRiskReward,
+                MovingAverage,
+                Both
+        }
 
-	public enum MovingAverageTypes
-	{
-		SMA,
-		EMA,
-		WMA,
-		VWMA
-	}
+        public enum MovingAverageTypes
+        {
+                SMA,
+                EMA,
+                WMA,
+                VWMA
+        }
 
 private readonly StrategyParam<int> _cutoffHour;
 private readonly StrategyParam<int> _cutoffMinute;

--- a/API/1140_Options_V13/CS/OptionsV13Strategy.cs
+++ b/API/1140_Options_V13/CS/OptionsV13Strategy.cs
@@ -13,19 +13,19 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-public enum SignalDirections
-{
-	Long,
-	Short,
-	Both
-}
-
 /// <summary>
 /// EMA crossover strategy with RSI and volume filter.
 /// </summary>
 public class OptionsV13Strategy : Strategy
 {
-	private readonly StrategyParam<int> _emaShortLength;
+        public enum SignalDirections
+        {
+                Long,
+                Short,
+                Both
+        }
+
+        private readonly StrategyParam<int> _emaShortLength;
 	private readonly StrategyParam<int> _emaLongLength;
 	private readonly StrategyParam<int> _rsiLength;
 	private readonly StrategyParam<int> _rsiLongThreshold;

--- a/API/1176_Power_Hour_Money/CS/PowerHourMoneyStrategy.cs
+++ b/API/1176_Power_Hour_Money/CS/PowerHourMoneyStrategy.cs
@@ -21,7 +21,28 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class PowerHourMoneyStrategy : Strategy
 {
-	private readonly StrategyParam<TradingSessions> _session;
+        /// <summary>
+        /// Trading sessions.
+        /// </summary>
+        public enum TradingSessions
+        {
+                /// <summary>
+                /// NY Session 9:30-11:30.
+                /// </summary>
+                NySession,
+
+                /// <summary>
+                /// Extended NY Session 8-16.
+                /// </summary>
+                ExtendedNy,
+
+                /// <summary>
+                /// All sessions.
+                /// </summary>
+                All
+        }
+
+        private readonly StrategyParam<TradingSessions> _session;
 	private readonly StrategyParam<bool> _useTrail;
 	private readonly StrategyParam<decimal> _longTrail;
 	private readonly StrategyParam<decimal> _shortTrail;
@@ -255,25 +276,4 @@ public class PowerHourMoneyStrategy : Strategy
 				BuyMarket(Math.Abs(Position));
 		}
 	}
-}
-
-/// <summary>
-/// Trading sessions.
-/// </summary>
-public enum TradingSessions
-{
-	/// <summary>
-	/// NY Session 9:30-11:30.
-	/// </summary>
-	NySession,
-
-	/// <summary>
-	/// Extended NY Session 8-16.
-	/// </summary>
-	ExtendedNy,
-
-	/// <summary>
-	/// All sessions.
-	/// </summary>
-	All
 }

--- a/API/1267_RSI_Divergence_AliferCrypto/CS/RsiDivergenceAliferCryptoStrategy.cs
+++ b/API/1267_RSI_Divergence_AliferCrypto/CS/RsiDivergenceAliferCryptoStrategy.cs
@@ -17,7 +17,46 @@ namespace StockSharp.Samples.Strategies;
 /// RSI divergence strategy with optional trend and RSI zone filters.
 /// </summary>
 public class RsiDivergenceAliferCryptoStrategy : Strategy {
-	private readonly StrategyParam<int> _rsiLength;
+        /// <summary>
+        /// Moving average types.
+        /// </summary>
+        public enum MaTypes
+        {
+                /// <summary> Simple moving average. </summary>
+                Sma,
+                /// <summary> Exponential moving average. </summary>
+                Ema,
+                /// <summary> Smoothed moving average. </summary>
+                Smma,
+                /// <summary> Weighted moving average. </summary>
+                Wma,
+                /// <summary> Volume weighted moving average. </summary>
+                Vwma
+        }
+
+        /// <summary>
+        /// Stop loss and take profit calculation method.
+        /// </summary>
+        public enum SlTpMethods
+        {
+                /// <summary> Use recent swing high/low. </summary>
+                Swing,
+                /// <summary> Use ATR based calculation. </summary>
+                Atr
+        }
+
+        /// <summary>
+        /// Exit levels mode.
+        /// </summary>
+        public enum ExitModes
+        {
+                /// <summary> Recalculate SL/TP each bar. </summary>
+                Dynamic,
+                /// <summary> Lock SL/TP at entry. </summary>
+                Static
+        }
+
+        private readonly StrategyParam<int> _rsiLength;
 	private readonly StrategyParam<int> _lookLeft;
 	private readonly StrategyParam<int> _lookRight;
 	private readonly StrategyParam<int> _rangeLower;
@@ -422,40 +461,4 @@ public class RsiDivergenceAliferCryptoStrategy : Strategy {
 			_ => new SimpleMovingAverage { Length = length },
 		};
 	}
-}
-
-/// <summary>
-/// Moving average types.
-/// </summary>
-public enum MaTypes {
-	/// <summary> Simple moving average. </summary>
-	Sma,
-	/// <summary> Exponential moving average. </summary>
-	Ema,
-	/// <summary> Smoothed moving average. </summary>
-	Smma,
-	/// <summary> Weighted moving average. </summary>
-	Wma,
-	/// <summary> Volume weighted moving average. </summary>
-	Vwma
-}
-
-/// <summary>
-/// Stop loss and take profit calculation method.
-/// </summary>
-public enum SlTpMethods {
-	/// <summary> Use recent swing high/low. </summary>
-	Swing,
-	/// <summary> Use ATR based calculation. </summary>
-	Atr
-}
-
-/// <summary>
-/// Exit levels mode.
-/// </summary>
-public enum ExitModes {
-	/// <summary> Recalculate SL/TP each bar. </summary>
-	Dynamic,
-	/// <summary> Lock SL/TP at entry. </summary>
-	Static
 }

--- a/API/1294_Separated_Moving_Average/CS/SeparatedMovingAverageStrategy.cs
+++ b/API/1294_Separated_Moving_Average/CS/SeparatedMovingAverageStrategy.cs
@@ -13,16 +13,16 @@ using StockSharp.Messages;
 
 namespace StockSharp.Samples.Strategies;
 
-public enum MaTypes
-{
-	SMA,
-	EMA,
-	HMA,
-}
-
 public class SeparatedMovingAverageStrategy : Strategy
 {
-	private readonly StrategyParam<MaTypes> _maType;
+        public enum MaTypes
+        {
+                SMA,
+                EMA,
+                HMA,
+        }
+
+        private readonly StrategyParam<MaTypes> _maType;
 	private readonly StrategyParam<int> _length;
 	private readonly StrategyParam<bool> _useHeikinAshi;
 	private readonly StrategyParam<DataType> _candleType;

--- a/API/1339_Stochastic_Heat_Map/CS/StochasticHeatMapStrategy.cs
+++ b/API/1339_Stochastic_Heat_Map/CS/StochasticHeatMapStrategy.cs
@@ -19,7 +19,28 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class StochasticHeatMapStrategy : Strategy
 {
-	private readonly StrategyParam<int> _increment;
+        /// <summary>
+        /// Moving average type.
+        /// </summary>
+        public enum MaTypes
+        {
+                /// <summary>
+                /// Simple moving average.
+                /// </summary>
+                SMA,
+
+                /// <summary>
+                /// Exponential moving average.
+                /// </summary>
+                EMA,
+
+                /// <summary>
+                /// Weighted moving average.
+                /// </summary>
+                WMA
+        }
+
+        private readonly StrategyParam<int> _increment;
 	private readonly StrategyParam<int> _smoothFast;
 	private readonly StrategyParam<int> _smoothSlow;
 	private readonly StrategyParam<int> _plotNumber;
@@ -294,25 +315,4 @@ public class StochasticHeatMapValue : ComplexIndicatorValue
 	/// Slow line value.
 	/// </summary>
 	public decimal Slow => (decimal)GetValue(nameof(Slow));
-}
-
-/// <summary>
-/// Moving average type.
-/// </summary>
-public enum MaTypes
-{
-	/// <summary>
-	/// Simple moving average.
-	/// </summary>
-	SMA,
-
-	/// <summary>
-	/// Exponential moving average.
-	/// </summary>
-	EMA,
-
-	/// <summary>
-	/// Weighted moving average.
-	/// </summary>
-	WMA
 }

--- a/API/1513_Uptrick_X_PineIndicators_Z_Score_Flow/CS/UptrickXPineIndicatorsZScoreFlowStrategy.cs
+++ b/API/1513_Uptrick_X_PineIndicators_Z_Score_Flow/CS/UptrickXPineIndicatorsZScoreFlowStrategy.cs
@@ -18,12 +18,12 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class UptrickXPineIndicatorsZScoreFlowStrategy : Strategy
 {
-public enum TradeModes
-{
-Standard,
-ZeroCross,
-TrendReversal
-}
+        public enum TradeModes
+        {
+                Standard,
+                ZeroCross,
+                TrendReversal
+        }
 
 private readonly StrategyParam<DataType> _candleType;
 private readonly StrategyParam<int> _zScorePeriod;

--- a/API/1569_YinYang_RSI_Volume_Trend/CS/YinYangRsiVolumeTrendStrategy.cs
+++ b/API/1569_YinYang_RSI_Volume_Trend/CS/YinYangRsiVolumeTrendStrategy.cs
@@ -21,7 +21,26 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class YinYangRsiVolumeTrendStrategy : Strategy
 {
-	private readonly StrategyParam<int> _trendLength;
+        /// <summary>
+        /// Options for resetting purchase availability.
+        /// </summary>
+        public enum ResetConditions
+        {
+                /// <summary>
+                /// Reset after entry condition is met.
+                /// </summary>
+                Entry,
+                /// <summary>
+                /// Reset after stop-loss triggers.
+                /// </summary>
+                StopLoss,
+                /// <summary>
+                /// No automatic reset.
+                /// </summary>
+                None
+        }
+
+        private readonly StrategyParam<int> _trendLength;
 	private readonly StrategyParam<bool> _useTakeProfit;
 	private readonly StrategyParam<bool> _useStopLoss;
 	private readonly StrategyParam<decimal> _stopLossMultiplier;
@@ -301,23 +320,4 @@ public class YinYangRsiVolumeTrendStrategy : Strategy
 			_ => candle.ClosePrice,
 		};
 	}
-}
-
-/// <summary>
-/// Options for resetting purchase availability.
-/// </summary>
-public enum ResetConditions
-{
-	/// <summary>
-	/// Reset after entry condition is met.
-	/// </summary>
-	Entry,
-	/// <summary>
-	/// Reset after stop-loss triggers.
-	/// </summary>
-	StopLoss,
-	/// <summary>
-	/// No automatic reset.
-	/// </summary>
-	None
 }

--- a/API/1630_EMA_WPR_Retracement/CS/EmaWprRetracementStrategy.cs
+++ b/API/1630_EMA_WPR_Retracement/CS/EmaWprRetracementStrategy.cs
@@ -142,12 +142,12 @@ trailingStop: UseTrailingStop ? new Unit(TrailingStop, UnitTypes.Price) : null);
 Volume = OrderVolume;
 }
 
-private enum TrendDirections
-{
-None,
-Up,
-Down
-}
+        private enum TrendDirections
+        {
+                None,
+                Up,
+                Down
+        }
 
 private TrendDirections GetTrend()
 {

--- a/API/1641_X_Trail_2/CS/XTrail2Strategy.cs
+++ b/API/1641_X_Trail_2/CS/XTrail2Strategy.cs
@@ -18,7 +18,43 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class XTrail2Strategy : Strategy
 {
-	private readonly StrategyParam<int> _ma1Length;
+        /// <summary>
+        /// Moving average calculation method.
+        /// </summary>
+        public enum MovingAverageTypes
+        {
+                /// <summary>Simple moving average.</summary>
+                Simple,
+                /// <summary>Exponential moving average.</summary>
+                Exponential,
+                /// <summary>Smoothed moving average.</summary>
+                Smoothed,
+                /// <summary>Weighted moving average.</summary>
+                Weighted
+        }
+
+        /// <summary>
+        /// Price type used for indicator calculations.
+        /// </summary>
+        public enum AppliedPriceTypes
+        {
+                /// <summary>Close price.</summary>
+                Close,
+                /// <summary>Open price.</summary>
+                Open,
+                /// <summary>High price.</summary>
+                High,
+                /// <summary>Low price.</summary>
+                Low,
+                /// <summary>Median price (high + low) / 2.</summary>
+                Median,
+                /// <summary>Typical price (high + low + close) / 3.</summary>
+                Typical,
+                /// <summary>Weighted price (high + low + close * 2) / 4.</summary>
+                Weighted
+        }
+
+        private readonly StrategyParam<int> _ma1Length;
 	private readonly StrategyParam<int> _ma2Length;
 	private readonly StrategyParam<MovingAverageTypes> _ma1Type;
 	private readonly StrategyParam<MovingAverageTypes> _ma2Type;
@@ -184,40 +220,4 @@ public class XTrail2Strategy : Strategy
 			_ => candle.ClosePrice,
 		};
 	}
-}
-
-/// <summary>
-/// Moving average calculation method.
-/// </summary>
-public enum MovingAverageTypes
-{
-	/// <summary>Simple moving average.</summary>
-	Simple,
-	/// <summary>Exponential moving average.</summary>
-	Exponential,
-	/// <summary>Smoothed moving average.</summary>
-	Smoothed,
-	/// <summary>Weighted moving average.</summary>
-	Weighted
-}
-
-/// <summary>
-/// Price type used for indicator calculations.
-/// </summary>
-public enum AppliedPriceTypes
-{
-	/// <summary>Close price.</summary>
-	Close,
-	/// <summary>Open price.</summary>
-	Open,
-	/// <summary>High price.</summary>
-	High,
-	/// <summary>Low price.</summary>
-	Low,
-	/// <summary>Median price (high + low) / 2.</summary>
-	Median,
-	/// <summary>Typical price (high + low + close) / 3.</summary>
-	Typical,
-	/// <summary>Weighted price (high + low + close * 2) / 4.</summary>
-	Weighted
 }

--- a/API/1682_X_Alert_3/CS/XAlert3Strategy.cs
+++ b/API/1682_X_Alert_3/CS/XAlert3Strategy.cs
@@ -19,7 +19,37 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class XAlert3Strategy : Strategy
 {
-	private readonly StrategyParam<int> _ma1Period;
+        public enum MovingAverageTypes
+        {
+                /// <summary>Simple Moving Average.</summary>
+                Simple,
+                /// <summary>Exponential Moving Average.</summary>
+                Exponential,
+                /// <summary>Smoothed Moving Average.</summary>
+                Smoothed,
+                /// <summary>Weighted Moving Average.</summary>
+                Weighted
+        }
+
+        public enum PriceTypes
+        {
+                /// <summary>Close price.</summary>
+                Close,
+                /// <summary>Open price.</summary>
+                Open,
+                /// <summary>High price.</summary>
+                High,
+                /// <summary>Low price.</summary>
+                Low,
+                /// <summary>Median price (high+low)/2.</summary>
+                Median,
+                /// <summary>Typical price (high+low+close)/3.</summary>
+                Typical,
+                /// <summary>Weighted close price (high+low+close*2)/4.</summary>
+                Weighted
+        }
+
+        private readonly StrategyParam<int> _ma1Period;
 	private readonly StrategyParam<MovingAverageTypes> _ma1Type;
 	private readonly StrategyParam<int> _ma2Period;
 	private readonly StrategyParam<MovingAverageTypes> _ma2Type;
@@ -197,34 +227,4 @@ public class XAlert3Strategy : Strategy
 			_ => candle.ClosePrice
 		};
 	}
-}
-
-public enum MovingAverageTypes
-{
-	/// <summary>Simple Moving Average.</summary>
-	Simple,
-	/// <summary>Exponential Moving Average.</summary>
-	Exponential,
-	/// <summary>Smoothed Moving Average.</summary>
-	Smoothed,
-	/// <summary>Weighted Moving Average.</summary>
-	Weighted
-}
-
-public enum PriceTypes
-{
-	/// <summary>Close price.</summary>
-	Close,
-	/// <summary>Open price.</summary>
-	Open,
-	/// <summary>High price.</summary>
-	High,
-	/// <summary>Low price.</summary>
-	Low,
-	/// <summary>Median price (high+low)/2.</summary>
-	Median,
-	/// <summary>Typical price (high+low+close)/3.</summary>
-	Typical,
-	/// <summary>Weighted close price (high+low+close*2)/4.</summary>
-	Weighted
 }

--- a/API/1691_Lego_4_Beta/CS/Lego4BetaStrategy.cs
+++ b/API/1691_Lego_4_Beta/CS/Lego4BetaStrategy.cs
@@ -19,7 +19,28 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class Lego4BetaStrategy : Strategy
 {
-	private readonly StrategyParam<bool> _useMaOpen;
+        /// <summary>
+        /// Moving average type.
+        /// </summary>
+        public enum MaTypes
+        {
+                /// <summary>
+                /// Simple moving average.
+                /// </summary>
+                SMA,
+
+                /// <summary>
+                /// Exponential moving average.
+                /// </summary>
+                EMA,
+
+                /// <summary>
+                /// Weighted moving average.
+                /// </summary>
+                WMA,
+        }
+
+        private readonly StrategyParam<bool> _useMaOpen;
 	private readonly StrategyParam<int> _fastMaLength;
 	private readonly StrategyParam<int> _slowMaLength;
 	private readonly StrategyParam<MaTypes> _maType;
@@ -347,25 +368,4 @@ public class Lego4BetaStrategy : Strategy
 			_ => new ExponentialMovingAverage { Length = length },
 		};
 	}
-}
-
-/// <summary>
-/// Moving average type.
-/// </summary>
-public enum MaTypes
-{
-	/// <summary>
-	/// Simple moving average.
-	/// </summary>
-	SMA,
-
-	/// <summary>
-	/// Exponential moving average.
-	/// </summary>
-	EMA,
-
-	/// <summary>
-	/// Weighted moving average.
-	/// </summary>
-	WMA,
 }

--- a/API/1781_Xmacd_Modes/CS/XmacdModesStrategy.cs
+++ b/API/1781_Xmacd_Modes/CS/XmacdModesStrategy.cs
@@ -18,7 +18,15 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class XmacdModesStrategy : Strategy
 {
-	private readonly StrategyParam<int> _fastEmaPeriod;
+        public enum XmacdModes
+        {
+                Breakdown,
+                MacdTwist,
+                SignalTwist,
+                MacdDisposition
+        }
+
+        private readonly StrategyParam<int> _fastEmaPeriod;
 	private readonly StrategyParam<int> _slowEmaPeriod;
 	private readonly StrategyParam<int> _signalPeriod;
 	private readonly StrategyParam<DataType> _candleType;
@@ -185,12 +193,4 @@ public class XmacdModesStrategy : Strategy
 		_prevSignal2 = _prevSignal;
 		_prevSignal = signal;
 	}
-}
-
-public enum XmacdModes
-{
-	Breakdown,
-	MacdTwist,
-	SignalTwist,
-	MacdDisposition
 }

--- a/API/1820_Price_Action/CS/PriceActionStrategy.cs
+++ b/API/1820_Price_Action/CS/PriceActionStrategy.cs
@@ -19,7 +19,23 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class PriceActionStrategy : Strategy
 {
-	private readonly StrategyParam<decimal> _tp;
+        /// <summary>
+        /// Trade direction options.
+        /// </summary>
+        public enum TradeDirections
+        {
+                /// <summary>
+                /// Start with long trades.
+                /// </summary>
+                Buy,
+
+                /// <summary>
+                /// Start with short trades.
+                /// </summary>
+                Sell
+        }
+
+        private readonly StrategyParam<decimal> _tp;
 	private readonly StrategyParam<decimal> _leverage;
 	private readonly StrategyParam<decimal> _trailingStop;
 	private readonly StrategyParam<decimal> _trailingStep;
@@ -152,10 +168,4 @@ public class PriceActionStrategy : Strategy
 				BuyMarket(-Position);
 		}
 	}
-}
-
-public enum TradeDirections
-{
-	Buy = 1,
-	Sell = 2
 }

--- a/API/1862_Bulls_vs_Bears_Crossover/CS/BullsVsBearsCrossoverStrategy.cs
+++ b/API/1862_Bulls_vs_Bears_Crossover/CS/BullsVsBearsCrossoverStrategy.cs
@@ -19,7 +19,33 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class BullsVsBearsCrossoverStrategy : Strategy
 {
-	private readonly StrategyParam<MovingAverageTypes> _maType;
+        /// <summary>
+        /// Moving average types.
+        /// </summary>
+        public enum MovingAverageTypes
+        {
+                /// <summary>
+                /// Simple moving average.
+                /// </summary>
+                SMA,
+
+                /// <summary>
+                /// Exponential moving average.
+                /// </summary>
+                EMA,
+
+                /// <summary>
+                /// Smoothed moving average.
+                /// </summary>
+                SMMA,
+
+                /// <summary>
+                /// Weighted moving average.
+                /// </summary>
+                WMA
+        }
+
+        private readonly StrategyParam<MovingAverageTypes> _maType;
 	private readonly StrategyParam<int> _maLength;
 	private readonly StrategyParam<decimal> _stopLoss;
 	private readonly StrategyParam<decimal> _takeProfit;
@@ -266,30 +292,4 @@ public class BullsVsBearsCrossoverStrategy : Strategy
 			_ => new SimpleMovingAverage { Length = length },
 		};
 	}
-}
-
-/// <summary>
-/// Moving average types.
-/// </summary>
-public enum MovingAverageTypes
-{
-	/// <summary>
-	/// Simple moving average.
-	/// </summary>
-	SMA,
-
-	/// <summary>
-	/// Exponential moving average.
-	/// </summary>
-	EMA,
-
-	/// <summary>
-	/// Smoothed moving average.
-	/// </summary>
-	SMMA,
-
-	/// <summary>
-	/// Weighted moving average.
-	/// </summary>
-	WMA
 }

--- a/API/1897_ExpOracle/CS/ExpOracleStrategy.cs
+++ b/API/1897_ExpOracle/CS/ExpOracleStrategy.cs
@@ -20,9 +20,30 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class ExpOracleStrategy : Strategy
 {
-	private readonly StrategyParam<int> _oraclePeriod;
-	private readonly StrategyParam<int> _smooth;
-	private readonly StrategyParam<AlgorithmModes> _mode;
+        /// <summary>
+        /// Trading algorithm modes.
+        /// </summary>
+        public enum AlgorithmModes
+        {
+                /// <summary>
+                /// Signal line crossing zero.
+                /// </summary>
+                Breakdown,
+
+                /// <summary>
+                /// Change of signal line direction.
+                /// </summary>
+                Twist,
+
+                /// <summary>
+                /// Signal line crossing main line.
+                /// </summary>
+                Disposition
+        }
+
+        private readonly StrategyParam<int> _oraclePeriod;
+        private readonly StrategyParam<int> _smooth;
+        private readonly StrategyParam<AlgorithmModes> _mode;
 	private readonly StrategyParam<DataType> _candleType;
 	private readonly StrategyParam<bool> _allowBuy;
 	private readonly StrategyParam<bool> _allowSell;
@@ -188,27 +209,6 @@ public class ExpOracleStrategy : Strategy
 		_prevSignal = signal;
 		_prevOracle = oracle;
 	}
-}
-
-/// <summary>
-/// Trading algorithm modes.
-/// </summary>
-public enum AlgorithmModes
-{
-	/// <summary>
-	/// Signal line crossing zero.
-	/// </summary>
-	Breakdown,
-
-	/// <summary>
-	/// Change of signal line direction.
-	/// </summary>
-	Twist,
-
-	/// <summary>
-	/// Signal line crossing main line.
-	/// </summary>
-	Disposition
 }
 
 /// <summary>

--- a/API/1900_JBrainUltraRsi/CS/JBrainUltraRsiStrategy.cs
+++ b/API/1900_JBrainUltraRsi/CS/JBrainUltraRsiStrategy.cs
@@ -19,6 +19,16 @@ namespace StockSharp.Samples.Strategies;
 /// </summary>
 public class JBrainUltraRsiStrategy : Strategy
 {
+        /// <summary>
+        /// Combination modes for indicators.
+        /// </summary>
+        public enum AlgorithmModes
+        {
+                JBrainSig1Filter,
+                UltraRsiFilter,
+                Composition
+        }
+
 	private readonly StrategyParam<int> _rsiPeriod;
 	private readonly StrategyParam<int> _stochLength;
 	private readonly StrategyParam<int> _signalLength;
@@ -287,14 +297,4 @@ public class JBrainUltraRsiStrategy : Strategy
 		_prevK = k;
 		_prevD = d;
 	}
-}
-
-/// <summary>
-/// Combination modes for indicators.
-/// </summary>
-public enum AlgorithmModes
-{
-	JBrainSig1Filter,
-	UltraRsiFilter,
-	Composition
 }


### PR DESCRIPTION
## Summary
- move the previously top-level enums into their corresponding strategy classes across the API strategies in the 1001-2000 range

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d840ef31fc8323bfc7e9992dee66f0