### PR TITLE
Nest enums inside 4xxx strategy classes

### DIFF
--- a/API/4105_Symbol_Synthesizer/CS/SymbolSynthesizerStrategy.cs
+++ b/API/4105_Symbol_Synthesizer/CS/SymbolSynthesizerStrategy.cs
@@ -41,6 +41,27 @@ public class SymbolSynthesizerStrategy : Strategy
 		new("GBPCHF", "GBPUSD", "USDCHF", true)
 	};
 
+	/// <summary>
+	/// Manual actions exposed by <see cref="SymbolSynthesizerStrategy"/>.
+	/// </summary>
+	public enum SyntheticTradeActions
+	{
+		/// <summary>
+		/// No action requested.
+		/// </summary>
+		None,
+
+		/// <summary>
+		/// Open the synthetic position using buy logic.
+		/// </summary>
+		Buy,
+
+		/// <summary>
+		/// Open the synthetic position using sell logic.
+		/// </summary>
+		Sell
+	}
+
 	private readonly StrategyParam<int> _combinationParam;
 	private readonly StrategyParam<SyntheticTradeActions> _tradeActionParam;
 
@@ -390,23 +411,3 @@ public class SymbolSynthesizerStrategy : Strategy
 	}
 }
 
-/// <summary>
-/// Manual actions exposed by <see cref="SymbolSynthesizerStrategy"/>.
-/// </summary>
-public enum SyntheticTradeActions
-{
-	/// <summary>
-	/// No action requested.
-	/// </summary>
-	None,
-
-	/// <summary>
-	/// Open the synthetic position using buy logic.
-	/// </summary>
-	Buy,
-
-	/// <summary>
-	/// Open the synthetic position using sell logic.
-	/// </summary>
-	Sell
-}

--- a/API/4140_FiftyFiveMedianSlope/CS/FiftyFiveMedianSlopeStrategy.cs
+++ b/API/4140_FiftyFiveMedianSlope/CS/FiftyFiveMedianSlopeStrategy.cs
@@ -39,6 +39,17 @@ public class FiftyFiveMedianSlopeStrategy : Strategy
 	private bool _allowSell = true;
 	private decimal _alignedBaseVolume;
 
+	/// <summary>
+	/// Moving average calculation methods supported by the strategy.
+	/// </summary>
+	public enum MovingAverageKinds
+	{
+		Simple,
+		Exponential,
+		Smoothed,
+		LinearWeighted
+	}
+
 	public FiftyFiveMedianSlopeStrategy()
 	{
 		_fixedVolume = Param(nameof(FixedVolume), 1m)
@@ -486,13 +497,3 @@ public class FiftyFiveMedianSlopeStrategy : Strategy
 	}
 }
 
-/// <summary>
-/// Moving average calculation methods supported by the strategy.
-/// </summary>
-public enum MovingAverageKinds
-{
-	Simple,
-	Exponential,
-	Smoothed,
-	LinearWeighted
-}

--- a/API/4142_CCFp_Advisor/CS/CcfpAdvisorStrategy.cs
+++ b/API/4142_CCFp_Advisor/CS/CcfpAdvisorStrategy.cs
@@ -46,6 +46,17 @@ public class CcfpAdvisorStrategy : Strategy
 	private int _expectedPairs;
 
 	/// <summary>
+	/// Moving-average calculation modes supported by the strategy.
+	/// </summary>
+	public enum MovingAverageModes
+	{
+		Simple,
+		Exponential,
+		Smoothed,
+		Weighted,
+	}
+
+	/// <summary>
 	/// Initializes a new instance of <see cref="CcfpAdvisorStrategy"/>.
 	/// </summary>
 	public CcfpAdvisorStrategy()
@@ -893,17 +904,6 @@ private struct ActiveTrade
 	public Sides Side { get; set; }
 	public decimal Volume { get; set; }
 	public decimal? StopPrice { get; set; }
-}
-
-/// <summary>
-/// Moving-average calculation modes supported by the strategy.
-/// </summary>
-public enum MovingAverageModes
-{
-	Simple,
-	Exponential,
-	Smoothed,
-	Weighted,
 }
 
 private enum CurrencyIndexes

--- a/API/4183_Heiken_Ashi_Smoothed_MTF/CS/HeikenAshiSmoothedMtfStrategy.cs
+++ b/API/4183_Heiken_Ashi_Smoothed_MTF/CS/HeikenAshiSmoothedMtfStrategy.cs
@@ -49,6 +49,32 @@ public class HeikenAshiSmoothedMtfStrategy : Strategy
 	private int _currentStopSteps;
 
 	/// <summary>
+	/// Moving average methods supported by the smoothed Heiken Ashi calculation.
+	/// </summary>
+	public enum HaMaMethods
+	{
+		/// <summary>
+		/// Simple moving average.
+		/// </summary>
+		Simple,
+
+		/// <summary>
+		/// Exponential moving average.
+		/// </summary>
+		Exponential,
+
+		/// <summary>
+		/// Smoothed moving average.
+		/// </summary>
+		Smoothed,
+
+		/// <summary>
+		/// Linear weighted moving average.
+		/// </summary>
+		LinearWeighted
+	}
+
+	/// <summary>
 	/// Trade volume used for new entries.
 	/// </summary>
 	public decimal TradeVolume
@@ -673,28 +699,3 @@ public class HeikenAshiSmoothedMtfStrategy : Strategy
 	}
 }
 
-/// <summary>
-/// Moving average methods supported by the smoothed Heiken Ashi calculation.
-/// </summary>
-public enum HaMaMethods
-{
-	/// <summary>
-	/// Simple moving average.
-	/// </summary>
-	Simple,
-
-	/// <summary>
-	/// Exponential moving average.
-	/// </summary>
-	Exponential,
-
-	/// <summary>
-	/// Smoothed moving average.
-	/// </summary>
-	Smoothed,
-
-	/// <summary>
-	/// Linear weighted moving average.
-	/// </summary>
-	LinearWeighted
-}

--- a/API/4191_Ard_Order_Management_Command/CS/ArdOrderManagementCommandStrategy.cs
+++ b/API/4191_Ard_Order_Management_Command/CS/ArdOrderManagementCommandStrategy.cs
@@ -14,38 +14,6 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies;
 
 /// <summary>
-/// Order commands supported by <see cref="ArdOrderManagementCommandStrategy"/>.
-/// Mirrors the constants used by the original MQL expert advisor.
-/// </summary>
-public enum ArdOrderCommands
-{
-	/// <summary>
-	/// No action requested.
-	/// </summary>
-	None = 0,
-
-	/// <summary>
-	/// Open a long position.
-	/// </summary>
-	Buy = 1,
-
-	/// <summary>
-	/// Open a short position.
-	/// </summary>
-	Sell = 2,
-
-	/// <summary>
-	/// Close every open position on the primary symbol.
-	/// </summary>
-	Close = 3,
-
-	/// <summary>
-	/// Rebuild stop-loss and take-profit orders around the active position.
-	/// </summary>
-	Modify = 4,
-}
-
-/// <summary>
 /// High-level implementation of the "ARD Order Management" expert advisor.
 /// Allows manual commands (buy, sell, close, modify) while automatically managing stop-loss and take-profit orders.
 /// </summary>
@@ -70,6 +38,38 @@ public class ArdOrderManagementCommandStrategy : Strategy
 	private decimal _pendingEntryVolume;
 	private decimal _pendingStopPoints;
 	private decimal _pendingTakePoints;
+
+	/// <summary>
+	/// Order commands supported by <see cref="ArdOrderManagementCommandStrategy"/>.
+	/// Mirrors the constants used by the original MQL expert advisor.
+	/// </summary>
+	public enum ArdOrderCommands
+	{
+		/// <summary>
+		/// No action requested.
+		/// </summary>
+		None = 0,
+
+		/// <summary>
+		/// Open a long position.
+		/// </summary>
+		Buy = 1,
+
+		/// <summary>
+		/// Open a short position.
+		/// </summary>
+		Sell = 2,
+
+		/// <summary>
+		/// Close every open position on the primary symbol.
+		/// </summary>
+		Close = 3,
+
+		/// <summary>
+		/// Rebuild stop-loss and take-profit orders around the active position.
+		/// </summary>
+		Modify = 4,
+	}
 
 	/// <summary>
 	/// Accepted execution slippage in price steps.

--- a/API/4196_TrailingStopFrCnSar/CS/TrailingStopFrCnSarStrategy.cs
+++ b/API/4196_TrailingStopFrCnSar/CS/TrailingStopFrCnSarStrategy.cs
@@ -54,6 +54,16 @@ public class TrailingStopFrCnSarStrategy : Strategy
 
 	private string _lastSummary;
 
+	public enum TrailingStopModes
+	{
+		Off = 0,
+		Candle = 1,
+		Fractal = 2,
+		Velocity = 3,
+		Parabolic = 4,
+		FixedPoints = 5,
+	}
+
 	public TrailingStopFrCnSarStrategy()
 	{
 		_mode = Param(nameof(Mode), (int)TrailingStopModes.Candle)
@@ -724,12 +734,3 @@ public class TrailingStopFrCnSarStrategy : Strategy
 	}
 }
 
-public enum TrailingStopModes
-{
-	Off = 0,
-	Candle = 1,
-	Fractal = 2,
-	Velocity = 3,
-	Parabolic = 4,
-	FixedPoints = 5,
-}

--- a/API/4211_Cyclops_CycleIdentifier/CS/CyclopsCycleIdentifierStrategy.cs
+++ b/API/4211_Cyclops_CycleIdentifier/CS/CyclopsCycleIdentifierStrategy.cs
@@ -77,6 +77,22 @@ private readonly StrategyParam<CycleFilterModes> _cycleFilterMode;
 	private DateTimeOffset _currentBarTime;
 
 	/// <summary>
+	/// Defines the data source used by the zero-lag filter.
+	/// </summary>
+	public enum CycleFilterModes
+	{
+		/// <summary>
+		/// Use the smoothed price series as filter input.
+		/// </summary>
+		Sma = 1,
+
+		/// <summary>
+		/// Use a Wilder style RSI computed on the smoothed price series as filter input.
+		/// </summary>
+		Rsi = 2,
+	}
+
+	/// <summary>
 	/// Initializes a new instance of the <see cref="CyclopsCycleIdentifierStrategy"/> class.
 	/// </summary>
 	public CyclopsCycleIdentifierStrategy()
@@ -791,22 +807,6 @@ if (this.CycleFilterMode == CycleFilterModes.Sma)
 		_shortTakeProfitPrice = null;
 		_shortBreakEvenActive = false;
 	}
-}
-
-/// <summary>
-/// Defines the data source used by the zero-lag filter.
-/// </summary>
-public enum CycleFilterModes
-{
-/// <summary>
-/// Use the smoothed price series as filter input.
-/// </summary>
-Sma = 1,
-
-	/// <summary>
-	/// Use a Wilder style RSI computed on the smoothed price series as filter input.
-	/// </summary>
-	Rsi = 2,
 }
 
 internal readonly record struct CycleSignals(bool MajorBuy, bool MajorSell, bool MinorBuyExit, bool MinorSellExit);

--- a/API/4217_CCIT3_Zero_Cross/CS/Ccit3ZeroCrossStrategy.cs
+++ b/API/4217_CCIT3_Zero_Cross/CS/Ccit3ZeroCrossStrategy.cs
@@ -14,63 +14,6 @@ using StockSharp.Messages;
 namespace StockSharp.Samples.Strategies;
 
 /// <summary>
-/// Operating modes supported by <see cref="Ccit3ZeroCrossStrategy"/>.
-/// </summary>
-public enum Ccit3Modes
-{
-	/// <summary>
-	/// Classic CCIT3 calculation with persistent Tillson T3 smoothing.
-	/// </summary>
-	Simple,
-
-	/// <summary>
-	/// Non-recalculated CCIT3 variant that evaluates the Tillson chain only for the latest bar.
-	/// </summary>
-	NoRecalc,
-}
-
-/// <summary>
-/// Applied price options compatible with the CCIT3 port.
-/// </summary>
-public enum CciAppliedPriceTypes
-{
-	/// <summary>
-	/// Use candle close price.
-	/// </summary>
-	Close,
-
-	/// <summary>
-	/// Use candle open price.
-	/// </summary>
-	Open,
-
-	/// <summary>
-	/// Use candle high price.
-	/// </summary>
-	High,
-
-	/// <summary>
-	/// Use candle low price.
-	/// </summary>
-	Low,
-
-	/// <summary>
-	/// Use median price ((High + Low) / 2).
-	/// </summary>
-	Median,
-
-	/// <summary>
-	/// Use typical price ((High + Low + Close) / 3).
-	/// </summary>
-	Typical,
-
-	/// <summary>
-	/// Use weighted price ((High + Low + 2 * Close) / 4).
-	/// </summary>
-	Weighted,
-}
-
-/// <summary>
 /// Port of the MetaTrader CCIT3 expert advisor that trades zero-line crosses of a Tillson-smoothed CCI.
 /// </summary>
 public class Ccit3ZeroCrossStrategy : Strategy
@@ -103,6 +46,63 @@ public class Ccit3ZeroCrossStrategy : Strategy
 	private decimal _simpleE5;
 	private decimal _simpleE6;
 	private decimal? _previousT3;
+
+	/// <summary>
+	/// Operating modes supported by <see cref="Ccit3ZeroCrossStrategy"/>.
+	/// </summary>
+	public enum Ccit3Modes
+	{
+		/// <summary>
+		/// Classic CCIT3 calculation with persistent Tillson T3 smoothing.
+		/// </summary>
+		Simple,
+
+		/// <summary>
+		/// Non-recalculated CCIT3 variant that evaluates the Tillson chain only for the latest bar.
+		/// </summary>
+		NoRecalc,
+	}
+
+	/// <summary>
+	/// Applied price options compatible with the CCIT3 port.
+	/// </summary>
+	public enum CciAppliedPriceTypes
+	{
+		/// <summary>
+		/// Use candle close price.
+		/// </summary>
+		Close,
+
+		/// <summary>
+		/// Use candle open price.
+		/// </summary>
+		Open,
+
+		/// <summary>
+		/// Use candle high price.
+		/// </summary>
+		High,
+
+		/// <summary>
+		/// Use candle low price.
+		/// </summary>
+		Low,
+
+		/// <summary>
+		/// Use median price ((High + Low) / 2).
+		/// </summary>
+		Median,
+
+		/// <summary>
+		/// Use typical price ((High + Low + Close) / 3).
+		/// </summary>
+		Typical,
+
+		/// <summary>
+		/// Use weighted price ((High + Low + 2 * Close) / 4).
+		/// </summary>
+		Weighted,
+	}
 
 	/// <summary>
 	/// Initializes a new instance of <see cref="Ccit3ZeroCrossStrategy"/>.

--- a/API/4226_VivaLasVegas/CS/VivaLasVegasStrategy.cs
+++ b/API/4226_VivaLasVegas/CS/VivaLasVegasStrategy.cs
@@ -28,6 +28,15 @@ private readonly StrategyParam<MoneyManagementModes> _moneyManagementMode;
 	private decimal _lastRealizedPnL;
 	private bool _orderInFlight;
 
+	public enum MoneyManagementModes
+	{
+		Martingale,
+		NegativePyramid,
+		Labouchere,
+		OscarsGrind,
+		System31,
+	}
+
 	public VivaLasVegasStrategy()
 	{
 		_stopTakePips = Param(nameof(StopTakePips), 50)
@@ -236,15 +245,6 @@ MoneyManagementModes.OscarsGrind => new OscarsGrindManagement(),
 MoneyManagementModes.System31 => new System31Management(),
 _ => new MartingaleManagement(),
 };
-}
-
-public enum MoneyManagementModes
-{
-Martingale,
-NegativePyramid,
-Labouchere,
-OscarsGrind,
-System31,
 }
 
 	private enum TradeResults


### PR DESCRIPTION
## Summary
- moved standalone enum declarations inside their corresponding strategy classes for the 4xxx range
- ensured each strategy now exposes its enums as nested types to match API expectations

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d840ff91108323a2de459141b283c0